### PR TITLE
 Configuring Debian Release Flow #258 

### DIFF
--- a/.github/deployDebian/Dockerfile
+++ b/.github/deployDebian/Dockerfile
@@ -1,0 +1,20 @@
+# Container image that runs your code
+FROM node:latest
+
+# install basics
+
+# RUN apt update
+# RUN apt-get install -y git default-jre sudo apt-utils apt-transport-https
+# RUN npm install -g @oclif/dev-cli
+# RUN "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list
+# RUN curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
+# RUN apt update
+# RUN apt-get install -y sbt
+# RUN apt-get install ruby-full -y
+# RUN gem install deb-s3
+
+# Copies your code file from your action repository to the filesystem path `/` of the container
+COPY entrypoint.sh /entrypoint.sh
+
+# Code file to execute when the docker container starts up (`entrypoint.sh`)
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/deployDebian/action.yml
+++ b/.github/deployDebian/action.yml
@@ -1,0 +1,18 @@
+name: 'Build Optic'
+description: 'Builds Optic'
+inputs:
+  AWS_ACCESS_KEY_ID:
+    description: "AWS_ACCESS_KEY_ID"
+    required: true
+  AWS_SECRET_ACCESS_KEY:
+    description: "AWS_SECRET_ACCESS_KEY"
+    required: true
+  BUCKET_NAME:
+    description: "BUCKET_NAME"
+    required: true
+  PACKAGE_NAME:
+    description: "PACKAGE_NAME"
+    required: true
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/.github/deployDebian/action.yml
+++ b/.github/deployDebian/action.yml
@@ -13,6 +13,9 @@ inputs:
   PACKAGE_NAME:
     description: "PACKAGE_NAME"
     required: true
+  PREFIX_NAME:
+    description: "The prefix for the package"
+    required: true
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/.github/deployDebian/entrypoint.sh
+++ b/.github/deployDebian/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 echo "Installing Essentials"
+echo $INPUT_NPM_PACKAGE_NAME
 apt update
 apt install -y git default-jre sudo apt-utils apt-transport-https
 npm install -g @oclif/dev-cli
@@ -8,9 +9,10 @@ echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.li
 curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
 apt update
 apt install -y sbt
+
 echo "Cloning Optic"
 cd /tmp
-git clone https://github.com/opticdev/optic
+git clone https://github.com/trulyronak/optic
 cd optic
 echo "Checking out specific branch (eventually this will just be release)"
 git checkout feature/debian-release-flow
@@ -27,6 +29,7 @@ gem install deb-s3
 cd /tmp/optic/workspaces/local-cli/dist/deb/
 export PATH_TO_DEB="/tmp/optic/workspaces/local-cli/dist/deb/api_$(npm view $INPUT_NPM_PACKAGE_NAME version)-1_amd64.deb"
 echo $PATH_TO_DEB
-ls $PATH_TO_DEB
-du $PATH_TO_DEB
-deb-s3 upload -e --access-key-id=$INPUT_AWS_ACCESS_KEY_ID --secret-access-key=$INPUT_AWS_SECRET_ACCESS_KEY --bucket $INPUT_BUCKET_NAME $INPUT_PACKAGE_NAME --preserve-versions $PATH_TO_DEB
+# ls $PATH_TO_DEB
+# du $PATH_TO_DEB
+/bin/bash
+# deb-s3 upload -e --access-key-id=$INPUT_AWS_ACCESS_KEY_ID --secret-access-key=$INPUT_AWS_SECRET_ACCESS_KEY --bucket $INPUT_BUCKET_NAME $INPUT_PACKAGE_NAME --preserve-versions $PATH_TO_DEB

--- a/.github/deployDebian/entrypoint.sh
+++ b/.github/deployDebian/entrypoint.sh
@@ -27,5 +27,5 @@ apt install ruby-full -y
 gem install deb-s3
 export PATH_TO_DEB_AMD="/tmp/optic/workspaces/local-cli/dist/deb/api_$(npm view $INPUT_NPM_PACKAGE_NAME version)-1_amd64.deb"
 export PATH_TO_DEB_ARM="/tmp/optic/workspaces/local-cli/dist/deb/api_$(npm view $INPUT_NPM_PACKAGE_NAME version)-1_armel.deb"
