### PR TITLE
Migrate to a session based diff manager

### DIFF
--- a/workspaces/cli-server/src/diffs/diff-manager.ts
+++ b/workspaces/cli-server/src/diffs/diff-manager.ts
@@ -10,9 +10,10 @@ import { readApiConfig } from '@useoptic/cli-config';
 
 export interface IDiffManagerConfig {
   configPath: string;
-  diffId: string;
   captureId: string;
   captureBaseDirectory: string;
+  diffId: string;
+  endpoints?: Array<{ pathId: string; method: string }>;
   specPath: string;
 }
 
@@ -36,7 +37,7 @@ export class DiffManager {
     await Promise.all([
       fs.copy(config.specPath, outputPaths.events),
       fs.writeJson(outputPaths.ignoreRequests, apiConfig.ignoreRequests || []),
-      fs.writeJson(outputPaths.filters, []), // TODO: accept endpoint filters
+      fs.writeJson(outputPaths.filters, config.endpoints || []),
       fs.writeJson(outputPaths.additionalCommands, []),
     ]);
 

--- a/workspaces/cli-server/src/diffs/diff-manager.ts
+++ b/workspaces/cli-server/src/diffs/diff-manager.ts
@@ -13,6 +13,7 @@ import { Readable } from 'stream';
 import { chain } from 'stream-chain';
 import { stringer as jsonStringer } from 'stream-json/Stringer';
 import { disassembler as jsonDisassembler } from 'stream-json/Disassembler';
+import { streamArray } from 'stream-json/streamers/StreamArray';
 import { parser as jsonlParser } from 'stream-json/jsonl/Parser';
 import { parser as jsonParser } from 'stream-json';
 
@@ -176,7 +177,14 @@ export class DiffQueries {
       ]);
     }
   }
-  undocumentedUrls() {}
+  undocumentedUrls(): Readable {
+    return chain([
+      Readable.from(lockedRead(this.paths.undocumentedUrls)),
+      jsonParser(),
+      streamArray(),
+      (data) => [data.value],
+    ]);
+  }
   stats() {}
 }
 

--- a/workspaces/cli-server/src/diffs/diff-manager.ts
+++ b/workspaces/cli-server/src/diffs/diff-manager.ts
@@ -166,14 +166,13 @@ export class DiffQueries {
         fs.createReadStream(this.paths.diffsStream),
         jsonlParser(),
         (data) => [data.value],
-        jsonDisassembler(),
-        jsonStringer({ makeArray: true }),
       ]);
     } else {
       return chain([
         Readable.from(lockedRead(this.paths.diffs)),
         jsonParser(), // parse as JSON, to guard against malformed persisted results
-        jsonStringer(),
+        streamArray(),
+        (data) => [data.value],
       ]);
     }
   }

