### PR TITLE
Attach release binaries to draft releases

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -27,7 +27,35 @@ jobs:
         with:
           name: optic_diff-macos-tarball
           path: optic_diff-macos-tarball
+      - name: Download linux tarball
+        uses: actions/download-artifact@c3f5d00c8784369c43779f3d2611769594a61f7a # https://github.com/actions/download-artifact/commits/v2
+        with:
+          name: optic_diff-linux-tarball
+          path: optic_diff-linux-tarball
+      - name: Download win64 tarball
+        uses: actions/download-artifact@c3f5d00c8784369c43779f3d2611769594a61f7a # https://github.com/actions/download-artifact/commits/v2
+        with:
+          name: optic_diff-win64-tarball
+          path: optic_diff-win64-tarball
       - name: Attach macOS tarball to release
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # https://github.com/actions/upload-release-asset/commits/v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          asset_path: optic_diff-macos-tarball/optic_diff-macos.tar.gz
+          asset_name: optic_diff-macos.tar.gz
+          asset_content_type: application/gzip
+          upload_url: '${{ steps.draft-release.outputs.upload_url }}'
+      - name: Attach Linux tarball to release
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # https://github.com/actions/upload-release-asset/commits/v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          asset_path: optic_diff-linux-tarball/optic_diff-linux.tar.gz
+          asset_name: optic_diff-linux.tar.gz
+          asset_content_type: application/gzip
+          upload_url: '${{ steps.draft-release.outputs.upload_url }}'
+      - name: Attach Windows tarball to release
         uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # https://github.com/actions/upload-release-asset/commits/v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -40,6 +40,15 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      # - name: 'Debug dependencies Linux'
+      #   if: runner.os == 'Linux'
+      #   run: |
+      #     sudo apt-get update
+      #     sudo apt-get install tree
+      # - name: 'Debug dependencies macOS'
+      #   if: runner.os == 'macOS'
+      #   run: |
+      #     brew install tree
       - name: 'Set CARGO_HOME and RUSTUP_HOME'
         run: | 
           echo "RUSTUP_HOME=$HOME/.rustup" >> $GITHUB_ENV
@@ -69,13 +78,19 @@ jobs:
         if: runner.os == 'macOS'
         run: sudo /usr/sbin/purge
       - name: 'Package binary'
+        env:
+          ARCHIVE_NAME: optic_diff-${{ matrix.platform_name }} # TODO: include version number?
+          FILE_NAME: optic_diff${{ matrix.suffix }}
         run: |
-          mkdir build
+          mkdir -p build/$ARCHIVE_NAME
           mkdir dist
-          cp target/${{ matrix.target }}/release/optic_diff${{ matrix.suffix }} build/${{ matrix.platform_name }}/optic_diff${{ matrix.suffix }}
-          tar -C build -czvf dist/optic_diff${{ matrix.platform_name }}.tar.gz ${{ matrix.platform_name }}
+          cp target/${{ matrix.target }}/release/$FILE_NAME build/$ARCHIVE_NAME/$FILE_NAME
+          tar -C build -czvf dist/$ARCHIVE_NAME.tar.gz $ARCHIVE_NAME
       - name: 'Debug archives'
+        env:
+          ARCHIVE_NAME: optic_diff-${{ matrix.platform_name }} # TODO: include version number?
         run: |
           ls -lsa dist
           ls -lsa build
-          ls -lsa build/${{ matrix.platform_name }}
+          tar -xzvf dist/$ARCHIVE_NAME.tar.gz -C dist
+          ls -lsa dist

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,21 +10,36 @@ on:
       - develop
   # TODO: remove the pull-request event, it's only for debugging this workflow
   pull_request:
-    branches: 
+    branches:
       - develop
 
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    # needs: package_binaries
     steps:
       - uses: release-drafter/release-drafter@06d4616a80cd7c09ea3cf12214165ad6c1859e67 # https://github.com/release-drafter/release-drafter/commits/v5
