### PR TITLE
logging output from domain should not make it to the end user. 

### DIFF
--- a/workspaces/local-cli/src/shared/logger.ts
+++ b/workspaces/local-cli/src/shared/logger.ts
@@ -1,4 +1,7 @@
-import {debug} from 'debug';
+import { debug } from 'debug';
+import { setLogger } from '@useoptic/domain';
+
+setLogger(() => {});
 
 export const developerDebugLogger = debug('optic-debug');
 export const userDebugLogger = debug('optic');


### PR DESCRIPTION
a developer may change the setLogger call to use a debug logger