### PR TITLE
Prevent DiffViewer from leaking values to FullStory

### DIFF
--- a/workspaces/ui/src/components/diff/v2/shape_viewers/InteractionBodyViewer.js
+++ b/workspaces/ui/src/components/diff/v2/shape_viewers/InteractionBodyViewer.js
@@ -134,7 +134,11 @@ function RowValue({ type, value, compliant, changeDescription }) {
   if (type === 'null') {
     return (
       <span
-        className={classNames(generalClasses.symbols, classes.symbolContent)}
+        className={classNames(
+          generalClasses.symbols,
+          classes.symbolContent,
+          'fs-exclude'
+        )}
       >
         {'null'}
       </span>
@@ -199,15 +203,19 @@ function RowValue({ type, value, compliant, changeDescription }) {
   }
 
   if (type === 'string') {
-    return <span className={classes.stringContent}>"{value}"</span>;
+    return (
+      <span className={classNames(classes.stringContent, 'fs-exclude')}>
+        "{value}"
+      </span>
+    );
   }
 
   if (type === 'boolean') {
-    return <span>{value ? 'true' : 'false'}</span>;
+    return <span className="fs-exclude">{value ? 'true' : 'false'}</span>;
   }
 
   if (type === 'number') {
-    return <span>{value}</span>;
+    return <span className="fs-exclude">{value}</span>;
   }
 
   if (type === 'undefined') {


### PR DESCRIPTION
As the title describes, we really don't want interaction body values in our analytics: that data belongs to the users and should not be captured by us (in this way, at least).

**Note: this has only been in the wild for a few days and only affected the most recent CLI version which very few users had installed, we're going through and deleting logs now and notifying folks as required.**