### PR TITLE
Review Only - exceptions: demo of a potential custom exception handler

### DIFF
--- a/workspaces/cli-shared/src/analytics-shared.ts
+++ b/workspaces/cli-shared/src/analytics-shared.ts
@@ -1,0 +1,84 @@
+/*
+  @TODO:
+  - Analytics should be abstracted with an interface: track(...)
+  - There should be one implementation that does nothing
+  - It should be easy to switch between implementations
+  - We should not be spawning a new process every time we want to track something. We should be flushing events out of this process and another process can take care of them
+ */
+// @ts-ignore
+import Analytics from 'analytics-node';
+import { runScriptByName } from '@useoptic/cli-scripts';
+import {
+  getCredentials,
+  getUserFromCredentials,
+} from './authentication-server-shared';
+import { IOpticTaskRunnerConfig, IUser } from '@useoptic/cli-config';
+
+const token = 'RvYGmY1bZqlbMukS8pP9DPEifG6CEBEs';
+const analytics = new Analytics(token, {
+  flushAt: 1,
+});
+
+export async function getUser(): Promise<IUser | null> {
+  return new Promise<IUser | null>(async (resolve, reject) => {
+    const credentials = await getCredentials();
+    if (credentials) {
+      const user = await getUserFromCredentials(credentials);
+      analytics.identify({
+        userId: user.sub,
+        traits: { name: user.name, email: user.email },
+      });
+      resolve(user);
+    }
+    resolve(null);
+  });
+}
+
+export async function track(event: string, properties: any = {}) {
+  await new Promise((resolve, reject) => {
+    getUser().then((user) => {
+      if (user) {
+        analytics.track({ userId: user.sub, event, properties }, resolve);
+      } else {
+        analytics.track({ anonymousId: 'anon', event, properties }, resolve);
+      }
+    });
+  });
+}
+
+// make me spawn a process so main thread can end
+export function trackAndSpawn(event: string, properties: any = {}) {
+  getUser().then((user) => {
+    runScriptByName(
+      'emit-analytics',
+      token,
+      JSON.stringify({
+        userId: user ? user.sub : 'anon',
+        event,
+        properties,
+      })
+    );
+  });
+}
+
+export function opticTaskToProps(
+  task: string,
+  config: IOpticTaskRunnerConfig
+): any {
+  if (config) {
+    return {
+      task,
+      command: config.command,
+      'serviceConfig.port': config.serviceConfig.port,
+      'serviceConfig.host': config.serviceConfig.host,
+      'serviceConfig.protocol': config.serviceConfig.protocol,
+      'serviceConfig.basePath': config.serviceConfig.basePath,
+      'proxyConfig.port': config.proxyConfig.port,
+      'proxyConfig.host': config.proxyConfig.host,
+      'proxyConfig.protocol': config.proxyConfig.protocol,
+      'proxyConfig.basePath': config.proxyConfig.basePath,
+    };
+  } else {
+    return { task };
+  }
+}

--- a/workspaces/cli-shared/src/authentication-server-shared.ts
+++ b/workspaces/cli-shared/src/authentication-server-shared.ts
@@ -1,0 +1,109 @@
+import cors from 'cors';
+import bodyParser from 'body-parser';
+import express from 'express';
+//@ts-ignore
+import jwtDecode from 'jwt-decode';
+import http from 'http';
+import { EventEmitter } from 'events';
+import getPort from 'get-port';
+import { IUser, IUserCredentials } from '@useoptic/cli-config';
+import path from 'path';
+import os from 'os';
+import fs from 'fs-extra';
+
+const opticrcPath = path.resolve(os.homedir(), '.opticrc');
+
+interface IUserStorage {
+  idToken: string;
+}
+
+interface ICredentialsServerConfig {
+  port: number;
+}
+
+export const loginBaseUrl =
+  process.env.OPTIC_AUTH_UI_HOST || `https://auth.useoptic.com`;
+export const tokenReceivedEvent: string = 'tokenReceived';
+
+class CredentialsServer {
+  private server!: http.Server;
+  public events: EventEmitter = new EventEmitter();
+
+  async start(config: ICredentialsServerConfig) {
+    const app = express();
+    const whitelist = [loginBaseUrl];
+    const corsOptions: cors.CorsOptions = {
+      origin: whitelist,
+    };
+
+    app.use(bodyParser.json({ limit: '1mb' }));
+    app.use(cors(corsOptions));
+    const path = '/api/token';
+    app.put(path, async (req, res) => {
+      const { body } = req;
+      const { idToken } = body;
+      if (typeof idToken === 'string') {
+        this.events.emit(tokenReceivedEvent, idToken);
+        return res.status(202).json({});
+      } else {
+        return res.status(400).json({});
+      }
+    });
+
+    this.server = app.listen(config.port);
+  }
+
+  async stop() {
+    await new Promise((resolve, reject) => {
+      this.server.close((err) => {
+        if (err) {
+          return reject(err);
+        }
+        resolve();
+      });
+    });
+  }
+}
+
+export async function ensureCredentialsServerStarted() {
+  const port = await getPort({ port: getPort.makeRange(3300, 3900) });
+  const server = new CredentialsServer();
+  await server.start({ port });
+  return {
+    server,
+    port,
+  };
+}
+
+export async function setCredentials(credentials: IUserCredentials) {
+  const storeValue: IUserStorage = {
+    idToken: credentials.token,
+  };
+
+  await fs.ensureFile(opticrcPath);
+  await fs.writeFile(opticrcPath, JSON.stringify(storeValue));
+}
+
+export async function deleteCredentials() {
+  try {
+    await fs.remove(opticrcPath);
+  } catch (e) {}
+}
+
+export async function getCredentials(): Promise<IUserCredentials | null> {
+  try {
+    const storage: IUserStorage = await fs.readJSON(opticrcPath);
+    if (storage.idToken) {
+      return { token: storage.idToken };
+    }
+    return null;
+  } catch (e) {
+    return null;
+  }
+}
+
+export async function getUserFromCredentials(
+  credentials: IUserCredentials
+): Promise<IUser> {
+  return jwtDecode(credentials.token);
+}

