### PR TITLE
Fixed a serious bug in the side-by-side diff viewer

### DIFF
--- a/core/optic/shared/src/main/scala/com/useoptic/diff/shapes/JsonLikeTraverser.scala
+++ b/core/optic/shared/src/main/scala/com/useoptic/diff/shapes/JsonLikeTraverser.scala
@@ -76,7 +76,7 @@ class JsonLikeTraverser(spec: RfcState, visitors: JsonLikeVisitors) {
         })
         val jsonTrail = bodyTrail.withChild(JsonObjectKey(key))
 
-        visitors.objectVisitor.visit(key, value, bodyTrail, resolvedTrail, resolved.bindings)
+        visitors.objectVisitor.visit(key, value, jsonTrail, resolvedTrail, resolved.bindings)
 
         traverse(Some(value), jsonTrail, resolvedTrail)
       })

--- a/core/optic/shared/src/main/scala/com/useoptic/ux/DiffPreviewer.scala
+++ b/core/optic/shared/src/main/scala/com/useoptic/ux/DiffPreviewer.scala
@@ -84,21 +84,23 @@ class ExampleRenderVisitor(spec: RfcState, diffs: Set[ShapeDiffResult]) extends 
 
   override val objectVisitor: ObjectVisitor = new ObjectVisitor {
     override def begin(value: Map[String, JsonLike], bodyTrail: JsonTrail, expected: ResolvedTrail, shapeTrail: ShapeTrail): Unit = {
+
+      def idFromName(name: String) = bodyTrail.withChild(JsonObjectKey(name)).toString
+
       val fieldNameToId = expected.shapeEntity.descriptor.fieldOrdering
         .map(fieldId => {
           val field = spec.shapesState.fields(fieldId)
           val fieldShape = Resolvers.resolveFieldToShape(spec.shapesState, fieldId, expected.bindings).flatMap(x => {
             Some(x.shapeEntity)
           }).get
-          (field.descriptor.name -> (fieldId, fieldShape))
+          (field.descriptor.name -> (idFromName(field.descriptor.name), fieldShape))
         }).toMap
 
       val knownFieldsIds = fieldNameToId.values.map(_._1)
       val missingFieldIds = fieldNameToId.flatMap(entry => {
-        val (fieldName, (fieldId, fieldShapeId)) = entry
+        val (fieldName, (fieldId, fieldShape)) = entry
         if (!value.contains(fieldName)) {
-          pushField(RenderField(fieldId, fieldName, None, value.get(fieldName).map(_.asJson), diffs = diffsByTrail(bodyTrail.withChild(JsonObjectKey(fieldName)))))
-          //          primitiveVisitor.visit(None, bodyTrail.withChild(JsonObjectKey(fieldName)), Some(shapeTrail.withChild(ObjectFieldTrail(fieldId, fieldShapeId))))
+          pushField(RenderField(fieldId, Some(fieldShape.shapeId), fieldName, None, value.get(fieldName).map(_.asJson), diffs = diffsByTrail(bodyTrail.withChild(JsonObjectKey(fieldName)))))
           Some(fieldId)
         } else None
       })
@@ -106,14 +108,14 @@ class ExampleRenderVisitor(spec: RfcState, diffs: Set[ShapeDiffResult]) extends 
       val extraFieldIds = value.flatMap { case (key, value) => {
         if (!fieldNameToId.contains(key)) {
           Logger.log(s"object has extra field ${key}")
-          val extraFieldId = "extra_field_" + ShapesHelper.newFieldId()
-          pushField(RenderField(extraFieldId, key, None, Some(value.asJson), diffs = diffsByTrail(bodyTrail.withChild(JsonObjectKey(key)))))
+          val extraFieldId = bodyTrail.toString
+          pushField(RenderField(extraFieldId, None, key, None, Some(value.asJson), diffs = diffsByTrail(bodyTrail.withChild(JsonObjectKey(key)))))
           Some(extraFieldId)
         } else None
       }
       }
       pushShape(
-        RenderShape(expected.shapeEntity.shapeId, ObjectKind.baseShapeId, Fields(
+        RenderShape(bodyTrail.toString, Some(expected.shapeEntity.shapeId), ObjectKind.baseShapeId, Fields(
           expected = knownFieldsIds.toSeq,
           missing = missingFieldIds.toSeq,
           unexpected = extraFieldIds.toSeq
@@ -127,11 +129,11 @@ class ExampleRenderVisitor(spec: RfcState, diffs: Set[ShapeDiffResult]) extends 
       val fieldIds = value.map{ case (key, value) => {
         val fieldId = "anon_" + ShapesHelper.newFieldId()
         val fieldShapeId = bodyTrail.withChild(JsonObjectKey(key)).toString
-        pushField(RenderField(fieldId, key, Some(fieldShapeId), Some(value.asJson)))
+        pushField(RenderField(fieldId, None, key, Some(fieldShapeId), Some(value.asJson)))
         fieldId
       }}.toSeq
 
-      pushShape(RenderShape(objectId, ObjectKind.baseShapeId, Fields(fieldIds, Seq.empty, Seq.empty)))
+      pushShape(RenderShape(objectId, None, ObjectKind.baseShapeId, Fields(fieldIds, Seq.empty, Seq.empty)))
     }
 
     override def visit(key: String, jsonLike: JsonLike, bodyTrail: JsonTrail, trail: Option[ShapeTrail], parentBindings: ParameterBindings): Unit = {
@@ -140,7 +142,8 @@ class ExampleRenderVisitor(spec: RfcState, diffs: Set[ShapeDiffResult]) extends 
         val fieldEntity = trail.get.lastField().flatMap(i => spec.shapesState.fields.get(i)).get
         val fieldShape = Resolvers.resolveFieldToShape(spec.shapesState, fieldEntity.fieldId, parentBindings)
         pushField(RenderField(
-          fieldEntity.fieldId,
+          bodyTrail.toString,
+          Some(fieldEntity.fieldId),
           key,
           fieldShape.map(_.shapeEntity.shapeId),
           Some(jsonLike.asJson),
@@ -153,15 +156,11 @@ class ExampleRenderVisitor(spec: RfcState, diffs: Set[ShapeDiffResult]) extends 
   }
   override val arrayVisitor: ArrayVisitor = new ArrayVisitor {
 
-    def toId(index: Int, shapeId: String) = {
-      shapeId + "_items_" + index.toString
-    }
-
     override def beginUnknown(value: Vector[JsonLike], bodyTrail: JsonTrail): Unit = {
       val arrayId = bodyTrail.toString
       val ids = value.zipWithIndex.map {
         case (i, index) => {
-          val id = "anon_"+toId(index, arrayId)
+          val id = s"anon_${index}_${arrayId}"
           pushItem(RenderItem(
             id,
             index.intValue(),
@@ -175,6 +174,7 @@ class ExampleRenderVisitor(spec: RfcState, diffs: Set[ShapeDiffResult]) extends 
 
       pushShape(RenderShape(
         arrayId,
+        None,
         ListKind.baseShapeId,
         items = Items(ids),
         exampleValue = Some(Json.fromValues(value.map(_.asJson))),
@@ -185,12 +185,13 @@ class ExampleRenderVisitor(spec: RfcState, diffs: Set[ShapeDiffResult]) extends 
     override def begin(value: Vector[JsonLike], bodyTrail: JsonTrail, shapeTrail: ShapeTrail, resolvedShapeTrail: ResolvedTrail): Unit = {
 
       val ids = value.zipWithIndex.map {
-        case (i, index) => toId(index, resolvedShapeTrail.shapeEntity.shapeId)
+        case (i, index) => bodyTrail.withChild(JsonArrayItem(index)).toString
       }
 
       pushShape(RenderShape(
-        resolvedShapeTrail.shapeEntity.shapeId,
-        resolvedShapeTrail.coreShapeKind.baseShapeId,
+        bodyTrail.toString,
+        Some(resolvedShapeTrail.shapeEntity.shapeId),
+        ListKind.toString,
         items = Items(ids),
         exampleValue = Some(Json.fromValues(value.map(_.asJson))),
         diffs = diffsByTrail(bodyTrail)
@@ -200,10 +201,8 @@ class ExampleRenderVisitor(spec: RfcState, diffs: Set[ShapeDiffResult]) extends 
     override def visit(index: Number, value: JsonLike, bodyTrail: JsonTrail, trail: Option[ShapeTrail]): Unit = {
       trail.foreach(shapeTrail => {
         val lastListItem = shapeTrail.lastListItem().get
-        val id = toId(index.intValue(), lastListItem.listShapeId)
-
         pushItem(RenderItem(
-          id,
+          bodyTrail.toString,
           index.intValue(),
           Resolvers.jsonToCoreKind(value).baseShapeId,
           Some(lastListItem.itemShapeId),
@@ -224,7 +223,7 @@ class ExampleRenderVisitor(spec: RfcState, diffs: Set[ShapeDiffResult]) extends 
         if (resolvedTrailOption.isDefined) {
           val shape = resolvedTrailOption.get.shapeEntity
           val baseShapeId = resolvedTrailOption.get.coreShapeKind.baseShapeId
-          pushShape(RenderShape(shape.shapeId, baseShapeId, exampleValue = value.map(_.asJson), diffs = diffsByTrail(bodyTrail)))
+          pushShape(RenderShape(bodyTrail.toString, Some(shape.shapeId), baseShapeId, exampleValue = value.map(_.asJson), diffs = diffsByTrail(bodyTrail)))
         }
       }
     }
@@ -233,7 +232,7 @@ class ExampleRenderVisitor(spec: RfcState, diffs: Set[ShapeDiffResult]) extends 
       if (value.isDefined) {
         val shapeId = bodyTrail.toString
         val baseShapeId = Resolvers.jsonToCoreKind(value.get).baseShapeId
-        pushShape(RenderShape(shapeId, baseShapeId, exampleValue = value.map(_.asJson)))
+        pushShape(RenderShape(shapeId, None, baseShapeId, exampleValue = value.map(_.asJson)))
       }
     }
   }
@@ -273,6 +272,7 @@ class ShapeRenderVisitor(spec: RfcState, diffs: Set[ShapeDiffResult], exampleVis
       //push root object
       pushShape(RenderShape(
         objectResolved.shapeEntity.shapeId,
+        None,
         ObjectKind.baseShapeId,
         Fields(expectedShapeIds, fieldsFromExample.missing, fieldsFromExample.unexpected, fieldsFromExample.hidden),
         Items(Seq.empty),
@@ -286,6 +286,7 @@ class ShapeRenderVisitor(spec: RfcState, diffs: Set[ShapeDiffResult], exampleVis
       val example = exampleFields.get(fieldId).flatMap(_.exampleValue)
       pushField(RenderField(
         fieldId,
+        None,
         key,
         Some(fieldShapeTrail.shapeEntity.shapeId),
         example,
@@ -308,6 +309,7 @@ class ShapeRenderVisitor(spec: RfcState, diffs: Set[ShapeDiffResult], exampleVis
       pushShape(
         RenderShape(
           listShape.shapeId,
+          None,
           ListKind.baseShapeId,
           items = Items(Seq(id)),
           diffs = diffsByTrail(shapeTrail),
@@ -335,6 +337,7 @@ class ShapeRenderVisitor(spec: RfcState, diffs: Set[ShapeDiffResult], exampleVis
 
       pushShape(RenderShape(
         objectResolved.shapeEntity.shapeId,
+        None,
         objectResolved.coreShapeKind.baseShapeId,
         diffs = diffsByTrail(shapeTrail),
         name = name
@@ -350,6 +353,7 @@ class ShapeRenderVisitor(spec: RfcState, diffs: Set[ShapeDiffResult], exampleVis
 
       pushShape(RenderShape(
         oneOfShape.shapeId,
+        None,
         OneOfKind.baseShapeId,
         branches = branches,
         diffs = diffsByTrail(shapeTrail),
@@ -366,6 +370,7 @@ class ShapeRenderVisitor(spec: RfcState, diffs: Set[ShapeDiffResult], exampleVis
     override def begin(shapeTrail: ShapeTrail, shape: ShapeEntity, innerShape: Option[ShapeEntity]): Unit = {
       pushShape(RenderShape(
         shape.shapeId,
+        None,
         OptionalKind.baseShapeId,
         innerId = innerShape.map(_.shapeId),
         diffs = diffsByTrail(shapeTrail),
@@ -377,6 +382,7 @@ class ShapeRenderVisitor(spec: RfcState, diffs: Set[ShapeDiffResult], exampleVis
     override def begin(shapeTrail: ShapeTrail, shape: ShapeEntity, innerShape: Option[ShapeEntity]): Unit = {
       pushShape(RenderShape(
         shape.shapeId,
+        None,
         NullableKind.baseShapeId,
         innerId = innerShape.map(_.shapeId),
         diffs = diffsByTrail(shapeTrail),

--- a/workspaces/ui/public/example-sessions/simple-one-of.json
+++ b/workspaces/ui/public/example-sessions/simple-one-of.json
@@ -1,0 +1,61 @@
+{
+  "events": [{"PathComponentAdded":{"pathId":"path_P9TQyLf47v","parentPathId":"root","name":"todos","eventContext":{"clientId":"anonymous","clientSessionId":"d592900e-468e-4ec0-b660-e5e0b88eba60","clientCommandBatchId":"8b42f629-3557-448e-b810-81fe79a941e5","createdAt":"2020-04-09T17:49:32.878Z"}}},{"ContributionAdded":{"id":"path_P9TQyLf47v.GET","key":"purpose","value":"get todos","eventContext":{"clientId":"anonymous","clientSessionId":"d592900e-468e-4ec0-b660-e5e0b88eba60","clientCommandBatchId":"8b42f629-3557-448e-b810-81fe79a941e5","createdAt":"2020-04-09T17:49:32.882Z"}}},{"BatchCommitStarted":{"batchId":"6faf1bfa-09ca-48e9-ae00-39bd66b937a9","commitMessage":"\n\nChanges:\n- Added Request with No Body\n- Added 200 Response with application/json Body","eventContext":{"clientId":"anonymous","clientSessionId":"d592900e-468e-4ec0-b660-e5e0b88eba60","clientCommandBatchId":"5ad2d528-dc81-4380-8234-6d9859926e09","createdAt":"2020-04-09T17:50:33.976Z"}}},{"RequestParameterAddedByPathAndMethod":{"parameterId":"parameter_9jeVaIjUdN","pathId":"path_P9TQyLf47v","httpMethod":"GET","parameterLocation":"query","name":"queryString","eventContext":{"clientId":"anonymous","clientSessionId":"d592900e-468e-4ec0-b660-e5e0b88eba60","clientCommandBatchId":"35f8d27c-6681-4418-9bfb-020cb79968c3","createdAt":"2020-04-09T17:50:33.977Z"}}},{"ShapeAdded":{"shapeId":"shape_sOPA3t7ajn","baseShapeId":"$object","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"d592900e-468e-4ec0-b660-e5e0b88eba60","clientCommandBatchId":"35f8d27c-6681-4418-9bfb-020cb79968c3","createdAt":"2020-04-09T17:50:33.977Z"}}},{"RequestParameterShapeSet":{"parameterId":"parameter_9jeVaIjUdN","parameterDescriptor":{"shapeId":"shape_sOPA3t7ajn","isRemoved":false},"eventContext":{"clientId":"anonymous","clientSessionId":"d592900e-468e-4ec0-b660-e5e0b88eba60","clientCommandBatchId":"35f8d27c-6681-4418-9bfb-020cb79968c3","createdAt":"2020-04-09T17:50:33.977Z"}}},{"RequestAdded":{"requestId":"request_IlY6c3mcyG","pathId":"path_P9TQyLf47v","httpMethod":"GET","eventContext":{"clientId":"anonymous","clientSessionId":"d592900e-468e-4ec0-b660-e5e0b88eba60","clientCommandBatchId":"35f8d27c-6681-4418-9bfb-020cb79968c3","createdAt":"2020-04-09T17:50:33.977Z"}}},{"ResponseAddedByPathAndMethod":{"responseId":"response_3k3wsdKnry","pathId":"path_P9TQyLf47v","httpMethod":"GET","httpStatusCode":200,"eventContext":{"clientId":"anonymous","clientSessionId":"d592900e-468e-4ec0-b660-e5e0b88eba60","clientCommandBatchId":"28871a21-653c-4fbf-af5a-5592b9315713","createdAt":"2020-04-09T17:50:33.978Z"}}},{"ShapeAdded":{"shapeId":"TjLcTK_0","baseShapeId":"$list","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"d592900e-468e-4ec0-b660-e5e0b88eba60","clientCommandBatchId":"28871a21-653c-4fbf-af5a-5592b9315713","createdAt":"2020-04-09T17:50:33.978Z"}}},{"ShapeAdded":{"shapeId":"TjLcTK_1","baseShapeId":"$object","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"d592900e-468e-4ec0-b660-e5e0b88eba60","clientCommandBatchId":"28871a21-653c-4fbf-af5a-5592b9315713","createdAt":"2020-04-09T17:50:33.978Z"}}},{"ShapeAdded":{"shapeId":"TjLcTK_3","baseShapeId":"$boolean","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"d592900e-468e-4ec0-b660-e5e0b88eba60","clientCommandBatchId":"28871a21-653c-4fbf-af5a-5592b9315713","createdAt":"2020-04-09T17:50:33.978Z"}}},{"FieldAdded":{"fieldId":"TjLcTK_2","shapeId":"TjLcTK_1","name":"a","shapeDescriptor":{"FieldShapeFromShape":{"fieldId":"TjLcTK_2","shapeId":"TjLcTK_3"}},"eventContext":{"clientId":"anonymous","clientSessionId":"d592900e-468e-4ec0-b660-e5e0b88eba60","clientCommandBatchId":"28871a21-653c-4fbf-af5a-5592b9315713","createdAt":"2020-04-09T17:50:33.979Z"}}},{"ShapeAdded":{"shapeId":"TjLcTK_4","baseShapeId":"TjLcTK_1","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"d592900e-468e-4ec0-b660-e5e0b88eba60","clientCommandBatchId":"28871a21-653c-4fbf-af5a-5592b9315713","createdAt":"2020-04-09T17:50:33.979Z"}}},{"ShapeParameterShapeSet":{"shapeDescriptor":{"ProviderInShape":{"shapeId":"TjLcTK_0","providerDescriptor":{"ShapeProvider":{"shapeId":"TjLcTK_4"}},"consumingParameterId":"$listItem"}},"eventContext":{"clientId":"anonymous","clientSessionId":"d592900e-468e-4ec0-b660-e5e0b88eba60","clientCommandBatchId":"28871a21-653c-4fbf-af5a-5592b9315713","createdAt":"2020-04-09T17:50:33.979Z"}}},{"ResponseBodySet":{"responseId":"response_3k3wsdKnry","bodyDescriptor":{"httpContentType":"application/json","shapeId":"TjLcTK_0","isRemoved":false},"eventContext":{"clientId":"anonymous","clientSessionId":"d592900e-468e-4ec0-b660-e5e0b88eba60","clientCommandBatchId":"28871a21-653c-4fbf-af5a-5592b9315713","createdAt":"2020-04-09T17:50:33.979Z"}}},{"BatchCommitEnded":{"batchId":"6faf1bfa-09ca-48e9-ae00-39bd66b937a9","eventContext":{"clientId":"anonymous","clientSessionId":"d592900e-468e-4ec0-b660-e5e0b88eba60","clientCommandBatchId":"94f2f41d-e65f-4500-a465-1ffc7b6adc14","createdAt":"2020-04-09T17:50:33.980Z"}}}],
+  "session": {
+    "metadata": {
+      "completed": false
+    },
+    "samples": [
+      {
+        "uuid": "2",
+        "request": {
+          "host": "localhost",
+          "method": "GET",
+          "path": "/todos",
+          "query": {
+            "asJsonString": null,
+            "asText": null,
+            "asShapeHashBytes": null
+          },
+          "headers": {
+            "asJsonString": null,
+            "asText": null,
+            "asShapeHashBytes": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "asJsonString": null,
+              "asText": null,
+              "asShapeHashBytes": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "asJsonString": null,
+            "asText": null,
+            "asShapeHashBytes": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "asJsonString": "[{\"a\": 6354}, {\"a\": 1234}, {\"a\": 987}]",
+              "asText": null,
+              "asShapeHashBytes": null
+            }
+          }
+        },
+        "tags": []
+      }
+    ],
+    "links": [
+      {
+        "rel": "next",
+        "href": ""
+      }
+    ]
+  },
+  "examples": {},
+  "refs": [{ "rel": "example-reports", "id": "todo-report" }]
+}

--- a/workspaces/ui/src/components/diff/v2/shape_viewers/SideBySideShapeRows.js
+++ b/workspaces/ui/src/components/diff/v2/shape_viewers/SideBySideShapeRows.js
@@ -172,6 +172,11 @@ function ValueContents({value, shape}) {
     return <ValueContents value={value} shape={getOrUndefined(shapeRender.unwrapInner(shape))}/>
   }
 
+
+  if (jsTypeString === '[object Null]') {
+    return <Symbols>{'null'}</Symbols>;
+  }
+
   if (jsTypeString === '[object Array]') {
     return <Symbols>{'['}</Symbols>;
   }
@@ -357,6 +362,7 @@ export const ItemRow = withShapeRenderContext((props) => {
   const {item, shapeRender, isLast, listId, listItemShape, diffDescription, suggestion} = props;
   const diff = headOrUndefined(item.item.diffs);
 
+  const exampleItemShape = shapeRender.getUnifiedShape(item.item.itemId)
   const resolvedShape = getOrUndefined(shapeRender.resolveItemShape(toOption(listItemShape))) || getOrUndefined(shapeRender.resolveItemShapeFromShapeId(item.item.shapeId));
 
   const diffNotif = diff && (
@@ -385,7 +391,7 @@ export const ItemRow = withShapeRenderContext((props) => {
               <div className={classes.rowContents}>
                 <IndexMarker>{item.index}</IndexMarker>
                 <div style={{flex: 1, paddingLeft: 4}}>
-                  <ValueContents value={getOrUndefinedJson(item.item.exampleValue)} shape={resolvedShape}/>
+                  <ValueContents value={getOrUndefinedJson(item.item.exampleValue)} shape={exampleItemShape}/>
                 </div>
               </div>
             </Indent>
@@ -412,7 +418,7 @@ export const ItemRow = withShapeRenderContext((props) => {
         })()}
       />
       {item.display !== 'hidden' &&
-      <ValueRows value={getOrUndefinedJson(item.item.exampleValue)} shape={resolvedShape}/>}
+      <ValueRows value={getOrUndefinedJson(item.item.exampleValue)} shape={exampleItemShape}/>}
     </>
   );
 });


### PR DESCRIPTION
Because of the way the Example rendering traversal was written (by me), any Lists of Objects would show the last item in the array for every item. The diff and suggestions were still correct, but w/o the proper UI everything was quite confusing. 

The issue boiled down to the fact that I tried to make the parallel traversal of spec + examples yield a map of ID -> RenderX where IDs were shared across both our spec and example domain. 

You would basically lookup two RenderX's and merge them

Unfortunately, sharing IDs like that allowed details from domain to bleed over into JSON land. In domain you can only have one listItem so the same ID was being used for every list item. You'd still get the right # of items, but each would be the last item in the array. oops

Now IDs from the JSON traversal are BodyTrail.toString and they contain a reference to their specShape. 

If I were doing this from scratch I would stop trying to have RenderX be shared between example and spec. 

For now, it's alright, but long term RenderExampleX and RenderSpecX will diverge more. 