### PR TITLE
Fixed issue where GitHub Actions Checked Out Non Existent Branch

### DIFF
--- a/.github/deployDebian/entrypoint.sh
+++ b/.github/deployDebian/entrypoint.sh
@@ -13,8 +13,8 @@ echo "Cloning Optic"
 cd /tmp
 git clone https://github.com/trulyronak/optic
 cd optic
-echo "Checking out specific branch (eventually this will just be release)"
-git checkout feature/debian-release-flow
+echo "Checking out specific branch"
+git checkout release
 echo "Building Optic"
 source sourceme.sh
 optic_build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2 # this part is required for github actions on the site
         with:
-          ref: feature/debian-release-flow
+          ref: release
       - uses: ./.github/deployDebian/
         with:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
**Why it happened**
When I was testing, I had configured the debian release flow to specifically check out the testing branch, so that I could make sure it was using the version that had the neccesary changes for deployment. 

However once we went into release, that branch no longer existed (and it kept pulling this older branch).

Adjusted it to always check out release