--- a/workspaces/cli-shared/src/exceptions.ts
+++ b/workspaces/cli-shared/src/exceptions.ts
@@ -1,0 +1,22 @@
+import { developerDebugLogger } from './index';
+import { opticTaskToProps, trackAndSpawn } from './analytics-shared';
+
+export function OpticException(e: Error, m: string) {
+    const message: string = m || '';
+    const stack = (new Error()).stack;
+    const error: Error = e || '';
+
+    developerDebugLogger(`Exception: ${message}`);
+    developerDebugLogger(`Exceptioni Details: ${error.stack}`);
+
+    trackAndSpawn('Exception in (some task?)', {
+        message: message,
+        exception: error,
+        stackTrace: error.stack,
+      });
+
+}
+
+OpticException.prototype = Object.create(Error.prototype);
+OpticException.prototype.name = "OpticException";
+OpticException.prototype.constructor = OpticException;

--- a/workspaces/cli-shared/src/httptoolkit-capturing-proxy.ts
+++ b/workspaces/cli-shared/src/httptoolkit-capturing-proxy.ts
@@ -10,6 +10,7 @@ import { IBody, IHttpInteraction } from '@useoptic/domain-types';
 //@ts-ignore
 import { toBytes } from 'shape-hash';
 import { developerDebugLogger } from './index';
+import { OpticException } from './exceptions';
 
 export interface IHttpToolkitCapturingProxyConfig {
   proxyTarget?: string;
@@ -184,10 +185,13 @@ export class HttpToolkitCapturingProxy {
         endPort: config.proxyPort,
       });
       developerDebugLogger(`proxy started on port ${proxy.port}`);
+      throw Error('This is an error that has been thrown!');
     } catch (e) {
-      throw new Error(
-        `Optic couldn't start a proxy on port ${config.proxyPort} - please make sure there is nothing running there`
-      );
+        throw OpticException(e, 
+          `Optic couldn't start a proxy on port ${config.proxyPort} - please make sure there is nothing running there`);
+      //developerDebugLogger(e);
+      //throw new Error(
+      //  `Optic couldn't start a proxy on port ${config.proxyPort} - please make sure there is nothing running there`
     }
   }
 


### PR DESCRIPTION
For review and discussion only, do not merge into the code!

I mocked up a sample custom exception last night that logs errors with various verbosity depending on the mode (normal run vs. DEBUG=* run for now, which is probably fine) and passes the full exception and stack trace originally thrown in verbose mode. It  also passes the trace out to analytics for triage and potential follow-up.

Of note: I tried to follow what I read as best practices, but it may not be idiomatic. Also, I had circular dependencies in auth and analytics, so I just duplicated them in the workspace for now...any full solution would probably involve either refactoring these into shared or into their own workspace. I'm not sure if/how they're currently made available to other CLI tools and this may be useful for more than just exceptions.

Happy to chat about this in depth, I wanted an artifact available to show off the idea. This shouldn't be merged into opticdev/optic.