### PR TITLE
Use ShapeViewer (InteractionBodyViewer) for rendering of all interaction bodies in BodyDiffs and NewRegions

### DIFF
--- a/workspaces/ui/src/components/diff/v2/DiffNewRegions.js
+++ b/workspaces/ui/src/components/diff/v2/DiffNewRegions.js
@@ -44,6 +44,7 @@ import { DiffToolTip } from './shape_viewers/styles';
 import Pagination from '@material-ui/lab/Pagination';
 import { RfcContext } from '../../../contexts/RfcContext';
 import DiffHunkViewer from './DiffHunkViewer';
+import InteractionBodyViewer from './shape_viewers/InteractionBodyViewer';
 import { ShapeExpandedStore } from './shape_viewers/ShapeRenderContext';
 import { ShapeBox } from './DiffReviewExpanded';
 import { ShapeOnlyViewer } from './shape_viewers/ShapeOnlyShapeRows';
@@ -62,7 +63,7 @@ import { Show } from '../../shared/Show';
 import { track } from '../../../Analytics';
 
 function _NewRegions(props) {
-  const { newRegions, ignoreDiff, captureId, endpointId } = props;
+  const { newRegions, ignoreDiff, captureId, endpointId, viewer } = props;
 
   const classes = useStyles();
 
@@ -123,7 +124,7 @@ function _NewRegions(props) {
           return getOrUndefined(suggestion);
         })
     );
-    track("Documented Changes")
+    track('Documented Changes');
 
     acceptSuggestion(...allApproved);
   };
@@ -146,6 +147,7 @@ function _NewRegions(props) {
               onChange={onChange}
               inferPolymorphism={inferPolymorphism}
               endpointId={endpointId}
+              viewer={viewer}
             />
           );
         }
@@ -165,6 +167,7 @@ function _NewRegions(props) {
               key={diff.diff.toString()}
               inferPolymorphism={inferPolymorphism}
               endpointId={endpointId}
+              viewer={viewer}
             />
           );
         }
@@ -182,7 +185,7 @@ function _NewRegions(props) {
     });
   }
 
-  track("Show Initial Documentation Page", props)
+  track('Show Initial Documentation Page', props);
 
   const approveCount =
     newResponses.length + newRequests.length - deselected.length;
@@ -342,6 +345,7 @@ const PreviewNewBodyRegion = ({
   isDeselected,
   onChange,
   endpointId,
+  viewer,
 }) => {
   const isChecked = !isDeselected(diff);
   const classes = useStyles();
@@ -420,7 +424,7 @@ const PreviewNewBodyRegion = ({
         })}
       >
         <div style={{ width: '55%', paddingRight: 15 }}>
