### PR TITLE
Fix bug where added fields describing object or array were not highlighted in DiffViewer

### DIFF
--- a/workspaces/ui/src/components/diff/v2/shape_viewers/InteractionBodyViewer.js
+++ b/workspaces/ui/src/components/diff/v2/shape_viewers/InteractionBodyViewer.js
@@ -598,13 +598,16 @@ function objectRows(
   const { trail } = field;
 
   rows.push(
-    createRow({
-      type: 'object_open',
-      fieldName: field.fieldName,
-      seqIndex: field.seqIndex,
-      trail,
-      indent,
-    })
+    createRow(
+      {
+        type: 'object_open',
+        fieldName: field.fieldName,
+        seqIndex: field.seqIndex,
+        trail,
+        indent,
+      },
+      { diffTrails }
+    )
   );
 
   const nestedDiffs = diffTrails.filter((diffTrail) =>
@@ -646,13 +649,16 @@ function listRows(list, diffTrails, rows, collapsedTrails, indent, field) {
   const { trail } = field;
 
   rows.push(
-    createRow({
-      type: 'array_open',
-      indent,
-      fieldName: field.fieldName,
-      seqIndex: field.seqIndex,
-      trail,
-    })
+    createRow(
+      {
+        type: 'array_open',
+        indent,
+        fieldName: field.fieldName,
+        seqIndex: field.seqIndex,
+        trail,
+      },
+      { diffTrails }
+    )
   );
 
   const nestedDiffs = diffTrails.filter(


### PR DESCRIPTION
Fixing problem as described in PR title. 

The `diffTrails` used for each row to mark itself as compliant wasn't being forwarded properly for rows that open an array or object, which caused the diff never to be rendered for it.