### PR TITLE
Create new Release Workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,32 @@
+# This is used to build a draft for the next release as changes are merged into develop
+# Configuration docs available @ https://github.com/release-drafter/release-drafter#configuration
+
+name-template: 'v$NEXT_PATCH_VERSION 🌈'
+tag-template: 'v$NEXT_PATCH_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,18 @@
+# Automatically builds a Release Notes Draft as PRs get merged into develop
+# Configure the format of the release notes @ /.github/release-drafter.yml
+
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - develop
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ name: Release
 
 env:
   HOMEBREW_REPO: opticdev/homebrew-optic
-  BUCKET_NAME: optic-deb-packages
+  BUCKET_NAME: optic-packages
   PACKAGE_NAME: api
   AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
   AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
@@ -51,7 +51,7 @@ jobs:
       #     ruby-version: '2.6'
       # - run: sudo gem install deb-s3
       # - name: Upload to s3
-      #   run: sudo deb-s3 upload --access-key-id=${{ env.AWS_ACCESS_KEY_ID }} --secret-access-key=${{ env.AWS_SECRET_ACCESS_KEY }} --bucket $BUCKET_NAME --codename ${{ env.PACKAGE_NAME }} --preserve-versions dist/deb/legume_$(npm view ${{ env.PACKAGE_NAME }} version)-1_amd64.deb
+      #   run: sudo deb-s3 upload -e --access-key-id=${{ env.AWS_ACCESS_KEY_ID }} --secret-access-key=${{ env.AWS_SECRET_ACCESS_KEY }} --bucket $BUCKET_NAME --codename ${{ env.PACKAGE_NAME }} --preserve-versions dist/deb/legume_$(npm view ${{ env.PACKAGE_NAME }} version)-1_amd64.deb
   
   # Triggers Homebrew Release - Configure homebrew/core fork repository in the env settings above
   # Requires Repository Access Token (https://github.com/peter-evans/repository-dispatch#token) with repo:write scope
@@ -59,10 +59,11 @@ jobs:
     needs: release-npm
     runs-on: ubuntu-latest
     steps:
-      - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v1.1.0
-        with:
-          token: ${{ env.REPO_ACCESS_TOKEN }}
-          repository: ${{ env.HOMEBREW_REPO }}
-          event-type: version-update
-          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
+      - run: echo "Brew Release has not been configured yet"
+      # - name: Repository Dispatch
+      #   uses: peter-evans/repository-dispatch@v1.1.0
+      #   with:
+      #     token: ${{ env.REPO_ACCESS_TOKEN }}
+      #     repository: ${{ env.HOMEBREW_REPO }}
+      #     event-type: version-update
+      #     client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+# Releases the latest version of Optic on NPM/Brew/Debian
+# Assumes the version has been updated
+# Triggers on all changes to the release branch
+
+name: Release
+
+env:
+  HOMEBREW_REPO: opticdev/homebrew-optic
+  BUCKET_NAME: optic-deb-packages
+  PACKAGE_NAME: api
+  AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+  AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }} # requires repo:write scope (https://github.com/peter-evans/repository-dispatch#token)
+
+on: 
+  push:
+    branches:
+      - release
+
+jobs:
+  # Deploys the current version to NPM, and also verifies that the version is correct in the process
+  # All Jobs rely on this job because it verifies the version
+  release-npm:
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo "NPM Release has not been configured yet"
+    # - uses: actions/checkout@v2
+    # - uses: actions/setup-node@v1
+    #   with:
+    #     node-version: 12
+    # - run: npm run publish
+  
+  # Creates debian package for users to install, hosted on s3
+  release-deb:
+    needs: release-npm
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Debian Release has not been configured yet"
+      # - uses: actions/checkout@v2
+      # - uses: actions/setup-node@v1
+      #   with:
+      #     node-version: 12
+      # - run: npm ci
+      # - name: Install APT Utils
+      #   run: sudo apt-get install apt-utils
+      # - run: sudo npm i -g @oclif/dev-cli
+      # - run: sudo oclif-dev pack:deb
+      # - uses: actions/setup-ruby@v1
+      #   with:
+      #     ruby-version: '2.6'
+      # - run: sudo gem install deb-s3
+      # - name: Upload to s3
+      #   run: sudo deb-s3 upload --access-key-id=${{ env.AWS_ACCESS_KEY_ID }} --secret-access-key=${{ env.AWS_SECRET_ACCESS_KEY }} --bucket $BUCKET_NAME --codename ${{ env.PACKAGE_NAME }} --preserve-versions dist/deb/legume_$(npm view ${{ env.PACKAGE_NAME }} version)-1_amd64.deb
+  
+  # Triggers Homebrew Release - Configure homebrew/core fork repository in the env settings above
+  # Requires Repository Access Token (https://github.com/peter-evans/repository-dispatch#token) with repo:write scope
+  trigger-brew-release:
+    needs: release-npm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v1.1.0
+        with:
+          token: ${{ env.REPO_ACCESS_TOKEN }}
+          repository: ${{ env.HOMEBREW_REPO }}
+          event-type: version-update
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
## Workflow

- As PRs are merged into `develop`, release-drafter updates a draft release that logs all changes that have been made
- When we want to release something, we simply need to make a PR from `develop` to `release`
    - **note**: before merging this PR, make sure to bump the version ahead of time
    - upon merge, this wil trigger
        - npm publish
        - brew package publish
        - debian package publish

## Key Changes

- Adds [release drafter](https://github.com/release-drafter/release-drafter)
- Adds release script (triggers on changes to `release`)