### PR TITLE
Support for test tasks

### DIFF
--- a/workspaces/cli-config/src/index.ts
+++ b/workspaces/cli-config/src/index.ts
@@ -151,8 +151,20 @@ function randomLowerBound(): number {
   return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
-export function isTestTask(aliasedTask: IOpticTaskAliased) {
-  return aliasedTask.useTask && aliasedTask.command;
+export function isTestTask(aliasedTask: IOpticTaskAliased): boolean {
+  return Boolean(aliasedTask.useTask && aliasedTask.command);
+}
+
+export function isRecommendedTask(aliasedTask: IOpticTaskAliased): boolean {
+  return Boolean(
+    aliasedTask.command && (aliasedTask.inboundUrl || aliasedTask.baseUrl)
+  );
+}
+
+export function isManualTask(aliasedTask: IOpticTaskAliased): boolean {
+  return Boolean(
+    (aliasedTask.inboundUrl || aliasedTask.baseUrl) && aliasedTask.targetUrl
+  );
 }
 
 export async function TaskToStartConfig(

--- a/workspaces/cli-config/src/index.ts
+++ b/workspaces/cli-config/src/index.ts
@@ -318,4 +318,10 @@ export interface ITestingConfig {
   authToken: string;
 }
 
+export enum Modes {
+  Recommended = 'Recommended',
+  Manual = 'Manual',
+  Test = 'Test',
+}
+
 export { parseIgnore, parseRule, IIgnoreRunnable };

--- a/workspaces/cli-shared/src/captures/avro/file-system/capture-saver.ts
+++ b/workspaces/cli-shared/src/captures/avro/file-system/capture-saver.ts
@@ -21,6 +21,9 @@ export class CaptureSaver implements ICaptureSaver {
     maxSize: 20,
     maxTime: 500,
   });
+
+  public savePromises: Promise<void>[] = [];
+
   private batchCount: number = 0;
 
   constructor(private config: IFileSystemCaptureSaverConfig) {}
@@ -93,10 +96,11 @@ export class CaptureSaver implements ICaptureSaver {
 
   async save(sample: IHttpInteraction) {
     // don't await flush, just enqueue
-    this.batcher.add(sample);
+    this.savePromises.push(this.batcher.add(sample));
   }
 
   async cleanup() {
+    await Promise.all(this.savePromises);
     developerDebugLogger('stopping capture saver');
   }
 }

--- a/workspaces/cli-shared/src/command-and-proxy-session-manager.ts
+++ b/workspaces/cli-shared/src/command-and-proxy-session-manager.ts
@@ -10,9 +10,13 @@ import {
 } from './index';
 import url from 'url';
 import { buildQueryStringParser } from './query/build-query-string-parser';
+import { awaitTaskUp, Modes } from './tasks/await-up';
 
 class CommandAndProxySessionManager {
-  constructor(private config: IOpticTaskRunnerConfig) {}
+  constructor(
+    private config: IOpticTaskRunnerConfig,
+    private onStarted?: () => void
+  ) {}
 
   async run(persistenceManager: ICaptureSaver) {
     const commandSession = new CommandSession();
@@ -83,6 +87,14 @@ class CommandAndProxySessionManager {
           ...opticServiceConfig,
         },
       });
+
+      if (this.onStarted) {
+        // run test task for manual mode
+        await awaitTaskUp(Modes.Recommended, this.config);
+        await this.onStarted();
+        await commandSession.stop();
+      }
+
       const commandStoppedPromise = new Promise((resolve) => {
         commandSession.events.on('stopped', ({ state }) => {
           developerDebugLogger(`command session stopped (${state})`);
@@ -90,6 +102,11 @@ class CommandAndProxySessionManager {
         });
       });
       promises.push(commandStoppedPromise);
+    } else {
+      if (this.onStarted) {
+        await awaitTaskUp(Modes.Manual, this.config);
+        await this.onStarted();
+      }
     }
 
     const processInterruptedPromise = new Promise((resolve) => {

--- a/workspaces/cli-shared/src/command-and-proxy-session-manager.ts
+++ b/workspaces/cli-shared/src/command-and-proxy-session-manager.ts
@@ -1,4 +1,4 @@
-import { IOpticTaskRunnerConfig } from '@useoptic/cli-config';
+import { IOpticTaskRunnerConfig, Modes } from '@useoptic/cli-config';
 import { IHttpInteraction } from '@useoptic/domain-types';
 import { CommandSession } from './command-session';
 import { HttpToolkitCapturingProxy } from './httptoolkit-capturing-proxy';
@@ -10,7 +10,7 @@ import {
 } from './index';
 import url from 'url';
 import { buildQueryStringParser } from './query/build-query-string-parser';
-import { awaitTaskUp, Modes } from './tasks/await-up';
+import { awaitTaskUp } from './tasks/await-up';
 
 class CommandAndProxySessionManager {
   constructor(

--- a/workspaces/cli-shared/src/index.ts
+++ b/workspaces/cli-shared/src/index.ts
@@ -66,7 +66,8 @@ export interface IOpticTaskRunner {
   run(
     cli: Command,
     cliConfig: IApiCliConfig,
-    taskConfig: IOpticTaskRunnerConfig
+    taskConfig: IOpticTaskRunnerConfig,
+    commandToRunWhenStarted?: string
   ): Promise<void>;
 }
 

--- a/workspaces/cli-shared/src/tasks/await-up.ts
+++ b/workspaces/cli-shared/src/tasks/await-up.ts
@@ -1,0 +1,60 @@
+import { IOpticTask, IOpticTaskRunnerConfig } from '@useoptic/cli-config';
+import url from 'url';
+import waitOn from 'wait-on';
+
+export enum Modes {
+  Recommended = 'Recommended',
+  Manual = 'Manual',
+}
+
+export async function awaitTaskUp(
+  mode: Modes,
+  runnerConfig: IOpticTaskRunnerConfig
+): Promise<void> {
+  const proxyStartedPromise = (() => {
+    const proxyConfig = runnerConfig.proxyConfig;
+    const proxyPort = proxyConfig.port;
+    const proxyHost = proxyConfig.host;
+
+    const expected = `${proxyHost}:${proxyPort}`;
+
+    return new Promise((resolve) => {
+      waitOn({
+        resources: [`tcp:${expected}`],
+        delay: 0,
+        tcpTimeout: 500,
+        timeout: 60000,
+      })
+        .then(() => {
+          resolve(true);
+        }) //if service resolves we assume it's up.
+        .catch(() => resolve(false));
+    });
+  })();
+
+  const serviceStartedPromise = (() => {
+    const serviceConfig = runnerConfig.serviceConfig;
+    const servicePort = serviceConfig.port;
+
+    return new Promise((resolve) => {
+      waitOn({
+        resources: [`tcp:${servicePort}`],
+        delay: 0,
+        tcpTimeout: 500,
+        timeout: 60000,
+      })
+        .then(() => {
+          resolve(true);
+        }) //if service resolves we assume it's up.
+        .catch(() => resolve(false));
+    });
+  })();
+
+  if (mode === Modes.Recommended) {
+    await Promise.all([serviceStartedPromise, proxyStartedPromise]);
+  }
+
+  if (mode === Modes.Manual) {
+    await Promise.all([proxyStartedPromise]);
+  }
+}

--- a/workspaces/cli-shared/src/tasks/await-up.ts
+++ b/workspaces/cli-shared/src/tasks/await-up.ts
@@ -1,11 +1,10 @@
-import { IOpticTask, IOpticTaskRunnerConfig } from '@useoptic/cli-config';
+import {
+  IOpticTask,
+  IOpticTaskRunnerConfig,
+  Modes,
+} from '@useoptic/cli-config';
 import url from 'url';
 import waitOn from 'wait-on';
-
-export enum Modes {
-  Recommended = 'Recommended',
-  Manual = 'Manual',
-}
 
 export async function awaitTaskUp(
   mode: Modes,

--- a/workspaces/cli-shared/src/tasks/index.ts
+++ b/workspaces/cli-shared/src/tasks/index.ts
@@ -1,6 +1,7 @@
 import { IOpticTaskRunner, Command } from '../index';
 import {
   IApiCliConfig,
+  IOpticTaskRunnerConfig,
   TargetPortUnavailableError,
   TaskNotFoundError,
   TaskToStartConfig,
@@ -11,14 +12,19 @@ import { errorFromOptic } from '../conversation';
 export class CliTaskSession {
   constructor(private runner: IOpticTaskRunner) {}
 
-  async start(cli: Command, config: IApiCliConfig, taskName: string) {
+  async start(
+    cli: Command,
+    config: IApiCliConfig,
+    taskName: string,
+    commandToRunWhenStarted?: string
+  ): Promise<void> {
     try {
       const task = config.tasks[taskName];
       if (!task) {
         throw new TaskNotFoundError(taskName);
       }
       const taskConfig = await TaskToStartConfig(task);
-      await this.runner.run(cli, config, taskConfig);
+      await this.runner.run(cli, config, taskConfig, commandToRunWhenStarted);
     } catch (e) {
       if (e instanceof TargetPortUnavailableError) {
         cli.log(errorFromOptic(e.message));

--- a/workspaces/local-cli/package.json
+++ b/workspaces/local-cli/package.json
@@ -37,6 +37,7 @@
     "listr": "^0.14.3",
     "nice-try": "^2.0.1",
     "react-dev-utils": "^10.0.0",
+    "wait-until": "^0.0.2",
     "jsesc": "^3.0.1",
     "slugify": "^1.4.0",
     "strip-ansi": "^6.0.0",

--- a/workspaces/local-cli/package.json
+++ b/workspaces/local-cli/package.json
@@ -37,7 +37,6 @@
     "listr": "^0.14.3",
     "nice-try": "^2.0.1",
     "react-dev-utils": "^10.0.0",
-    "wait-until": "^0.0.2",
     "jsesc": "^3.0.1",
     "slugify": "^1.4.0",
     "strip-ansi": "^6.0.0",

--- a/workspaces/local-cli/src/commands/scripts.ts
+++ b/workspaces/local-cli/src/commands/scripts.ts
@@ -11,6 +11,7 @@ import { spawn, SpawnOptions } from 'child_process';
 import { IOpticScript } from '@useoptic/cli-config/build';
 import { fromOptic } from '@useoptic/cli-shared';
 import { generateOas } from './generate/oas';
+import { spawnProcess } from '../shared/spawn-process';
 export default class Scripts extends Command {
   static description = 'Run one of the scripts in your optic.yml file';
 
@@ -148,24 +149,4 @@ async function tryInstall(installScript: string): Promise<boolean> {
   const status = await spawnProcess(installScript);
   cli.action.stop('Success!');
   return status;
-}
-
-async function spawnProcess(command: string, env: any = {}): Promise<boolean> {
-  const taskOptions: SpawnOptions = {
-    env: {
-      ...process.env,
-      ...env,
-    },
-    shell: true,
-    cwd: process.cwd(),
-    stdio: 'inherit',
-  };
-
-  const child = spawn(command, taskOptions);
-
-  return await new Promise((resolve) => {
-    child.on('exit', (code) => {
-      resolve(code === 0);
-    });
-  });
 }

--- a/workspaces/local-cli/src/shared/local-cli-task-runner.ts
+++ b/workspaces/local-cli/src/shared/local-cli-task-runner.ts
@@ -214,7 +214,7 @@ ${blockers.map((x) => `[pid ${x.pid}]: ${x.cmd}`).join('\n')}
             OPTIC_PROXY_HOST: taskConfig.proxyConfig.host.toString(),
             OPTIC_PROXY: `http://${taskConfig.proxyConfig.host.toString()}:${taskConfig.proxyConfig.port.toString()}`,
           });
-          return new Promise((resolve) => setTimeout(resolve, 500)); // needs time to finish saving
+          // return new Promise((resolve) => setTimeout(resolve, 500)); // needs time to finish saving
         }
       : undefined;
 

--- a/workspaces/local-cli/src/shared/local-cli-task-runner.ts
+++ b/workspaces/local-cli/src/shared/local-cli-task-runner.ts
@@ -178,18 +178,20 @@ ${blockers.map((x) => `[pid ${x.pid}]: ${x.cmd}`).join('\n')}
     process.env.OPTIC_ENABLE_CAPTURE_BODY = 'yes';
 
     const testCommand = commandToRunWhenStarted
-      ? () => {
+      ? async () => {
           console.log(
             fromOptic(
               'Running test command ' +
                 colors.grey.bold(commandToRunWhenStarted)
             )
           );
-          spawnProcess(commandToRunWhenStarted!, {
+
+          await spawnProcess(commandToRunWhenStarted!, {
             OPTIC_PROXY_PORT: taskConfig.proxyConfig.port.toString(),
             OPTIC_PROXY_HOST: taskConfig.proxyConfig.host.toString(),
             OPTIC_PROXY: `http://${taskConfig.proxyConfig.host.toString()}:${taskConfig.proxyConfig.port.toString()}`,
           });
+          return new Promise((resolve) => setTimeout(resolve, 500)); // needs time to finish saving
         }
       : undefined;
 

--- a/workspaces/local-cli/src/shared/local-cli-task-runner.ts
+++ b/workspaces/local-cli/src/shared/local-cli-task-runner.ts
@@ -1,18 +1,21 @@
 import { Command, flags } from '@oclif/command';
 import { ensureDaemonStarted } from '@useoptic/cli-server';
 import path from 'path';
+import colors from 'colors';
 import {
   IApiCliConfig,
   IOpticTaskRunnerConfig,
   IPathMapping,
   TargetPortUnavailableError,
   deprecationLogger,
+  isTestTask,
 } from '@useoptic/cli-config';
 import { opticTaskToProps, trackUserEvent } from './analytics';
 import { lockFilePath } from './paths';
 import { Client, SpecServiceClient } from '@useoptic/cli-client';
 import findProcess from 'find-process';
 import stripAnsi from 'strip-ansi';
+import cliux from 'cli-ux';
 import {
   ExitedTaskWithLocalCli,
   StartedTaskWithLocalCli,
@@ -38,9 +41,9 @@ import { CliTaskSession } from '@useoptic/cli-shared/build/tasks';
 import { CaptureSaverWithDiffs } from '@useoptic/cli-shared/build/captures/avro/file-system/capture-saver-with-diffs';
 import { EventEmitter } from 'events';
 import { Config } from '../config';
-import { Debugger } from 'debug';
-import { ApiCheckCompleted } from '@useoptic/analytics/lib/events/onboarding';
 import { printCoverage } from './coverage';
+import { spawnProcess } from './spawn-process';
+import { command } from '@oclif/test';
 
 export const runCommandFlags = {
   coverage: flags.boolean({ char: 'c', default: false, required: false }),
@@ -69,7 +72,16 @@ export async function LocalTaskSessionWrapper(
   const captureId = uuid.v4();
   const runner = new LocalCliTaskRunner(captureId, paths);
   const session = new CliTaskSession(runner);
-  await session.start(cli, config, taskName);
+
+  const task = config.tasks[taskName];
+  if (task && isTestTask(task)) {
+    cli.log(
+      fromOptic(`Running dependent task ${colors.grey.bold(task.useTask!)}...`)
+    );
+    await session.start(cli, config, task.useTask!, task.command!);
+  } else {
+    await session.start(cli, config, taskName);
+  }
 
   if (flags.coverage) {
     await printCoverage(paths, taskName, captureId);
@@ -84,7 +96,8 @@ export class LocalCliTaskRunner implements IOpticTaskRunner {
   async run(
     cli: Command,
     config: IApiCliConfig,
-    taskConfig: IOpticTaskRunnerConfig
+    taskConfig: IOpticTaskRunnerConfig,
+    commandToRunWhenStarted?: string
   ): Promise<void> {
     ////////////////////////////////////////////////////////////////////////////////
 
@@ -163,7 +176,27 @@ ${blockers.map((x) => `[pid ${x.pid}]: ${x.cmd}`).join('\n')}
 
     ////////////////////////////////////////////////////////////////////////////////
     process.env.OPTIC_ENABLE_CAPTURE_BODY = 'yes';
-    const sessionManager = new CommandAndProxySessionManager(taskConfig);
+
+    const testCommand = commandToRunWhenStarted
+      ? () => {
+          console.log(
+            fromOptic(
+              'Running test command ' +
+                colors.grey.bold(commandToRunWhenStarted)
+            )
+          );
+          spawnProcess(commandToRunWhenStarted!, {
+            OPTIC_PROXY_PORT: taskConfig.proxyConfig.port.toString(),
+            OPTIC_PROXY_HOST: taskConfig.proxyConfig.host.toString(),
+            OPTIC_PROXY: `http://${taskConfig.proxyConfig.host.toString()}:${taskConfig.proxyConfig.port.toString()}`,
+          });
+        }
+      : undefined;
+
+    const sessionManager = new CommandAndProxySessionManager(
+      taskConfig,
+      testCommand
+    );
 
     await sessionManager.run(persistenceManager);
 

--- a/workspaces/local-cli/src/shared/local-cli-task-runner.ts
+++ b/workspaces/local-cli/src/shared/local-cli-task-runner.ts
@@ -78,6 +78,25 @@ export async function LocalTaskSessionWrapper(
   const session = new CliTaskSession(runner);
 
   const task = config.tasks[taskName];
+
+  if (!task) {
+    cli.log(
+      fromOptic(
+        `Task ${colors.grey.bold(
+          taskName
+        )} does not exist. Try one of these ${colors.grey.bold(
+          'api run <taskname>'
+        )}`
+      )
+    );
+    return cli.log(
+      Object.keys(config.tasks || [])
+        .map((i) => '- ' + i)
+        .sort()
+        .join('\n')
+    );
+  }
+
   if (task && isTestTask(task)) {
     cli.log(
       fromOptic(`Running dependent task ${colors.grey.bold(task.useTask!)}...`)

--- a/workspaces/local-cli/src/shared/spawn-process.ts
+++ b/workspaces/local-cli/src/shared/spawn-process.ts
@@ -1,0 +1,24 @@
+import { spawn, SpawnOptions } from 'child_process';
+
+export async function spawnProcess(
+  command: string,
+  env: any = {}
+): Promise<boolean> {
+  const taskOptions: SpawnOptions = {
+    env: {
+      ...process.env,
+      ...env,
+    },
+    shell: true,
+    cwd: process.cwd(),
+    stdio: 'inherit',
+  };
+
+  const child = spawn(command, taskOptions);
+
+  return await new Promise((resolve) => {
+    child.on('exit', (code) => {
+      resolve(code === 0);
+    });
+  });
+}

--- a/workspaces/local-cli/src/shared/verify/verify.ts
+++ b/workspaces/local-cli/src/shared/verify/verify.ts
@@ -13,6 +13,8 @@ import {
   IOpticTaskAliased,
   IApiCliConfig,
   isTestTask,
+  isManualTask,
+  isRecommendedTask,
 } from '@useoptic/cli-config';
 import {
   HttpToolkitCapturingProxy,
@@ -86,132 +88,133 @@ export async function verifyTask(
     return false;
   }
 
-  const mode: Modes | null = (() => {
-    if (isTestTask(foundTask!)) {
-      return Modes.Test;
-    }
+  if (taskExists && foundTask) {
+    const mode: Modes | null = (() => {
+      if (isTestTask(foundTask!)) {
+        return Modes.Test;
+      }
 
-    const isManual =
-      (foundTask!.inboundUrl || foundTask!.baseUrl) && foundTask!.targetUrl;
-    if (isManual) {
-      return Modes.Manual;
-    }
+      if (isManualTask(foundTask)) {
+        return Modes.Manual;
+      }
 
-    const isRecommended =
-      foundTask!.command && (foundTask!.inboundUrl || foundTask!.baseUrl);
-    if (isRecommended) {
-      return Modes.Recommended;
-    }
+      if (isRecommendedTask(foundTask)) {
+        return Modes.Recommended;
+      }
 
-    return null;
-  })();
+      return null;
+    })();
 
-  cli.log(
-    '\n' + fromOptic(colors.underline(`Checking task ${colors.bold(taskName)}`))
-  );
-
-  if (mode === null) {
-    cli.log(fromOptic(colors.red(`Invalid task configuration. `)));
-    return false;
-  }
-
-  let passedAll = false;
-
-  if (mode === Modes.Test) {
-    if (dependent) {
-      passedAll = false;
-      cli.log(
-        fromOptic(
-          colors.red(
-            `Test tasks can not depend on other test tasks. ${colors.bold(
-              foundTask!.useTask!
-            )} cannot be used here.`
-          )
-        )
-      );
-    } else {
-      cli.log(
-        fromOptic(
-          colors.green(
-            `This is a test task, checking dependent task ${colors.bold(
-              foundTask!.useTask!
-            )}`
-          )
-        )
-      );
-
-      passedAll = await verifyTask(cli, foundTask!.useTask!, true);
-    }
-  }
-
-  if (mode == Modes.Recommended) {
-    const startConfig = await TaskToStartConfig(foundTask!);
-    const results = await verifyRecommended(foundTask!, startConfig!);
-    passedAll = results.passedAll;
-
-    await trackUserEvent(
-      ApiCheckCompleted.withProps({
-        passed: passedAll,
-        mode: mode,
-        taskName: taskName,
-        task: {
-          ...foundTask!,
-        },
-        recommended: {
-          commandIsLongRunning: results.assertions.longRunningAssertion,
-          apiProcessStartsOnAssignedHost:
-            results.assertions.startOnHostAssertion,
-          apiProcessStartsOnAssignedPort:
-            results.assertions.startOnPortAssertion,
-          proxyCanStartAtInboundUrl:
-            results.assertions.proxyCanStartAtInboundUrl,
-        },
-      })
+    cli.log(
+      '\n' +
+        fromOptic(colors.underline(`Checking task ${colors.bold(taskName)}`))
     );
-  }
-  if (mode == Modes.Manual) {
-    const startConfig = await TaskToStartConfig(foundTask!);
-    const results = await verifyManual(foundTask!, startConfig!);
-    passedAll = results.passedAll;
-    await trackUserEvent(
-      ApiCheckCompleted.withProps({
-        passed: passedAll,
-        mode: mode,
-        taskName: taskName,
-        task: {
-          ...foundTask!,
-        },
-        manual: {
-          proxyCanStartAtInboundUrl:
-            results.assertions.proxyCanStartAtInboundUrl,
-          proxyTargetUrlResolves: results.assertions.isTargetResolvable,
-        },
-      })
-    );
-  }
 
-  if (!dependent) {
-    if (passedAll) {
-      cli.log(
-        '\n' +
+    if (mode === null) {
+      cli.log(fromOptic(colors.red(`Invalid task configuration. `)));
+      return false;
+    }
+
+    let passedAll = false;
+
+    if (mode === Modes.Test) {
+      if (dependent) {
+        passedAll = false;
+        cli.log(
           fromOptic(
-            colors.green.bold(
-              `All Passed! This task is setup properly. Nice work!`
+            colors.red(
+              `Test tasks can not depend on other test tasks. ${colors.bold(
+                foundTask!.useTask!
+              )} cannot be used here.`
             )
           )
-      );
-    } else {
-      cli.log(
-        '\n' +
+        );
+      } else {
+        cli.log(
           fromOptic(
-            colors.red.bold(
-              `Some checks failed. Steps to fix can be found here: useoptic.com/docs/check-fail`
+            colors.green(
+              `This is a test task, checking dependent task ${colors.bold(
+                foundTask!.useTask!
+              )}`
             )
           )
-      );
-      // console.log(results);
+        );
+
+        passedAll = await verifyTask(cli, foundTask!.useTask!, true);
+      }
     }
+
+    if (mode == Modes.Recommended) {
+      const startConfig = await TaskToStartConfig(foundTask!);
+      const results = await verifyRecommended(foundTask!, startConfig!);
+      passedAll = results.passedAll;
+
+      await trackUserEvent(
+        ApiCheckCompleted.withProps({
+          passed: passedAll,
+          mode: mode,
+          taskName: taskName,
+          task: {
+            ...foundTask!,
+          },
+          recommended: {
+            commandIsLongRunning: results.assertions.longRunningAssertion,
+            apiProcessStartsOnAssignedHost:
+              results.assertions.startOnHostAssertion,
+            apiProcessStartsOnAssignedPort:
+              results.assertions.startOnPortAssertion,
+            proxyCanStartAtInboundUrl:
+              results.assertions.proxyCanStartAtInboundUrl,
+          },
+        })
+      );
+    }
+    if (mode == Modes.Manual) {
+      const startConfig = await TaskToStartConfig(foundTask!);
+      const results = await verifyManual(foundTask!, startConfig!);
+      passedAll = results.passedAll;
+      await trackUserEvent(
+        ApiCheckCompleted.withProps({
+          passed: passedAll,
+          mode: mode,
+          taskName: taskName,
+          task: {
+            ...foundTask!,
+          },
+          manual: {
+            proxyCanStartAtInboundUrl:
+              results.assertions.proxyCanStartAtInboundUrl,
+            proxyTargetUrlResolves: results.assertions.isTargetResolvable,
+          },
+        })
+      );
+    }
+
+    if (!dependent) {
+      if (passedAll) {
+        cli.log(
+          '\n' +
+            fromOptic(
+              colors.green.bold(
+                `All Passed! This task is setup properly. Nice work!`
+              )
+            )
+        );
+      } else {
+        cli.log(
+          '\n' +
+            fromOptic(
+              colors.red.bold(
+                `Some checks failed. Steps to fix can be found here: useoptic.com/docs/check-fail`
+              )
+            )
+        );
+        // console.log(results);
+      }
+    }
+
+    return passedAll;
   }
 
-  return passedAll;
+  return false;
 }

--- a/workspaces/local-cli/src/shared/verify/verify.ts
+++ b/workspaces/local-cli/src/shared/verify/verify.ts
@@ -32,11 +32,7 @@ import {
   ProxyCanStartAtInboundUrl,
   ProxyTargetUrlResolves,
 } from '@useoptic/analytics/lib/interfaces/ApiCheck';
-
-enum Modes {
-  Recommended = 'Recommended',
-  Manual = 'Manual',
-}
+import { Modes } from '@useoptic/cli-shared/build/tasks/await-up';
 
 export async function verifyTask(
   cli: Command,

--- a/yarn.lock
+++ b/yarn.lock
@@ -16776,6 +16776,11 @@ wait-on@^4.0.0:
     request-promise-native "^1.0.8"
     rxjs "^6.5.5"
 
+wait-until@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/wait-until/-/wait-until-0.0.2.tgz#7a8abaef5590d970fd44697d436b5761e3eaedbe"
+  integrity sha1-eoq671WQ2XD9RGl9Q2tXYePq7b4=
+
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16776,11 +16776,6 @@ wait-on@^4.0.0:
     request-promise-native "^1.0.8"
     rxjs "^6.5.5"
 
-wait-until@^0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/wait-until/-/wait-until-0.0.2.tgz#7a8abaef5590d970fd44697d436b5761e3eaedbe"
-  integrity sha1-eoq671WQ2XD9RGl9Q2tXYePq7b4=
-
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"


### PR DESCRIPTION
**Problem**: During our off-cycle time, Lou and I have been thinking a lot about how to bring more sources of traffic into Optic. This should aid activation by giving people more to do once they're inside the tool. One traffic source, which many teams may come with, is their code tests, poly traffic, or postman collections, etc. Today it's non-trivial to use automated traffic with Optic tasks -- it is only doable today w/ two shells and some out-of-band knowledge for the traffic generator to know where the proxy runs. 

**Goal**: Make it possible to run automated traffic through Optic in a single shell, both locally and (eventually) in CI

**Solution**: Test tasks that are designed to run traffic against a service whose lifecycle Optic manages. For example:
- start task (`docker up`), test task (`newman run ... $OPTIC_PROXY`)
- start task (`npm start`), test task (`yarn run tests --host $OPTIC_PROXY`)

```
tasks:
  # The default task, invoke using `api run start`
  # Learn how to set up and use Optic at https://app.useoptic.com
  start:
    command: npm run server-start
    inboundUrl: http://localhost:3005
  test:
    command: "mocha test1.js"
    useTask: start
```

<img width="968" alt="Screen Shot 2020-10-06 at 12 36 49 PM" src="https://user-images.githubusercontent.com/5900338/95231003-9cc9e080-07d0-11eb-9a0a-e4a7c24907b7.png">


**Things to review:** 
- This feels a bit 'jammed in' today, but I think it's mainly down to the dependency injection choices we've made (which make sense given the multiple clis). Open to other approaches :) 
- There's some unknown race condition with traffic saving we've never seen before. The traffic runs right away once the service is up and if we shut down the proxy before it saves it never hits the capture repository. With this in local-cli-task-runner it works, `return new Promise((resolve) => setTimeout(resolve, 500));`. Basically seems like the tail logs are liable to get lost if it's received within a few ms of triggering shutdown and cleanup of the proxy. 