### PR TITLE
Prevent ShapeViewer in diff review to be re-mounted upon choosing a suggestion

### DIFF
--- a/workspaces/ui/src/components/diff/v2/DiffReviewExpanded.js
+++ b/workspaces/ui/src/components/diff/v2/DiffReviewExpanded.js
@@ -27,6 +27,7 @@ import { useDiffDescription, useInteractionWithPointer } from './DiffHooks';
 import LinearProgress from '@material-ui/core/LinearProgress';
 import { DiffReviewLoading } from './LoadingNextDiff';
 import { DiffViewSimulation } from './DiffViewSimulation';
+import ShapeViewer from './shape_viewers/ShapeViewer';
 import { track } from '../../../Analytics';
 
 const useStyles = makeStyles((theme) => ({
@@ -198,16 +199,24 @@ export const DiffReviewExpanded = (props) => {
                     />
                   }
                 >
-                  <DiffViewSimulation
-                    renderDiff={diff.inRequest}
-                    diff={diff}
-                    interactionScala={interactionScala}
-                    description={description}
-                    body={interactionScala.response.body} // TODO: shouldn't this be the request body?
-                    outerRfcState={outerRfcState}
-                    selectedInterpretation={selectedInterpretation}
-                    viewer={viewer}
-                  />
+                  {viewer === 'flattened' && diff.inRequest ? (
+                    <ShapeViewer
+                      diff={diff}
+                      diffDescription={description}
+                      interaction={interactionScala}
+                      selectedInterpretation={selectedInterpretation}
+                    />
+                  ) : (
+                    <DiffViewSimulation
+                      renderDiff={diff.inRequest}
+                      diff={diff}
+                      interactionScala={interactionScala}
+                      description={description}
+                      body={interactionScala.response.body} // TODO: shouldn't this be the request body?
+                      outerRfcState={outerRfcState}
+                      selectedInterpretation={selectedInterpretation}
+                    />
+                  )}
                 </ShapeBox>
               }
               right={
@@ -246,16 +255,24 @@ export const DiffReviewExpanded = (props) => {
                     />
                   }
                 >
-                  <DiffViewSimulation
-                    renderDiff={diff.inResponse}
-                    diff={diff}
-                    interactionScala={interactionScala}
-                    description={description}
-                    body={interactionScala.response.body}
-                    outerRfcState={outerRfcState}
-                    selectedInterpretation={selectedInterpretation}
-                    viewer={viewer}
-                  />
+                  {viewer === 'flattened' && diff.inResponse ? (
+                    <ShapeViewer
+                      diff={diff}
+                      diffDescription={description}
+                      interaction={interactionScala}
+                      selectedInterpretation={selectedInterpretation}
+                    />
+                  ) : (
+                    <DiffViewSimulation
+                      renderDiff={diff.inResponse}
+                      diff={diff}
+                      interactionScala={interactionScala}
+                      description={description}
+                      body={interactionScala.response.body}
+                      outerRfcState={outerRfcState}
+                      selectedInterpretation={selectedInterpretation}
+                    />
+                  )}
                 </ShapeBox>
               }
               right={

--- a/workspaces/ui/src/components/diff/v2/DiffViewSimulation.js
+++ b/workspaces/ui/src/components/diff/v2/DiffViewSimulation.js
@@ -8,7 +8,6 @@ import {
 import SimulatedCommandContext from '../SimulatedCommandContext';
 import { RfcContext, withRfcContext } from '../../../contexts/RfcContext';
 import DiffHunkViewer from './DiffHunkViewer';
-import ShapeViewer from './shape_viewers/ShapeViewer';
 
 class _DiffViewSimulation extends React.Component {
   shouldComponentUpdate(nextProps, nextState, nextContext) {
@@ -41,7 +40,6 @@ class _DiffViewSimulation extends React.Component {
       selectedInterpretation,
       rfcId,
       eventStore,
-      viewer,
     } = this.props;
 
     const renderKey = 'render ' + diff.diff.toString() + interactionScala.uuid;
@@ -63,32 +61,21 @@ class _DiffViewSimulation extends React.Component {
               {({ rfcService, rfcId }) => {
                 const currentRfcState = rfcService.currentState(rfcId);
 
-                if (viewer === 'flattened') {
-                  return (
-                    <ShapeViewer
-                      diff={diff}
-                      diffDescription={description}
-                      interaction={interactionScala}
-                      selectedInterpretation={selectedInterpretation}
-                    />
-                  );
-                } else {
-                  console.time('Making preview ' + renderKey);
-                  let preview = DiffResultHelper.previewDiff(
-                    diff,
-                    interactionScala,
-                    currentRfcState
-                  );
-                  console.timeEnd('Making preview ' + renderKey);
-                  return (
-                    <DiffHunkViewer
-                      suggestion={selectedInterpretation}
-                      diff={diff}
-                      preview={getOrUndefined(preview)}
-                      diffDescription={description}
-                    />
-                  );
-                }
+                console.time('Making preview ' + renderKey);
+                let preview = DiffResultHelper.previewDiff(
+                  diff,
+                  interactionScala,
+                  currentRfcState
+                );
+                console.timeEnd('Making preview ' + renderKey);
+                return (
+                  <DiffHunkViewer
+                    suggestion={selectedInterpretation}
+                    diff={diff}
+                    preview={getOrUndefined(preview)}
+                    diffDescription={description}
+                  />
+                );
               }}
             </RfcContext.Consumer>
           </SimulatedCommandContext>


### PR DESCRIPTION
This PR fixes a bug where the new `ShapeViewer` (still behind a feature flag and opt-in route) was re-mounted when a suggested was chosen to resolve the observed diff. Not only did this remounting incur a heavy performance penalty as the view model was generated again from scratch, it also caused the unwanted behaviour of all unfolded items to collapse again.

It was fixed by moving the `ShapeViewer` up the component hierarchy, from the `DiffViewSimulation` to the `DiffReviewExpanded`. The `SimulatedRfcContext` rendered by the former caused the complete re-render, as it previews what the updated spec must look like with the suggested change applied. However, we're not using any of this spec information and most likely will not again for the foreseeable future (until we find a way to query the domain efficiently for it).

Note that in the case where no diff is detected in the body rendered (as might happen if we're rendering bodies for both request and response), we fall back on the current production viewer. That's because the current implementation of `ShapeViewer` requires a `diff`, something we'll be addressing separately, at which time we'll revisit this fallback strategy.