+        id: release_draft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  rust_binaries:
+      - name: Download macOS tarball
+        uses: actions/download-artifact@c3f5d00c8784369c43779f3d2611769594a61f7a # https://github.com/actions/download-artifact/commits/v2
+        with:
+          name: optic_diff-macos-tarball
+          path: optic_diff_macos-tarball
+      - name: Attach macOS tarball to release
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # https://github.com/actions/upload-release-asset/commits/v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.release_draft.outputs.upload_url }}
+          asset_path: optic_diff-macos-tarball/optic_diff-macos.tar.gz
+          asset_name: optic_diff_macos.tar.gz
+          asset_content_type: application/gzip
+  build_rust_binaries:
     strategy:
       matrix:
-        include: 
+        include:
           - os: macos-latest
             target: x86_64-apple-darwin
             platform_name: macos
@@ -38,7 +53,9 @@ jobs:
             platform_name: linux
             suffix: ''
     runs-on: ${{ matrix.os }}
-
+    env:
+      ARCHIVE_NAME: optic_diff-${{ matrix.platform_name }} # TODO: include version number?
+      FILE_NAME: optic_diff${{ matrix.suffix }}
     steps:
       # - name: 'Debug dependencies Linux'
       #   if: runner.os == 'Linux'
@@ -50,7 +67,7 @@ jobs:
       #   run: |
       #     brew install tree
       - name: 'Set CARGO_HOME and RUSTUP_HOME'
-        run: | 
+        run: |
           echo "RUSTUP_HOME=$HOME/.rustup" >> $GITHUB_ENV
           echo "CARGO_HOME=$HOME/.cargo" >> $GITHUB_ENV
       - name: 'Checkout source'
@@ -61,8 +78,12 @@ jobs:
           path: |
             ${{ env.CARGO_HOME }}/registry
             ${{ env.CARGO_HOME }}/git
-            target
-          key: '${{ runner.os }}-cargo-${{ hashFiles(''**/Cargo.lock'') }}-v4'
+          key: "${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-vendor-v1"
+      - name: 'Cache build target'
+        uses: actions/cache@d1255ad9362389eac595a9ae406b8e8cb3331f16 # https://github.com/actions/cache/commits/v2
+        with:
+          path: target
+          key: "${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-release-target-v1"
       - name: 'Rust toolchain'
         uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # https://github.com/actions-rs/toolchain/commits/v1
         with:
@@ -77,20 +98,50 @@ jobs:
       - name: 'Flush Cargo cache to disk on macOS'
         if: runner.os == 'macOS'
         run: sudo /usr/sbin/purge
-      - name: 'Package binary'
-        env:
-          ARCHIVE_NAME: optic_diff-${{ matrix.platform_name }} # TODO: include version number?
-          FILE_NAME: optic_diff${{ matrix.suffix }}
+      - name: 'Upload artifact'
+        uses: actions/upload-artifact@27bce4eee761b5bc643f46a8dfb41b430c8d05f6 # https://github.com/actions/upload-artifact/commits/v2
+        with:
+          name: ${{ env.ARCHIVE_NAME }}-build
+          path: target/${{ matrix.target }}/release/${{ env.FILE_NAME }}
+  package_binaries:
+    strategy:
+      matrix:
+        include:
+          - platform_name: macos
+            suffix: ''
+          - platform_name: win64
+            suffix: .exe
+          - platform_name: linux
+            suffix: ''
+    runs-on: ubuntu-latest
+    needs: build_rust_binaries
+    env:
+      ARCHIVE_NAME: optic_diff-${{ matrix.platform_name }} # TODO: include version number?
+      FILE_NAME: optic_diff${{ matrix.suffix }}
+    steps:
+      - name: Prepare directory structure
         run: |
           mkdir -p build/$ARCHIVE_NAME
           mkdir dist
