### PR TITLE
moved logfile to be inside optic folder and ignored it closes #68

### DIFF
--- a/workspaces/cli-config/src/index.ts
+++ b/workspaces/cli-config/src/index.ts
@@ -234,7 +234,6 @@ export async function createFileTree(config: string, basePath: string) {
       path: gitignorePath,
       contents: `
 captures/
-optic-daemon.log
 `,
     },
     {

--- a/workspaces/cli-config/src/index.ts
+++ b/workspaces/cli-config/src/index.ts
@@ -234,6 +234,7 @@ export async function createFileTree(config: string, basePath: string) {
       path: gitignorePath,
       contents: `
 captures/
+optic-daemon.log
 `,
     },
     {

--- a/workspaces/cli-server/src/server.ts
+++ b/workspaces/cli-server/src/server.ts
@@ -11,6 +11,7 @@ import getPort from 'get-port';
 import bodyParser from 'body-parser';
 import http from 'http';
 import { Socket } from 'net';
+import os from 'os';
 import path from 'path';
 import fs from 'fs-extra';
 import {
@@ -21,7 +22,7 @@ import {
 import { basePath } from '@useoptic/ui';
 import { createProxyMiddleware } from 'http-proxy-middleware';
 
-export const log = fs.createWriteStream('./.optic-daemon.log');
+export const log = fs.createWriteStream(path.join(os.homedir(), '.optic', 'optic-daemon.log'));
 
 export interface ICliServerConfig {
   cloudApiBaseUrl: string;

--- a/workspaces/cli-server/src/server.ts
+++ b/workspaces/cli-server/src/server.ts
@@ -22,7 +22,9 @@ import {
 import { basePath } from '@useoptic/ui';
 import { createProxyMiddleware } from 'http-proxy-middleware';
 
-export const log = fs.createWriteStream(path.join(os.homedir(), '.optic', 'optic-daemon.log'));
+const logFilePath = path.join(os.homedir(), '.optic', 'optic-daemon.log');
+fs.ensureDirSync(path.dirname(logFilePath));
+export const log = fs.createWriteStream(logFilePath);
 
 export interface ICliServerConfig {
   cloudApiBaseUrl: string;


### PR DESCRIPTION
## Key changes
- `.optic-daemon.log` is no longer hidden, and is now in `.optic/`
- `optic-daemon.log` is in the default created gitignore

