### PR TITLE
Partition diffs by pathId and method

### DIFF
--- a/core/optic/shared/src/main/scala/com/useoptic/contexts/requests/Commands.scala
+++ b/core/optic/shared/src/main/scala/com/useoptic/contexts/requests/Commands.scala
@@ -8,6 +8,7 @@ import scala.scalajs.js.annotation.{JSExportAll, JSExportDescendentClasses}
 
 object Commands {
   type PathComponentId = String
+  type RequestMethod = String
   type RequestId = String
   type RequestParameterId = String
   type ResponseId = String
@@ -44,7 +45,7 @@ object Commands {
   case class RenamePathParameter(pathId: PathComponentId, name: String) extends RequestsCommand
   case class RemovePathParameter(pathId: PathComponentId) extends RequestsCommand
 
-  case class AddRequest(requestId: RequestId, pathId: PathComponentId, httpMethod: String) extends RequestsCommand
+  case class AddRequest(requestId: RequestId, pathId: PathComponentId, httpMethod: RequestMethod) extends RequestsCommand
   //@GOTCHA #leftovers-from-designer-ui @TODO we should probably not support this command anymore, or enforce uniqueness of content types across multiple requests
   case class SetRequestContentType(requestId: RequestId, httpContentType: String) extends RequestsCommand
   //@GOTCHA #leftovers-from-designer-ui @TODO we should probably not support this command's ability to change the content type anymore, or enforce uniqueness of content types across multiple requests
@@ -71,7 +72,7 @@ object Commands {
   case class RemoveHeaderParameter(parameterId: RequestParameterId) extends RequestsCommand
   @Deprecated
   case class AddResponse(responseId: ResponseId, requestId: RequestId, httpStatusCode: Int) extends RequestsCommand
-  case class AddResponseByPathAndMethod(responseId: ResponseId, pathId: PathComponentId, httpMethod: String, httpStatusCode: Int) extends RequestsCommand
+  case class AddResponseByPathAndMethod(responseId: ResponseId, pathId: PathComponentId, httpMethod: RequestMethod, httpStatusCode: Int) extends RequestsCommand
   //@GOTCHA #leftovers-from-designer-ui @TODO we should probably not support this command anymore, or enforce uniqueness of content types across multiple requests
   case class SetResponseContentType(responseId: ResponseId, httpContentType: String) extends RequestsCommand
   //@GOTCHA #leftovers-from-designer-ui @TODO we should probably not support this command anymore

--- a/workspaces/ci-cli/package.json
+++ b/workspaces/ci-cli/package.json
@@ -55,7 +55,7 @@
   "main": "lib/index.js",
   "oclif": {
     "commands": "./lib/commands",
-    "bin": "optic-agent",
+    "bin": "optic-ci",
     "plugins": [
       "@oclif/plugin-help"
     ]

--- a/workspaces/ui/src/components/diff/v2/CaptureManagerPage.js
+++ b/workspaces/ui/src/components/diff/v2/CaptureManagerPage.js
@@ -322,6 +322,7 @@ function CaptureDiffWrapper(props) {
         <TrafficSessionContext.Consumer>
           {({ diffManager }) => {
             diffManager.updatedRfcState(rfcState, shapesResolvers);
+            diffManager.clearEndpointFilter();
 
             const ignoredAsSeq = JsonHelper.jsArrayToSeq(ignoredDiffs);
             const stats = diffManager.stats(ignoredAsSeq);

--- a/workspaces/ui/src/components/diff/v2/DiffPageNew.js
+++ b/workspaces/ui/src/components/diff/v2/DiffPageNew.js
@@ -333,6 +333,7 @@ const InnerDiffWrapper = withTrafficSessionContext(
     }
     const rfcState = rfcService.currentState(rfcId);
     const { shapesResolvers } = cachedQueryResults;
+    diffManager.updateEndpointFilter(pathId, method, true);
     diffManager.updatedRfcState(rfcState, shapesResolvers);
 
     const ignored = jsonHelper.jsArrayToSeq(ignoredDiffs);


### PR DESCRIPTION
This PR addresses some low-hanging, high-value fruit on the diff manager performance. 

My research/performance audit from today revealed a stale assumption: 
Every suggestion we approve requires us to re-run the entire diff. **Stale**

**Now that all shapes are distinct and aren't referenced across the endpoint boundaries, we can confidently partition the interactions by endpoint. The diff is the expensive thing so only having to run a subset of the interactions through it is an instant win** 

<img width="179" alt="look at that partition" src="https://user-images.githubusercontent.com/5900338/83919271-3c566400-a748-11ea-9750-74a21257629d.png">

I don't think this is the final word on performance, but it made my experience using Optic with a large session at least 5x faster -- like almost usable :) 