### PR TITLE
[Experimental] Added script capability to Optic

### DIFF
--- a/workspaces/cli-config/src/index.ts
+++ b/workspaces/cli-config/src/index.ts
@@ -34,6 +34,12 @@ export interface IOpticTask {
   targetUrl?: string;
 }
 
+export interface IOpticScript {
+  command?: string;
+  dependsOn: string | string[];
+  install?: string;
+}
+
 export interface IOpticTaskAliases {
   inboundUrl?: string;
 }
@@ -44,6 +50,9 @@ export interface IApiCliConfig {
   name: string;
   tasks: {
     [key: string]: IOpticTask;
+  };
+  scripts?: {
+    [key: string]: string | IOpticScript;
   };
   ignoreRequests?: string[];
 }

--- a/workspaces/cli-config/src/index.ts
+++ b/workspaces/cli-config/src/index.ts
@@ -35,8 +35,8 @@ export interface IOpticTask {
 }
 
 export interface IOpticScript {
-  command?: string;
-  dependsOn: string | string[];
+  command: string;
+  dependsOn?: string | string[];
   install?: string;
 }
 

--- a/workspaces/local-cli/package.json
+++ b/workspaces/local-cli/package.json
@@ -37,7 +37,8 @@
     "strip-ansi": "^6.0.0",
     "tslib": "^1",
     "url-join": "^4.0.1",
-    "uuid": "^8.0.0"
+    "uuid": "^8.0.0",
+    "which": "^2.0.2"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1",

