### PR TITLE
Add GH issue/pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugfix.md
+++ b/.github/ISSUE_TEMPLATE/bugfix.md
@@ -1,0 +1,35 @@
+---
+name: Bugfix
+about: Submit a bug fix.
+title: New Bug Fix
+labels: 'bug'
+assignees: ''
+
+---
+## Context
+
+consectetur adipiscing elit pellentesque habitant morbi tristique senectus et
+
+## Issue
+
+sem viverra aliquet eget sit amet tellus cras adipiscing enim eu turpis egestas
+pretium aenean pharetra magna ac placerat vestibulum lectus mauris ultrices
+eros in
+
+```
+  // issue in code (or psuedo-code)
+
+  ...
+```
+
+## Solution
+
+tortor at auctor urna nunc id cursus metus aliquam eleifend mi in nulla posuere
+sollicitudin aliquam ultrices sagittis orci a scelerisque purus semper eget
+duis
+
+```
+  // solution in code (or psuedo-code)
+
+  ...
+```

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,23 @@
+---
+name: Feedback
+about: Submit feedback.
+title: New Feedback
+labels: 'documentation'
+assignees: ''
+
+---
+## Context
+
+consectetur adipiscing elit pellentesque habitant morbi tristique senectus et
+
+## Feedback
+
+sem viverra aliquet eget sit amet tellus cras adipiscing enim eu turpis egestas
+pretium aenean pharetra magna ac placerat vestibulum lectus mauris ultrices
+eros in
+
+```
+  // suggestion in code (or psuedo-code)
+
+  ...
+```

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,23 @@
+---
+name: Enhancement
+about: Suggest an enhancement.
+title: New Enhancement
+labels: 'enhancement'
+assignees: ''
+
+---
+## Context
+
+consectetur adipiscing elit pellentesque habitant morbi tristique senectus et
+
+## Enhancement
+
+sem viverra aliquet eget sit amet tellus cras adipiscing enim eu turpis egestas
+pretium aenean pharetra magna ac placerat vestibulum lectus mauris ultrices
+eros in
+
+```
+  // suggestion in code (or psuedo-code)
+
+  ...
+```

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,23 @@
+---
+name: Feature
+about: Submit a feature request.
+title: New Feature
+labels: 'feature request'
+assignees: ''
+
+---
+## Context
+
+consectetur adipiscing elit pellentesque habitant morbi tristique senectus et
+
+## Feature Request
+
+sem viverra aliquet eget sit amet tellus cras adipiscing enim eu turpis egestas
+pretium aenean pharetra magna ac placerat vestibulum lectus mauris ultrices
+eros in
+
+```
+  // suggestion in code (or psuedo-code)
+
+  ...
+```

--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -1,0 +1,23 @@
+---
+name: Other
+about: Report an issue.
+title: New Issue
+labels: 'feedback'
+assignees: ''
+
+---
+## Context
+
+consectetur adipiscing elit pellentesque habitant morbi tristique senectus et
+
+## Issue
+
+sem viverra aliquet eget sit amet tellus cras adipiscing enim eu turpis egestas
+pretium aenean pharetra magna ac placerat vestibulum lectus mauris ultrices
+eros in
+
+```
+  // issue in code (or psuedo-code)
+
+  ...
+```

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,25 @@
+---
+name: Question
+about: Ask a question.
+title: New Question
+labels: 'question'
+assignees: ''
+
+---
+## Context
+
+sem viverra aliquet eget sit amet tellus cras adipiscing enim eu turpis egestas
+pretium aenean pharetra magna ac placerat vestibulum lectus mauris ultrices
+eros in
+
+## Question
+
+sem viverra aliquet eget sit amet tellus cras adipiscing enim eu turpis egestas
+pretium aenean pharetra magna ac placerat vestibulum lectus mauris ultrices
+eros in
+
+```
+  // question in code (or psuedo-code)
+
+  ...
+```

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,20 @@
+## Todo
+
+- [ ] Push to issue branch, e.g. `issue-123`
+- [ ] Reference github issue, e.g. `Closes #123`
+
+## Context
+
+consectetur adipiscing elit pellentesque habitant morbi tristique senectus et
+
+## Implements
+
+sem viverra aliquet eget sit amet tellus cras adipiscing enim eu turpis egestas
+pretium aenean pharetra magna ac placerat vestibulum lectus mauris ultrices
+eros in
+
+```
+  // code (or psuedo-code)
+
+  ...
+```


### PR DESCRIPTION
Once this PR is merged into master, whenever a user click the _"new issue"_ button in GitHub they will be presented with a list of issue types and when one is selected the issue will appear with a specific prefilled text and labels.