### PR TITLE
Added auto labeling of Pull Requests

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,3 @@
+feature: ['feature/*', 'feat/*', 'feature-*', 'feat-*', 'enhancement-*', 'enhancement/*']
+fix: ['fix/*', 'issue-*']
+chore: chore/*

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,14 @@
+name: PR Labeler
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  pr-labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: TimonVS/pr-labeler-action@v3
+        with:
+          configuration-path: .github/pr-labeler.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What it Does

it will automatically label all PRs that follow the branch name (feature-, feature/, enhancement/, etc) with the appropriate label

## Why I added it

This will help with #240 , ensuring that the release draft has already preorganized the pull requests for release, and it saves us time from having to remember to always manually set the labels

## Where it can be improved

The exact naming specifications can 100% be changed - i just went with what I saw in the repo already, but it's fairly easy to add more patterns