--- a/workspaces/local-cli/src/commands/generate/oas.ts
+++ b/workspaces/local-cli/src/commands/generate/oas.ts
@@ -12,51 +12,77 @@ export default class GenerateOas extends Command {
   static description = 'export an OpenAPI 3.0.1 spec';
 
   static flags = {
-    json: flags.boolean({
-      default: true,
-      exclusive: ['yaml'],
-    }),
-    yaml: flags.boolean({
-      exclusive: ['json'],
-    }),
+    json: flags.boolean({}),
+    yaml: flags.boolean({}),
   };
 
   async run() {
-    try {
-      const paths = await getPathsRelativeToConfig();
-      const { specStorePath } = paths;
-      try {
-        const eventsBuffer = await fs.readFile(specStorePath);
-        const eventsString = eventsBuffer.toString();
-        cli.action.start('Generating OAS file');
-        const parsedOas = OasProjectionHelper.fromEventString(eventsString);
-        const outputFile = await this.emit(paths, parsedOas);
-        cli.action.stop(
-          '\n' + fromOptic('Generated OAS file at ' + outputFile)
-        );
-      } catch (e) {
-        this.error(e);
-      }
-    } catch (e) {
-      this.error(e);
-    }
-  }
-
-  async emit(paths: IPathMapping, parsedOas: object): Promise<string> {
     const { flags } = this.parse(GenerateOas);
-
-    const shouldOutputYaml = flags.yaml;
-
-    const outputPath = path.join(paths.basePath, 'generated');
-    await fs.ensureDir(outputPath);
-    if (shouldOutputYaml) {
-      const outputFile = path.join(outputPath, 'openapi.yaml');
-      await fs.writeFile(outputFile, yaml.safeDump(parsedOas, { indent: 1 }));
-      return outputFile;
-    } else {
-      const outputFile = path.join(outputPath, 'openapi.json');
-      await fs.writeJson(outputFile, parsedOas, { spaces: 2 });
-      return outputFile;
-    }
+    await generateOas(
+      flags.yaml || (!flags.json && !flags.yaml) /* make this default */,
+      flags.json
+    );
   }
+}
+
+export async function generateOas(
+  flagYaml: boolean,
+  flagJson: boolean
+): Promise<{ json: string | undefined; yaml: string | undefined } | undefined> {
+  try {
+    const paths = await getPathsRelativeToConfig();
+    const { specStorePath } = paths;
+    try {
+      const eventsBuffer = await fs.readFile(specStorePath);
+      const eventsString = eventsBuffer.toString();
+      cli.action.start('Generating OAS file');
+      const parsedOas = OasProjectionHelper.fromEventString(eventsString);
+      const outputFiles = await emit(paths, parsedOas, flagYaml, flagJson);
+      const filePaths = Object.values(outputFiles);
+      cli.action.stop(
+        '\n' +
+          fromOptic(
+            `Generated OAS file${filePaths.length > 1 && 's'} \n` +
+              filePaths.join('\n')
+          )
+      );
+
+      return outputFiles;
+    } catch (e) {
+      console.error(e);
+    }
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+export async function emit(
+  paths: IPathMapping,
+  parsedOas: object,
+  flagYaml: boolean,
+  flagJson: boolean
+): Promise<{ json: string | undefined; yaml: string | undefined }> {
+  const shouldOutputYaml = flagYaml;
+  const shouldOutputJson = flagJson;
+
+  const outputPath = path.join(paths.basePath, 'generated');
+
+  let yamlPath, jsonPath;
+
+  await fs.ensureDir(outputPath);
+  if (shouldOutputYaml) {
+    const outputFile = path.join(outputPath, 'openapi.yaml');
+    await fs.writeFile(outputFile, yaml.safeDump(parsedOas, { indent: 1 }));
+    yamlPath = outputFile;
+  }
+  if (shouldOutputJson) {
+    const outputFile = path.join(outputPath, 'openapi.json');
+    await fs.writeJson(outputFile, parsedOas, { spaces: 2 });
+    jsonPath = outputFile;
+  }
+
+  return {
+    json: jsonPath,
+    yaml: yamlPath,
+  };
 }

--- a/workspaces/local-cli/src/commands/scripts.ts
+++ b/workspaces/local-cli/src/commands/scripts.ts
@@ -1,5 +1,6 @@
 import { Command, flags } from '@oclif/command';
 import { verifyTask } from '../shared/verify';
+// @ts-ignore
 import {
   getPathsRelativeToConfig,
   IOpticTask,
@@ -92,14 +93,12 @@ export default class Scripts extends Command {
   }
 
   async executeScript(script: IOpticScript) {
-    const { json, yaml } = (await generateOas(true, true)) as {
-      json: string;
-      yaml: string;
-    };
-
-    const env = {
-      OPENAPI_JSON: json,
-      OPENAPI_YAML: yaml,
+    const paths: any = await generateOas(true, true)!;
+    const env: any = {
+      //@ts-ignore
+      OPENAPI_JSON: paths.json,
+      //@ts-ignore
+      OPENAPI_YAML: paths.yaml,
     };
 
     console.log(`Running command: ${colors.grey(script.command)} `);

--- a/workspaces/local-cli/src/commands/scripts.ts
+++ b/workspaces/local-cli/src/commands/scripts.ts
@@ -1,0 +1,178 @@
+import { Command, flags } from '@oclif/command';
+import { verifyTask } from '../shared/verify';
+import {
+  getPathsRelativeToConfig,
+  IOpticTask,
+  readApiConfig,
+  TaskToStartConfig,
+} from '@useoptic/cli-config';
+//@ts-ignore
+import niceTry from 'nice-try';
+import { cli } from 'cli-ux';
+//@ts-ignore
+import which from 'which';
+import colors from 'colors';
+import { exec, spawn, SpawnOptions } from 'child_process';
+import { IOpticScript } from '@useoptic/cli-config/build';
+import { developerDebugLogger, fromOptic } from '@useoptic/cli-shared';
+import GenerateOas, { generateOas } from './generate/oas';
+export default class Scripts extends Command {
+  static description = 'Run one of the scripts in your optic.yml file';
+
+  static args = [
+    {
+      name: 'scriptName',
+      required: false,
+    },
+  ];
+
+  static flags = {
+    install: flags.boolean({
+      required: false,
+      char: 'i',
+    }),
+  };
+
+  async run() {
+    const { args, flags } = this.parse(Scripts);
+    const scriptName: string | undefined = args.scriptName;
+
+    if (!scriptName) {
+      return console.log('list all scripts...');
+    }
+
+    const script: IOpticScript | undefined = await niceTry(async () => {
+      const paths = await getPathsRelativeToConfig();
+      const config = await readApiConfig(paths.configPath);
+      const foundScript = config.scripts?.[scriptName!];
+      if (foundScript) {
+        return normalizeScript(foundScript);
+      }
+    });
+
+    if (scriptName && script) {
+      this.log(fromOptic(`Found Script ${colors.bold(scriptName)}`));
+      const { found, missing } = await checkDependencies(script);
+      if (missing.length) {
+        const hasInstallScript = Boolean(script.install);
+        this.log(
+          fromOptic(
+            colors.red(
+              `Some bin dependencies are missing ${JSON.stringify(missing)}. ${
+                hasInstallScript &&
+                !flags.install &&
+                "Run the command again with the flag '--install' to install them"
+              }`
+            )
+          )
+        );
+        if (hasInstallScript && flags.install) {
+          const result = await tryInstall(script.install!);
+          if (!result) {
+            return this.log(
+              fromOptic(
+                colors.red(
+                  'Install command failed. Please install the dependencies for this script manually'
+                )
+              )
+            );
+          } else {
+            return this.executeScript(script);
+          }
+        }
+        return;
+      } else {
+        return this.executeScript(script);
+      }
+    } else {
+      this.log(
+        fromOptic(colors.red(`No script ${scriptName} found in optic.yml`))
+      );
+    }
+  }
+
+  async executeScript(script: IOpticScript) {
+    const { json, yaml } = (await generateOas(true, true)) as {
+      json: string;
+      yaml: string;
+    };
+
+    const env = {
+      OPENAPI_JSON: json,
+      OPENAPI_YAML: yaml,
+    };
+
+    console.log(`Running command: ${colors.grey(script.command)} `);
+    await spawnProcess(script.command, env);
+  }
+}
+
+function normalizeScript(scriptRaw: string | IOpticScript): IOpticScript {
+  if (typeof scriptRaw === 'string') {
+    return {
+      command: scriptRaw,
+      dependsOn: [],
+    };
+  } else {
+    const dependsOn =
+      (scriptRaw.dependsOn && typeof scriptRaw.dependsOn === 'string'
+        ? [scriptRaw.dependsOn]
+        : scriptRaw.dependsOn) || [];
+    return { ...scriptRaw, dependsOn };
+  }
+}
+
+async function checkDependencies(
+  script: IOpticScript
+): Promise<{ found: string[]; missing: string[] }> {
+  const dependencies = script.dependsOn as Array<string>;
+  cli.action.start(
+    `${colors.bold(`Checking bin dependencies`)} ${colors.grey(
+      'Requiring ' + JSON.stringify(dependencies)
+    )}`
+  );
+
+  const results: [string, string][] = [];
+  for (const bin of dependencies) {
+    const pathToBin = which.sync(bin, { nothrow: true });
+    results.push([bin, pathToBin]);
+  }
+
+  const found = results.filter((i) => Boolean(i[1])).map((i) => i[0]);
+  const missing = results.filter((i) => !Boolean(i[1])).map((i) => i[0]);
+
+  if (missing.length === 0) {
+    cli.action.stop(colors.green.bold('✓ All dependencies found'));
+  } else {
+    cli.action.stop(colors.red('Missing dependencies'));
+  }
+
+  return { found, missing };
+}
+
+async function tryInstall(installScript: string): Promise<boolean> {
+  cli.action.start(`Running install command: ${colors.grey(installScript)} `);
+  const status = await spawnProcess(installScript);
+  cli.action.stop('Success!');
+  return status;
+}
+
+async function spawnProcess(command: string, env: any = {}): Promise<boolean> {
+  const taskOptions: SpawnOptions = {
+    env: {
+      ...process.env,
+      ...env,
+    },
+    shell: true,
+    cwd: process.cwd(),
+    stdio: 'inherit',
+  };
+
+  const child = spawn(command, taskOptions);
+
+  return await new Promise((resolve) => {
+    child.on('exit', (code) => {
+      resolve(code === 0);
+    });
+  });
+}


### PR DESCRIPTION
@LouManglass -- as discussed, in this PR I've implemented the `scripts` command to back up the demand-gen project. 

Scripts are registered similarly to how you setup a task. 

The most basic script looks like this:

```
scripts:
  do-thing: rdme push $OPENAPI_YAML --id xyz
```

^ But a naked command like this is hard to share with your team. Unlike an npm script there's no affordances in bash to require certain dependencies to be on your /bin. This means you also need to tell your teammates or CI pipeline to install these manually. 

To address this, you can also use the expanded syntax (this is what I imagine we'd share in our blog posts to make things work automagically).
```
scripts:
  publish-redoc:
    command: redoc-cli bundle $OPENAPI_YAML
    dependsOn: redoc-cli
    install: npm install redoc-cli -g
```

Add this to your `optic.yml` and run `apidev scripts publish-redoc`

<img width="900" alt="Screen Shot 2020-08-22 at 10 18 05 AM" src="https://user-images.githubusercontent.com/5900338/90958190-c6b58680-e460-11ea-90d1-11f98cb9fe04.png">

The check for `redoc-cli` fails and asks you to run the command again with the `--install` flag. This won't catch everything (if npm isn't installed you're still screwed), but it should help most teams get aligned. You can always see the failures and fallback to manual dependency resolution. 

Presto! Script executed -- static docs built

<img width="904" alt="Screen Shot 2020-08-22 at 10 19 43 AM" src="https://user-images.githubusercontent.com/5900338/90958225-ffedf680-e460-11ea-8682-8cf880096a8f.png">

**Note**
All scripts get `OPENAPI_JSON` and `OPENAPI_YAML`. These are paths to their respective files and are injected as env variables. 