### PR TITLE
Add normalisation of diffs produced through new Rust diff engine

### DIFF
--- a/workspaces/cli-server/src/routers/capture-router.ts
+++ b/workspaces/cli-server/src/routers/capture-router.ts
@@ -160,30 +160,7 @@ export function makeRouter(dependencies: ICaptureRouterDependencies) {
 
     let diffsStream = diffQueries.diffs();
 
-    async function* normalizeDiffs(resultsStream: Readable) {
-      let pointersByFingerprint: Map<String, string[]> = new Map();
-      let diffs: [any, string][] = [];
-
-      for await (let [diff, pointers, fingerprint] of resultsStream) {
-        let existingPointers = pointersByFingerprint.get(fingerprint) || [];
-        if (existingPointers.length < 1) {
-          diffs.push([diff, fingerprint]);
-        }
-        pointersByFingerprint.set(
-          fingerprint,
-          existingPointers.concat(pointers)
-        );
-      }
-
-      for (let [diff, fingerprint] of diffs) {
-        let pointers = pointersByFingerprint.get(fingerprint);
-        yield [diff, pointers];
-      }
-    }
-
-    toJSONArray(Readable.from(normalizeDiffs(diffsStream)))
-      .pipe(res)
-      .type('application/json');
+    toJSONArray(diffsStream).pipe(res).type('application/json');
   });
 
   router.get('/diffs/:diffId/undocumented-urls', async (req, res) => {

--- a/workspaces/cli-server/src/routers/capture-router.ts
+++ b/workspaces/cli-server/src/routers/capture-router.ts
@@ -159,7 +159,31 @@ export function makeRouter(dependencies: ICaptureRouterDependencies) {
     }
 
     let diffsStream = diffQueries.diffs();
-    toJSONArray(diffsStream).pipe(res).type('application/json');
+
+    async function* normalizeDiffs(resultsStream: Readable) {
+      let pointersByFingerprint: Map<String, string[]> = new Map();
+      let diffs: [any, string][] = [];
+
+      for await (let [diff, pointers, fingerprint] of resultsStream) {
+        let existingPointers = pointersByFingerprint.get(fingerprint) || [];
+        if (existingPointers.length < 1) {
+          diffs.push([diff, fingerprint]);
+        }
+        pointersByFingerprint.set(
+          fingerprint,
+          existingPointers.concat(pointers)
+        );
+      }
+
+      for (let [diff, fingerprint] of diffs) {
+        let pointers = pointersByFingerprint.get(fingerprint);
+        yield [diff, pointers];
+      }
+    }
+
+    toJSONArray(Readable.from(normalizeDiffs(diffsStream)))
+      .pipe(res)
+      .type('application/json');
   });
 
   router.get('/diffs/:diffId/undocumented-urls', async (req, res) => {

--- a/workspaces/diff-engine/src/interactions/result.rs
+++ b/workspaces/diff-engine/src/interactions/result.rs
@@ -2,7 +2,7 @@ use crate::shapes::ShapeDiffResult;
 use crate::state::endpoint::{PathComponentId, RequestId, ResponseId, ShapeId};
 use serde::Serialize;
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Hash)]
 pub enum InteractionDiffResult {
   UnmatchedRequestUrl(UnmatchedRequestUrl),
   UnmatchedRequestBodyContentType(UnmatchedRequestBodyContentType),
@@ -18,7 +18,7 @@ pub enum InteractionDiffResult {
   MatchedResponseBodyContentType(MatchedResponseBodyContentType),
 }
 ////////////////////////////////////////////////////////////////////////////////
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct UnmatchedRequestUrl {
   pub interaction_trail: InteractionTrail,
@@ -34,7 +34,7 @@ impl UnmatchedRequestUrl {
   }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct UnmatchedRequestBodyContentType {
   pub interaction_trail: InteractionTrail,
@@ -49,7 +49,7 @@ impl UnmatchedRequestBodyContentType {
     };
   }
 }
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Hash)]
 pub struct MatchedRequestBodyContentType {
   pub interaction_trail: InteractionTrail,
   pub requests_trail: RequestSpecTrail,
@@ -78,7 +78,7 @@ impl MatchedRequestBodyContentType {
   }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct UnmatchedResponseBodyContentType {
   pub interaction_trail: InteractionTrail,
@@ -94,7 +94,7 @@ impl UnmatchedResponseBodyContentType {
   }
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Clone, Hash)]
 pub struct MatchedResponseBodyContentType {
   pub interaction_trail: InteractionTrail,
   pub requests_trail: RequestSpecTrail,
@@ -121,7 +121,7 @@ impl MatchedResponseBodyContentType {
     )
   }
 }
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct UnmatchedRequestBodyShape {
   pub interaction_trail: InteractionTrail,
@@ -143,7 +143,7 @@ impl UnmatchedRequestBodyShape {
   }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct UnmatchedResponseBodyShape {
   pub interaction_trail: InteractionTrail,
@@ -166,7 +166,7 @@ impl UnmatchedResponseBodyShape {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Hash)]
 pub struct InteractionTrail {
   pub path: Vec<InteractionTrailPathComponent>,
 }
@@ -181,7 +181,7 @@ impl InteractionTrail {
   }
 }
 ////////////////////////////////////////////////////////////////////////////////
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Hash)]
 pub enum RequestSpecTrail {
   SpecRoot(SpecRoot),
   SpecPath(SpecPath),
@@ -191,40 +191,40 @@ pub enum RequestSpecTrail {
   SpecResponseBody(SpecResponseBody),
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Hash)]
 pub struct SpecRoot {}
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct SpecPath {
   pub path_id: PathComponentId,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct SpecRequestRoot {
   pub request_id: RequestId,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct SpecRequestBody {
   pub request_id: RequestId,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct SpecResponseRoot {
   pub response_id: ResponseId,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct SpecResponseBody {
   pub response_id: ResponseId,
 }
 //@GOTCHA make sure these serialize matching the existing scala code
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Hash)]
 pub enum InteractionTrailPathComponent {
   Url {},
   Method {

--- a/workspaces/diff-engine/src/interactions/result.rs
+++ b/workspaces/diff-engine/src/interactions/result.rs
@@ -1,6 +1,8 @@
 use crate::shapes::ShapeDiffResult;
 use crate::state::endpoint::{PathComponentId, RequestId, ResponseId, ShapeId};
 use serde::Serialize;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 
 #[derive(Debug, Serialize, Hash)]
 pub enum InteractionDiffResult {
@@ -17,6 +19,15 @@ pub enum InteractionDiffResult {
   #[serde(skip)]
   MatchedResponseBodyContentType(MatchedResponseBodyContentType),
 }
+
+impl InteractionDiffResult {
+  pub fn fingerprint(&self) -> String {
+    let mut hash_state = DefaultHasher::new();
+    Hash::hash(self, &mut hash_state);
+    format!("{:x}", hash_state.finish())
+  }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 #[derive(Debug, Serialize, Hash)]
 #[serde(rename_all = "camelCase")]

--- a/workspaces/diff-engine/src/main.rs
+++ b/workspaces/diff-engine/src/main.rs
@@ -9,8 +9,6 @@ use optic_diff::InteractionDiffResult;
 use optic_diff::SpecEvent;
 use optic_diff::SpecProjection;
 use std::cmp;
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
 use std::process;
 use std::sync::Arc;
 use tokio::io::{stdin, stdout};
@@ -163,15 +161,10 @@ struct TaggedInput<T>(T, Tags);
 struct ResultContainer<T>(T, Tags, String);
 type Tags = Vec<String>;
 
-impl<T> From<(T, &Tags)> for ResultContainer<T>
-where
-  T: Hash,
-{
-  fn from((result, tags): (T, &Tags)) -> Self {
-    let mut hash_state = DefaultHasher::new();
-    result.hash(&mut hash_state);
-    let hash = hash_state.finish();
-    Self(result, tags.clone(), format!("{:x}", hash))
+impl From<(InteractionDiffResult, &Tags)> for ResultContainer<InteractionDiffResult> {
+  fn from((result, tags): (InteractionDiffResult, &Tags)) -> Self {
+    let fingerprint = result.fingerprint();
+    Self(result, tags.clone(), fingerprint)
   }
 }
 

--- a/workspaces/diff-engine/src/shapes/result.rs
+++ b/workspaces/diff-engine/src/shapes/result.rs
@@ -1,7 +1,7 @@
 use crate::shapes::{JsonTrail, ShapeTrail};
 use serde::Serialize;
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Hash)]
 pub enum ShapeDiffResult {
   #[serde(rename_all = "camelCase")]
   UnspecifiedShape {

--- a/workspaces/diff-engine/src/shapes/result.rs
+++ b/workspaces/diff-engine/src/shapes/result.rs
@@ -1,5 +1,7 @@
 use crate::shapes::{JsonTrail, ShapeTrail};
 use serde::Serialize;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 
 #[derive(Debug, Serialize, Hash)]
 pub enum ShapeDiffResult {
@@ -13,4 +15,12 @@ pub enum ShapeDiffResult {
     json_trail: JsonTrail,
     shape_trail: ShapeTrail,
   },
+}
+
+impl ShapeDiffResult {
+  pub fn fingerprint(&self) -> String {
+    let mut hash_state = DefaultHasher::new();
+    Hash::hash(self, &mut hash_state);
+    format!("{:x}", hash_state.finish())
+  }
 }

--- a/workspaces/diff-engine/src/shapes/traverser.rs
+++ b/workspaces/diff-engine/src/shapes/traverser.rs
@@ -208,7 +208,7 @@ impl<'a> Traverser<'a> {
   }
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Clone, Hash)]
 pub enum ShapeTrailPathComponent {
   #[serde(rename_all = "camelCase")]
   ObjectTrail { shape_id: ShapeId },
@@ -250,7 +250,7 @@ pub enum ShapeTrailPathComponent {
   UnknownTrail {},
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Clone, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct ShapeTrail {
   pub root_shape_id: ShapeId,
@@ -271,7 +271,8 @@ impl ShapeTrail {
   }
 }
 
-#[derive(Debug, Serialize, Clone)]
+// @TODO: implement Hash manually, so we can hash all array items as 0
+#[derive(Debug, Serialize, Clone, Hash)]
 pub enum JsonTrailPathComponent {
   #[serde(rename_all = "camelCase")]
   JsonObject {},
@@ -283,7 +284,7 @@ pub enum JsonTrailPathComponent {
   JsonArrayItem { index: u32 },
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Clone, Hash)]
 pub struct JsonTrail {
   path: Vec<JsonTrailPathComponent>,
 }

--- a/workspaces/diff-engine/src/shapes/traverser.rs
+++ b/workspaces/diff-engine/src/shapes/traverser.rs
@@ -6,6 +6,7 @@ use crate::state::body::BodyDescriptor;
 use crate::state::shape::{FieldId, ShapeId, ShapeKind, ShapeParameterId};
 use serde::Serialize;
 use serde_json::Value as JsonValue;
+use std::hash::{Hash, Hasher};
 
 pub struct Traverser<'a> {
   shape_queries: &'a ShapeQueries<'a>,
@@ -271,7 +272,6 @@ impl ShapeTrail {
   }
 }
 
-// @TODO: implement Hash manually, so we can hash all array items as 0
 #[derive(Debug, Serialize, Clone, Hash)]
 pub enum JsonTrailPathComponent {
   #[serde(rename_all = "camelCase")]
@@ -284,7 +284,7 @@ pub enum JsonTrailPathComponent {
   JsonArrayItem { index: u32 },
 }
 
-#[derive(Debug, Serialize, Clone, Hash)]
+#[derive(Debug, Serialize, Clone)]
 pub struct JsonTrail {
   path: Vec<JsonTrailPathComponent>,
 }
@@ -296,5 +296,23 @@ impl JsonTrail {
     let mut new_trail = self.clone();
     new_trail.path.push(component);
     new_trail
+  }
+}
+
+impl Hash for JsonTrail {
+  fn hash<H: Hasher>(&self, hash_state: &mut H) {
+    let components = self
+      .path
+      .clone()
+      .into_iter()
+      .map(|component| match component {
+        JsonTrailPathComponent::JsonArrayItem { index } => {
+          JsonTrailPathComponent::JsonArrayItem { index: 0 }
+        }
+        _ => component,
+      })
+      .collect::<Vec<_>>();
+
+    components.hash(hash_state);
   }
 }

--- a/workspaces/diff-engine/tests/interaction_diff.rs
+++ b/workspaces/diff-engine/tests/interaction_diff.rs
@@ -75,6 +75,7 @@ async fn can_yield_umatched_request_url() {
   println!("{:?}", interaction);
 
   let results = diff_interaction(&spec_projection, interaction);
+
   println!("{:?}", results);
   assert_eq!(results.len(), 1);
 
@@ -214,5 +215,10 @@ async fn can_yield_unmatched_shape() {
   .expect("example http interaction should deserialize");
 
   results = diff_interaction(&spec_projection, incompliant_interaction);
+  let fingerprints = results
+    .iter()
+    .map(|result| result.fingerprint())
+    .collect::<Vec<_>>();
   assert_debug_snapshot!(results);
+  assert_debug_snapshot!("can_yield_unmatched_shape__fingerprints", fingerprints);
 }

--- a/workspaces/diff-engine/tests/shape_diff.rs
+++ b/workspaces/diff-engine/tests/shape_diff.rs
@@ -40,11 +40,16 @@ fn can_diff_primitive_json_and_yield_unmatched_shape() {
   let number_body = json!(36);
   let shape_id = String::from("example_shape_1");
   let results = diff_shape(&shape_projection, Some(BodyDescriptor::from(number_body)), &shape_id);
+  let fingerprints = results.iter().map(|result| result.fingerprint()).collect::<Vec<_>>();
 
   assert_eq!(results.len(), 1);
   assert_debug_snapshot!(
     "can_diff_primitive_json_and_yield_unmatched_shape__results",
     results
+  );
+  assert_debug_snapshot!(
+    "can_diff_primitive_json_and_yield_unmatched_shape__fingerprints",
+    fingerprints
   );
 }
 
@@ -94,9 +99,11 @@ fn can_match_array_json() {
   let array_body = json!([4, 6, 8, 10]);
   let shape_id = String::from("list_1");
   let results = diff_shape(&shape_projection, Some(BodyDescriptor::from(array_body)), &shape_id);
+  let fingerprints = results.iter().map(|result| result.fingerprint()).collect::<Vec<_>>();
 
   assert_debug_snapshot!("can_match_array_json__results", results);
   assert_eq!(results.len(), 0);
+  assert_debug_snapshot!("can_match_array_json__fingerprints", fingerprints);
 }
 
 #[test]
@@ -116,9 +123,11 @@ fn can_yield_unmatched_shape_for_array_body() {
   let array_body = json!([3, 9, 12, 15]);
   let shape_id = String::from("shape_1");
   let results = diff_shape(&shape_projection, Some(BodyDescriptor::from(array_body)), &shape_id);
+  let fingerprints = results.iter().map(|result| result.fingerprint()).collect::<Vec<_>>();
 
   assert_debug_snapshot!("can_yield_unmatched_shape_for_array_body__results", results);
   assert_eq!(results.len(), 1);
+  assert_debug_snapshot!("can_yield_unmatched_shape_for_array_body__fingerprints", fingerprints);
 }
 
 #[test]
@@ -140,12 +149,17 @@ fn can_yield_unmatched_shape_for_mismatched_array_items() {
   let array_body = json!(["4", 8, false]);
   let shape_id = String::from("list_1");
   let results = diff_shape(&shape_projection, Some(BodyDescriptor::from(array_body)), &shape_id);
+  let fingerprints = results.iter().map(|result| result.fingerprint()).collect::<Vec<_>>();
 
   assert_debug_snapshot!(
     "can_yield_unmatched_shape_for_mismatched_array_items__results",
     results
   );
   assert_eq!(results.len(), 2); // one per unique type of array item
+  assert_debug_snapshot!(
+    "can_yield_unmatched_shape_for_mismatched_array_items__fingerprints",
+    fingerprints
+  );
 }
 
 #[test]
@@ -167,12 +181,17 @@ fn yields_unmatched_shape_once_for_each_uniquely_shaped_array_item() {
   let array_body = json!(["4", "6", 8, "10", { "not-a": "number" }, { "not-a": "boolean" }, { "different": "object-structure" }]);
   let shape_id = String::from("list_1");
   let results = diff_shape(&shape_projection, Some(BodyDescriptor::from(array_body)), &shape_id);
+  let fingerprints = results.iter().map(|result| result.fingerprint()).collect::<Vec<_>>();
 
   assert_debug_snapshot!(
     "yields_unmatched_shape_once_for_each_uniqu_array_item__results",
     results
   );
   assert_eq!(results.len(), 3); // one per unique type of array item
+  assert_debug_snapshot!(
+    "yields_unmatched_shape_once_for_each_uniquely_shaped_array_item__fingerprints",
+    fingerprints
+  );
 }
 
 #[test]
@@ -196,9 +215,11 @@ fn can_match_shape_for_nested_arrays() {
   let array_body = json!([[4, 6, 8, 10], [3, 9, 12, 15]]);
   let shape_id = String::from("list_1");
   let results = diff_shape(&shape_projection, Some(BodyDescriptor::from(array_body)), &shape_id);
+  let fingerprints = results.iter().map(|result| result.fingerprint()).collect::<Vec<_>>();
 
   assert_debug_snapshot!("can_match_shape_for_nested_arrays__results", results);
   assert_eq!(results.len(), 0);
+  assert_debug_snapshot!("can_match_shape_for_nested_arrays__fingerprints", fingerprints);
 }
 
 #[test]
@@ -231,9 +252,11 @@ fn can_yield_unmatched_shape_for_field() {
   });
   let shape_id = String::from("object_1");
   let results = diff_shape(&shape_projection, Some(BodyDescriptor::from(object_body)), &shape_id);
+  let fingerprints = results.iter().map(|result| result.fingerprint()).collect::<Vec<_>>();
 
   assert_debug_snapshot!("can_yield_unmatched_shape_for_field__results", results);
   assert_ne!(results.len(), 0);
+  assert_debug_snapshot!("can_yield_unmatched_shape_for_field__fingerprints", fingerprints);
 }
 
 #[test]
@@ -261,10 +284,15 @@ fn can_yield_unmatched_shape_for_missing_field() {
   });
   let shape_id = String::from("object_1");
   let results = diff_shape(&shape_projection, Some(BodyDescriptor::from(object_body)), &shape_id);
+  let fingerprints = results.iter().map(|result| result.fingerprint()).collect::<Vec<_>>();
 
   assert_debug_snapshot!(
     "can_yield_unmatched_shape_for_missing_field__results",
     results
   );
   assert_ne!(results.len(), 0);
+  assert_debug_snapshot!(
+    "can_yield_unmatched_shape_for_missing_field__fingerprints",
+    fingerprints
+  );
 }

--- a/workspaces/diff-engine/tests/snapshots/interaction_diff__can_yield_unmatched_shape__fingerprints.snap
+++ b/workspaces/diff-engine/tests/snapshots/interaction_diff__can_yield_unmatched_shape__fingerprints.snap
@@ -1,0 +1,7 @@
+---
+source: tests/interaction_diff.rs
+expression: fingerprints
+---
+[
+    "2917414c919fbd64",
+]

--- a/workspaces/diff-engine/tests/snapshots/shape_diff__can_diff_primitive_json_and_yield_unmatched_shape__fingerprints.snap
+++ b/workspaces/diff-engine/tests/snapshots/shape_diff__can_diff_primitive_json_and_yield_unmatched_shape__fingerprints.snap
@@ -1,0 +1,7 @@
+---
+source: tests/shape_diff.rs
+expression: fingerprints
+---
+[
+    "b1cc34c74f4e6d23",
+]

--- a/workspaces/diff-engine/tests/snapshots/shape_diff__can_match_array_json__fingerprints.snap
+++ b/workspaces/diff-engine/tests/snapshots/shape_diff__can_match_array_json__fingerprints.snap
@@ -1,0 +1,5 @@
+---
+source: tests/shape_diff.rs
+expression: fingerprints
+---
+[]

--- a/workspaces/diff-engine/tests/snapshots/shape_diff__can_match_shape_for_nested_arrays__fingerprints.snap
+++ b/workspaces/diff-engine/tests/snapshots/shape_diff__can_match_shape_for_nested_arrays__fingerprints.snap
@@ -1,0 +1,5 @@
+---
+source: tests/shape_diff.rs
+expression: fingerprints
+---
+[]

--- a/workspaces/diff-engine/tests/snapshots/shape_diff__can_yield_unmatched_shape_for_array_body__fingerprints.snap
+++ b/workspaces/diff-engine/tests/snapshots/shape_diff__can_yield_unmatched_shape_for_array_body__fingerprints.snap
@@ -1,0 +1,7 @@
+---
+source: tests/shape_diff.rs
+expression: fingerprints
+---
+[
+    "e6d99ca6f08fea",
+]

--- a/workspaces/diff-engine/tests/snapshots/shape_diff__can_yield_unmatched_shape_for_field__fingerprints.snap
+++ b/workspaces/diff-engine/tests/snapshots/shape_diff__can_yield_unmatched_shape_for_field__fingerprints.snap
@@ -1,0 +1,7 @@
+---
+source: tests/shape_diff.rs
+expression: fingerprints
+---
+[
+    "be008d3d36400d4e",
+]

--- a/workspaces/diff-engine/tests/snapshots/shape_diff__can_yield_unmatched_shape_for_mismatched_array_items__fingerprints.snap
+++ b/workspaces/diff-engine/tests/snapshots/shape_diff__can_yield_unmatched_shape_for_mismatched_array_items__fingerprints.snap
@@ -1,0 +1,8 @@
+---
+source: tests/shape_diff.rs
+expression: fingerprints
+---
+[
+    "5ae1f9ae76cf25e7",
+    "5ae1f9ae76cf25e7",
+]

--- a/workspaces/diff-engine/tests/snapshots/shape_diff__can_yield_unmatched_shape_for_missing_field__fingerprints.snap
+++ b/workspaces/diff-engine/tests/snapshots/shape_diff__can_yield_unmatched_shape_for_missing_field__fingerprints.snap
@@ -1,0 +1,7 @@
+---
+source: tests/shape_diff.rs
+expression: fingerprints
+---
+[
+    "be008d3d36400d4e",
+]

--- a/workspaces/diff-engine/tests/snapshots/shape_diff__yields_unmatched_shape_once_for_each_uniquely_shaped_array_item__fingerprints.snap
+++ b/workspaces/diff-engine/tests/snapshots/shape_diff__yields_unmatched_shape_once_for_each_uniquely_shaped_array_item__fingerprints.snap
@@ -1,0 +1,9 @@
+---
+source: tests/shape_diff.rs
+expression: fingerprints
+---
+[
+    "5ae1f9ae76cf25e7",
+    "5ae1f9ae76cf25e7",
+    "5ae1f9ae76cf25e7",
+]


### PR DESCRIPTION
So far in the Rust diff engine identical diffs recorded across multiple interactions are treated as separate diffs, rather than a single diff tagged with multiple interactions. These changes re-implements this.

This is a work in progress, I'll add more information as this PR makes it out of draft.