-          cp target/${{ matrix.target }}/release/$FILE_NAME build/$ARCHIVE_NAME/$FILE_NAME
-          tar -C build -czvf dist/$ARCHIVE_NAME.tar.gz $ARCHIVE_NAME
-      - name: 'Debug archives'
-        env:
-          ARCHIVE_NAME: optic_diff-${{ matrix.platform_name }} # TODO: include version number?
+      - name: Download binary
+        uses: actions/download-artifact@c3f5d00c8784369c43779f3d2611769594a61f7a # https://github.com/actions/download-artifact/commits/v2
+        with:
+          name: ${{ env.ARCHIVE_NAME }}-build
+          path: build/${{ env.ARCHIVE_NAME }}
+      - name: 'Package binary'
         run: |
-          ls -lsa dist
-          ls -lsa build
-          tar -xzvf dist/$ARCHIVE_NAME.tar.gz -C dist
-          ls -lsa dist
+          chmod +x build/$ARCHIVE_NAME/$FILE_NAME
+          tar -C build -czvf dist/$ARCHIVE_NAME.tar.gz $ARCHIVE_NAME
+      - name: 'Upload artifact'
+        uses: actions/upload-artifact@27bce4eee761b5bc643f46a8dfb41b430c8d05f6 # https://github.com/actions/upload-artifact/commits/v2
+        with:
+          name: ${{ env.ARCHIVE_NAME }}-tarball
+          path: dist/${{ env.ARCHIVE_NAME }}.tar.gz
+      # - name: 'Debug archives'
+      #   env:
+      #     ARCHIVE_NAME: optic_diff-${{ matrix.platform_name }} # TODO: include version number?
+      #   run: |
+      #     ls -lsa dist
+      #     ls -lsa build
+      #     tar -xzvf dist/$ARCHIVE_NAME.tar.gz -C dist
+      #     ls -lsa dist

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -22,6 +22,8 @@ jobs:
         id: draft-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 'release drafter outputs check'
+        run: echo 'Output id=${{ steps.draft-release.outputs.id}} name=${{ steps.draft-release.outputs.name }} upload-url=${{steps.draft-release.outputs.upload_url}} '
       - name: Download macOS tarball
         uses: actions/download-artifact@c3f5d00c8784369c43779f3d2611769594a61f7a # https://github.com/actions/download-artifact/commits/v2
         with:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
-    # needs: package_binaries
+    needs: package_binaries
     steps:
       - uses: release-drafter/release-drafter@06d4616a80cd7c09ea3cf12214165ad6c1859e67 # https://github.com/release-drafter/release-drafter/commits/v5
         id: release_draft

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -26,16 +26,14 @@ jobs:
         uses: actions/download-artifact@c3f5d00c8784369c43779f3d2611769594a61f7a # https://github.com/actions/download-artifact/commits/v2
         with:
           name: optic_diff-macos-tarball
-          path: optic_diff_macos-tarball
-      - name: Debug downloaded artifact
-        run: ls optic_diff_macos-tarball
+          path: optic_diff-macos-tarball
       - name: Attach macOS tarball to release
         uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # https://github.com/actions/upload-release-asset/commits/v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           asset_path: optic_diff-macos-tarball/optic_diff-macos.tar.gz
-          asset_name: optic_diff_macos.tar.gz
+          asset_name: optic_diff-macos.tar.gz
           asset_content_type: application/gzip
           upload_url: '${{ steps.draft-release.outputs.upload_url }}'
   build_rust_binaries:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -27,6 +27,8 @@ jobs:
         with:
           name: optic_diff-macos-tarball
           path: optic_diff_macos-tarball
+      - name: Debug downloaded artifact
+        run: ls optic_diff_macos-tarball
       - name: Attach macOS tarball to release
         uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # https://github.com/actions/upload-release-asset/commits/v1
         env:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -19,7 +19,7 @@ jobs:
     needs: package_binaries
     steps:
       - uses: release-drafter/release-drafter@06d4616a80cd7c09ea3cf12214165ad6c1859e67 # https://github.com/release-drafter/release-drafter/commits/v5
