### PR TITLE
Start command Flags

### DIFF
--- a/api-cli/src/commands/start.ts
+++ b/api-cli/src/commands/start.ts
@@ -113,7 +113,7 @@ export default class Start extends Command {
       target,
       port: proxyPort
     })
-    this.log(fromOptic(`Starting ${colors.bold(config.name)} on Port: ${colors.bold(config.proxy.port.toString())}, with ${colors.bold(config.commands.start)}`))
+    this.log(fromOptic(`Starting ${colors.bold(config.name)} on Port: ${colors.bold(proxyPort)}, with ${colors.bold(config.commands.start)}`))
     this.log(fromOptic(`Starting Integration Gateway on Port: ${colors.bold(integrationsPort.toString())}`))
     this.log('\n')
     //starting outbound proxy

--- a/api-cli/src/commands/start.ts
+++ b/api-cli/src/commands/start.ts
@@ -23,7 +23,15 @@ export default class Start extends Command {
   static description = 'start your API and diff its behavior against the spec'
 
   static flags = {
-    'keep-alive': flags.boolean({description: 'use this when your command terminates before the server terminates'})
+    'keep-alive': flags.boolean({description: 'use this when your command terminates before the server terminates'}),
+    port: flags.string({
+      char: 'p',
+      description: 'Override the port defined in api.yml',
+    }),
+    target: flags.string({
+      char: 't',
+      description: 'Override the target defined in api.yml',
+    }),
   }
 
   static args = [{
@@ -98,10 +106,12 @@ export default class Start extends Command {
     }
 
     //inbound proxy
-    const target = processSetting(config.proxy.target, inputs)
+    const proxyTarget = flags.target ? flags.target : config.proxy.target
+    const proxyPort = flags.port ? parseInt(flags.port, 10) : config.proxy.port
+    const target = processSetting(proxyTarget, inputs)
     await proxySession.start({
       target,
-      port: config.proxy.port
+      port: proxyPort
     })
     this.log(fromOptic(`Starting ${colors.bold(config.name)} on Port: ${colors.bold(config.proxy.port.toString())}, with ${colors.bold(config.commands.start)}`))
     this.log(fromOptic(`Starting Integration Gateway on Port: ${colors.bold(integrationsPort.toString())}`))


### PR DESCRIPTION
**Purpose:**  To allow for overriding variables at runtime.

**User Story:** 

> As an Optic User
> I Need to change my port at runtime
> So that I can match different test environments

**Updated Command Examples:**
`api start --port 8012`
`api start --target "http://externalservice:4343"`