-deb-s3 upload -e --access-key-id=$INPUT_AWS_ACCESS_KEY_ID --secret-access-key=$INPUT_AWS_SECRET_ACCESS_KEY --bucket $INPUT_BUCKET_NAME --codename $INPUT_PACKAGE_NAME --preserve-versions $PATH_TO_DEB_AMD
-deb-s3 upload -e --access-key-id=$INPUT_AWS_ACCESS_KEY_ID --secret-access-key=$INPUT_AWS_SECRET_ACCESS_KEY --bucket $INPUT_BUCKET_NAME --codename $INPUT_PACKAGE_NAME --preserve-versions $PATH_TO_DEB_ARM
+deb-s3 upload -e --access-key-id=$INPUT_AWS_ACCESS_KEY_ID --secret-access-key=$INPUT_AWS_SECRET_ACCESS_KEY --bucket $INPUT_BUCKET_NAME --prefix $INPUT_PREFIX_NAME --codename $INPUT_PACKAGE_NAME --preserve-versions $PATH_TO_DEB_AMD
+deb-s3 upload -e --access-key-id=$INPUT_AWS_ACCESS_KEY_ID --secret-access-key=$INPUT_AWS_SECRET_ACCESS_KEY --bucket $INPUT_BUCKET_NAME --prefix $INPUT_PREFIX_NAME --codename $INPUT_PACKAGE_NAME --preserve-versions $PATH_TO_DEB_ARM

--- a/.github/deployDebian/entrypoint.sh
+++ b/.github/deployDebian/entrypoint.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 echo "Installing Essentials"
-echo $INPUT_NPM_PACKAGE_NAME
 apt update
 apt install -y git default-jre sudo apt-utils apt-transport-https
 npm install -g @oclif/dev-cli
@@ -26,10 +25,5 @@ oclif-dev pack:deb
 echo "Installing Ruby"
 apt install ruby-full -y
 gem install deb-s3
-cd /tmp/optic/workspaces/local-cli/dist/deb/
 export PATH_TO_DEB="/tmp/optic/workspaces/local-cli/dist/deb/api_$(npm view $INPUT_NPM_PACKAGE_NAME version)-1_amd64.deb"
-echo $PATH_TO_DEB
-# ls $PATH_TO_DEB
-# du $PATH_TO_DEB
-/bin/bash
-# deb-s3 upload -e --access-key-id=$INPUT_AWS_ACCESS_KEY_ID --secret-access-key=$INPUT_AWS_SECRET_ACCESS_KEY --bucket $INPUT_BUCKET_NAME $INPUT_PACKAGE_NAME --preserve-versions $PATH_TO_DEB
+deb-s3 upload -e --access-key-id=$INPUT_AWS_ACCESS_KEY_ID --secret-access-key=$INPUT_AWS_SECRET_ACCESS_KEY --bucket $INPUT_BUCKET_NAME --codename $INPUT_PACKAGE_NAME --preserve-versions $PATH_TO_DEB

--- a/.github/deployDebian/entrypoint.sh
+++ b/.github/deployDebian/entrypoint.sh
@@ -25,5 +25,7 @@ oclif-dev pack:deb
 echo "Installing Ruby"
 apt install ruby-full -y
 gem install deb-s3
-export PATH_TO_DEB="/tmp/optic/workspaces/local-cli/dist/deb/api_$(npm view $INPUT_NPM_PACKAGE_NAME version)-1_amd64.deb"
-deb-s3 upload -e --access-key-id=$INPUT_AWS_ACCESS_KEY_ID --secret-access-key=$INPUT_AWS_SECRET_ACCESS_KEY --bucket $INPUT_BUCKET_NAME --codename $INPUT_PACKAGE_NAME --preserve-versions $PATH_TO_DEB
+export PATH_TO_DEB_AMD="/tmp/optic/workspaces/local-cli/dist/deb/api_$(npm view $INPUT_NPM_PACKAGE_NAME version)-1_amd64.deb"
+export PATH_TO_DEB_ARM="/tmp/optic/workspaces/local-cli/dist/deb/api_$(npm view $INPUT_NPM_PACKAGE_NAME version)-1_armel.deb"
+deb-s3 upload -e --access-key-id=$INPUT_AWS_ACCESS_KEY_ID --secret-access-key=$INPUT_AWS_SECRET_ACCESS_KEY --bucket $INPUT_BUCKET_NAME --codename $INPUT_PACKAGE_NAME --preserve-versions $PATH_TO_DEB_AMD
+deb-s3 upload -e --access-key-id=$INPUT_AWS_ACCESS_KEY_ID --secret-access-key=$INPUT_AWS_SECRET_ACCESS_KEY --bucket $INPUT_BUCKET_NAME --codename $INPUT_PACKAGE_NAME --preserve-versions $PATH_TO_DEB_ARM

