### PR TITLE
Publish Rust binaries to S3 for each development version

### DIFF
--- a/.github/workflows/develop-binaries.yml
+++ b/.github/workflows/develop-binaries.yml
@@ -1,0 +1,108 @@
+# Build binaries and publish to S3 for every version of the `develop` branch.
+
+name: Develop binaries
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - develop
+  # TODO: remove the pull-request event, it's only for debugging this workflow
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  build_rust_binaries:
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            platform_name: macos
+            suffix: ''
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            platform_name: win64
+            suffix: .exe
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            platform_name: linux
+            suffix: ''
+    runs-on: ${{ matrix.os }}
+    env:
+      ARCHIVE_NAME: optic_diff-${{ matrix.platform_name }} # TODO: include version number?
+      FILE_NAME: optic_diff${{ matrix.suffix }}
+    steps:
+      - name: 'Set CARGO_HOME and RUSTUP_HOME'
+        run: |
+          echo "RUSTUP_HOME=$HOME/.rustup" >> $GITHUB_ENV
+          echo "CARGO_HOME=$HOME/.cargo" >> $GITHUB_ENV
+      - name: 'Checkout source'
+        uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b # https://github.com/actions/checkout/commits/v2
+      - name: 'Cache cargo registry'
+        uses: actions/cache@d1255ad9362389eac595a9ae406b8e8cb3331f16 # https://github.com/actions/cache/commits/v2
+        with:
+          path: |
+            ${{ env.CARGO_HOME }}/registry
+            ${{ env.CARGO_HOME }}/git
+          key: "${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-vendor-v1"
+      - name: 'Cache build target'
+        uses: actions/cache@d1255ad9362389eac595a9ae406b8e8cb3331f16 # https://github.com/actions/cache/commits/v2
+        with:
+          path: target
+          key: "${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-release-target-v1"
+      - name: 'Rust toolchain'
+        uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # https://github.com/actions-rs/toolchain/commits/v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: 'Build'
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # https://github.com/actions-rs/cargo/commits/v1
+        with:
+          command: build
+          args: --workspace --release --target=${{ matrix.target }}
+      - name: 'Flush Cargo cache to disk on macOS'
+        if: runner.os == 'macOS'
+        run: sudo /usr/sbin/purge
+      - name: 'Upload artifact'
+        uses: actions/upload-artifact@27bce4eee761b5bc643f46a8dfb41b430c8d05f6 # https://github.com/actions/upload-artifact/commits/v2
+        with:
+          name: ${{ env.ARCHIVE_NAME }}-build
+          path: target/${{ matrix.target }}/release/${{ env.FILE_NAME }}
+  publish_binaries:
+    strategy:
+      matrix:
+        include:
+          - platform_name: macos
+            suffix: ''
+          - platform_name: win64
+            suffix: .exe
+          - platform_name: linux
+            suffix: ''
+    runs-on: ubuntu-latest
+    needs: build_rust_binaries
+    env:
+      ARCHIVE_NAME: optic_diff-${{ matrix.platform_name }} # TODO: include version number?
+      FILE_NAME: optic_diff${{ matrix.suffix }}
+    steps:
+      - name: Prepare directory structure
+        run: |
+          mkdir -p build/$ARCHIVE_NAME
+          mkdir dist
+      - name: Download binary
+        uses: actions/download-artifact@c3f5d00c8784369c43779f3d2611769594a61f7a # https://github.com/actions/download-artifact/commits/v2
+        with:
+          name: ${{ env.ARCHIVE_NAME }}-build
+          path: build/${{ env.ARCHIVE_NAME }}
+      - name: 'Package binary'
+        run: |
+          chmod +x build/$ARCHIVE_NAME/$FILE_NAME
+          tar -C build -czvf dist/$ARCHIVE_NAME.tar.gz $ARCHIVE_NAME
+      - name: 'Debug archives'
+        run: |
+          ls -lsa dist
+          ls -lsa build
+          tar -xzvf dist/$ARCHIVE_NAME.tar.gz -C dist
+          ls -lsa dist


### PR DESCRIPTION
We'll need some place to host the binary part of the new Diff engine, ready to be downloaded on install. Publishing them to an S3 bucket we control should be a fairly straightforward and totally within our control. The first step in making the entire system work end-to-end is making sure we have the workflow ready to do this for the `develop` branch, so the installer can be developed against it (behind a feature flag).