### PR TITLE
Traverse and visit BodyDescriptor instead of JsonValue to allow for future optimisations

### DIFF
--- a/workspaces/diff-engine/src/lib.rs
+++ b/workspaces/diff-engine/src/lib.rs
@@ -16,6 +16,7 @@ pub use interactions::result::InteractionDiffResult;
 pub use projections::{EndpointProjection, ShapeProjection, SpecProjection};
 pub use protos::shapehash;
 pub use shapes::diff as diff_shape;
+pub use state::body::BodyDescriptor;
 
 pub mod errors {
   pub use super::events::EventLoadingError;

--- a/workspaces/diff-engine/src/shapes/mod.rs
+++ b/workspaces/diff-engine/src/shapes/mod.rs
@@ -1,4 +1,4 @@
-use serde_json::Value as JsonValue;
+use crate::state::body::BodyDescriptor;
 
 mod result;
 pub mod traverser;
@@ -14,7 +14,7 @@ use visitors::JsonBodyVisitors;
 
 pub fn diff(
   shapes_projection: &ShapeProjection,
-  json_body: Option<JsonValue>,
+  body: Option<BodyDescriptor>,
   shape_id: &ShapeId,
 ) -> Vec<ShapeDiffResult> {
   let shapes_queries = ShapeQueries::new(shapes_projection);
@@ -23,10 +23,10 @@ pub fn diff(
 
   eprintln!(
     "shape-diff: diffing body with shape id {},  {:?}",
-    shape_id, json_body
+    shape_id, body
   );
 
-  shape_traverser.traverse_root_shape(json_body, shape_id, &mut diff_visitors);
+  shape_traverser.traverse_root_shape(body, shape_id, &mut diff_visitors);
 
   diff_visitors.take_results().unwrap()
 }

--- a/workspaces/diff-engine/src/shapes/traverser.rs
+++ b/workspaces/diff-engine/src/shapes/traverser.rs
@@ -2,6 +2,7 @@ use super::visitors::{
   JlasArrayVisitor, JlasObjectKeyVisitor, JlasObjectVisitor, JlasPrimitiveVisitor, JsonBodyVisitors,
 };
 use crate::queries::shape::{ChoiceOutput, ShapeQueries};
+use crate::state::body::BodyDescriptor;
 use crate::state::shape::{FieldId, ShapeId, ShapeKind, ShapeParameterId};
 use serde::Serialize;
 use serde_json::Value as JsonValue;
@@ -17,45 +18,39 @@ impl<'a> Traverser<'a> {
 
   pub fn traverse_root_shape<R>(
     &self,
-    json_body_option: Option<JsonValue>,
+    body_option: Option<BodyDescriptor>,
     shape_id: &ShapeId,
     visitors: &mut impl JsonBodyVisitors<R>,
   ) {
     let body_trail = JsonTrail::empty();
     let trail_origin = ShapeTrail::new(shape_id.clone());
     let choices: Vec<ChoiceOutput> = self.shape_queries.list_trail_choices(&trail_origin);
-    self.traverse(
-      json_body_option,
-      body_trail,
-      trail_origin,
-      &choices,
-      visitors,
-    )
+    self.traverse(body_option, body_trail, trail_origin, &choices, visitors)
   }
 
   pub fn traverse<R>(
     &self,
-    json_body_option: Option<JsonValue>,
+    body_option: Option<BodyDescriptor>,
     body_trail: JsonTrail,
     trail_origin: ShapeTrail,
     trail_choices: &Vec<ChoiceOutput>,
     visitors: &mut impl JsonBodyVisitors<R>,
   ) {
-    // eprintln!("shape-traverser: traversing json value");
-    if let None = json_body_option {
-      // eprintln!("shape-traverser: no json value available");
+    // eprintln!("shape-traverser: traversing body");
+    if let None = body_option {
+      // eprintln!("shape-traverser: no body available");
       return;
     }
 
-    // eprintln!("shape-traverser: json value found");
-    let json_body = json_body_option.unwrap();
+    // eprintln!("shape-traverser: body found");
+    let body = body_option.unwrap();
 
-    match json_body {
-      JsonValue::Array(_) => {
+    match body {
+      BodyDescriptor::Array(_) => {
         // eprintln!("shape-traverser: visiting array");
         let array_visitor = visitors.array();
         let matching_choices =
-          array_visitor.visit(&json_body, &body_trail, &trail_origin, trail_choices);
+          array_visitor.visit(&body, &body_trail, &trail_origin, trail_choices);
         let item_choices = matching_choices
           .iter()
           .flat_map(move |choice| {
@@ -83,43 +78,41 @@ impl<'a> Traverser<'a> {
             }
           })
           .collect::<Vec<_>>();
-        let items = match json_body {
-          JsonValue::Array(items) => items,
+
+        let items = match body {
+          BodyDescriptor::Array(items) => items,
           _ => unreachable!("expect json body to be an array"),
         };
-        items
-          .into_iter()
-          .enumerate()
-          .for_each(|(index, item_json)| {
-            let item_json_trail =
-              body_trail.with_component(JsonTrailPathComponent::JsonArrayItem {
-                index: index as u32,
-              });
 
-            let new_trail_origin = trail_origin.clone();
-
-            if !item_choices.is_empty() {
-              self.traverse(
-                Some(item_json),
-                item_json_trail,
-                new_trail_origin,
-                &item_choices,
-                visitors,
-              )
-            }
+        items.into_all().enumerate().for_each(|(index, item)| {
+          let item_json_trail = body_trail.with_component(JsonTrailPathComponent::JsonArrayItem {
+            index: index as u32,
           });
+
+          let new_trail_origin = trail_origin.clone();
+
+          if !item_choices.is_empty() {
+            self.traverse(
+              Some(item),
+              item_json_trail,
+              new_trail_origin,
+              &item_choices,
+              visitors,
+            )
+          }
+        });
       }
-      JsonValue::Object(_) => {
+      BodyDescriptor::Object(_) => {
         // eprintln!("shape-traverser: visiting object");
         let matching_choices = {
           let object_visitor = visitors.object();
-          object_visitor.visit(&json_body, &body_trail, &trail_origin, trail_choices)
+          object_visitor.visit(&body, &body_trail, &trail_origin, trail_choices)
         };
         // eprintln!("shape-traverser: visiting object keys");
         let object_key_visitor = visitors.object_key();
 
-        let fields = match json_body {
-          JsonValue::Object(fields) => fields,
+        let object = match body {
+          BodyDescriptor::Object(fields) => fields,
           _ => unreachable!("expect json body to be an object"),
         };
 
@@ -151,10 +144,10 @@ impl<'a> Traverser<'a> {
           })
           .collect::<Vec<_>>();
 
-        let object_keys = fields.keys().map(|x| (*x).clone()).collect::<Vec<_>>();
+        let object_keys = object.keys().map(|x| (*x).clone()).collect::<Vec<_>>();
         object_key_visitor.visit(&body_trail, &object_keys, &object_key_choices);
 
-        fields.into_iter().for_each(|(field_key, field_json)| {
+        object.entries().for_each(|(field_key, field_body)| {
           let field_json_trail = body_trail.with_component(JsonTrailPathComponent::JsonObjectKey {
             key: field_key.clone(),
           });
@@ -197,7 +190,7 @@ impl<'a> Traverser<'a> {
 
           if !field_choices.is_empty() {
             self.traverse(
-              Some(field_json),
+              Some(field_body),
               field_json_trail,
               new_trail_origin,
               &field_choices,

--- a/workspaces/diff-engine/src/shapes/visitors/diff.rs
+++ b/workspaces/diff-engine/src/shapes/visitors/diff.rs
@@ -5,6 +5,7 @@ use super::{
 use crate::queries::shape::ChoiceOutput;
 use crate::shapes::ShapeDiffResult;
 use crate::shapes::{JsonTrail, JsonTrailPathComponent, ShapeTrail, ShapeTrailPathComponent};
+use crate::state::body::BodyDescriptor;
 use crate::state::shape::{FieldId, ShapeId, ShapeKind};
 use serde_json::Value as JsonValue;
 
@@ -75,7 +76,7 @@ impl JsonBodyVisitor<ShapeDiffResult> for DiffPrimitiveVisitor {
 impl JlasPrimitiveVisitor<ShapeDiffResult> for DiffPrimitiveVisitor {
   fn visit(
     &mut self,
-    json: JsonValue,
+    body: BodyDescriptor,
     json_trail: JsonTrail,
     trail_origin: ShapeTrail,
     trail_choices: &Vec<ChoiceOutput>,
@@ -89,20 +90,20 @@ impl JlasPrimitiveVisitor<ShapeDiffResult> for DiffPrimitiveVisitor {
     }
 
     let (matched, unmatched): (Vec<&ChoiceOutput>, Vec<&ChoiceOutput>) =
-      trail_choices.iter().partition(|choice| match &json {
-        JsonValue::Bool(x) => match choice.core_shape_kind {
+      trail_choices.iter().partition(|choice| match &body {
+        BodyDescriptor::Boolean => match choice.core_shape_kind {
           ShapeKind::BooleanKind => true,
           _ => false,
         },
-        JsonValue::Number(x) => match choice.core_shape_kind {
+        BodyDescriptor::Number => match choice.core_shape_kind {
           ShapeKind::NumberKind => true,
           _ => false,
         },
-        JsonValue::String(x) => match choice.core_shape_kind {
+        BodyDescriptor::String => match choice.core_shape_kind {
           ShapeKind::StringKind => true,
           _ => false,
         },
-        JsonValue::Null => match choice.core_shape_kind {
+        BodyDescriptor::Null => match choice.core_shape_kind {
           ShapeKind::NullableKind => true,
           _ => false,
         },
@@ -143,7 +144,7 @@ impl JsonBodyVisitor<ShapeDiffResult> for DiffArrayVisitor {
 impl JlasArrayVisitor<ShapeDiffResult> for DiffArrayVisitor {
   fn visit(
     &mut self,
-    json: &JsonValue,
+    body: &BodyDescriptor,
     json_trail: &JsonTrail,
     trail_origin: &ShapeTrail,
     trail_choices: &Vec<ChoiceOutput>,
@@ -157,8 +158,8 @@ impl JlasArrayVisitor<ShapeDiffResult> for DiffArrayVisitor {
     }
 
     let (matched, unmatched): (Vec<&ChoiceOutput>, Vec<&ChoiceOutput>) =
-      trail_choices.into_iter().partition(|choice| match json {
-        JsonValue::Array(_) => match choice.core_shape_kind {
+      trail_choices.into_iter().partition(|choice| match body {
+        BodyDescriptor::Array(_) => match choice.core_shape_kind {
           ShapeKind::ListKind => true,
           _ => false,
         },
@@ -202,7 +203,7 @@ impl JsonBodyVisitor<ShapeDiffResult> for DiffObjectVisitor {
 impl JlasObjectVisitor<ShapeDiffResult> for DiffObjectVisitor {
   fn visit(
     &mut self,
-    json: &JsonValue,
+    body: &BodyDescriptor,
     json_trail: &JsonTrail,
     trail_origin: &ShapeTrail,
     trail_choices: &Vec<ChoiceOutput>,
@@ -216,8 +217,8 @@ impl JlasObjectVisitor<ShapeDiffResult> for DiffObjectVisitor {
     }
 
     let (matched, unmatched): (Vec<&ChoiceOutput>, Vec<&ChoiceOutput>) =
-      trail_choices.into_iter().partition(|choice| match json {
-        JsonValue::Object(_) => match choice.core_shape_kind {
+      trail_choices.into_iter().partition(|choice| match body {
+        BodyDescriptor::Object(_) => match choice.core_shape_kind {
           ShapeKind::ObjectKind => true,
           _ => false,
         },

--- a/workspaces/diff-engine/src/shapes/visitors/mod.rs
+++ b/workspaces/diff-engine/src/shapes/visitors/mod.rs
@@ -1,5 +1,6 @@
 use super::traverser::{JsonTrail, ShapeTrail};
 use crate::queries::shape::ChoiceOutput;
+use crate::state::body::BodyDescriptor;
 use crate::state::shape::{FieldId, ShapeId};
 use serde_json::Value as JsonValue;
 pub mod diff;
@@ -53,7 +54,7 @@ pub trait JsonBodyVisitor<R> {
 pub trait JlasObjectVisitor<R>: JsonBodyVisitor<R> {
   fn visit(
     &mut self,
-    json: &JsonValue,
+    body: &BodyDescriptor,
     json_trail: &JsonTrail,
     trail_origin: &ShapeTrail,
     trail_choices: &Vec<ChoiceOutput>,
@@ -72,7 +73,7 @@ pub trait JlasObjectKeyVisitor<R>: JsonBodyVisitor<R> {
 pub trait JlasArrayVisitor<R>: JsonBodyVisitor<R> {
   fn visit(
     &mut self,
-    json: &JsonValue,
+    body: &BodyDescriptor,
     json_trail: &JsonTrail,
     trail_origin: &ShapeTrail,
     trail_choices: &Vec<ChoiceOutput>,
@@ -82,7 +83,7 @@ pub trait JlasArrayVisitor<R>: JsonBodyVisitor<R> {
 pub trait JlasPrimitiveVisitor<R>: JsonBodyVisitor<R> {
   fn visit(
     &mut self,
-    json: JsonValue,
+    body: BodyDescriptor,
     json_trail: JsonTrail,
     trail_origin: ShapeTrail,
     trail_choices: &Vec<ChoiceOutput>,

--- a/workspaces/diff-engine/src/state/body.rs
+++ b/workspaces/diff-engine/src/state/body.rs
@@ -1,0 +1,117 @@
+use crate::shapehash;
+use serde_json::map::Map as JsonMap;
+use serde_json::Value as JsonValue;
+
+#[derive(PartialEq, Clone, Debug)]
+pub enum BodyDescriptor {
+  Object(Vec<FieldDescriptor>),
+  Array(ItemsDescriptor),
+  String,
+  Number,
+  Boolean,
+  Null,
+}
+
+#[derive(PartialEq, Clone, Debug)]
+pub struct FieldDescriptor {
+  pub key: String,
+  pub body: Box<BodyDescriptor>,
+}
+
+impl FieldDescriptor {
+  pub fn new(key: String, body: BodyDescriptor) -> Self {
+    Self {
+      key,
+      body: Box::new(body),
+    }
+  }
+}
+
+#[derive(PartialEq, Clone, Debug)]
+pub struct ItemsDescriptor {
+  pub all_items: Box<Vec<BodyDescriptor>>,
+}
+
+impl<T> From<T> for ItemsDescriptor
+where
+  T: Iterator<Item = BodyDescriptor>,
+{
+  fn from(all_items: T) -> Self {
+    Self {
+      all_items: Box::new(all_items.collect::<Vec<_>>()),
+    }
+  }
+}
+
+impl ItemsDescriptor {
+  // @TODO: implement way to get unique items rather than all items
+  // pub fn unique(&self) -> Vec<(BodyDescriptor, Vec<usize>)> {}
+}
+
+impl From<shapehash::ShapeDescriptor> for BodyDescriptor {
+  fn from(mut shape_hash_descriptor: shapehash::ShapeDescriptor) -> Self {
+    match shape_hash_descriptor.field_type {
+      shapehash::ShapeDescriptor_PrimitiveType::OBJECT => {
+        let fields = shape_hash_descriptor
+          .take_fields()
+          .into_iter()
+          .map(|field_descriptor| {
+            FieldDescriptor::new(
+              field_descriptor.key.clone(),
+              BodyDescriptor::from(field_descriptor.hash.unwrap()),
+            )
+          });
+        BodyDescriptor::Object(fields.collect())
+      }
+      shapehash::ShapeDescriptor_PrimitiveType::ARRAY => {
+        let items = shape_hash_descriptor
+          .take_items()
+          .into_iter()
+          .map(|item_descriptor| BodyDescriptor::from(item_descriptor));
+
+        BodyDescriptor::Array(ItemsDescriptor::from(items))
+      }
+      shapehash::ShapeDescriptor_PrimitiveType::BOOLEAN => BodyDescriptor::Boolean,
+      shapehash::ShapeDescriptor_PrimitiveType::NULL => BodyDescriptor::Null,
+      shapehash::ShapeDescriptor_PrimitiveType::NUMBER => BodyDescriptor::Number,
+      shapehash::ShapeDescriptor_PrimitiveType::STRING => BodyDescriptor::String,
+    }
+  }
+}
+
+impl From<JsonValue> for BodyDescriptor {
+  fn from(json_value: JsonValue) -> Self {
+    match json_value {
+      JsonValue::Object(json_fields) => {
+        let fields = json_fields
+          .into_iter()
+          .map(|(key, value)| FieldDescriptor::new(key, BodyDescriptor::from(value)));
+
+        BodyDescriptor::Object(fields.collect())
+      }
+      JsonValue::Array(json_items) => {
+        let items = json_items
+          .into_iter()
+          .map(|item_descriptor| BodyDescriptor::from(item_descriptor));
+
+        BodyDescriptor::Array(ItemsDescriptor::from(items))
+      }
+      JsonValue::Bool(_) => BodyDescriptor::Boolean,
+      JsonValue::Null => BodyDescriptor::Null,
+      JsonValue::Number(_) => BodyDescriptor::Number,
+      JsonValue::String(_) => BodyDescriptor::String,
+    }
+  }
+}
+
+impl From<String> for BodyDescriptor {
+  fn from(string: String) -> Self {
+    BodyDescriptor::String
+  }
+}
+
+impl From<&String> for BodyDescriptor {
+  fn from(str: &String) -> Self {
+    BodyDescriptor::String
+  }
+}

--- a/workspaces/diff-engine/src/state/mod.rs
+++ b/workspaces/diff-engine/src/state/mod.rs
@@ -1,2 +1,3 @@
+pub mod body;
 pub mod endpoint;
 pub mod shape;

--- a/workspaces/diff-engine/tests/shape_diff.rs
+++ b/workspaces/diff-engine/tests/shape_diff.rs
@@ -1,5 +1,5 @@
 use insta::assert_debug_snapshot;
-use optic_diff::{diff_shape, ShapeProjection, SpecEvent};
+use optic_diff::{BodyDescriptor, diff_shape, ShapeProjection, SpecEvent};
 use petgraph::dot::Dot;
 use serde_json::json;
 
@@ -15,7 +15,7 @@ fn can_match_primitive_json() {
   let string_body = json!("a-string");
   let shape_id = String::from("example_shape_1");
 
-  let results = diff_shape(&shape_projection, Some(string_body), &shape_id);
+  let results = diff_shape(&shape_projection, Some(BodyDescriptor::from(string_body)), &shape_id);
 
   assert_eq!(
     results.len(),
@@ -39,7 +39,7 @@ fn can_diff_primitive_json_and_yield_unmatched_shape() {
   );
   let number_body = json!(36);
   let shape_id = String::from("example_shape_1");
-  let results = diff_shape(&shape_projection, Some(number_body), &shape_id);
+  let results = diff_shape(&shape_projection, Some(BodyDescriptor::from(number_body)), &shape_id);
 
   assert_eq!(results.len(), 1);
   assert_debug_snapshot!(
@@ -67,7 +67,7 @@ fn can_diff_primitive_json_and_yield_unspecified_shape() {
   let string_body = json!("a-string");
   let unknown_shape_id = String::from("not-a-shape-id");
   // TODO: consider returning a Result with Err instead of panicking
-  let results = diff_shape(&shape_projection, Some(string_body), &unknown_shape_id);
+  let results = diff_shape(&shape_projection, Some(BodyDescriptor::from(string_body)), &unknown_shape_id);
   assert_eq!(results.len(), 1);
   assert_debug_snapshot!(
     "can_diff_primitive_json_and_yield_unspecified_shape__results",
@@ -93,7 +93,7 @@ fn can_match_array_json() {
   );
   let array_body = json!([4, 6, 8, 10]);
   let shape_id = String::from("list_1");
-  let results = diff_shape(&shape_projection, Some(array_body), &shape_id);
+  let results = diff_shape(&shape_projection, Some(BodyDescriptor::from(array_body)), &shape_id);
 
   assert_debug_snapshot!("can_match_array_json__results", results);
   assert_eq!(results.len(), 0);
@@ -115,7 +115,7 @@ fn can_yield_unmatched_shape_for_array_body() {
 
   let array_body = json!([3, 9, 12, 15]);
   let shape_id = String::from("shape_1");
-  let results = diff_shape(&shape_projection, Some(array_body), &shape_id);
+  let results = diff_shape(&shape_projection, Some(BodyDescriptor::from(array_body)), &shape_id);
 
   assert_debug_snapshot!("can_yield_unmatched_shape_for_array_body__results", results);
   assert_eq!(results.len(), 1);
@@ -139,7 +139,7 @@ fn can_yield_unmatched_shape_for_mismatched_array_items() {
   );
   let array_body = json!(["4", "6", 8, "10"]);
   let shape_id = String::from("list_1");
-  let results = diff_shape(&shape_projection, Some(array_body), &shape_id);
+  let results = diff_shape(&shape_projection, Some(BodyDescriptor::from(array_body)), &shape_id);
 
   assert_debug_snapshot!(
     "can_yield_unmatched_shape_for_mismatched_array_items__results",
@@ -168,7 +168,7 @@ fn can_match_shape_for_nested_arrays() {
   );
   let array_body = json!([[4, 6, 8, 10], [3, 9, 12, 15]]);
   let shape_id = String::from("list_1");
-  let results = diff_shape(&shape_projection, Some(array_body), &shape_id);
+  let results = diff_shape(&shape_projection, Some(BodyDescriptor::from(array_body)), &shape_id);
 
   assert_debug_snapshot!("can_match_shape_for_nested_arrays__results", results);
   assert_eq!(results.len(), 0);
@@ -203,7 +203,7 @@ fn can_yield_unmatched_shape_for_field() {
     "age": "not-a-valid-number"
   });
   let shape_id = String::from("object_1");
-  let results = diff_shape(&shape_projection, Some(object_body), &shape_id);
+  let results = diff_shape(&shape_projection, Some(BodyDescriptor::from(object_body)), &shape_id);
 
   assert_debug_snapshot!("can_yield_unmatched_shape_for_field__results", results);
   assert_ne!(results.len(), 0);
@@ -233,7 +233,7 @@ fn can_yield_unmatched_shape_for_missing_field() {
     "lastName": "Simpson"
   });
   let shape_id = String::from("object_1");
-  let results = diff_shape(&shape_projection, Some(object_body), &shape_id);
+  let results = diff_shape(&shape_projection, Some(BodyDescriptor::from(object_body)), &shape_id);
 
   assert_debug_snapshot!(
     "can_yield_unmatched_shape_for_missing_field__results",


### PR DESCRIPTION
One of the major optimisations we found (deduplicating array items and only visiting uniques) relies on a construct that can encode the structure of a body, rather than all values of it. Rather than only applying this optimisation where the inputs source allows for it (shape hashes), this PR changes it so that each type of source is converted into this one intermediate representation and always perform the optimisation.

This new construct is called `BodyDescriptor` (should probably be a `ShapeDescriptor`, but that name is already used to indicate specced shapes) into which `JsonValue` and `shape_hash::ShapeDescriptor` are converted. Like  `shape_hash::ShapeDescriptor` it encodes only the shape, not actual values for now. However, it is not limited by that, in that it _could_ hold some value information if available, but also metadata about how it maps back to the full body (like mapping of unique array items to all array items). Since `shape_hash::ShapeDescriptor` is codegened from a protobuf, retrofitting that seems like a bad idea.