### PR TITLE
Use a single debug .env file for all CLI packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 node_modules
+.env

--- a/sourceme.sh
+++ b/sourceme.sh
@@ -2,12 +2,14 @@
 # usage: $ source ./sourceme.sh
 export OPTIC_SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 echo "Optic development scripts will run from $OPTIC_SRC_DIR"
+export OPTIC_DEBUG_ENV_FILE="$OPTIC_SRC_DIR/.env"
+## Don't expose this below, instead create .env and add to there, so we can all 
+## use our own local clusters to run against.
+# export OPTIC_LOCAL_CLI__API_GATEWAY="https://yx9uc028d6.execute-api.us-east-1.amazonaws.com/stage"
+
 alias apidev="OPTIC_DAEMON_ENABLE_DEBUGGING=yes OPTIC_UI_HOST=http://localhost:3000 OPTIC_AUTH_UI_HOST=http://localhost:4005 $OPTIC_SRC_DIR/workspaces/local-cli/bin/run"
 alias apistage="OPTIC_DAEMON_ENABLE_DEBUGGING=yes $OPTIC_SRC_DIR/workspaces/local-cli/bin/run"
 
-## Don't expose this below, instead create workspaces/local-cli/.env and add to there, so we can all 
-## use our own local clusters to run against.
-# export OPTIC_LOCAL_CLI__API_GATEWAY="https://yx9uc028d6.execute-api.us-east-1.amazonaws.com/stage"
 alias cidev="$OPTIC_SRC_DIR/workspaces/ci-cli/bin/run"
 alias agentdev="$OPTIC_SRC_DIR/workspaces/agent-cli/bin/run"
 optic_workspace_clean() {

--- a/workspaces/agent-cli/src/index.ts
+++ b/workspaces/agent-cli/src/index.ts
@@ -1,7 +1,10 @@
 import dotenv from 'dotenv';
 import path from 'path';
-dotenv.config({
-  path: path.join(__dirname, '../.env'),
-});
+
+if (process.env.OPTIC_DEBUG_ENV_FILE) {
+  dotenv.config({
+    path: process.env.OPTIC_DEBUG_ENV_FILE,
+  });
+}
 
 export { run } from '@oclif/command';

--- a/workspaces/ci-cli/src/index.ts
+++ b/workspaces/ci-cli/src/index.ts
@@ -1,7 +1,10 @@
 import dotenv from 'dotenv';
 import path from 'path';
-dotenv.config({
-  path: path.join(__dirname, '../.env'),
-});
+
+if (process.env.OPTIC_DEBUG_ENV_FILE) {
+  dotenv.config({
+    path: process.env.OPTIC_DEBUG_ENV_FILE,
+  });
+}
 
 export { run } from '@oclif/command';

--- a/workspaces/local-cli/src/index.ts
+++ b/workspaces/local-cli/src/index.ts
@@ -1,7 +1,10 @@
 import dotenv from 'dotenv';
 import path from 'path';
-dotenv.config({
-  path: path.join(__dirname, '../.env'),
-});
+
+if (process.env.OPTIC_DEBUG_ENV_FILE) {
+  dotenv.config({
+    path: process.env.OPTIC_DEBUG_ENV_FILE,
+  });
+}
 
 export { run } from '@oclif/command';


### PR DESCRIPTION
As I started to use the `agent-cli` and `ci-cli` for local debugging, I realised that each requires it's own `.env` file, even though they all host the single flag. This is annoying, as evidenced by this ENV variable making it into the _sourceme.sh_.

This PR allows all CLI packages to use the single env file, which is only read for the dev aliases from _sourceme.sh_ of the CLIs. This should now be _the_ place for anyone to inject their own env config. 

Note that the UI workspace still has it's own .env files: these serve a different purpose (feature flags) and _should_ be kept separate: we don't want the frontend code to have access to all these various env variables.