### PR TITLE
disabled back button when path is known in on-boarding url

### DIFF
--- a/workspaces/ui/src/Analytics.js
+++ b/workspaces/ui/src/Analytics.js
@@ -44,9 +44,11 @@ export const analyticsEvents = newAnalyticsEventBus(async (batchId) => {
 
 //forward analytics to central CLI server bus
 analyticsEvents.listen((event) => {
-  try {
-    client.postTrackingEvents([event]);
-  } catch (e) {}
+  if (isAnalyticsEnabled) {
+    try {
+      client.postTrackingEvents([event]);
+    } catch (e) {}
+  }
 });
 
 export function trackUserEvent(event) {

--- a/workspaces/ui/src/components/diff/v2/AddUrlModal.js
+++ b/workspaces/ui/src/components/diff/v2/AddUrlModal.js
@@ -28,7 +28,10 @@ import { PathAndMethod } from './PathAndMethod';
 import { useHistory } from 'react-router-dom';
 import { useBaseUrl } from '../../../contexts/BaseUrlContext';
 import { trackUserEvent, track } from '../../../Analytics';
-import { AddUrlModalNaming, AddUrlModalIdentifyingPathComponents } from '@useoptic/analytics/lib/events/diffs'
+import {
+  AddUrlModalNaming,
+  AddUrlModalIdentifyingPathComponents,
+} from '@useoptic/analytics/lib/events/diffs';
 import { CaptureContext } from '../../../contexts/CaptureContext';
 import {
   UserBeganAddingNewUrl,
@@ -80,18 +83,22 @@ export const NewUrlModal = withRfcContext((props) => {
   useEffect(() => {
     if (naming) {
       // AddUrlModal - Naming Endpoint
-      trackUserEvent(AddUrlModalNaming.withProps({
-        path: newUrl.path, 
-        method: newUrl.method
-      }))
+      trackUserEvent(
+        AddUrlModalNaming.withProps({
+          path: newUrl.path,
+          method: newUrl.method,
+        })
+      );
     } else {
       // AddUrlModal - Path Components
-      trackUserEvent(AddUrlModalIdentifyingPathComponents.withProps({
-        path: newUrl.path, 
-        method: newUrl.method
-      }))
+      trackUserEvent(
+        AddUrlModalIdentifyingPathComponents.withProps({
+          path: newUrl.path,
+          method: newUrl.method,
+        })
+      );
     }
-  }, [naming])
+  }, [naming]);
 
   const handleClose = () => {
     // track('Closed AddUrlModal');
@@ -197,7 +204,12 @@ export const NewUrlModal = withRfcContext((props) => {
             />
           </DialogContent>
           <DialogActions>
-            <Button onClick={() => setNaming(false)}>Back</Button>
+            <Button
+              disabled={Boolean(knownPathId)}
+              onClick={() => setNaming(false)}
+            >
+              Back
+            </Button>
             <Button
               type="submit"
               onClick={() => handleCreate(purpose)}


### PR DESCRIPTION
Resolves frequent user issue that emerges after documenting > 0 paths and building out that graph a bit. 

<img width="1128" alt="Screen Shot 2020-09-23 at 9 30 36 AM" src="https://user-images.githubusercontent.com/5900338/94019244-8b6be780-fd7f-11ea-8a0f-d3d4ec4d760f.png">
