### PR TITLE
Ensure pull-requests do not break the build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,58 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ 'feature/testing-dashboard' ]
+  pull_request:
+    branches: [ 'feature/testing-dashboard' ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - name: "checkout source"
+      uses: actions/checkout@v2
+    - name: "Set up JDK 1.8"
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+        
+    - name: pwd
+      run: pwd
+    - name: "where is the code"
+      run: echo $GITHUB_WORKSPACE
+    - name: ls
+      run: ls -la $GITHUB_WORKSPACE
+    - name: "list sbt projects"
+      run: cd "$GITHUB_WORKSPACE/core" && sbt projects
+    - name: "build domain.js artifact"
+      run: cd "$GITHUB_WORKSPACE/core" && sbt fullOptJS
+      env:
+        SBT_OPTS: "-Xmx2G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=2G -Xss2M -Duser.timezone=GMT"
+    - name: "check artifact"
+      run: ls -la "$GITHUB_WORKSPACE/core/optic/js/target/scala-2.12/optic-core-opt.js"
+    - name: "copy artifact"
+      run: cp "$GITHUB_WORKSPACE/core/optic/js/target/scala-2.12/optic-core-opt.js" "$GITHUB_WORKSPACE/workspaces/domain/src/domain.js"
+
+    - name: "set up node.js"
+      uses: actions/setup-node@v1
+      with:
+        node-version: "12.x"
+    - name: "install dependencies"
+      run: yarn install
+    - name: "build workspaces"
+      run: yarn wsrun --stages --report --fast-exit ws:build
+    - name: "check domain src directory"
+      run: ls -laR "$GITHUB_WORKSPACE/workspaces/domain/src"
+    - name: "check domain build directory"
+      run: ls -laR "$GITHUB_WORKSPACE/workspaces/domain/build"


### PR DESCRIPTION
The build process should run on commits or PRs to feature/testing-dashboard until we settle on a git flow