### PR TITLE
 Run End to End Tests before Release #271 

### DIFF
--- a/.github/workflows/endToEndTests.yml
+++ b/.github/workflows/endToEndTests.yml
@@ -1,0 +1,40 @@
+name: Test end to end
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - release
+  push:
+    branches:
+      - develop
+      - release
+
+jobs:
+  test-end-to-end:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12
+    - run: echo "::add-path::$(yarn global bin)"
+    - name: Check out Optic Repo
+      uses: actions/checkout@v2
+      with:
+        path: ./optic-repo
+    - name: Release Optic Locally
+      run: |
+        source sourceme.sh && optic_local_registry_start
+        source sourceme.sh && optic_build_and_publish_locally
+      working-directory: ./optic-repo
+    - uses: actions/checkout@v2
+      with:
+        repository: opticdev/optic-end-end-tests
+        token: ${{ secrets.END_TO_END_ACCESS_KEY }}
+        path: ./tests
+    - run: npm install
+      working-directory: ./tests
+    - run: npm test
+      working-directory: ./tests
+      env:
+        DEBUG: "*,-babel*" # Helps with tracing errors

--- a/docker/private-npm-registry/conf/config.yaml
+++ b/docker/private-npm-registry/conf/config.yaml
@@ -1,8 +1,11 @@
-storage: /verdaccio/storage
+store:
+  memory:
+    limit: 1000
 packages:
   '@useoptic/*':
       access: $all
       publish: $all
+      proxy: npmjs
   '*/*':
       access: $all
       proxy: npmjs

--- a/docker/private-npm-registry/docker-compose.yml
+++ b/docker/private-npm-registry/docker-compose.yml
@@ -1,13 +1,7 @@
 version: '2.1'
 services:
   verdaccio:
-    image: verdaccio/verdaccio:4
-    container_name: verdaccio-docker-local-storage-vol
+    image: verdaccio/verdaccio:4.6
+    container_name: verdaccio-local-registry
     ports:
       - "4873:4873"
-    volumes:
-        - "./storage:/verdaccio/storage"
-        - "./conf:/verdaccio/conf"
-volumes:
-  verdaccio:
-    driver: local

--- a/sourceme.sh
+++ b/sourceme.sh
@@ -100,7 +100,8 @@ optic_build_and_publish_locally() {
     set -o errexit
     optic_build_for_release
     cd "$OPTIC_SRC_DIR"
-    yarn run publish-local
+    npm-cli-login -u testUser -p testPass -e test@example.com -r http://localhost:4873
+    OPTIC_PUBLISH_SCOPE=private node ./workspaces/scripts/publish.js
   )
 }
 optic_release_and_install_locally() {
@@ -127,3 +128,17 @@ optic_install_from_local_registry() {
   )
 }
 # DEBUG=optic* apidev daemon:stop && DEBUG=optic* apidev agent:start
+optic_local_registry_start() {
+  (
+    set -o errexit
+    cd "$OPTIC_SRC_DIR"
+    cd docker/private-npm-registry
+    yarn global add verdaccio-memory npm-cli-login
+    docker-compose up &
+
+    cd "$OPTIC_SRC_DIR"
+    yarn install
+    yarn wait-on http://localhost:4873
+    printf "local npm registry started on http://localhost:4873 \n"
+  )
+}

--- a/workspaces/scripts/publish.js
+++ b/workspaces/scripts/publish.js
@@ -90,7 +90,7 @@ promise
                 'npm',
                 isPrivatePublish
                   ? ['publish', '--registry', registry]
-                  : ['publish', '--access', 'public'],
+                  : ['publish', '--access', 'public', '-ddd'],
                 {
                   cwd,
                   stdio: 'inherit',


### PR DESCRIPTION
This runs optic's end-to-end tests before any release, blocking release if they do not pass.

Before merging, note that will require a new org secret — a repo access token for end-to-end tests, called `END_TO_END_ACCESS_KEY`

After adding the `END_TO_END_ACCESS_KEY` token to the org secrets, this should be good to go

