### PR TITLE
Prevent visiting of duplicate array items when diffing Body with Shape

### DIFF
--- a/workspaces/diff-engine/src/shapes/traverser.rs
+++ b/workspaces/diff-engine/src/shapes/traverser.rs
@@ -84,9 +84,9 @@ impl<'a> Traverser<'a> {
           _ => unreachable!("expect body to be an array"),
         };
 
-        items.into_all().enumerate().for_each(|(index, item)| {
+        items.into_unique().for_each(|(item, indexes)| {
           let item_json_trail = body_trail.with_component(JsonTrailPathComponent::JsonArrayItem {
-            index: index as u32,
+            index: *(indexes.first().unwrap()) as u32,
           });
 
           let new_trail_origin = trail_origin.clone();

--- a/workspaces/diff-engine/src/state/body.rs
+++ b/workspaces/diff-engine/src/state/body.rs
@@ -1,8 +1,9 @@
 use crate::shapehash;
 use serde_json::map::Map as JsonMap;
 use serde_json::Value as JsonValue;
+use std::collections::HashMap;
 
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Clone, Debug, Hash, Eq)]
 pub enum BodyDescriptor {
   Object(ObjectDescriptor),
   Array(ItemsDescriptor),
@@ -12,7 +13,7 @@ pub enum BodyDescriptor {
   Null,
 }
 
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Clone, Debug, Hash, Eq)]
 pub struct FieldDescriptor(pub String, pub Box<BodyDescriptor>);
 
 impl FieldDescriptor {
@@ -21,7 +22,7 @@ impl FieldDescriptor {
   }
 }
 
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Clone, Debug, Hash, Eq)]
 pub struct ObjectDescriptor {
   fields: Vec<FieldDescriptor>,
 }
@@ -52,9 +53,9 @@ where
   }
 }
 
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Clone, Debug, Hash, Eq)]
 pub struct ItemsDescriptor {
-  pub all_items: Box<Vec<BodyDescriptor>>,
+  unique_items: Box<Vec<(BodyDescriptor, Vec<usize>)>>,
 }
 
 impl<T> From<T> for ItemsDescriptor
