### PR TITLE
Added end-to-end-tests as the first step of release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,34 @@ on:
       - release
 
 jobs:
+  # Runs Optic End to End Tests to ensure the the build is good before deploying
+  # Root dependency
+  test-optic:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install Docker Compose
+      run: |
+        apt-get update
+        apt-get install sudo -y
+        sudo curl -L "https://github.com/docker/compose/releases/download/1.26.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+        sudo chmod +x /usr/local/bin/docker-compose
+    - uses: actions/checkout@v2
+      with:
+          repository: opticdev/optic-end-end-tests
+          token: ${{ secrets.END_TO_END_ACCESS_KEY }}
+    - uses: actions/setup-node@v1
+      with:
+          node-version: 12
+    - run: npm install
+    - run: npm test
+      with:
+          DEBUG: "*" # Helps with tracing errors
+
   # Deploys the current version to NPM, and also verifies that the version is correct in the process
-  # All Jobs rely on this job because it verifies the version
+  # All Jobs rely on this job because it verifies the version and because it depends on test-optic
   release-npm:
     runs-on: ubuntu-latest
+    needs: test-optic
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
This runs optic's end-to-end tests before any release, blocking release if they do not pass.