### PR TITLE
Add development route for easy loading of user debug sessions while preventing publishing it

### DIFF
--- a/workspaces/ui/.gitignore
+++ b/workspaces/ui/.gitignore
@@ -25,3 +25,5 @@ yarn-error.log*
 
 # ide
 .idea/
+
+public/customer-sessions

--- a/workspaces/ui/src/contexts/MockDataContext.js
+++ b/workspaces/ui/src/contexts/MockDataContext.js
@@ -6,13 +6,14 @@ MockDataContext.displayName = 'MockDataContext';
 // only expose the Provider component, but hide the Consumer in favour of hooks
 export const { Provider } = MockDataContext;
 
-function createDebugSession({ sessionId }) {
+function createDebugSession({ sessionId, customerSession }) {
+  const collection = customerSession ? 'customer-sessions' : 'example-sessions';
   let fetchedData = null;
   async function getData(refresh = false) {
     if (!fetchedData || refresh) {
       // only fetch data once
-      fetchedData = fetch(`/example-sessions/${sessionId}.json`, {
-        headers: { accept: 'application/json' }
+      fetchedData = fetch(`/${collection}/${sessionId}.json`, {
+        headers: { accept: 'application/json' },
       }).then((response) => {
         if (response.ok) {
           return response.json();
@@ -26,17 +27,17 @@ function createDebugSession({ sessionId }) {
 
   return {
     sessionId,
-    getData
+    getData,
   };
 }
 
 // Hooks
 // -----
 
-export function useMockSession({ sessionId }) {
+export function useMockSession({ sessionId, customerSession }) {
   const dashboardContext = useMemo(
-    () => createDebugSession({ sessionId }),
-    [sessionId]
+    () => createDebugSession({ sessionId, customerSession }),
+    [sessionId, customerSession]
   );
   return dashboardContext;
 }

--- a/workspaces/ui/src/entrypoints/development.js
+++ b/workspaces/ui/src/entrypoints/development.js
@@ -1,27 +1,33 @@
 import React from 'react';
-import {useParams, useRouteMatch} from 'react-router-dom';
-import {ApiSpecServiceLoader} from '../components/loaders/ApiLoader';
-import {Provider as DebugSessionContextProvider, useMockSession} from '../contexts/MockDataContext';
-import {ApiRoutes} from '../routes';
-import {Provider as BaseUrlContext} from '../contexts/BaseUrlContext';
+import { useParams, useRouteMatch, matchPath } from 'react-router-dom';
+import { ApiSpecServiceLoader } from '../components/loaders/ApiLoader';
+import {
+  Provider as DebugSessionContextProvider,
+  useMockSession,
+} from '../contexts/MockDataContext';
+import { ApiRoutes } from '../routes';
+import { Provider as BaseUrlContext } from '../contexts/BaseUrlContext';
 
 export default function Development(props) {
-
   const match = useRouteMatch();
-  const {sessionId} = useParams();
+  const { sessionId } = useParams();
+  const isCustomerSession = !!matchPath(
+    match.path,
+    '/development/customer-sessions'
+  );
 
   const debugSession = useMockSession({
     sessionId: sessionId,
+    customerSession: isCustomerSession,
   });
 
   return (
-    <BaseUrlContext value={{path: match.path, url: match.url}}>
+    <BaseUrlContext value={{ path: match.path, url: match.url }}>
       <DebugSessionContextProvider value={debugSession}>
         <ApiSpecServiceLoader>
-          <ApiRoutes/>
+          <ApiRoutes />
         </ApiSpecServiceLoader>
       </DebugSessionContextProvider>
     </BaseUrlContext>
   );
-
 }

--- a/workspaces/ui/src/entrypoints/index.js
+++ b/workspaces/ui/src/entrypoints/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Route, Switch} from 'react-router-dom';
+import { Route, Switch } from 'react-router-dom';
 import Development from './development';
 import LocalCli from './localcli';
 import WelcomePage from '../components/support/WelcomePage';
@@ -7,9 +7,14 @@ import WelcomePage from '../components/support/WelcomePage';
 export default function TopLevelRoutes() {
   return (
     <Switch>
+      <Route
+        strict
+        path="/development/customer-sessions/:sessionId"
+        component={Development}
+      />
       <Route strict path="/development/:sessionId" component={Development} />
       <Route strict path="/apis/:apiId" component={LocalCli} />
-      <Route strict path={"/"} component={WelcomePage} />
+      <Route strict path={'/'} component={WelcomePage} />
     </Switch>
   );
 }


### PR DESCRIPTION
Now that we've made it easier for users to share their debug captures / sessions with us, we should make sure we can work with them easily, while making sure we don't ever leak it any further.

At the core, this change basically gives us a git-ignored version of `public/example-sessions`, so we won't accidentally commit one of these sessions. Any capture files placed in `public/customer-sessions/` will be available through `localhost:3000/development/customer-sessions/:sessionId`.

Since the debug context is aware of this being a customer file, the hook is there to add additional measures in the future, if we uncover the need for them. For example, a little debug banner warning we're looking at customer data, something that suggests deleting after we've been using it for a while, etc. 

In addition, I can imagine a post-install script that purges old captures from this folder, to make sure we don't keep these captures hanging around locally for any longer than we have to.

For now, though, I think this is a good first step worth adding. 