### PR TITLE
fixed bug where debian wasnt releasing

### DIFF
--- a/.github/deployDebian/action.yml
+++ b/.github/deployDebian/action.yml
@@ -16,6 +16,9 @@ inputs:
   PREFIX_NAME:
     description: "The prefix for the package"
     required: true
+  NPM_PACKAGE_NAME:
+    description: "The name of the npm package to deploy into debian"
+    required: true
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,7 @@ jobs:
           BUCKET_NAME: optic-packages
           PACKAGE_NAME: api
           PREFIX_NAME: deb
+          NPM_PACKAGE_NAME: "@useoptic/cli"
   
   # Triggers Homebrew Release - Configure homebrew/core fork repository in the env settings above
   # Requires Repository Access Token (https://github.com/peter-evans/repository-dispatch#token) with repo:write scope


### PR DESCRIPTION
Confirmed this fix works — https://github.com/opticdev/optic/runs/1125692261?check_suite_focus=true

`deployDebian/entrypoint.sh` required an input called `NPM_PACKAGE_NAME`, but this wasn't specified in the config file @ `deployDebian/action.yml`. Thinking this to be an extra added field, I removed that from the original input (which caused a failure, since that was a requirement to run. I have since made sure to update the config and actual release run file to include the required variables.

tl;dr: extra non required but needed parameter caused headaches/failures, added this parameter to be required in config and we're happy now