### PR TITLE
Hotfix diffing of spec changes yet to be committed

### DIFF
--- a/workspaces/cli-server/src/diffs/index.ts
+++ b/workspaces/cli-server/src/diffs/index.ts
@@ -51,6 +51,7 @@ export interface DiffConfigObject {
   captureId: string;
   captureBaseDirectory: string;
   diffId: string;
+  events?: Array<{ [key: string]: any}>;
   endpoints?: Array<{ pathId: string; method: string }>;
   specPath: string;
 }

--- a/workspaces/cli-server/src/diffs/on-demand.ts
+++ b/workspaces/cli-server/src/diffs/on-demand.ts
@@ -52,8 +52,9 @@ export class OnDemandDiff implements Diff {
 
     const outputPaths = this.paths();
     await fs.ensureDir(outputPaths.base);
+
     await Promise.all([
-      fs.copy(config.specPath, outputPaths.events),
+      config.events ? fs.writeJson(outputPaths.events, config.events) : fs.copy(config.specPath, outputPaths.events),
       fs.writeJson(outputPaths.ignoreRequests, ignoreRules.allRules || []),
       fs.writeJson(outputPaths.filters, config.endpoints || []),
       fs.writeJson(outputPaths.additionalCommands, []),

--- a/workspaces/cli-server/src/routers/capture-router.ts
+++ b/workspaces/cli-server/src/routers/capture-router.ts
@@ -82,7 +82,7 @@ export function makeRouter(dependencies: ICaptureRouterDependencies) {
 
       let diffId;
       try {
-        diffId = await req.optic.session.diffCapture(captureId, filters);
+        diffId = await req.optic.session.diffCapture(captureId, events, filters);
       } catch (e) {
         return res.status(500).json({ message: e.message });
       }

--- a/workspaces/cli-server/src/sessions.ts
+++ b/workspaces/cli-server/src/sessions.ts
@@ -59,6 +59,7 @@ export class Session {
 
   async diffCapture(
     captureId: string,
+    events?: Array<{ [key: string]: any }>,
     endpoints?: Array<{ pathId: string; method: string }>
   ) {
     if (!this.diffs)
@@ -66,7 +67,7 @@ export class Session {
         'Session must have been started before it can diff a capture'
       );
 
-    return this.diffs.startDiff(captureId, endpoints);
+    return this.diffs.startDiff(captureId, events, endpoints);
   }
 
   diffProgress(diffId: string) {
@@ -103,6 +104,7 @@ class SessionDiffs {
 
   async startDiff(
     captureId: string,
+    events?: Array<{[key: string ]: any }>,
     endpoints?: Array<{ pathId: string; method: string }>
   ): Promise<string> {
     const diffId = Uuid.v4();
@@ -112,6 +114,7 @@ class SessionDiffs {
       configPath: this.configPath,
       captureBaseDirectory: this.capturesPath,
       diffId,
+      events,
       endpoints,
       specPath: this.specPath,
     });


### PR DESCRIPTION
#371 inadvertently introduced a change in behaviour where only endpoints with a single diff could be handled by the UI. Endpoints with multiple diffs, involving the diffing of events that have not yet been committed, got stuck at the first diff.

This fixes the issue by once again accepting the spec events to diff from the API endpoint the UI uses to start a diff. There's a bunch of good reasons why we're trying to move away from that interface, but this use case went unconsidered in that so far. We should figure that out before re-enabling this.