--- a/.github/deployDebian/entrypoint.sh
+++ b/.github/deployDebian/entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+echo "Installing Essentials"
+apt update
+apt install -y git default-jre sudo apt-utils apt-transport-https
+npm install -g @oclif/dev-cli
+echo "Installing SBT for Scala"
+echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list
+curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
+apt update
+apt install -y sbt
+echo "Cloning Optic"
+cd /tmp
+git clone https://github.com/opticdev/optic
+cd optic
+echo "Checking out specific branch (eventually this will just be release)"
+git checkout feature/debian-release-flow
+export PATH_TO_DEB="/tmp/optic/workspaces/local-cli/dist/deb/api_$(npm view $INPUT_NPM_PACKAGE_NAME version)-1_amd64.deb"
+echo $PATH_TO_DEB
+echo "Building Optic"
+source sourceme.sh
+optic_build
+echo "Packing Debian Release"
+cd ./workspaces/local-cli
+npm install
+oclif-dev pack:deb
+echo "Installing Ruby"
+apt install ruby-full -y
+gem install deb-s3
+cd /tmp/optic/workspaces/local-cli/dist/deb/
+ls
+deb-s3 upload -e --access-key-id=$INPUT_AWS_ACCESS_KEY_ID --secret-access-key=$INPUT_AWS_SECRET_ACCESS_KEY --bucket $INPUT_BUCKET_NAME $INPUT_PACKAGE_NAME --preserve-versions $PATH_TO_DEB

--- a/.github/deployDebian/entrypoint.sh
+++ b/.github/deployDebian/entrypoint.sh
@@ -14,8 +14,6 @@ git clone https://github.com/opticdev/optic
 cd optic
 echo "Checking out specific branch (eventually this will just be release)"
 git checkout feature/debian-release-flow
-export PATH_TO_DEB="/tmp/optic/workspaces/local-cli/dist/deb/api_$(npm view $INPUT_NPM_PACKAGE_NAME version)-1_amd64.deb"
-echo $PATH_TO_DEB
 echo "Building Optic"
 source sourceme.sh
 optic_build
@@ -27,5 +25,8 @@ echo "Installing Ruby"
 apt install ruby-full -y
 gem install deb-s3
 cd /tmp/optic/workspaces/local-cli/dist/deb/
-ls
+export PATH_TO_DEB="/tmp/optic/workspaces/local-cli/dist/deb/api_$(npm view $INPUT_NPM_PACKAGE_NAME version)-1_amd64.deb"
+echo $PATH_TO_DEB
+ls $PATH_TO_DEB
+du $PATH_TO_DEB
 deb-s3 upload -e --access-key-id=$INPUT_AWS_ACCESS_KEY_ID --secret-access-key=$INPUT_AWS_SECRET_ACCESS_KEY --bucket $INPUT_BUCKET_NAME $INPUT_PACKAGE_NAME --preserve-versions $PATH_TO_DEB

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,6 @@ env:
   HOMEBREW_REPO: opticdev/homebrew-optic
   BUCKET_NAME: optic-packages
   PACKAGE_NAME: api
-  AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
-  AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   REPO_ACCESS_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }} # requires repo:write scope (https://github.com/peter-evans/repository-dispatch#token)
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,25 +46,19 @@ jobs:
   
   # Creates debian package for users to install, hosted on s3
   release-deb:
-    needs: release-npm
     runs-on: ubuntu-latest
     steps:
