### PR TITLE
Render new ShapeViewer by directly traversing HttpInteraction

### DIFF
--- a/workspaces/ui/src/components/diff/v2/DiffViewSimulation.js
+++ b/workspaces/ui/src/components/diff/v2/DiffViewSimulation.js
@@ -64,20 +64,8 @@ class _DiffViewSimulation extends React.Component {
                 const currentRfcState = rfcService.currentState(rfcId);
 
                 if (viewer === 'flattened') {
-                  console.time('Making preview ' + renderKey);
-                  let preview = getOrUndefined(
-                    DiffResultHelper.previewDiff(
-                      diff,
-                      interactionScala,
-                      currentRfcState
-                    )
-                  );
-                  console.timeEnd('Making preview ' + renderKey);
-
                   return (
-                    <ShapeViewer
-                      shape={preview && getOrUndefined(preview.getRootShape)}
-                    />
+                    <ShapeViewer diff={diff} interaction={interactionScala} />
                   );
                 } else {
                   console.time('Making preview ' + renderKey);

--- a/workspaces/ui/src/components/diff/v2/shape_viewers/ShapeViewer.js
+++ b/workspaces/ui/src/components/diff/v2/shape_viewers/ShapeViewer.js
@@ -293,18 +293,31 @@ function objectRows(objectShape, rows, indent, field) {
     indent,
   });
 
-  Object.entries(objectShape).forEach(([key, value]) => {
-    const fieldName = key;
+  Object.entries(objectShape)
+    .sort(alphabetizeEntryKeys)
+    .forEach(([key, value]) => {
+      const fieldName = key;
 
-    return shapeRows(value, rows, indent + 1, {
-      fieldName,
-      fieldValue: value,
-      trail: [...trail, fieldName],
+      return shapeRows(value, rows, indent + 1, {
+        fieldName,
+        fieldValue: value,
+        trail: [...trail, fieldName],
+      });
     });
-  });
 
   rows.push({ type: 'object_close', indent, trail });
 }
+
+function alphabetizeEntryKeys([keyA], [keyB]) {
+  if (keyA > keyB) {
+    return 1;
+  } else if (keyB > keyA) {
+    return -1;
+  }
+
+  return 0;
+}
+
 function listRows(list, rows, indent, field) {
   const { trail } = field;
 


### PR DESCRIPTION
Side-stepping a whole bunch of the domain, any browser is perfectly capable of traversing a JSON structure itself. In our case, traversing the `body` of either the `Request` or `Response` of an `HttpInteraction` to render the basic shape of the shape viewer, powering the row-level view model.

This depends on #299 to get merged, first. Through that, this all happens behind a feature flag, so not much to review. All missing functionality `RenderShape` provided, like marking missing fields and folding of collections, will be reimplemented incrementally and is beyond the scope of this PR.