@@ -62,19 +63,35 @@ where
   T: Iterator<Item = BodyDescriptor>,
 {
   fn from(all_items: T) -> Self {
+    let unique_items = all_items
+      .enumerate()
+      .fold(HashMap::new(), |mut indexes_by_unique_items, (i, item)| {
+        {
+          let items = indexes_by_unique_items.entry(item).or_insert(vec![]);
+          items.push(i);
+        };
+
+        indexes_by_unique_items
+      })
+      .into_iter()
+      .map(|(item, indexes)| (item.clone(), indexes))
+      .collect::<Vec<_>>();
+
     Self {
-      all_items: Box::new(all_items.collect::<Vec<_>>()),
+      unique_items: Box::new(unique_items),
     }
   }
 }
 
 impl ItemsDescriptor {
-  pub fn into_all(self) -> impl Iterator<Item = BodyDescriptor> {
-    self.all_items.into_iter()
-  }
+  // @TODO: decide if this is still interesting at all. Could be reconstructed from unique_items
+  // pub fn into_all(self) -> impl Iterator<Item = BodyDescriptor> {
+  //
+  // }
 
-  // @TODO: implement way to get unique items rather than all items
-  // pub fn unique(&self) -> Vec<(BodyDescriptor, Vec<usize>)> {}
+  pub fn into_unique(self) -> impl Iterator<Item = (BodyDescriptor, Vec<usize>)> {
+    self.unique_items.into_iter()
+  }
 }
 
 impl From<shapehash::ShapeDescriptor> for BodyDescriptor {

--- a/workspaces/diff-engine/src/state/body.rs
+++ b/workspaces/diff-engine/src/state/body.rs
@@ -63,7 +63,7 @@ where
   T: Iterator<Item = BodyDescriptor>,
 {
   fn from(all_items: T) -> Self {
-    let unique_items = all_items
+    let mut unique_items = all_items
       .enumerate()
       .fold(HashMap::new(), |mut indexes_by_unique_items, (i, item)| {
         {
@@ -76,6 +76,8 @@ where
       .into_iter()
       .map(|(item, indexes)| (item.clone(), indexes))
       .collect::<Vec<_>>();
+
+    unique_items.sort_by_key(|(_, indexes)| *indexes.first().unwrap());
 
     Self {
       unique_items: Box::new(unique_items),

--- a/workspaces/diff-engine/tests/snapshots/shape_diff__can_yield_unmatched_shape_for_mismatched_array_items__results.snap
+++ b/workspaces/diff-engine/tests/snapshots/shape_diff__can_yield_unmatched_shape_for_mismatched_array_items__results.snap
@@ -25,25 +25,7 @@ expression: results
         json_trail: JsonTrail {
             path: [
                 JsonArrayItem {
-                    index: 1,
-                },
-            ],
-        },
-        shape_trail: ShapeTrail {
-            root_shape_id: "list_1",
-            path: [
-                ListItemTrail {
-                    list_shape_id: "list_1",
-                    item_shape_id: "number_shape_1",
-                },
-            ],
-        },
-    },
-    UnmatchedShape {
-        json_trail: JsonTrail {
-            path: [
-                JsonArrayItem {
-                    index: 3,
+                    index: 2,
                 },
             ],
         },

--- a/workspaces/diff-engine/tests/snapshots/shape_diff__yields_unmatched_shape_once_for_each_uniqu_array_item__results.snap
+++ b/workspaces/diff-engine/tests/snapshots/shape_diff__yields_unmatched_shape_once_for_each_uniqu_array_item__results.snap
@@ -1,0 +1,60 @@
+---
+source: tests/shape_diff.rs
+expression: results
+---
+[
+    UnmatchedShape {
+        json_trail: JsonTrail {
+            path: [
+                JsonArrayItem {
+                    index: 0,
+                },
+            ],
+        },
+        shape_trail: ShapeTrail {
+            root_shape_id: "list_1",
+            path: [
+                ListItemTrail {
+                    list_shape_id: "list_1",
+                    item_shape_id: "number_shape_1",
+                },
+            ],
+        },
+    },
+    UnmatchedShape {
+        json_trail: JsonTrail {
+            path: [
+                JsonArrayItem {
+                    index: 4,
+                },
+            ],
+        },
+        shape_trail: ShapeTrail {
+            root_shape_id: "list_1",
+            path: [
+                ListItemTrail {
+                    list_shape_id: "list_1",
+                    item_shape_id: "number_shape_1",
+                },
+            ],
+        },
+    },
+    UnmatchedShape {
+        json_trail: JsonTrail {
+            path: [
+                JsonArrayItem {
+                    index: 6,
+                },
+            ],
+        },
+        shape_trail: ShapeTrail {
+            root_shape_id: "list_1",
+            path: [
+                ListItemTrail {
+                    list_shape_id: "list_1",
+                    item_shape_id: "number_shape_1",
+                },
+            ],
+        },
+    },
+]

--- a/workspaces/diff-engine/tests/snapshots/shape_diff__yields_unmatched_shape_once_for_each_uniquely_shaped_array_item__shape_projection_graph.snap
+++ b/workspaces/diff-engine/tests/snapshots/shape_diff__yields_unmatched_shape_once_for_each_uniquely_shaped_array_item__shape_projection_graph.snap
@@ -1,0 +1,27 @@
+---
+source: tests/shape_diff.rs
+expression: "Dot::with_config(&shape_projection.graph, &[])"
+---
+digraph {
+    0 [ label = "CoreShape(\l    CoreShapeNode(\l        \"$string\",\l        CoreShapeNodeDescriptor {\l            kind: StringKind,\l        },\l    ),\l)\l" ]
+    1 [ label = "CoreShape(\l    CoreShapeNode(\l        \"$number\",\l        CoreShapeNodeDescriptor {\l            kind: NumberKind,\l        },\l    ),\l)\l" ]
+    2 [ label = "CoreShape(\l    CoreShapeNode(\l        \"$boolean\",\l        CoreShapeNodeDescriptor {\l            kind: BooleanKind,\l        },\l    ),\l)\l" ]
+    3 [ label = "CoreShape(\l    CoreShapeNode(\l        \"$list\",\l        CoreShapeNodeDescriptor {\l            kind: ListKind,\l        },\l    ),\l)\l" ]
+    4 [ label = "ShapeParameter(\l    ShapeParameterNode(\l        \"$listItem\",\l        ShapeParameterNodeDescriptor,\l    ),\l)\l" ]
+    5 [ label = "CoreShape(\l    CoreShapeNode(\l        \"$object\",\l        CoreShapeNodeDescriptor {\l            kind: ObjectKind,\l        },\l    ),\l)\l" ]
+    6 [ label = "CoreShape(\l    CoreShapeNode(\l        \"$nullable\",\l        CoreShapeNodeDescriptor {\l            kind: NullableKind,\l        },\l    ),\l)\l" ]
+    7 [ label = "ShapeParameter(\l    ShapeParameterNode(\l        \"$nullableInner\",\l        ShapeParameterNodeDescriptor,\l    ),\l)\l" ]
+    8 [ label = "CoreShape(\l    CoreShapeNode(\l        \"$unknown\",\l        CoreShapeNodeDescriptor {\l            kind: UnknownKind,\l        },\l    ),\l)\l" ]
+    9 [ label = "CoreShape(\l    CoreShapeNode(\l        \"$optional\",\l        CoreShapeNodeDescriptor {\l            kind: OptionalKind,\l        },\l    ),\l)\l" ]
+    10 [ label = "ShapeParameter(\l    ShapeParameterNode(\l        \"$optionalInner\",\l        ShapeParameterNodeDescriptor,\l    ),\l)\l" ]
+    11 [ label = "CoreShape(\l    CoreShapeNode(\l        \"$oneOf\",\l        CoreShapeNodeDescriptor {\l            kind: OneOfKind,\l        },\l    ),\l)\l" ]
+    12 [ label = "Shape(\l    ShapeNode(\l        \"list_1\",\l        ShapeNodeDescriptor,\l    ),\l)\l" ]
+    13 [ label = "Shape(\l    ShapeNode(\l        \"number_shape_1\",\l        ShapeNodeDescriptor,\l    ),\l)\l" ]
+    4 -> 3 [ label = "IsParameterOf\l" ]
+    7 -> 6 [ label = "IsParameterOf\l" ]
+    10 -> 9 [ label = "IsParameterOf\l" ]
+    12 -> 3 [ label = "IsDescendantOf\l" ]
+    13 -> 1 [ label = "IsDescendantOf\l" ]
+    12 -> 4 [ label = "HasBinding(\l    ShapeParameterBinding {\l        shape_id: \"number_shape_1\",\l    },\l)\l" ]
+}
+


### PR DESCRIPTION
This PR implements an optimisation around the visiting of array items of a body we're diffing. 

In our experiments, visiting array items is where most time is spent when diffing larger bodies. Conceptually, this makes sense, as this is the main unit of scale: it's rare to see thousands of fields for objects, it's common to see thousands or array elements. 

Fortunately, by nature of array semantics, multiple items often share the exact same structure. Taking the time to deduplicate them by comparing the structure by hashing it and perform a deep comparison, pays off very well. In one a particular debug capture taken from real-world usage, we saw a diff reduce from approx  `4m30s` to approx `0m10s`.

It uses Rust's built-in `Hash` and `Eq` traits to perform the comparison, reducing an array of items down to the unique ones and only storing those. A vector of indexes of the original elements is kept, so it can be mapped when writing results about the original `Body`. This yields the same performance improvement as from our experiments.