### PR TITLE
Fix bug where Rust diff engine's locally-compiled binary could not be found

### DIFF
--- a/workspaces/diff-engine/ts/config.ts
+++ b/workspaces/diff-engine/ts/config.ts
@@ -1,5 +1,13 @@
 import Path from 'path';
 
 export default {
-  binaryPath: Path.join(__dirname, '..', 'target', 'debug', 'optic_diff'),
+  binaryPath: Path.join(
+    __dirname,
+    '..',
+    '..',
+    '..',
+    'target',
+    'debug',
+    'optic_diff'
+  ),
 };

--- a/workspaces/diff-engine/ts/index.ts
+++ b/workspaces/diff-engine/ts/index.ts
@@ -1,5 +1,6 @@
 import Execa from 'execa';
 import { Duplex, PassThrough } from 'stream';
+import fs from 'fs';
 
 import Config from './config';
 
@@ -15,6 +16,10 @@ export default function spawn({
   const input = new PassThrough();
   const output = new PassThrough();
   const error = new PassThrough();
+
+  if (!fs.existsSync(Config.binaryPath)) {
+    throw new Error(`expected binary at ${Config.binaryPath}`);
+  }
 
   const diffProcess = Execa(Config.binaryPath, [specPath], {
     input,


### PR DESCRIPTION
While working on building and testing the Diff engine during CI (#395), all local builds now end up in the root `target` folder. This broke the Node.js part of the `diff-engine` spawning it. This is a temporary fix and points back to the workspace root. While not ideal on the long term, we'll soon been changing all of this logic anyway, as we implement the mechanism for downloading / installing pre-built binaries.