### PR TITLE
Fix bug where text bodies of interactions would render an empty InteractionBodyViewer

### DIFF
--- a/workspaces/ui/public/example-sessions/diff-test-cases.json
+++ b/workspaces/ui/public/example-sessions/diff-test-cases.json
@@ -606,6 +606,92 @@
           }
         },
         "tags": []
+      },
+      {
+        "uuid": "14",
+        "request": {
+          "host": "localhost",
+          "method": "GET",
+          "path": "/malformed-json-body",
+          "query": {
+            "asJsonString": null,
+            "asText": null,
+            "asShapeHashBytes": null
+          },
+          "headers": {
+            "asJsonString": null,
+            "asText": null,
+            "asShapeHashBytes": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "asJsonString": null,
+              "asText": null,
+              "asShapeHashBytes": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "asJsonString": null,
+            "asText": null,
+            "asShapeHashBytes": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "asJsonString": null,
+              "asText": "{ not-valid-json: without-quotes}",
+              "asShapeHashBytes": null
+            }
+          }
+        },
+        "tags": []
+      },
+      {
+        "uuid": "15",
+        "request": {
+          "host": "localhost",
+          "method": "GET",
+          "path": "/html-body",
+          "query": {
+            "asJsonString": null,
+            "asText": null,
+            "asShapeHashBytes": null
+          },
+          "headers": {
+            "asJsonString": null,
+            "asText": null,
+            "asShapeHashBytes": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "asJsonString": null,
+              "asText": null,
+              "asShapeHashBytes": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "asJsonString": null,
+            "asText": null,
+            "asShapeHashBytes": null
+          },
+          "body": {
+            "contentType": "text/html",
+            "value": {
+              "asJsonString": null,
+              "asText": "<html>\n<head><title>Testing</title></head>\n<body>\n<h1>welcome!</h1></body>\n</html>",
+              "asShapeHashBytes": null
+            }
+          }
+        },
+        "tags": []
       }
     ],
     "links": [

--- a/workspaces/ui/src/components/diff/v2/shape_viewers/InteractionBodyViewer.js
+++ b/workspaces/ui/src/components/diff/v2/shape_viewers/InteractionBodyViewer.js
@@ -575,8 +575,11 @@ function shapeRows(
       break;
     default:
       // debugger
-      let type = getFieldType(field.fieldValue);
-      let row = createRow({ type, ...field, indent }, { diffTrails });
+      let type = getFieldType(shape);
+      let row = createRow(
+        { type, ...field, fieldValue: field.fieldValue || shape, indent },
+        { diffTrails }
+      );
       rows.push(createRow(row));
       break;
   }


### PR DESCRIPTION
PR as described in the title. It was found while testing what would happen to html, malformed json and other non-json bodies. Just like the `DiffHunkViewer`, it renders this a string, by virtue of how non-json interactions are represented.