-        id: release_draft
+        id: draft-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Download macOS tarball
@@ -32,10 +32,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.release_draft.outputs.upload_url }}
           asset_path: optic_diff-macos-tarball/optic_diff-macos.tar.gz
           asset_name: optic_diff_macos.tar.gz
           asset_content_type: application/gzip
+          upload_url: '${{ steps.draft-release.outputs.upload_url }}'
   build_rust_binaries:
     strategy:
       matrix:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -8,6 +8,10 @@ on:
     # branches to consider in the event; optional, defaults to all
     branches:
       - develop
+  # TODO: remove the pull-request event, it's only for debugging this workflow
+  pull_request:
+    branches: 
+      - develop
 
 jobs:
   update_release_draft:
@@ -16,3 +20,62 @@ jobs:
       - uses: release-drafter/release-drafter@06d4616a80cd7c09ea3cf12214165ad6c1859e67 # https://github.com/release-drafter/release-drafter/commits/v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  rust_binaries:
+    strategy:
+      matrix:
+        include: 
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            platform_name: macos
+            suffix: ''
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            platform_name: win64
+            suffix: .exe
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            platform_name: linux
+            suffix: ''
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: 'Set CARGO_HOME and RUSTUP_HOME'
+        run: | 
+          echo "RUSTUP_HOME=$HOME/.rustup" >> $GITHUB_ENV
+          echo "CARGO_HOME=$HOME/.cargo" >> $GITHUB_ENV
+      - name: 'Checkout source'
+        uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b # https://github.com/actions/checkout/commits/v2
+      - name: 'Cache cargo registry'
+        uses: actions/cache@d1255ad9362389eac595a9ae406b8e8cb3331f16 # https://github.com/actions/cache/commits/v2
+        with:
+          path: |
+            ${{ env.CARGO_HOME }}/registry
+            ${{ env.CARGO_HOME }}/git
+            target
+          key: '${{ runner.os }}-cargo-${{ hashFiles(''**/Cargo.lock'') }}-v4'
+      - name: 'Rust toolchain'
+        uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # https://github.com/actions-rs/toolchain/commits/v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: 'Build'
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # https://github.com/actions-rs/cargo/commits/v1
+        with:
+          command: build
+          args: --workspace --release --target=${{ matrix.target }}
+      - name: 'Flush Cargo cache to disk on macOS'
+        if: runner.os == 'macOS'
+        run: sudo /usr/sbin/purge
+      - name: 'Package binary'
+        run: |
+          mkdir build
+          mkdir dist
+          cp target/${{ matrix.target }}/release/optic_diff${{ matrix.suffix }} build/${{ matrix.platform_name }}/optic_diff${{ matrix.suffix }}
+          tar -C build -czvf dist/optic_diff${{ matrix.platform_name }}.tar.gz ${{ matrix.platform_name }}
+      - name: 'Debug archives'
+        run: |
+          ls -lsa dist
+          ls -lsa build
+          ls -lsa build/${{ matrix.platform_name }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,15 +3,13 @@
 
 name: Release Drafter
 
-on:
-  push:
-    # branches to consider in the event; optional, defaults to all
-    branches:
-      - develop
-  # TODO: remove the pull-request event, it's only for debugging this workflow
-  pull_request:
-    branches:
-      - develop
+on: push # TODO: restrict back to only develop pushes, this is only for debugging
+
+# on:
+  # push:
+  #   # branches to consider in the event; optional, defaults to all
+  #   branches:
+  #     - develop
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
We'll need some place to host the binary part of the new Diff engine, ready to be downloaded on install. The Github release seems to be the most straightforward spot. We're already updating a draft release on each push to develop: we should include building the binaries and attaching them to the release, ready for publishing at any time.