### PR TITLE
Fix layout issues in the Diff Review UI

### DIFF
--- a/workspaces/ui/src/App.css
+++ b/workspaces/ui/src/App.css
@@ -1,5 +1,5 @@
 #root {
-  height: 100vh !important;
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
 }

--- a/workspaces/ui/src/components/diff/v2/DiffReviewPage.js
+++ b/workspaces/ui/src/components/diff/v2/DiffReviewPage.js
@@ -243,7 +243,6 @@ export function DiffReviewPage(props) {
 const useStyles = makeStyles((theme) => ({
   container: {
     display: 'flex',
-    overflow: 'hidden',
   },
   navigationContainer: {
     width: 230,


### PR DESCRIPTION
In QA / browser testing for the new Diff viewer, I found 2 regressions in the Diff Review UI more generally.

- scrolling in Safari was completely broken: one could not scroll down a diff body.
- Diff Cursor and actions card did not "stick" in the viewport, remaining in their initial position, making it hard to work on bigger bodies.

The improvements made in #296 to the correct use of Flexbox made these fixes pretty straightforward.