### PR TITLE
Optic should gracefully handle APIs that send a content-type header without any actual body

### DIFF
--- a/core/optic/shared/src/main/scala/com/useoptic/diff/interactions/interpretations/BasicInterpretations.scala
+++ b/core/optic/shared/src/main/scala/com/useoptic/diff/interactions/interpretations/BasicInterpretations.scala
@@ -85,17 +85,28 @@ class BasicInterpretations(rfcState: RfcState) {
     interactionTrail.requestBodyContentTypeOption() match {
       case Some(contentType) => {
         val jsonBody = Resolvers.tryResolveJsonLike(interactionTrail, JsonTrail(Seq()), interaction)
+        val actuallyHasBody = jsonBody.isDefined
+        if (actuallyHasBody) {
         val builtShape = new ShapeBuilder(jsonBody.get).run
         val commands = baseCommands ++ builtShape.commands ++ Seq(
           RequestsCommands.SetRequestBodyShape(requestId, ShapedBodyDescriptor(contentType, builtShape.rootShapeId, isRemoved = false))
         )
-
         InteractiveDiffInterpretation(
-          s"Add Request with ${interactionTrail.responseBodyContentTypeOption().getOrElse("No")} Body",
-          s"Added Request with ${interactionTrail.responseBodyContentTypeOption().getOrElse("No")} Body",
+            s"Add Request with ${contentType} Body",
+            s"Added Request with ${contentType} Body",
+            commands,
+            ChangeType.Addition
+          )
+        } else {
+          val commands = baseCommands
+          InteractiveDiffInterpretation(
+            s"Add Request with ${contentType} Content-Type but no Body",
+            s"Added Request with ${contentType} Content-Type but no Body",
           commands,
           ChangeType.Addition
         )
+      }
+
       }
       case None => {
         val commands = baseCommands
@@ -118,17 +129,29 @@ class BasicInterpretations(rfcState: RfcState) {
     interactionTrail.responseBodyContentTypeOption() match {
       case Some(contentType) => {
         val jsonBody = Resolvers.tryResolveJsonLike(interactionTrail, JsonTrail(Seq()), interaction)
+        val actuallyHasBody = jsonBody.isDefined
+        if (actuallyHasBody) {
         val builtShape = new ShapeBuilder(jsonBody.get).run
         val commands = baseCommands ++ builtShape.commands ++ Seq(
           RequestsCommands.SetResponseBodyShape(responseId, ShapedBodyDescriptor(contentType, builtShape.rootShapeId, isRemoved = false))
         )
 
         InteractiveDiffInterpretation(
-          s"Add ${interactionTrail.statusCode()} Response with ${interactionTrail.responseBodyContentTypeOption().getOrElse("No")} Body",
-          s"Added ${interactionTrail.statusCode()} Response with ${interactionTrail.responseBodyContentTypeOption().getOrElse("No")} Body",
+            s"Add ${interactionTrail.statusCode()} Response with ${contentType} Body",
+            s"Added ${interactionTrail.statusCode()} Response with ${contentType} Body",
           commands,
           ChangeType.Addition
         )
+        } else {
+          val commands = baseCommands
+
+          InteractiveDiffInterpretation(
+            s"Add ${interactionTrail.statusCode()} Response with ${contentType} Content-Type but no Body",
+            s"Added ${interactionTrail.statusCode()} Response with ${contentType} Content-Type but no Body",
+            commands,
+            ChangeType.Addition
+          )
+        }
       }
       case None => {
         val commands = baseCommands

--- a/workspaces/proxy/package.json
+++ b/workspaces/proxy/package.json
@@ -12,9 +12,13 @@
     "@useoptic/domain": "0.2.1",
     "fs-extra": "^8.1.0",
     "mockttp": "^0.19.2",
-    "shape-hash": "^1.0.6"
+    "shape-hash": "^1.0.6",
+    "whatwg-mimetype": "^2.3.0"
   },
   "files": [
     "/build"
-  ]
+  ],
+  "devDependencies": {
+    "@types/whatwg-mimetype": "^2.1.0"
+  }
 }


### PR DESCRIPTION
Optic should gracefully handle APIs that send a content-type header without any actual body