### PR TITLE
Implement default folding behaviour of ShapeViewer and ability to unfold

### DIFF
--- a/workspaces/ui/package.json
+++ b/workspaces/ui/package.json
@@ -25,6 +25,7 @@
     "date-fns": "^2.11.1",
     "lodash.compose": "^2.4.1",
     "lodash.debounce": "^4.0.8",
+    "lodash.get": "^4.4.2",
     "lodash.groupby": "^4.6.0",
     "lodash.isequal": "^4.5.0",
     "lodash.sortby": "^4.7.0",

--- a/workspaces/ui/package.json
+++ b/workspaces/ui/package.json
@@ -26,6 +26,7 @@
     "lodash.compose": "^2.4.1",
     "lodash.debounce": "^4.0.8",
     "lodash.groupby": "^4.6.0",
+    "lodash.isequal": "^4.5.0",
     "lodash.sortby": "^4.7.0",
     "memoize-weak": "^1.0.2",
     "mini-css-extract-plugin": "0.5.0",

--- a/workspaces/ui/src/components/diff/v2/shape_viewers/ShapeViewer.js
+++ b/workspaces/ui/src/components/diff/v2/shape_viewers/ShapeViewer.js
@@ -106,7 +106,7 @@ function RowValue({ type, value }) {
   }
 
   if (type === 'array_item_collapsed') {
-    return <span>COLLAPSED</span>;
+    return <span className={classes.collapsedSymbol}>{'⋯'}</span>;
   }
 
   if (type === 'array_close') {
@@ -189,6 +189,15 @@ const useStyles = makeStyles((theme) => ({
     fontFamily: "'Source Code Pro', monospace",
     whiteSpace: 'pre',
     color: SymbolColor,
+  },
+
+  collapsedSymbol: {
+    paddingLeft: theme.spacing(1),
+    paddingRight: theme.spacing(1),
+    color: '#070707',
+    fontSize: 10,
+    backgroundColor: '#ababab',
+    borderRadius: 12,
   },
 
   booleanContent: {


### PR DESCRIPTION
This PR implements default folding of the interaction when first rendered in the ShapeViewer.

Rather processing the entire interaction body all at once, we're only rendering rows that will actually be visible. To reduce the amount of visible rows for first render, we only have the first element of every array unfolded, with the rest hidden. When clicking on a folded line, the view model can be updated by only rendering the bit of missing shape and inserting it in the right place, rather than having to recalculate the entire thing.

The exact behaviour of what and what not to fold is arbitrary, but what we have now is a good default until we start considering diffs (out side the scope of this PR). In case of the example I'm testing with, instead of processing and rendering `781` rows straight from the beginning, we collapsed `19` trails and only render `96` rows initially.

Since we start with a small amount of initial rows and can then incrementally process additional subsets, that also gives us the partitioning we need to decide what to perform additional transformations on, like annotating each row with the expected type.

Another thing that's worth mentioning is that the view model expressed using the reducer pattern. This makes all the state transformations into stateless functions, which doesn't only help us get the logic right in this first implementation, but is also a first great step to it being extracted to it's own module later (for use of Typescript, easier testing, re-use of logic, etc). Any additional enhancements are easily expressed as actions as well.

Final note: this is still behind a disabled-by-default feature flag + opt-in URL.