-      - run: echo "Debian Release has not been configured yet"
-      # - uses: actions/checkout@v2
-      # - uses: actions/setup-node@v1
-      #   with:
-      #     node-version: 12
-      # - run: npm ci
-      # - name: Install APT Utils
-      #   run: sudo apt-get install apt-utils
-      # - run: sudo npm i -g @oclif/dev-cli
-      # - run: sudo oclif-dev pack:deb
-      # - uses: actions/setup-ruby@v1
-      #   with:
-      #     ruby-version: '2.6'
-      # - run: sudo gem install deb-s3
-      # - name: Upload to s3
-      #   run: sudo deb-s3 upload -e --access-key-id=${{ env.AWS_ACCESS_KEY_ID }} --secret-access-key=${{ env.AWS_SECRET_ACCESS_KEY }} --bucket $BUCKET_NAME --codename ${{ env.PACKAGE_NAME }} --preserve-versions dist/deb/legume_$(npm view ${{ env.PACKAGE_NAME }} version)-1_amd64.deb
+      - uses: actions/checkout@v2 # this part is required for github actions on the site
+        with:
+          ref: feature/debian-release-flow
+      - uses: ./.github/deployDebian/
+        with:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          BUCKET_NAME: optic-packages
+          PACKAGE_NAME: api
+          NPM_PACKAGE_NAME: "@useoptic/cli"
+          PREFIX_NAME: deb
   
   # Triggers Homebrew Release - Configure homebrew/core fork repository in the env settings above
   # Requires Repository Access Token (https://github.com/peter-evans/repository-dispatch#token) with repo:write scope

--- a/.github/workflows/testDebian.yml
+++ b/.github/workflows/testDebian.yml
@@ -1,0 +1,21 @@
+name: test debian
+on:
+  push:
+    branches:
+     - feature/debian-release-flow
+
+env:
+  HOMEBREW_REPO: opticdev/homebrew-optic
+  PACKAGE_NAME: api
+
+jobs:
+  test-deploy-debian:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/deployDebian/
+        with:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          BUCKET_NAME: optic-packages
+          PACKAGE_NAME: api
+          NPM_PACKAGE_NAME: "@useoptic/cli"

--- a/.github/workflows/testDebian.yml
+++ b/.github/workflows/testDebian.yml
@@ -12,9 +12,9 @@ jobs:
   test-deploy-debian:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: feature/debian-release-flow
+      # - uses: actions/checkout@v2
+      #   with:
+      #     ref: feature/debian-release-flow
       - uses: ./.github/deployDebian/
         with:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/testDebian.yml
+++ b/.github/workflows/testDebian.yml
@@ -12,6 +12,9 @@ jobs:
   test-deploy-debian:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: feature/debian-release-flow
       - uses: ./.github/deployDebian/
         with:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/testDebian.yml
+++ b/.github/workflows/testDebian.yml
@@ -22,3 +22,4 @@ jobs:
           BUCKET_NAME: optic-packages
           PACKAGE_NAME: api
           NPM_PACKAGE_NAME: "@useoptic/cli"
+          PREFIX_NAME: deb

--- a/.github/workflows/testDebian.yml
+++ b/.github/workflows/testDebian.yml
@@ -12,9 +12,9 @@ jobs:
   test-deploy-debian:
     runs-on: ubuntu-latest
     steps:
-      # - uses: actions/checkout@v2
-      #   with:
-      #     ref: feature/debian-release-flow
+      - uses: actions/checkout@v2 # this part is required for github actions on the site
+        with:
+          ref: feature/debian-release-flow
       - uses: ./.github/deployDebian/
         with:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/workspaces/local-cli/package.json
+++ b/workspaces/local-cli/package.json
@@ -83,7 +83,7 @@
   "scripts": {
     "postpack": "rm -f oclif.manifest.json",
     "posttest": "echo 'skipping posttest';#eslint . --ext .ts --config .eslintrc",
-    "prepack": "rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme",
+    "prepack": "oclif-dev manifest && oclif-dev readme",
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\"",
     "version": "oclif-dev readme && git add README.md",
     "ws:build": "tsc -b --verbose",


### PR DESCRIPTION
This will enable auto deployments to https://optic-packages.s3.amazonaws.com

to test this out right now, you can download the package (just spin up a docker container)

```
apt-get update
# We trust HTTPS rather than GPG for this repo - but you can config
# GPG signing if you prefer.
cat > /etc/apt/sources.list.d/api.list << EOF
deb [trusted=yes] https://optic-packages.s3.amazonaws.com api main
EOF
# and ensure you update the package info on the server
apt-get install -y ca-certificates
apt-get update
apt-get install api
```

### important
right now, debian calls it `api` — is this good or should we call it `optic` (homebrew calls it optic as of now, and npm calls it @useoptic/cli)