### PR TITLE
Use new InteractionBodyViewer in all diff viewing when REACT_APP_FLATENED_SHAPE_VIEWER feature flag enabled

### DIFF
--- a/workspaces/ui/src/RouterPaths.js
+++ b/workspaces/ui/src/RouterPaths.js
@@ -9,8 +9,6 @@ const routerPaths = {
   diffsRoot: (base = '') => `${base}/diffs`,
   captureRoot: (base = '') => `${routerPaths.diffsRoot(base)}/:captureId`,
   captureRequestDiffsRoot: (base = '') => `${routerPaths.captureRoot(base)}/paths/:pathId/methods/:method`,
-  captureRequestDiffsRootWithViewer: (base = '') =>
-    `${routerPaths.captureRoot(base)}/paths/:pathId/methods/:method/:viewer`,
 };
 
 export function useRouterPaths() {

--- a/workspaces/ui/src/components/diff/v2/DiffCursor.js
+++ b/workspaces/ui/src/components/diff/v2/DiffCursor.js
@@ -93,7 +93,7 @@ export class DiffCursor extends React.Component {
   }
 
   render = () => {
-    const { diffs, captureId, viewer } = this.props;
+    const { diffs, captureId } = this.props;
     const diffCount = diffs.length;
     const { showAllDiffs, selectedDiff } = this.state;
 
@@ -115,7 +115,6 @@ export class DiffCursor extends React.Component {
         <DiffReviewExpandedCached
           captureId={captureId}
           key={selectedDiff.diff.toString()}
-          viewer={viewer}
           {...{ selectedDiff, setSelectedDiff: this.setSelectedDiff }}
         />
       </div>

--- a/workspaces/ui/src/components/diff/v2/DiffNewRegions.js
+++ b/workspaces/ui/src/components/diff/v2/DiffNewRegions.js
@@ -63,7 +63,7 @@ import { Show } from '../../shared/Show';
 import { track } from '../../../Analytics';
 
 function _NewRegions(props) {
-  const { newRegions, ignoreDiff, captureId, endpointId, viewer } = props;
+  const { newRegions, ignoreDiff, captureId, endpointId } = props;
 
   const classes = useStyles();
 
@@ -147,7 +147,6 @@ function _NewRegions(props) {
               onChange={onChange}
               inferPolymorphism={inferPolymorphism}
               endpointId={endpointId}
-              viewer={viewer}
             />
           );
         }
@@ -167,7 +166,6 @@ function _NewRegions(props) {
               key={diff.diff.toString()}
               inferPolymorphism={inferPolymorphism}
               endpointId={endpointId}
-              viewer={viewer}
             />
           );
         }
@@ -345,7 +343,6 @@ const PreviewNewBodyRegion = ({
   isDeselected,
   onChange,
   endpointId,
-  viewer,
 }) => {
   const isChecked = !isDeselected(diff);
   const classes = useStyles();
@@ -424,7 +421,8 @@ const PreviewNewBodyRegion = ({
         })}
       >
         <div style={{ width: '55%', paddingRight: 15 }}>
-          {viewer === 'flattened' && currentInteraction ? (
+          {process.env.REACT_APP_FLATTENED_SHAPE_VIEWER == 'true' &&
+          currentInteraction ? (
             <ShapeBox
               header={
                 <div style={{ display: 'flex', alignItems: 'center' }}>
@@ -446,7 +444,7 @@ const PreviewNewBodyRegion = ({
               />
             </ShapeBox>
           ) : (
-            viewer !== 'flattened' &&
+            process.env.REACT_APP_FLATTENED_SHAPE_VIEWER !== 'true' &&
             bodyPreview && (
               <ShapeBox
                 header={

--- a/workspaces/ui/src/components/diff/v2/DiffPageNew.js
+++ b/workspaces/ui/src/components/diff/v2/DiffPageNew.js
@@ -38,7 +38,6 @@ function DiffPageNew(props) {
   const services = useServices();
 
   const { pathId, method, captureId } = props.match.params;
-  const viewer = props.match.params.viewer || null;
 
   return (
     <CaptureSessionInlineContext
@@ -54,12 +53,7 @@ function DiffPageNew(props) {
         inContextOfDiff={true}
         notFound={<Redirect to={`${baseUrl}/diffs`} />}
       >
-        <DiffReviewPage
-          captureId={captureId}
-          pathId={pathId}
-          method={method}
-          viewer={viewer}
-        />
+        <DiffReviewPage captureId={captureId} pathId={pathId} method={method} />
       </EndpointsContextStore>
     </CaptureSessionInlineContext>
   );

--- a/workspaces/ui/src/components/diff/v2/DiffReviewExpanded.js
+++ b/workspaces/ui/src/components/diff/v2/DiffReviewExpanded.js
@@ -81,12 +81,11 @@ export class DiffReviewExpandedCached extends React.Component {
   }
 
   render() {
-    const { selectedDiff, captureId, setSelectedDiff, viewer } = this.props;
+    const { selectedDiff, captureId, setSelectedDiff } = this.props;
     return (
       <DiffReviewExpanded
         diff={selectedDiff}
         captureId={captureId}
-        viewer={viewer}
         {...{ selectedDiff, setSelectedDiff }}
       />
     );
@@ -95,14 +94,7 @@ export class DiffReviewExpandedCached extends React.Component {
 
 export const DiffReviewExpanded = (props) => {
   const classes = useStyles();
-  const {
-    diff,
-    selectedDiff,
-    setSelectedDiff,
-    rfcContext,
-    captureId,
-    viewer,
-  } = props;
+  const { diff, selectedDiff, setSelectedDiff, rfcContext, captureId } = props;
 
   const description = useDiffDescription(diff);
 
@@ -199,7 +191,8 @@ export const DiffReviewExpanded = (props) => {
                     />
                   }
                 >
-                  {viewer === 'flattened' && diff.inRequest ? (
+                  {process.env.REACT_APP_FLATTENED_SHAPE_VIEWER === 'true' &&
+                  diff.inRequest ? (
                     <InteractionBodyViewer
                       diff={diff.inRequest && diff}
                       diffDescription={description}
@@ -255,7 +248,7 @@ export const DiffReviewExpanded = (props) => {
                     />
                   }
                 >
-                  {viewer === 'flattened' ? (
+                  {process.env.REACT_APP_FLATTENED_SHAPE_VIEWER === 'true' ? (
                     <InteractionBodyViewer
                       diff={diff.inResponse && diff}
                       diffDescription={description}

--- a/workspaces/ui/src/components/diff/v2/DiffReviewPage.js
+++ b/workspaces/ui/src/components/diff/v2/DiffReviewPage.js
@@ -36,7 +36,7 @@ import Button from '@material-ui/core/Button';
 export const newRegionsConst = 'new_regions';
 
 export function DiffReviewPage(props) {
-  const { captureId, method, pathId, viewer } = props;
+  const { captureId, method, pathId } = props;
   const classes = useStyles();
 
   const { rfcId, rfcService } = useContext(RfcContext);
@@ -212,7 +212,6 @@ export function DiffReviewPage(props) {
               captureId={captureId}
               endpointId={pathId + method}
               newRegions={JsonHelper.seqToJsArray(regions.newRegions)}
-              viewer={viewer}
             />
           )}
 
@@ -225,7 +224,6 @@ export function DiffReviewPage(props) {
               )}
               completed={completed}
               tab={currentTab}
-              viewer={viewer}
             />
           )}
         </div>


### PR DESCRIPTION
While we got the new viewer up to parity, it was super useful to render the new  viewer behind a URL suffix. However, now we're at the point where we want to test it as an integral part of the entire diffing experience, we should serve it under the right URL. Still hidden behind the feature flag, of course.