### PR TITLE
Fix a bug where InteractionBodyViewer would crash the app rendering new endpoints with empty bodies

### DIFF
--- a/workspaces/ui/src/components/diff/v2/DiffNewRegions.js
+++ b/workspaces/ui/src/components/diff/v2/DiffNewRegions.js
@@ -65,7 +65,7 @@ import {
 } from './DiffHooks';
 import { Show } from '../../shared/Show';
 import { trackUserEvent } from '../../../Analytics';
-import { ShowInitialDocumentingView } from '@useoptic/analytics/lib/events/diffs'
+import { ShowInitialDocumentingView } from '@useoptic/analytics/lib/events/diffs';
 function _NewRegions(props) {
   const { newRegions, ignoreDiff, captureId, endpointId } = props;
 
@@ -81,8 +81,8 @@ function _NewRegions(props) {
 
   useEffect(() => {
     trackUserEvent(ShowInitialDocumentingView.withProps({}));
-  }, [])
-  
+  }, []);
+
   if (newRegions.length === 0) {
     return null;
   }
@@ -435,49 +435,48 @@ const PreviewNewBodyRegion = ({
         })}
       >
         <div style={{ width: '55%', paddingRight: 15 }}>
-          {process.env.REACT_APP_FLATTENED_SHAPE_VIEWER == 'true' &&
-          currentInteraction ? (
-            <ShapeBox
-              header={
-                <div style={{ display: 'flex', alignItems: 'center' }}>
-                  <BreadcumbX
-                    itemStyles={{ fontSize: 13, color: 'white' }}
-                    location={['Example']}
+          {process.env.REACT_APP_FLATTENED_SHAPE_VIEWER == 'true'
+            ? getOrUndefined(diff.contentType) && (
+                <ShapeBox
+                  header={
+                    <div style={{ display: 'flex', alignItems: 'center' }}>
+                      <BreadcumbX
+                        itemStyles={{ fontSize: 13, color: 'white' }}
+                        location={['Example']}
+                      />
+                      <div style={{ flex: 1 }}></div>
+                      <span style={{ color: 'white' }}>⮕</span>
+                    </div>
+                  }
+                >
+                  <InteractionBodyViewer
+                    body={
+                      diff.inRequest
+                        ? currentInteraction.interactionScala.request.body
+                        : currentInteraction.interactionScala.response.body
+                    }
                   />
-                  <div style={{ flex: 1 }}></div>
-                  <span style={{ color: 'white' }}>⮕</span>
-                </div>
-              }
-            >
-              <InteractionBodyViewer
-                body={
-                  diff.inRequest
-                    ? currentInteraction.interactionScala.request.body
-                    : currentInteraction.interactionScala.response.body
-                }
-              />
-            </ShapeBox>
-          ) : (
-            process.env.REACT_APP_FLATTENED_SHAPE_VIEWER !== 'true' &&
-            bodyPreview && (
-              <ShapeBox
-                header={
-                  <div style={{ display: 'flex', alignItems: 'center' }}>
-                    <BreadcumbX
-                      itemStyles={{ fontSize: 13, color: 'white' }}
-                      location={['Example']}
-                    />
-                    <div style={{ flex: 1 }}></div>
-                    <span style={{ color: 'white' }}>⮕</span>
-                  </div>
-                }
-              >
-                <ShapeExpandedStore>
-                  <DiffHunkViewer preview={bodyPreview} exampleOnly />
-                </ShapeExpandedStore>
-              </ShapeBox>
-            )
-          )}
+                </ShapeBox>
+              )
+            : process.env.REACT_APP_FLATTENED_SHAPE_VIEWER !== 'true' &&
+              bodyPreview && (
+                <ShapeBox
+                  header={
+                    <div style={{ display: 'flex', alignItems: 'center' }}>
+                      <BreadcumbX
+                        itemStyles={{ fontSize: 13, color: 'white' }}
+                        location={['Example']}
+                      />
+                      <div style={{ flex: 1 }}></div>
+                      <span style={{ color: 'white' }}>⮕</span>
+                    </div>
+                  }
+                >
+                  <ShapeExpandedStore>
+                    <DiffHunkViewer preview={bodyPreview} exampleOnly />
+                  </ShapeExpandedStore>
+                </ShapeBox>
+              )}
         </div>
         <div style={{ flex: 1 }}>
           {shapePreview && (

--- a/workspaces/ui/src/components/diff/v2/shape_viewers/InteractionBodyViewer.js
+++ b/workspaces/ui/src/components/diff/v2/shape_viewers/InteractionBodyViewer.js
@@ -493,7 +493,9 @@ function createInitialState({ diff, body }) {
         JsonTrailHelper.toJs(jsonTrail)
       )
     : [];
-  const shape = JsonHelper.toJs(body.jsonOption);
+
+  const bodyJson = getOrUndefined(body.jsonOption);
+  const shape = bodyJson && JsonHelper.toJs(bodyJson);
 
   const [rows, collapsedTrails] = shapeRows(shape, diffTrails);
 


### PR DESCRIPTION
While porting the `DiffNewRegions` component to use the new `InteractionBodyViewer`, we didn't account for a slight difference in use case, where a `diff` points at the `request` of `response` of an `interaction`, but does not necessarily have a body. This PR makes two fixes:

- prevents a crash when `InteractionBodyViewer` is used with an empty body (`None`), rendering an empty shape. It doesn't make much sense to render without, but it shouldn't produce a cryptic error message.
- prevents shape viewers to be rendered for requests or responses that don't have one.