-          {bodyPreview && (
+          {viewer === 'flattened' && currentInteraction ? (
             <ShapeBox
               header={
                 <div style={{ display: 'flex', alignItems: 'center' }}>
@@ -433,10 +437,34 @@ const PreviewNewBodyRegion = ({
                 </div>
               }
             >
-              <ShapeExpandedStore>
-                <DiffHunkViewer preview={bodyPreview} exampleOnly />
-              </ShapeExpandedStore>
+              <InteractionBodyViewer
+                body={
+                  diff.inRequest
+                    ? currentInteraction.interactionScala.request.body
+                    : currentInteraction.interactionScala.response.body
+                }
+              />
             </ShapeBox>
+          ) : (
+            viewer !== 'flattened' &&
+            bodyPreview && (
+              <ShapeBox
+                header={
+                  <div style={{ display: 'flex', alignItems: 'center' }}>
+                    <BreadcumbX
+                      itemStyles={{ fontSize: 13, color: 'white' }}
+                      location={['Example']}
+                    />
+                    <div style={{ flex: 1 }}></div>
+                    <span style={{ color: 'white' }}>⮕</span>
+                  </div>
+                }
+              >
+                <ShapeExpandedStore>
+                  <DiffHunkViewer preview={bodyPreview} exampleOnly />
+                </ShapeExpandedStore>
+              </ShapeBox>
+            )
           )}
         </div>
         <div style={{ flex: 1 }}>

--- a/workspaces/ui/src/components/diff/v2/DiffReviewExpanded.js
+++ b/workspaces/ui/src/components/diff/v2/DiffReviewExpanded.js
@@ -201,7 +201,7 @@ export const DiffReviewExpanded = (props) => {
                 >
                   {viewer === 'flattened' && diff.inRequest ? (
                     <InteractionBodyViewer
-                      diff={diff}
+                      diff={diff.inRequest && diff}
                       diffDescription={description}
                       body={interactionScala.request.body}
                       selectedInterpretation={selectedInterpretation}
@@ -255,9 +255,9 @@ export const DiffReviewExpanded = (props) => {
                     />
                   }
                 >
-                  {viewer === 'flattened' && diff.inResponse ? (
+                  {viewer === 'flattened' ? (
                     <InteractionBodyViewer
-                      diff={diff}
+                      diff={diff.inResponse && diff}
                       diffDescription={description}
                       body={interactionScala.response.body}
                       selectedInterpretation={selectedInterpretation}

--- a/workspaces/ui/src/components/diff/v2/DiffReviewExpanded.js
+++ b/workspaces/ui/src/components/diff/v2/DiffReviewExpanded.js
@@ -203,7 +203,7 @@ export const DiffReviewExpanded = (props) => {
                     <ShapeViewer
                       diff={diff}
                       diffDescription={description}
-                      interaction={interactionScala}
+                      body={interactionScala.request.body}
                       selectedInterpretation={selectedInterpretation}
                     />
                   ) : (
@@ -259,7 +259,7 @@ export const DiffReviewExpanded = (props) => {
                     <ShapeViewer
                       diff={diff}
                       diffDescription={description}
-                      interaction={interactionScala}
+                      body={interactionScala.response.body}
                       selectedInterpretation={selectedInterpretation}
                     />
                   ) : (

--- a/workspaces/ui/src/components/diff/v2/DiffReviewExpanded.js
+++ b/workspaces/ui/src/components/diff/v2/DiffReviewExpanded.js
@@ -27,7 +27,7 @@ import { useDiffDescription, useInteractionWithPointer } from './DiffHooks';
 import LinearProgress from '@material-ui/core/LinearProgress';
 import { DiffReviewLoading } from './LoadingNextDiff';
 import { DiffViewSimulation } from './DiffViewSimulation';
-import ShapeViewer from './shape_viewers/ShapeViewer';
+import InteractionBodyViewer from './shape_viewers/InteractionBodyViewer';
 import { track } from '../../../Analytics';
 
 const useStyles = makeStyles((theme) => ({
@@ -200,7 +200,7 @@ export const DiffReviewExpanded = (props) => {
                   }
                 >
                   {viewer === 'flattened' && diff.inRequest ? (
-                    <ShapeViewer
+                    <InteractionBodyViewer
                       diff={diff}
                       diffDescription={description}
                       body={interactionScala.request.body}
@@ -256,7 +256,7 @@ export const DiffReviewExpanded = (props) => {
                   }
                 >
                   {viewer === 'flattened' && diff.inResponse ? (
-                    <ShapeViewer
+                    <InteractionBodyViewer
                       diff={diff}
                       diffDescription={description}
                       body={interactionScala.response.body}

--- a/workspaces/ui/src/components/diff/v2/DiffReviewPage.js
+++ b/workspaces/ui/src/components/diff/v2/DiffReviewPage.js
@@ -212,6 +212,7 @@ export function DiffReviewPage(props) {
               captureId={captureId}
               endpointId={pathId + method}
               newRegions={JsonHelper.seqToJsArray(regions.newRegions)}
+              viewer={viewer}
             />
           )}
 

--- a/workspaces/ui/src/components/diff/v2/shape_viewers/InteractionBodyViewer.js
+++ b/workspaces/ui/src/components/diff/v2/shape_viewers/InteractionBodyViewer.js
@@ -21,7 +21,7 @@ import {
 import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 import WarningIcon from '@material-ui/icons/Warning';
 
-export default function ShapeViewer({
+export default function InteractionBodyViewer({
   diff,
   diffDescription,
   body,

--- a/workspaces/ui/src/components/diff/v2/shape_viewers/ShapeViewer.js
+++ b/workspaces/ui/src/components/diff/v2/shape_viewers/ShapeViewer.js
@@ -24,18 +24,18 @@ import WarningIcon from '@material-ui/icons/Warning';
 export default function ShapeViewer({
   diff,
   diffDescription,
-  interaction,
+  body,
   selectedInterpretation,
 }) {
   const generalClasses = useShapeViewerStyles();
 
   const [{ rows }, dispatch] = useReducer(
     updateState,
-    { diff, interaction },
+    { diff, body },
     createInitialState
   );
 
-  const diffDetails = {
+  const diffDetails = diff && {
     diffDescription,
     changeType: selectedInterpretation
       ? selectedInterpretation.changeTypeAsString
@@ -487,14 +487,12 @@ const useStyles = makeStyles((theme) => ({
 // TODO: consider moving this to it's own module, partly to enable the usecase
 // stated above.
 
-function createInitialState({ diff, interaction }) {
-  let body = diff.inRequest
-    ? interaction.request.body
-    : interaction.response.body;
-
-  const diffTrails = JsonHelper.seqToJsArray(diff.jsonTrails).map((jsonTrail) =>
-    JsonTrailHelper.toJs(jsonTrail)
-  );
+function createInitialState({ diff, body }) {
+  const diffTrails = diff
+    ? JsonHelper.seqToJsArray(diff.jsonTrails).map((jsonTrail) =>
+        JsonTrailHelper.toJs(jsonTrail)
+      )
+    : [];
   const shape = JsonHelper.toJs(body.jsonOption);
 
   const [rows, collapsedTrails] = shapeRows(shape, diffTrails);


### PR DESCRIPTION
This PR renames the `ShapeViewer` to `InteractionBodyViewer` and applies it everywhere in the Diffing where interaction examples are rendered.

The rename has been done to better describe the situations where the viewer can currently be used, especially as "Shape" has a more specific meaning (a `Shape` as in described by the stored or simulated spec). In the future, one can imagine a `Shape` instances having it's own way to generate the required view model for the viewer, allowing it to be use as well, but that's clearly beyond the scope of what we're currently targeting. We're better off being explicit in the meantime.

The additional places where the viewer is now used (still behind feature flag and `/flattened` URL suffix) are:
- rendering an example interaction for a new region
- rendering a body of either response or request when that's not the body containing the diff.

To make this work, the `InteractionBodyViewer` now no longer relies on the `diff` prop being provided, only rendering anything diff related if it was. To make sure we're rendering the right body, the `body` itself is required as a prop, replacing the `interaction` prop (from which the body was previously parsed using the `diff`).