### PR TITLE
Never learn the request body for an interaction that yields a non 2xx resposne

### DIFF
--- a/core/optic/shared/src/main/scala/com/useoptic/ux/DiffManager.scala
+++ b/core/optic/shared/src/main/scala/com/useoptic/ux/DiffManager.scala
@@ -43,8 +43,8 @@ class DiffManager(initialInteractions: Seq[HttpInteraction], onUpdated: () => Un
 
       // Never learn from the request body for an interaction that yields a non 2xx-response
       def filterInteractionsWithErrorResponses(diff: InteractionDiffResult, interactions: Seq[HttpInteraction]) = diff match {
-        case _: UnmatchedRequestBodyContentType => interactions.filter(i => i.response.statusCode >=200 && i.response.statusCode < 300)
-        case _: UnmatchedRequestBodyShape => interactions.filter(i => i.response.statusCode >=200 && i.response.statusCode < 300)
+        case _: UnmatchedRequestBodyContentType => interactions.filter(i => i.response.statusCode >=200 && i.response.statusCode < 400)
+        case _: UnmatchedRequestBodyShape => interactions.filter(i => i.response.statusCode >=200 && i.response.statusCode < 400)
         case _ => interactions
       }
 

--- a/core/optic/shared/src/main/scala/com/useoptic/ux/DiffManager.scala
+++ b/core/optic/shared/src/main/scala/com/useoptic/ux/DiffManager.scala
@@ -40,9 +40,19 @@ class DiffManager(initialInteractions: Seq[HttpInteraction], onUpdated: () => Un
 
   def recomputeDiff() = {
     if (_currentRfcState != null) {
-      _interactionsGroupedByDiffs = DiffHelpers.groupByDiffs(_currentRfcState, _interactions).map {
-        case (diff, interactions) => (diff, interactions)
+
+      // Never learn from the request body for an interaction that yields a non 2xx-response
+      def filterInteractionsWithErrorResponses(diff: InteractionDiffResult, interactions: Seq[HttpInteraction]) = diff match {
+        case _: UnmatchedRequestBodyContentType => interactions.filter(i => i.response.statusCode >=200 && i.response.statusCode < 300)
+        case _: UnmatchedRequestBodyShape => interactions.filter(i => i.response.statusCode >=200 && i.response.statusCode < 300)
+        case _ => interactions
       }
+
+      _interactionsGroupedByDiffs = DiffHelpers.groupByDiffs(_currentRfcState, _interactions).collect {
+        case (diff, interactions) => (diff, filterInteractionsWithErrorResponses(diff, interactions))
+      }.filter(_._2.nonEmpty)
+
+
     } else {
       _interactionsGroupedByDiffs = Map.empty
     }


### PR DESCRIPTION
In Optic 6 + 7 requests that yielded a non-2xx response were never used while learning the spec. 

This logic could be in the visitor -- but since we are using that same visitor to do testing and verification it didn't seem right to include this documentation-only concern there. 

I elected to put the logic in the Diff Manager right after we compute the diff for the set of interactions. First Optic filters out interactions for `UnmatchedRequest*` that are not 2xx, then it removes keys from the Diff -> Interaction Map that are now empty. 