--- a/workspaces/cli-server/src/diffs/index.ts
+++ b/workspaces/cli-server/src/diffs/index.ts
@@ -74,4 +74,16 @@ export interface DiffStats {
 //        has to play ball. Perhaps a pragmatic first step is a PassThrough<T> that can be used to tack
 //        on to an existing pipeline. But if we're casting types anyway, we could just do that during read?
 //
+//        Ideal would be:
 // interface ResultStream<T> extends Readable<T> {}
+//
+//        Alternatively, we could use TypeScript's native support for AsyncIterable's and the flawless
+//        interop with streams provided by Node. Issue with that is that tooling around AsyncIterables is
+//        pretty meager.
+// export async function* resultStreamGenerator<T>(
+//   stream: Readable
+// ): AsyncIterable<T> {
+//   for await (let item of stream) {
+//     yield item as T;
+//   }
+// }

--- a/workspaces/cli-server/src/diffs/index.ts
+++ b/workspaces/cli-server/src/diffs/index.ts
@@ -6,7 +6,7 @@ export interface Diff {
   readonly events: DiffEvents;
 
   start(): Promise<void>;
-  progress(): Readable;
+  progress(): ProgressStream;
   queries(): DiffQueries;
   stop(): Promise<void>;
 }
@@ -53,6 +53,8 @@ export interface DiffConfigObject {
   endpoints?: Array<{ pathId: string; method: string }>;
   specPath: string;
 }
+
+export interface ProgressStream extends Readable {}
 
 export interface ProgressEvent {
   type: 'progress';

--- a/workspaces/cli-server/src/diffs/index.ts
+++ b/workspaces/cli-server/src/diffs/index.ts
@@ -1,0 +1,77 @@
+import { EventEmitter } from 'events';
+import { Readable } from 'stream';
+
+export interface Diff {
+  readonly id: string;
+  readonly events: DiffEvents;
+
+  start(): Promise<void>;
+  progress(): Readable;
+  queries(): DiffQueries;
+  stop(): Promise<void>;
+}
+
+export interface DiffConstructor {
+  new (config: DiffConfigObject): Diff;
+}
+
+export function createDiff(ctor: DiffConstructor, config: DiffConfigObject) {
+  return new ctor(config);
+}
+
+export interface DiffEvents extends EventEmitter {
+  addListener(event: 'finish', listener: () => void): this;
+  addListener(event: 'error', listener: (err: Error) => void): this;
+
+  emit(event: 'finish'): boolean;
+  emit(event: 'error', err: Error): boolean;
+
+  on(event: 'finish', listener: () => void): this;
+  on(event: 'error', listener: (err: Error) => void): this;
+
+  once(event: 'finish', listener: () => void): this;
+  once(event: 'error', listener: (err: Error) => void): this;
+
+  prependListener(event: 'finish', listener: () => void): this;
+  prependListener(event: 'error', listener: (err: Error) => void): this;
+
+  prependOnceListener(event: 'finish', listener: () => void): this;
+  prependOnceListener(event: 'error', listener: (err: Error) => void): this;
+}
+
+export interface DiffQueries {
+  diffs(): Readable;
+  undocumentedUrls(): Readable;
+  stats(): Promise<DiffStats>;
+}
+
+export interface DiffConfigObject {
+  configPath: string;
+  captureId: string;
+  captureBaseDirectory: string;
+  diffId: string;
+  endpoints?: Array<{ pathId: string; method: string }>;
+  specPath: string;
+}
+
+export interface ProgressEvent {
+  type: 'progress';
+  data: {
+    diffedInteractionsCounter: string;
+    skippedInteractionsCounter: string;
+    hasMoreInteractions: string;
+  };
+}
+
+export interface DiffStats {
+  [key: string]: number | string | boolean;
+}
+
+// @TODO: Figure out a reasonable way to type the streams, defining the objects that are yielded.
+//        It will require the construction of the stream that's returned to have the required
+//        Readable interface implemented. The tricky thing about that is that streams are constructed
+//        in a lot of different possible ways. For really strong typing, every part of the pipeline
+//        has to play ball. Perhaps a pragmatic first step is a PassThrough<T> that can be used to tack
+//        on to an existing pipeline. But if we're casting types anyway, we could just do that during read?
+//
+// interface ResultStream<T> extends Readable<T> {}

--- a/workspaces/cli-server/src/diffs/on-demand.ts
+++ b/workspaces/cli-server/src/diffs/on-demand.ts
@@ -83,10 +83,8 @@ export class OnDemandDiff implements Diff {
     const onExit = (code: number, signal: string | null) => {
       cleanup();
       if (code !== 0) {
-        this.events.emit(
-          'error',
-          new Error('Diff worker exited with non-zero status code')
-        );
+        // @TODO: wonder how we'll ever find out about this happening.
+        console.error('Diff Worker exited with non-zero exit code');
       } else {
         this.finished = true;
         this.events.emit('finish');

--- a/workspaces/cli-server/src/diffs/on-demand.ts
+++ b/workspaces/cli-server/src/diffs/on-demand.ts
@@ -22,7 +22,7 @@ import { streamArray } from 'stream-json/streamers/StreamArray';
 import { parser as jsonlParser } from 'stream-json/jsonl/Parser';
 import { parser as jsonParser } from 'stream-json';
 
-export class DiffManager implements Diff {
+export class OnDemandDiff implements Diff {
   public readonly events: EventEmitter = new EventEmitter();
   private child!: ChildProcess;
   public readonly id: string;

--- a/workspaces/cli-server/src/routers/capture-router.ts
+++ b/workspaces/cli-server/src/routers/capture-router.ts
@@ -83,20 +83,11 @@ export function makeRouter(dependencies: ICaptureRouterDependencies) {
 
       let diff;
       try {
-        diff = await req.optic.session.diffCapture(
-          captureId /* TODO: , filters*/
-        );
+        diff = await req.optic.session.diffCapture(captureId, filters);
       } catch (e) {
         return res.status(500).json({ message: e.message });
       }
 
-      // await fs.ensureDir(diffOutputPaths.base);
-      // await Promise.all([
-      //   fs.writeJson(diffOutputPaths.events, events),
-      //   fs.writeJson(diffOutputPaths.ignoreRequests, ignoreRequests),
-      //   fs.writeJson(diffOutputPaths.filters, filters),
-      //   fs.writeJson(diffOutputPaths.additionalCommands, additionalCommands),
-      // ]);
       const diffMetadata = {
         id: diff.id,
         manager: diff,

--- a/workspaces/cli-server/src/routers/capture-router.ts
+++ b/workspaces/cli-server/src/routers/capture-router.ts
@@ -6,7 +6,7 @@ import {
   IInteractionPointerConverter,
   LocalCaptureInteractionContext,
 } from '@useoptic/cli-shared/build/captures/avro/file-system/interaction-iterator';
-import { DiffManager } from '../diffs/diff-manager';
+import { Diff } from '../diffs';
 import fs from 'fs-extra';
 import { getDiffOutputPaths } from '@useoptic/cli-shared/build/diffs/diff-worker';
 import lockfile from 'proper-lockfile';
@@ -30,7 +30,7 @@ export interface ICaptureRouterDependencies {
 
 export interface ICaptureDiffMetadata {
   id: string;
-  manager: DiffManager;
+  manager: Diff;
 }
 
 export function makeRouter(dependencies: ICaptureRouterDependencies) {

--- a/workspaces/cli-server/src/routers/capture-router.ts
+++ b/workspaces/cli-server/src/routers/capture-router.ts
@@ -155,7 +155,7 @@ export function makeRouter(dependencies: ICaptureRouterDependencies) {
     const diffQueries = diffMetadata.manager.queries();
 
     let diffsStream = diffQueries.diffs();
-    diffsStream.pipe(res).type('application/json');
+    diffsStream.pipe(toJSONArray()).pipe(res).type('application/json');
   });
 
   router.get('/diffs/:diffId/undocumented-urls', async (req, res) => {

--- a/workspaces/cli-server/src/routers/spec-router.ts
+++ b/workspaces/cli-server/src/routers/spec-router.ts
@@ -19,6 +19,7 @@ import {
 } from '@useoptic/cli-shared';
 import { makeRouter as makeCaptureRouter } from './capture-router';
 import { LocalCaptureInteractionPointerConverter } from '@useoptic/cli-shared/build/captures/avro/file-system/interaction-iterator';
+import { SessionsManager } from '../sessions';
 type CaptureId = string;
 type Iso8601Timestamp = string;
 export type InvalidCaptureState = {
@@ -158,7 +159,7 @@ export class ExampleRequestsHelpers {
   }
 }
 
-export function makeRouter(sessions: ICliServerSession[]) {
+export function makeRouter(sessions: SessionsManager) {
   function prepareEvents(events: any): string {
     return `[
 ${events.map((x: any) => JSON.stringify(x)).join('\n,')}
@@ -172,7 +173,7 @@ ${events.map((x: any) => JSON.stringify(x)).join('\n,')}
   ) {
     const { specId } = req.params;
     developerDebugLogger({ specId, sessions });
-    const session = sessions.find((x) => x.id === specId);
+    const session = sessions.findById(specId);
     if (!session) {
       res.sendStatus(404);
       return;

--- a/workspaces/cli-server/src/routers/spec-router.ts
+++ b/workspaces/cli-server/src/routers/spec-router.ts
@@ -191,6 +191,7 @@ ${events.map((x: any) => JSON.stringify(x)).join('\n,')}
         paths,
         capturesHelpers,
         exampleRequestsHelpers,
+        session,
       };
       next();
     } catch (e) {

--- a/workspaces/cli-server/src/server.ts
+++ b/workspaces/cli-server/src/server.ts
@@ -41,6 +41,7 @@ export interface IOpticExpressRequestAdditions {
   config: IApiCliConfig;
   capturesHelpers: CapturesHelpers;
   exampleRequestsHelpers: ExampleRequestsHelpers;
+  session: Session;
 }
 
 declare global {

--- a/workspaces/cli-server/src/server.ts
+++ b/workspaces/cli-server/src/server.ts
@@ -24,6 +24,7 @@ import { createProxyMiddleware } from 'http-proxy-middleware';
 import { TrackingEventBase } from '@useoptic/analytics/lib/interfaces/TrackingEventBase';
 import { analyticsEventEmitter, track } from './analytics';
 import cors from 'cors';
+import { Session, SessionsManager } from './sessions';
 
 const pJson = require('../package.json');
 
@@ -87,7 +88,7 @@ class CliServer {
     const app = express();
     app.use(cors(this.corsOptions));
     app.set('etag', false);
-    const sessions: ICliServerSession[] = [];
+    const sessions = new SessionsManager();
     let user: object | null;
 
     app.get('/api/identity', async (req, res: express.Response) => {
@@ -172,22 +173,13 @@ class CliServer {
             },
           });
         }
-        const existingSession = sessions.find((x) => x.path === path);
-        if (existingSession) {
-          return res.json({
-            session: existingSession,
-          });
-        }
 
-        const sessionId = (sessions.length + 1).toString();
-        const session: ICliServerSession = {
-          id: sessionId,
-          path,
-        };
-        sessions.push(session);
-
+        const session = await sessions.start(path);
         return res.json({
-          session,
+          session: {
+            id: session.id,
+            path: session.path,
+          },
         });
       }
     );

--- a/workspaces/cli-server/src/sessions.ts
+++ b/workspaces/cli-server/src/sessions.ts
@@ -81,7 +81,14 @@ class SessionDiffs {
     if (existingDiff) return existingDiff;
 
     const diffId = Uuid.v4();
-    const newDiff = new DiffManager(diffId);
+    const newDiff = new DiffManager({
+      captureId,
+      configPath: this.configPath,
+      captureBaseDirectory: this.capturesPath,
+      diffId,
+      endpoints,
+      specPath: this.specPath,
+    });
     this.diffsByCaptureId.set(captureId, newDiff);
 
     newDiff.events.once('finish', () => {
@@ -91,14 +98,7 @@ class SessionDiffs {
       throw err;
     });
 
-    await newDiff.start({
-      captureId,
-      configPath: this.configPath,
-      captureBaseDirectory: this.capturesPath,
-      diffId,
-      endpoints,
-      specPath: this.specPath,
-    });
+    await newDiff.start();
 
     return newDiff;
   }

--- a/workspaces/cli-server/src/sessions.ts
+++ b/workspaces/cli-server/src/sessions.ts
@@ -49,13 +49,16 @@ export class Session {
     );
   }
 
-  async diffCapture(captureId: string) {
+  async diffCapture(
+    captureId: string,
+    endpoints?: Array<{ pathId: string; method: string }>
+  ) {
     if (!this.diffs)
       throw new Error(
         'Session must have been started before it can diff a capture'
       );
 
-    return this.diffs.startDiff(captureId);
+    return this.diffs.startDiff(captureId, endpoints);
   }
 
   async stop() {}
@@ -70,7 +73,10 @@ class SessionDiffs {
     readonly specPath: string
   ) {}
 
-  async startDiff(captureId: string): Promise<DiffManager> {
+  async startDiff(
+    captureId: string,
+    endpoints?: Array<{ pathId: string; method: string }>
+  ): Promise<DiffManager> {
     const existingDiff = this.diffsByCaptureId.get(captureId);
     if (existingDiff) return existingDiff;
 
@@ -90,6 +96,7 @@ class SessionDiffs {
       configPath: this.configPath,
       captureBaseDirectory: this.capturesPath,
       diffId,
+      endpoints,
       specPath: this.specPath,
     });
 

--- a/workspaces/cli-server/src/sessions.ts
+++ b/workspaces/cli-server/src/sessions.ts
@@ -103,9 +103,6 @@ class SessionDiffs {
     captureId: string,
     endpoints?: Array<{ pathId: string; method: string }>
   ): Promise<string> {
-    const existingDiff = this.activeDiffsByCaptureId.get(captureId);
-    if (existingDiff) return existingDiff.id;
-
     const diffId = Uuid.v4();
     const newDiff = createDiff(OnDemandDiff, {
       captureId,

--- a/workspaces/cli-server/src/sessions.ts
+++ b/workspaces/cli-server/src/sessions.ts
@@ -4,7 +4,7 @@ import {
   IApiCliConfig,
 } from '@useoptic/cli-config';
 import { createDiff, Diff } from './diffs';
-import { DiffManager as OneOffDiff } from './diffs/diff-manager';
+import { OnDemandDiff } from './diffs/on-demand';
 import * as Uuid from 'uuid';
 
 export class SessionsManager {
@@ -82,7 +82,7 @@ class SessionDiffs {
     if (existingDiff) return existingDiff;
 
     const diffId = Uuid.v4();
-    const newDiff = createDiff(OneOffDiff, {
+    const newDiff = createDiff(OnDemandDiff, {
       captureId,
       configPath: this.configPath,
       captureBaseDirectory: this.capturesPath,

--- a/workspaces/cli-server/src/sessions.ts
+++ b/workspaces/cli-server/src/sessions.ts
@@ -1,0 +1,37 @@
+export class SessionsManager {
+  private sessions: Session[] = [];
+
+  private create(path: string) {
+    let id = '' + (this.sessions.length + 1);
+    let session = new Session(id, path);
+    this.sessions.push(session);
+    return session;
+  }
+
+  async start(path: string): Promise<Session> {
+    let existingSession = this.sessions.find(
+      (session) => path && session.path === path
+    );
+
+    let session = existingSession || this.create(path);
+
+    await session.start();
+
+    return session;
+  }
+
+  findById(sessionId: string): Session | undefined {
+    return (
+      (sessionId &&
+        this.sessions.find((session) => session.id === sessionId)) ||
+      undefined
+    );
+  }
+}
+
+export class Session {
+  constructor(readonly id: string, readonly path: string) {}
+
+  async start() {}
+  async stop() {}
+}

--- a/workspaces/cli-server/src/sessions.ts
+++ b/workspaces/cli-server/src/sessions.ts
@@ -78,9 +78,11 @@ class SessionDiffs {
     const newDiff = new DiffManager(diffId);
     this.diffsByCaptureId.set(captureId, newDiff);
 
-    const workerStarted = new Promise((resolve, reject) => {
-      newDiff.events.once('progress', resolve);
-      newDiff.events.once('error', reject);
+    newDiff.events.once('finish', () => {
+      this.diffsByCaptureId.delete(captureId);
+    });
+    newDiff.events.once('error', (err) => {
+      throw err;
     });
 
     await newDiff.start({
@@ -90,8 +92,6 @@ class SessionDiffs {
       diffId,
       specPath: this.specPath,
     });
-
-    await workerStarted;
 
     return newDiff;
   }

--- a/workspaces/cli-server/src/sessions.ts
+++ b/workspaces/cli-server/src/sessions.ts
@@ -3,7 +3,8 @@ import {
   readApiConfig,
   IApiCliConfig,
 } from '@useoptic/cli-config';
-import { DiffManager } from './diffs/diff-manager';
+import { createDiff, Diff } from './diffs';
+import { DiffManager as OneOffDiff } from './diffs/diff-manager';
 import * as Uuid from 'uuid';
 
 export class SessionsManager {
@@ -65,7 +66,7 @@ export class Session {
 }
 
 class SessionDiffs {
-  private diffsByCaptureId: Map<string, DiffManager> = new Map();
+  private diffsByCaptureId: Map<string, Diff> = new Map();
 
   constructor(
     readonly configPath: string,
@@ -76,12 +77,12 @@ class SessionDiffs {
   async startDiff(
     captureId: string,
     endpoints?: Array<{ pathId: string; method: string }>
-  ): Promise<DiffManager> {
+  ): Promise<Diff> {
     const existingDiff = this.diffsByCaptureId.get(captureId);
     if (existingDiff) return existingDiff;
 
     const diffId = Uuid.v4();
-    const newDiff = new DiffManager({
+    const newDiff = createDiff(OneOffDiff, {
       captureId,
       configPath: this.configPath,
       captureBaseDirectory: this.capturesPath,

--- a/workspaces/ui/src/contexts/CaptureContext.js
+++ b/workspaces/ui/src/contexts/CaptureContext.js
@@ -72,6 +72,9 @@ class _CaptureContextStore extends React.Component {
       if (notifData && notifData.hasOwnProperty('hasMoreInteractions')) {
         if (!notifData.hasMoreInteractions) {
           console.log('completed diff');
+          if (this.state.notificationChannel) {
+            this.state.notificationChannel.close();
+          }
           // track('Completed Diff', {
           //   captureId: this.props.captureId,
           // });

--- a/workspaces/ui/src/services/diff/LocalCliDiffService.ts
+++ b/workspaces/ui/src/services/diff/LocalCliDiffService.ts
@@ -46,7 +46,7 @@ export class LocalCliDiffService implements IDiffService {
 
   async listUnrecognizedUrls(): Promise<IListUnrecognizedUrlsResponse> {
     const url = `${this.baseUrl}/undocumented-urls`;
-    const json = (await JsonHttpClient.getJson(url)).urls;
+    const json = await JsonHttpClient.getJson(url);
     const result = UrlCounterHelper.fromJsonToSeq(json, this.rfcState);
     return result;
   }

--- a/workspaces/ui/src/services/diff/LocalCliDiffService.ts
+++ b/workspaces/ui/src/services/diff/LocalCliDiffService.ts
@@ -46,7 +46,7 @@ export class LocalCliDiffService implements IDiffService {
 
   async listUnrecognizedUrls(): Promise<IListUnrecognizedUrlsResponse> {
     const url = `${this.baseUrl}/undocumented-urls`;
-    const json = await JsonHttpClient.getJson(url);
+    const json = (await JsonHttpClient.getJson(url)).urls;
     const result = UrlCounterHelper.fromJsonToSeq(json, this.rfcState);
     return result;
   }


### PR DESCRIPTION
Currently, diffs of interactions vs spec happen on-demand, triggered from the UI. A lot of the logic for how to perform diffs and read the results were woven into the route handlers of the local `cli-server`. This is a first step in moving the diffing to the background and into a more reactive model.

Mostly an exercise in exploring the right interface and model, this PR introduces a `Session` construct for each local API running against optic, and a `SessionDiffs` manager, in charge of spawning and managing diff workers for said API. It does so through a generic `Diff` interface, exposing `DiffProgress` and `DiffQueries` interfaces to the route handlers to interact with the diffs with. Results are generally returned as `Readable` streams that can be piped straight through or manipulated. The existing `DiffManager` is renamed `OnDemandDiff` and implements this generic interface, putting it now fully in charge of matters like running the worker, persistence of results, etc.

Behaviour wise, nothing has really changed thus far. It's still the UI starting the diff that's the main trigger for a diff being performed for now. However, this PR puts us in a situation where we can implement a longer running, continuous type of diff, that be driven through other triggers. As long as the generic `Diff` interface is implemented, this can happen without changes to the route handlers or UI side.