### PR TITLE
Add a pathway for prereleases to be created and published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,12 +159,6 @@ jobs:
         node-version: 12
     - name: Install Dependencies and Build Optic
       run:  |
-        # sudo apt-get update
-        # sudo apt-get install apt-transport-https -y
-        # echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list
-        # curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
-        # sudo apt-get update
-        # sudo apt-get install sbt -y
         source ./sourceme.sh && optic_build_for_release
     - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.PUBLISH_NPM_OPTIC_BOT }}" > ~/.npmrc
     - run: node ./workspaces/scripts/publish.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,6 @@ on:
   push:
     branches:
       - release
-  # TODO: remove this trigger after we're done developing the prerelease specifics
-  pull_request:
-    branches:
-      - develop
 
 jobs:
   build-rust-binaries:
@@ -149,9 +145,8 @@ jobs:
       is_prerelease: ${{ steps.release_type.outputs.is_prerelease }}
     steps:
     - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # https://github.com/actions/checkout/releases/tag/v2.3.3
-      # TODO: re-enable publishing the release branch before merging
-      # with:
-      #     ref: release
+      with:
+        ref: release
     - uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d # https://github.com/actions/setup-node/releases/tag/v1.4.4
       with:
         node-version: 12
@@ -183,7 +178,6 @@ jobs:
       - run: |
           echo "determined as not a prerelease" 
           echo "is_prelease=${{ needs.release-npm.outputs.is_prerelease }}"
-          exit 1 # TODO: remove this safety that's preventing actual releases from happening
       - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # https://github.com/actions/checkout/releases/tag/v2.3.3
         with:
           ref: release
@@ -201,9 +195,8 @@ jobs:
   trigger-brew-release:
     runs-on: ubuntu-latest
     needs: release-npm
-    if: needs.release-npm.outputs.is_prerelease != 'true'
+    if: needs.release-npm.outputs.is_prerelease == 'false'
     steps:
-      - run: exit 1 # TODO: remove this safety that's preventing actual releases from happening
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@95531d6358eb144ac65db1d7f39af794979ea97e # https://github.com/peter-evans/repository-dispatch/releases/tag/v1.1.2
         with:
@@ -214,7 +207,6 @@ jobs:
 
   # Tells slack a release has happened
   notify-slack:
-    if: false # TODO: remove this safety that's preventing actual releases from happening
     runs-on: ubuntu-latest
     needs: release-npm
     name: Message Slack that Release has happened

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,8 +176,10 @@ jobs:
       run: |
         OPTIC_VERSION=$(node -e "console.log(require('./workspaces/local-cli/package.json').version)")
         if [[ $OPTIC_VERSION == *'-'* ]]; then
+          echo "v$OPTIC_VERSION is a prerelease"
           echo "::set-output name=is_prerelease::true"
         else
+          echo "v$OPTIC_VERSION is not a prerelease"
           echo "::set-output name=is_prerelease::false"
         fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,10 @@ on:
   push:
     branches:
       - release
+  # TODO: remove this trigger after we're done developing the prerelease specifics
+  pull_request:
+    branches:
+      - develop
 
 jobs:
   build-rust-binaries:
@@ -127,12 +131,14 @@ jobs:
           tar -xzvf dist/$ARCHIVE_NAME.tar.gz -C dist
           ls -lsa dist
       - name: Configure AWS Credentials
+        if: false # TODO: remove this safety that's preventing actual releases from happening
         uses: aws-actions/configure-aws-credentials@32d908adfb55576ba0c59f3c557058e80b5194c3 # https://github.com/aws-actions/configure-aws-credentials/releases/tag/v1.5.3
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: 'us-east-1'
       - name: 'Upload to S3'
+        if: false # TODO: remove this safety that's preventing actual releases from happening
         run: |
           aws s3 cp dist/$ARCHIVE_NAME.tar.gz s3://$BUCKET/dists/optic_diff/v$OPTIC_VERSION/$ARCHIVE_NAME.tar.gz --sse=AES256 --acl=public-read
 
@@ -149,6 +155,7 @@ jobs:
       with:
         node-version: 12
     - name: Install Dependencies and Build Optic
+      if: false # TODO: remove this skipping after we're done developing the prerelease specifics
       run:  |
         sudo apt-get update
         sudo apt-get install apt-transport-https -y
@@ -159,6 +166,7 @@ jobs:
         source ./sourceme.sh && optic_build_for_release
     - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.PUBLISH_NPM_OPTIC_BOT }}" > ~/.npmrc
     - run: node ./workspaces/scripts/publish.js
+      if: false
       env:
         OPTIC_PUBLISH_SCOPE: public
 
@@ -167,6 +175,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: release-npm
     steps:
+      - run: exit 1 # TODO: remove this safety that's preventing actual releases from happening
       - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # https://github.com/actions/checkout/releases/tag/v2.3.3
         with:
           ref: release
@@ -185,6 +194,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: release-npm
     steps:
+      - run: exit 1 # TODO: remove this safety that's preventing actual releases from happening
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@95531d6358eb144ac65db1d7f39af794979ea97e # https://github.com/peter-evans/repository-dispatch/releases/tag/v1.1.2
         with:
@@ -195,6 +205,7 @@ jobs:
 
   # Tells slack a release has happened
   notify-slack:
+    if: false # TODO: remove this safety that's preventing actual releases from happening
     runs-on: ubuntu-latest
     needs: release-npm
     name: Message Slack that Release has happened

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,9 +148,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: publish-binaries
     outputs: 
-      is_prerelease: 
-        description: "Whether release is a prerelease"
-        value: ${{ steps.release_type.outputs.is_prerelease }}
+      is_prerelease: ${{ steps.release_type.outputs.is_prerelease }}
     steps:
     - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # https://github.com/actions/checkout/releases/tag/v2.3.3
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,8 +151,9 @@ jobs:
       is_prerelease: ${{ steps.release_type.outputs.is_prerelease }}
     steps:
     - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # https://github.com/actions/checkout/releases/tag/v2.3.3
-      with:
-          ref: release
+      # TODO: re-enable publishing the release branch before merging
+      # with:
+      #     ref: release
     - uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d # https://github.com/actions/setup-node/releases/tag/v1.4.4
       with:
         node-version: 12

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,7 +188,7 @@ jobs:
   release-deb:
     runs-on: ubuntu-latest
     needs: release-npm
-    if: needs.release-npm.outputs.is_prerelease != 'true'
+    if: needs.release-npm.outputs.is_prerelease == 'false'
     steps:
       - run: |
           echo "determined as not a prerelease" 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,6 +147,10 @@ jobs:
   release-npm:
     runs-on: ubuntu-latest
     needs: publish-binaries
+    outputs: 
+      is_prerelease: 
+        description: "Whether release is a prerelease"
+        value: ${{ steps.release_type.outputs.is_prerelease }}
     steps:
     - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # https://github.com/actions/checkout/releases/tag/v2.3.3
       with:
@@ -169,11 +173,21 @@ jobs:
       if: false
       env:
         OPTIC_PUBLISH_SCOPE: public
+    - name: Set is_prerelease output
+      id: release_type
+      run: |
+        OPTIC_VERSION=$(node -e "console.log(require('./workspaces/local-cli/package.json').version)")
+        if [[ $OPTIC_VERSION == *'-'* ]]; then
+          echo "::set-output name=is_prerelease::true"
+        else
+          echo "::set-output name=is_prerelease::false"
+        fi
 
   # Creates debian package for users to install, hosted on s3
   release-deb:
     runs-on: ubuntu-latest
     needs: release-npm
+    if: needs.release-npm.outputs.is_prerelease != 'true'
     steps:
       - run: exit 1 # TODO: remove this safety that's preventing actual releases from happening
       - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # https://github.com/actions/checkout/releases/tag/v2.3.3
@@ -193,6 +207,7 @@ jobs:
   trigger-brew-release:
     runs-on: ubuntu-latest
     needs: release-npm
+    if: needs.release-npm.outputs.is_prerelease != 'true'
     steps:
       - run: exit 1 # TODO: remove this safety that's preventing actual releases from happening
       - name: Repository Dispatch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,14 +158,13 @@ jobs:
       with:
         node-version: 12
     - name: Install Dependencies and Build Optic
-      if: false # TODO: remove this skipping after we're done developing the prerelease specifics
       run:  |
-        sudo apt-get update
-        sudo apt-get install apt-transport-https -y
-        echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list
-        curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
-        sudo apt-get update
-        sudo apt-get install sbt -y
+        # sudo apt-get update
+        # sudo apt-get install apt-transport-https -y
+        # echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list
+        # curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
+        # sudo apt-get update
+        # sudo apt-get install sbt -y
         source ./sourceme.sh && optic_build_for_release
     - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.PUBLISH_NPM_OPTIC_BOT }}" > ~/.npmrc
     - run: node ./workspaces/scripts/publish.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,14 +131,12 @@ jobs:
           tar -xzvf dist/$ARCHIVE_NAME.tar.gz -C dist
           ls -lsa dist
       - name: Configure AWS Credentials
-        if: false # TODO: remove this safety that's preventing actual releases from happening
         uses: aws-actions/configure-aws-credentials@32d908adfb55576ba0c59f3c557058e80b5194c3 # https://github.com/aws-actions/configure-aws-credentials/releases/tag/v1.5.3
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: 'us-east-1'
       - name: 'Upload to S3'
-        if: false # TODO: remove this safety that's preventing actual releases from happening
         run: |
           aws s3 cp dist/$ARCHIVE_NAME.tar.gz s3://$BUCKET/dists/optic_diff/v$OPTIC_VERSION/$ARCHIVE_NAME.tar.gz --sse=AES256 --acl=public-read
 
@@ -162,7 +160,6 @@ jobs:
         source ./sourceme.sh && optic_build_for_release
     - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.PUBLISH_NPM_OPTIC_BOT }}" > ~/.npmrc
     - run: node ./workspaces/scripts/publish.js
-      if: false
       env:
         OPTIC_PUBLISH_SCOPE: public
     - name: Set is_prerelease output

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,7 +187,10 @@ jobs:
     needs: release-npm
     if: needs.release-npm.outputs.is_prerelease != 'true'
     steps:
-      - run: exit 1 # TODO: remove this safety that's preventing actual releases from happening
+      - run: |
+          echo "determined as not a prerelease" 
+          echo "is_prelease=${{ needs.release-npm.outputs.is_prerelease }}"
+          exit 1 # TODO: remove this safety that's preventing actual releases from happening
       - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # https://github.com/actions/checkout/releases/tag/v2.3.3
         with:
           ref: release

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/debug": "^4.1.5",
     "all-contributors-cli": "^6.14.0",
     "prettier": "^2.0.4",
+    "semver": "^7.3.2",
     "typescript": "^3.8",
     "wait-on": "^4.0.0",
     "wsrun": "^5.2.0"

--- a/workspaces/agent-cli/package.json
+++ b/workspaces/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/agent-cli",
-  "version": "8.6.0-0",
+  "version": "8.6.0-beta.0",
   "author": "@useoptic",
   "bin": {
     "optic-agent": "./bin/run"
@@ -15,7 +15,7 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^3",
-    "@useoptic/cli-shared": "8.6.0-0",
+    "@useoptic/cli-shared": "8.6.0-beta.0",
     "dotenv": "^8.2.0",
     "jwt-decode": "^2.2.0",
     "tslib": "^1",

--- a/workspaces/agent-cli/package.json
+++ b/workspaces/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/agent-cli",
-  "version": "8.6.0-beta.1",
+  "version": "8.6.0-beta.2",
   "author": "@useoptic",
   "bin": {
     "optic-agent": "./bin/run"
@@ -15,7 +15,7 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^3",
-    "@useoptic/cli-shared": "8.6.0-beta.1",
+    "@useoptic/cli-shared": "8.6.0-beta.2",
     "dotenv": "^8.2.0",
     "jwt-decode": "^2.2.0",
     "tslib": "^1",

--- a/workspaces/agent-cli/package.json
+++ b/workspaces/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/agent-cli",
-  "version": "8.5.0",
+  "version": "8.6.0-0",
   "author": "@useoptic",
   "bin": {
     "optic-agent": "./bin/run"
@@ -15,7 +15,7 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^3",
-    "@useoptic/cli-shared": "8.5.0",
+    "@useoptic/cli-shared": "8.6.0-0",
     "dotenv": "^8.2.0",
     "jwt-decode": "^2.2.0",
     "tslib": "^1",

--- a/workspaces/agent-cli/package.json
+++ b/workspaces/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/agent-cli",
-  "version": "8.6.0-beta.2",
+  "version": "8.6.0-beta.3",
   "author": "@useoptic",
   "bin": {
     "optic-agent": "./bin/run"
@@ -15,7 +15,7 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^3",
-    "@useoptic/cli-shared": "8.6.0-beta.2",
+    "@useoptic/cli-shared": "8.6.0-beta.3",
     "dotenv": "^8.2.0",
     "jwt-decode": "^2.2.0",
     "tslib": "^1",

--- a/workspaces/agent-cli/package.json
+++ b/workspaces/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/agent-cli",
-  "version": "8.6.0-beta.0",
+  "version": "8.6.0-beta.1",
   "author": "@useoptic",
   "bin": {
     "optic-agent": "./bin/run"
@@ -15,7 +15,7 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^3",
-    "@useoptic/cli-shared": "8.6.0-beta.0",
+    "@useoptic/cli-shared": "8.6.0-beta.1",
     "dotenv": "^8.2.0",
     "jwt-decode": "^2.2.0",
     "tslib": "^1",

--- a/workspaces/analytics/package.json
+++ b/workspaces/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/analytics",
-  "version": "8.6.0-beta.1",
+  "version": "8.6.0-beta.2",
   "scripts": {
     "ws:build": "tsc -b --verbose",
     "ws:clean": "rm -rf build/*",

--- a/workspaces/analytics/package.json
+++ b/workspaces/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/analytics",
-  "version": "8.6.0-beta.2",
+  "version": "8.6.0-beta.3",
   "scripts": {
     "ws:build": "tsc -b --verbose",
     "ws:clean": "rm -rf build/*",

--- a/workspaces/analytics/package.json
+++ b/workspaces/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/analytics",
-  "version": "8.6.0-0",
+  "version": "8.6.0-beta.0",
   "scripts": {
     "ws:build": "tsc -b --verbose",
     "ws:clean": "rm -rf build/*",

--- a/workspaces/analytics/package.json
+++ b/workspaces/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/analytics",
-  "version": "8.6.0-beta.0",
+  "version": "8.6.0-beta.1",
   "scripts": {
     "ws:build": "tsc -b --verbose",
     "ws:clean": "rm -rf build/*",

--- a/workspaces/analytics/package.json
+++ b/workspaces/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/analytics",
-  "version": "8.5.0",
+  "version": "8.6.0-0",
   "scripts": {
     "ws:build": "tsc -b --verbose",
     "ws:clean": "rm -rf build/*",

--- a/workspaces/ci-cli/package.json
+++ b/workspaces/ci-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/ci-cli",
-  "version": "8.6.0-0",
+  "version": "8.6.0-beta.0",
   "author": "@useoptic",
   "bin": {
     "optic-ci": "./bin/run"
@@ -15,8 +15,8 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^3",
-    "@useoptic/cli-config": "8.6.0-0",
-    "@useoptic/cli-shared": "8.6.0-0",
+    "@useoptic/cli-config": "8.6.0-beta.0",
+    "@useoptic/cli-shared": "8.6.0-beta.0",
     "dotenv": "^8.2.0",
     "jwt-decode": "^2.2.0",
     "tslib": "^1",

--- a/workspaces/ci-cli/package.json
+++ b/workspaces/ci-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/ci-cli",
-  "version": "8.6.0-beta.2",
+  "version": "8.6.0-beta.3",
   "author": "@useoptic",
   "bin": {
     "optic-ci": "./bin/run"
@@ -15,8 +15,8 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^3",
-    "@useoptic/cli-config": "8.6.0-beta.2",
-    "@useoptic/cli-shared": "8.6.0-beta.2",
+    "@useoptic/cli-config": "8.6.0-beta.3",
+    "@useoptic/cli-shared": "8.6.0-beta.3",
     "dotenv": "^8.2.0",
     "jwt-decode": "^2.2.0",
     "tslib": "^1",

--- a/workspaces/ci-cli/package.json
+++ b/workspaces/ci-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/ci-cli",
-  "version": "8.5.0",
+  "version": "8.6.0-0",
   "author": "@useoptic",
   "bin": {
     "optic-ci": "./bin/run"
@@ -15,8 +15,8 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^3",
-    "@useoptic/cli-config": "8.5.0",
-    "@useoptic/cli-shared": "8.5.0",
+    "@useoptic/cli-config": "8.6.0-0",
+    "@useoptic/cli-shared": "8.6.0-0",
     "dotenv": "^8.2.0",
     "jwt-decode": "^2.2.0",
     "tslib": "^1",

--- a/workspaces/ci-cli/package.json
+++ b/workspaces/ci-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/ci-cli",
-  "version": "8.6.0-beta.1",
+  "version": "8.6.0-beta.2",
   "author": "@useoptic",
   "bin": {
     "optic-ci": "./bin/run"
@@ -15,8 +15,8 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^3",
-    "@useoptic/cli-config": "8.6.0-beta.1",
-    "@useoptic/cli-shared": "8.6.0-beta.1",
+    "@useoptic/cli-config": "8.6.0-beta.2",
+    "@useoptic/cli-shared": "8.6.0-beta.2",
     "dotenv": "^8.2.0",
     "jwt-decode": "^2.2.0",
     "tslib": "^1",

--- a/workspaces/ci-cli/package.json
+++ b/workspaces/ci-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/ci-cli",
-  "version": "8.6.0-beta.0",
+  "version": "8.6.0-beta.1",
   "author": "@useoptic",
   "bin": {
     "optic-ci": "./bin/run"
@@ -15,8 +15,8 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^3",
-    "@useoptic/cli-config": "8.6.0-beta.0",
-    "@useoptic/cli-shared": "8.6.0-beta.0",
+    "@useoptic/cli-config": "8.6.0-beta.1",
+    "@useoptic/cli-shared": "8.6.0-beta.1",
     "dotenv": "^8.2.0",
     "jwt-decode": "^2.2.0",
     "tslib": "^1",

--- a/workspaces/cli-client/package.json
+++ b/workspaces/cli-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-client",
-  "version": "8.6.0-beta.1",
+  "version": "8.6.0-beta.2",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",
@@ -14,9 +14,9 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "dependencies": {
-    "@useoptic/analytics": "8.6.0-beta.1",
-    "@useoptic/cli-config": "8.6.0-beta.1",
-    "@useoptic/client-utilities": "8.6.0-beta.1",
+    "@useoptic/analytics": "8.6.0-beta.2",
+    "@useoptic/cli-config": "8.6.0-beta.2",
+    "@useoptic/client-utilities": "8.6.0-beta.2",
     "bottleneck": "^2.19.5",
     "cross-fetch": "^3.0.4"
   },

--- a/workspaces/cli-client/package.json
+++ b/workspaces/cli-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-client",
-  "version": "8.6.0-beta.2",
+  "version": "8.6.0-beta.3",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",
@@ -14,9 +14,9 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "dependencies": {
-    "@useoptic/analytics": "8.6.0-beta.2",
-    "@useoptic/cli-config": "8.6.0-beta.2",
-    "@useoptic/client-utilities": "8.6.0-beta.2",
+    "@useoptic/analytics": "8.6.0-beta.3",
+    "@useoptic/cli-config": "8.6.0-beta.3",
+    "@useoptic/client-utilities": "8.6.0-beta.3",
     "bottleneck": "^2.19.5",
     "cross-fetch": "^3.0.4"
   },

--- a/workspaces/cli-client/package.json
+++ b/workspaces/cli-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-client",
-  "version": "8.5.0",
+  "version": "8.6.0-0",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",
@@ -14,9 +14,9 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "dependencies": {
-    "@useoptic/analytics": "8.5.0",
-    "@useoptic/cli-config": "8.5.0",
-    "@useoptic/client-utilities": "8.5.0",
+    "@useoptic/analytics": "8.6.0-0",
+    "@useoptic/cli-config": "8.6.0-0",
+    "@useoptic/client-utilities": "8.6.0-0",
     "bottleneck": "^2.19.5",
     "cross-fetch": "^3.0.4"
   },

--- a/workspaces/cli-client/package.json
+++ b/workspaces/cli-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-client",
-  "version": "8.6.0-0",
+  "version": "8.6.0-beta.0",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",
@@ -14,9 +14,9 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "dependencies": {
-    "@useoptic/analytics": "8.6.0-0",
-    "@useoptic/cli-config": "8.6.0-0",
-    "@useoptic/client-utilities": "8.6.0-0",
+    "@useoptic/analytics": "8.6.0-beta.0",
+    "@useoptic/cli-config": "8.6.0-beta.0",
+    "@useoptic/client-utilities": "8.6.0-beta.0",
     "bottleneck": "^2.19.5",
     "cross-fetch": "^3.0.4"
   },

--- a/workspaces/cli-client/package.json
+++ b/workspaces/cli-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-client",
-  "version": "8.6.0-beta.0",
+  "version": "8.6.0-beta.1",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",
@@ -14,9 +14,9 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "dependencies": {
-    "@useoptic/analytics": "8.6.0-beta.0",
-    "@useoptic/cli-config": "8.6.0-beta.0",
-    "@useoptic/client-utilities": "8.6.0-beta.0",
+    "@useoptic/analytics": "8.6.0-beta.1",
+    "@useoptic/cli-config": "8.6.0-beta.1",
+    "@useoptic/client-utilities": "8.6.0-beta.1",
     "bottleneck": "^2.19.5",
     "cross-fetch": "^3.0.4"
   },

--- a/workspaces/cli-config/package.json
+++ b/workspaces/cli-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-config",
-  "version": "8.6.0-beta.2",
+  "version": "8.6.0-beta.3",
   "scripts": {
     "ws:test": "jest",
     "ws:build": "yarn run tsc -b --verbose",

--- a/workspaces/cli-config/package.json
+++ b/workspaces/cli-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-config",
-  "version": "8.6.0-beta.1",
+  "version": "8.6.0-beta.2",
   "scripts": {
     "ws:test": "jest",
     "ws:build": "yarn run tsc -b --verbose",

--- a/workspaces/cli-config/package.json
+++ b/workspaces/cli-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-config",
-  "version": "8.6.0-0",
+  "version": "8.6.0-beta.0",
   "scripts": {
     "ws:test": "jest",
     "ws:build": "yarn run tsc -b --verbose",

--- a/workspaces/cli-config/package.json
+++ b/workspaces/cli-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-config",
-  "version": "8.6.0-beta.0",
+  "version": "8.6.0-beta.1",
   "scripts": {
     "ws:test": "jest",
     "ws:build": "yarn run tsc -b --verbose",

--- a/workspaces/cli-config/package.json
+++ b/workspaces/cli-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-config",
-  "version": "8.5.0",
+  "version": "8.6.0-0",
   "scripts": {
     "ws:test": "jest",
     "ws:build": "yarn run tsc -b --verbose",

--- a/workspaces/cli-scripts/package.json
+++ b/workspaces/cli-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-scripts",
-  "version": "8.6.0-beta.1",
+  "version": "8.6.0-beta.2",
   "scripts": {
     "ws:test": "echo scripts",
     "ws:build": "yarn run tsc -b --verbose",
@@ -16,7 +16,7 @@
   "dependencies": {
     "node-notifier": "^7.0.0",
     "analytics-node": "^3.4.0-beta.1",
-    "@useoptic/cli-shared": "8.6.0-beta.1"
+    "@useoptic/cli-shared": "8.6.0-beta.2"
   },
   "devDependencies": {
     "@types/node-notifier": "^6.0.1"

--- a/workspaces/cli-scripts/package.json
+++ b/workspaces/cli-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-scripts",
-  "version": "8.5.0",
+  "version": "8.6.0-0",
   "scripts": {
     "ws:test": "echo scripts",
     "ws:build": "yarn run tsc -b --verbose",
@@ -16,7 +16,7 @@
   "dependencies": {
     "node-notifier": "^7.0.0",
     "analytics-node": "^3.4.0-beta.1",
-    "@useoptic/cli-shared": "8.5.0"
+    "@useoptic/cli-shared": "8.6.0-0"
   },
   "devDependencies": {
     "@types/node-notifier": "^6.0.1"

--- a/workspaces/cli-scripts/package.json
+++ b/workspaces/cli-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-scripts",
-  "version": "8.6.0-beta.0",
+  "version": "8.6.0-beta.1",
   "scripts": {
     "ws:test": "echo scripts",
     "ws:build": "yarn run tsc -b --verbose",
@@ -16,7 +16,7 @@
   "dependencies": {
     "node-notifier": "^7.0.0",
     "analytics-node": "^3.4.0-beta.1",
-    "@useoptic/cli-shared": "8.6.0-beta.0"
+    "@useoptic/cli-shared": "8.6.0-beta.1"
   },
   "devDependencies": {
     "@types/node-notifier": "^6.0.1"

--- a/workspaces/cli-scripts/package.json
+++ b/workspaces/cli-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-scripts",
-  "version": "8.6.0-0",
+  "version": "8.6.0-beta.0",
   "scripts": {
     "ws:test": "echo scripts",
     "ws:build": "yarn run tsc -b --verbose",
@@ -16,7 +16,7 @@
   "dependencies": {
     "node-notifier": "^7.0.0",
     "analytics-node": "^3.4.0-beta.1",
-    "@useoptic/cli-shared": "8.6.0-0"
+    "@useoptic/cli-shared": "8.6.0-beta.0"
   },
   "devDependencies": {
     "@types/node-notifier": "^6.0.1"

--- a/workspaces/cli-scripts/package.json
+++ b/workspaces/cli-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-scripts",
-  "version": "8.6.0-beta.2",
+  "version": "8.6.0-beta.3",
   "scripts": {
     "ws:test": "echo scripts",
     "ws:build": "yarn run tsc -b --verbose",
@@ -16,7 +16,7 @@
   "dependencies": {
     "node-notifier": "^7.0.0",
     "analytics-node": "^3.4.0-beta.1",
-    "@useoptic/cli-shared": "8.6.0-beta.2"
+    "@useoptic/cli-shared": "8.6.0-beta.3"
   },
   "devDependencies": {
     "@types/node-notifier": "^6.0.1"

--- a/workspaces/cli-server/package.json
+++ b/workspaces/cli-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-server",
-  "version": "8.6.0-beta.2",
+  "version": "8.6.0-beta.3",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",
@@ -14,12 +14,12 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "dependencies": {
-    "@useoptic/analytics": "8.6.0-beta.2",
-    "@useoptic/cli-client": "8.6.0-beta.2",
-    "@useoptic/cli-config": "8.6.0-beta.2",
-    "@useoptic/cli-scripts": "8.6.0-beta.2",
-    "@useoptic/cli-shared": "8.6.0-beta.2",
-    "@useoptic/ui": "8.6.0-beta.2",
+    "@useoptic/analytics": "8.6.0-beta.3",
+    "@useoptic/cli-client": "8.6.0-beta.3",
+    "@useoptic/cli-config": "8.6.0-beta.3",
+    "@useoptic/cli-scripts": "8.6.0-beta.3",
+    "@useoptic/cli-shared": "8.6.0-beta.3",
+    "@useoptic/ui": "8.6.0-beta.3",
     "avsc": "^5.4.18",
     "analytics-node": "^3.4.0-beta.2",
     "body-parser": "^1.19.0",

--- a/workspaces/cli-server/package.json
+++ b/workspaces/cli-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-server",
-  "version": "8.6.0-beta.1",
+  "version": "8.6.0-beta.2",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",
@@ -14,12 +14,12 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "dependencies": {
-    "@useoptic/analytics": "8.6.0-beta.1",
-    "@useoptic/cli-client": "8.6.0-beta.1",
-    "@useoptic/cli-config": "8.6.0-beta.1",
-    "@useoptic/cli-scripts": "8.6.0-beta.1",
-    "@useoptic/cli-shared": "8.6.0-beta.1",
-    "@useoptic/ui": "8.6.0-beta.1",
+    "@useoptic/analytics": "8.6.0-beta.2",
+    "@useoptic/cli-client": "8.6.0-beta.2",
+    "@useoptic/cli-config": "8.6.0-beta.2",
+    "@useoptic/cli-scripts": "8.6.0-beta.2",
+    "@useoptic/cli-shared": "8.6.0-beta.2",
+    "@useoptic/ui": "8.6.0-beta.2",
     "avsc": "^5.4.18",
     "analytics-node": "^3.4.0-beta.2",
     "body-parser": "^1.19.0",

--- a/workspaces/cli-server/package.json
+++ b/workspaces/cli-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-server",
-  "version": "8.5.0",
+  "version": "8.6.0-0",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",
@@ -14,12 +14,12 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "dependencies": {
-    "@useoptic/analytics": "8.5.0",
-    "@useoptic/cli-client": "8.5.0",
-    "@useoptic/cli-config": "8.5.0",
-    "@useoptic/cli-scripts": "8.5.0",
-    "@useoptic/cli-shared": "8.5.0",
-    "@useoptic/ui": "8.5.0",
+    "@useoptic/analytics": "8.6.0-0",
+    "@useoptic/cli-client": "8.6.0-0",
+    "@useoptic/cli-config": "8.6.0-0",
+    "@useoptic/cli-scripts": "8.6.0-0",
+    "@useoptic/cli-shared": "8.6.0-0",
+    "@useoptic/ui": "8.9.0-0",
     "avsc": "^5.4.18",
     "analytics-node": "^3.4.0-beta.2",
     "body-parser": "^1.19.0",

--- a/workspaces/cli-server/package.json
+++ b/workspaces/cli-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-server",
-  "version": "8.6.0-0",
+  "version": "8.6.0-beta.0",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",
@@ -14,12 +14,12 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "dependencies": {
-    "@useoptic/analytics": "8.6.0-0",
-    "@useoptic/cli-client": "8.6.0-0",
-    "@useoptic/cli-config": "8.6.0-0",
-    "@useoptic/cli-scripts": "8.6.0-0",
-    "@useoptic/cli-shared": "8.6.0-0",
-    "@useoptic/ui": "8.9.0-0",
+    "@useoptic/analytics": "8.6.0-beta.0",
+    "@useoptic/cli-client": "8.6.0-beta.0",
+    "@useoptic/cli-config": "8.6.0-beta.0",
+    "@useoptic/cli-scripts": "8.6.0-beta.0",
+    "@useoptic/cli-shared": "8.6.0-beta.0",
+    "@useoptic/ui": "8.6.0-beta.0",
     "avsc": "^5.4.18",
     "analytics-node": "^3.4.0-beta.2",
     "body-parser": "^1.19.0",

--- a/workspaces/cli-server/package.json
+++ b/workspaces/cli-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-server",
-  "version": "8.6.0-beta.0",
+  "version": "8.6.0-beta.1",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",
@@ -14,12 +14,12 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "dependencies": {
-    "@useoptic/analytics": "8.6.0-beta.0",
-    "@useoptic/cli-client": "8.6.0-beta.0",
-    "@useoptic/cli-config": "8.6.0-beta.0",
-    "@useoptic/cli-scripts": "8.6.0-beta.0",
-    "@useoptic/cli-shared": "8.6.0-beta.0",
-    "@useoptic/ui": "8.6.0-beta.0",
+    "@useoptic/analytics": "8.6.0-beta.1",
+    "@useoptic/cli-client": "8.6.0-beta.1",
+    "@useoptic/cli-config": "8.6.0-beta.1",
+    "@useoptic/cli-scripts": "8.6.0-beta.1",
+    "@useoptic/cli-shared": "8.6.0-beta.1",
+    "@useoptic/ui": "8.6.0-beta.1",
     "avsc": "^5.4.18",
     "analytics-node": "^3.4.0-beta.2",
     "body-parser": "^1.19.0",

--- a/workspaces/cli-shared/package.json
+++ b/workspaces/cli-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-shared",
-  "version": "8.6.0-beta.0",
+  "version": "8.6.0-beta.1",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",
@@ -15,10 +15,10 @@
   "types": "build/index.d.ts",
   "dependencies": {
     "@oclif/command": "^1.6.1",
-    "@useoptic/cli-client": "8.6.0-beta.0",
-    "@useoptic/cli-config": "8.6.0-beta.0",
-    "@useoptic/client-utilities": "8.6.0-beta.0",
-    "@useoptic/diff-engine": "8.6.0-beta.0",
+    "@useoptic/cli-client": "8.6.0-beta.1",
+    "@useoptic/cli-config": "8.6.0-beta.1",
+    "@useoptic/client-utilities": "8.6.0-beta.1",
+    "@useoptic/diff-engine": "8.6.0-beta.1",
     "@useoptic/domain": "10.0.17",
     "@useoptic/domain-types": "10.0.17",
     "@useoptic/domain-utilities": "10.0.17",

--- a/workspaces/cli-shared/package.json
+++ b/workspaces/cli-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-shared",
-  "version": "8.6.0-0",
+  "version": "8.6.0-beta.0",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",
@@ -15,10 +15,10 @@
   "types": "build/index.d.ts",
   "dependencies": {
     "@oclif/command": "^1.6.1",
-    "@useoptic/cli-client": "8.6.0-0",
-    "@useoptic/cli-config": "8.6.0-0",
-    "@useoptic/client-utilities": "8.6.0-0",
-    "@useoptic/diff-engine": "8.6.0-0",
+    "@useoptic/cli-client": "8.6.0-beta.0",
+    "@useoptic/cli-config": "8.6.0-beta.0",
+    "@useoptic/client-utilities": "8.6.0-beta.0",
+    "@useoptic/diff-engine": "8.6.0-beta.0",
     "@useoptic/domain": "10.0.17",
     "@useoptic/domain-types": "10.0.17",
     "@useoptic/domain-utilities": "10.0.17",

--- a/workspaces/cli-shared/package.json
+++ b/workspaces/cli-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-shared",
-  "version": "8.6.0-beta.2",
+  "version": "8.6.0-beta.3",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",
@@ -15,10 +15,10 @@
   "types": "build/index.d.ts",
   "dependencies": {
     "@oclif/command": "^1.6.1",
-    "@useoptic/cli-client": "8.6.0-beta.2",
-    "@useoptic/cli-config": "8.6.0-beta.2",
-    "@useoptic/client-utilities": "8.6.0-beta.2",
-    "@useoptic/diff-engine": "8.6.0-beta.2",
+    "@useoptic/cli-client": "8.6.0-beta.3",
+    "@useoptic/cli-config": "8.6.0-beta.3",
+    "@useoptic/client-utilities": "8.6.0-beta.3",
+    "@useoptic/diff-engine": "8.6.0-beta.3",
     "@useoptic/domain": "10.0.17",
     "@useoptic/domain-types": "10.0.17",
     "@useoptic/domain-utilities": "10.0.17",

--- a/workspaces/cli-shared/package.json
+++ b/workspaces/cli-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-shared",
-  "version": "8.5.0",
+  "version": "8.6.0-0",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",
@@ -15,10 +15,10 @@
   "types": "build/index.d.ts",
   "dependencies": {
     "@oclif/command": "^1.6.1",
-    "@useoptic/cli-client": "8.5.0",
-    "@useoptic/cli-config": "8.5.0",
-    "@useoptic/client-utilities": "8.5.0",
-    "@useoptic/diff-engine": "8.5.0",
+    "@useoptic/cli-client": "8.6.0-0",
+    "@useoptic/cli-config": "8.6.0-0",
+    "@useoptic/client-utilities": "8.6.0-0",
+    "@useoptic/diff-engine": "8.6.0-0",
     "@useoptic/domain": "10.0.17",
     "@useoptic/domain-types": "10.0.17",
     "@useoptic/domain-utilities": "10.0.17",

--- a/workspaces/cli-shared/package.json
+++ b/workspaces/cli-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-shared",
-  "version": "8.6.0-beta.1",
+  "version": "8.6.0-beta.2",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",
@@ -15,10 +15,10 @@
   "types": "build/index.d.ts",
   "dependencies": {
     "@oclif/command": "^1.6.1",
-    "@useoptic/cli-client": "8.6.0-beta.1",
-    "@useoptic/cli-config": "8.6.0-beta.1",
-    "@useoptic/client-utilities": "8.6.0-beta.1",
-    "@useoptic/diff-engine": "8.6.0-beta.1",
+    "@useoptic/cli-client": "8.6.0-beta.2",
+    "@useoptic/cli-config": "8.6.0-beta.2",
+    "@useoptic/client-utilities": "8.6.0-beta.2",
+    "@useoptic/diff-engine": "8.6.0-beta.2",
     "@useoptic/domain": "10.0.17",
     "@useoptic/domain-types": "10.0.17",
     "@useoptic/domain-utilities": "10.0.17",

--- a/workspaces/client-utilities/package.json
+++ b/workspaces/client-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/client-utilities",
-  "version": "8.6.0-0",
+  "version": "8.6.0-beta.0",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",

--- a/workspaces/client-utilities/package.json
+++ b/workspaces/client-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/client-utilities",
-  "version": "8.6.0-beta.1",
+  "version": "8.6.0-beta.2",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",

--- a/workspaces/client-utilities/package.json
+++ b/workspaces/client-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/client-utilities",
-  "version": "8.6.0-beta.0",
+  "version": "8.6.0-beta.1",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",

--- a/workspaces/client-utilities/package.json
+++ b/workspaces/client-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/client-utilities",
-  "version": "8.6.0-beta.2",
+  "version": "8.6.0-beta.3",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",

--- a/workspaces/client-utilities/package.json
+++ b/workspaces/client-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/client-utilities",
-  "version": "8.5.0",
+  "version": "8.6.0-0",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",

--- a/workspaces/diff-engine/lib/index.js
+++ b/workspaces/diff-engine/lib/index.js
@@ -2,7 +2,6 @@ const Execa = require('execa');
 const { PassThrough } = require('stream');
 const Fs = require('fs');
 const Path = require('path');
-const Toml = require('@iarna/toml');
 const OS = require('os');
 const Rimraf = require('rimraf');
 const Bent = require('bent');

--- a/workspaces/diff-engine/package.json
+++ b/workspaces/diff-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/diff-engine",
-  "version": "8.6.0-beta.0",
+  "version": "8.6.0-beta.1",
   "scripts": {
     "postinstall": "node scripts/install",
     "preuninstall": "node scripts/uninstall",

--- a/workspaces/diff-engine/package.json
+++ b/workspaces/diff-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/diff-engine",
-  "version": "8.6.0-0",
+  "version": "8.6.0-beta.0",
   "scripts": {
     "postinstall": "node scripts/install",
     "preuninstall": "node scripts/uninstall",

--- a/workspaces/diff-engine/package.json
+++ b/workspaces/diff-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/diff-engine",
-  "version": "8.5.0",
+  "version": "8.6.0-0",
   "scripts": {
     "postinstall": "node scripts/install",
     "preuninstall": "node scripts/uninstall",

--- a/workspaces/diff-engine/package.json
+++ b/workspaces/diff-engine/package.json
@@ -16,6 +16,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "dependencies": {
+    "@iarna/toml": "^2.2.5",
     "bent": "^7.3.12",
     "execa": "^4.0.3",
     "read-package-json": "^3.0.0",

--- a/workspaces/diff-engine/package.json
+++ b/workspaces/diff-engine/package.json
@@ -2,8 +2,8 @@
   "name": "@useoptic/diff-engine",
   "version": "8.6.0-beta.1",
   "scripts": {
-    "postinstall": "node scripts/install",
-    "preuninstall": "node scripts/uninstall",
+    "postinstall": "echo 'Disabled for now' # node scripts/install",
+    "preuninstall": "ecoh 'Disabled for now' # node scripts/uninstall",
     "ws:build-binaries": "scripts/build-binaries.sh",
     "ws:clean": "rm -rf build/* && rm -rf target/*",
     "ws:test": "scripts/test.sh"

--- a/workspaces/diff-engine/package.json
+++ b/workspaces/diff-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/diff-engine",
-  "version": "8.6.0-beta.2",
+  "version": "8.6.0-beta.3",
   "scripts": {
     "postinstall": "echo 'Disabled for now' # node scripts/install",
     "preuninstall": "ecoh 'Disabled for now' # node scripts/uninstall",

--- a/workspaces/diff-engine/package.json
+++ b/workspaces/diff-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/diff-engine",
-  "version": "8.6.0-beta.1",
+  "version": "8.6.0-beta.2",
   "scripts": {
     "postinstall": "echo 'Disabled for now' # node scripts/install",
     "preuninstall": "ecoh 'Disabled for now' # node scripts/uninstall",

--- a/workspaces/diff-engine/package.json
+++ b/workspaces/diff-engine/package.json
@@ -16,7 +16,6 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@iarna/toml": "^2.2.5",
     "bent": "^7.3.12",
     "execa": "^4.0.3",
     "read-package-json": "^3.0.0",

--- a/workspaces/local-cli/package.json
+++ b/workspaces/local-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/cli",
   "description": "The Optic CLI",
-  "version": "8.6.0-0",
+  "version": "8.6.0-beta.0",
   "author": "@useoptic",
   "bin": {
     "api": "./bin/run"
@@ -18,12 +18,12 @@
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^2",
     "cli-table3": "^0.6.0",
-    "@useoptic/analytics": "8.6.0-0",
-    "@useoptic/cli-client": "8.6.0-0",
-    "@useoptic/cli-config": "8.6.0-0",
-    "@useoptic/cli-scripts": "8.6.0-0",
-    "@useoptic/cli-server": "8.6.0-0",
-    "@useoptic/cli-shared": "8.6.0-0",
+    "@useoptic/analytics": "8.6.0-beta.0",
+    "@useoptic/cli-client": "8.6.0-beta.0",
+    "@useoptic/cli-config": "8.6.0-beta.0",
+    "@useoptic/cli-scripts": "8.6.0-beta.0",
+    "@useoptic/cli-server": "8.6.0-beta.0",
+    "@useoptic/cli-shared": "8.6.0-beta.0",
     "@useoptic/domain": "10.0.17",
     "analytics-node": "^3.4.0-beta.1",
     "cli-ux": "^5.4.1",

--- a/workspaces/local-cli/package.json
+++ b/workspaces/local-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/cli",
   "description": "The Optic CLI",
-  "version": "8.5.0",
+  "version": "8.6.0-0",
   "author": "@useoptic",
   "bin": {
     "api": "./bin/run"
@@ -18,12 +18,12 @@
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^2",
     "cli-table3": "^0.6.0",
-    "@useoptic/analytics": "8.5.0",
-    "@useoptic/cli-client": "8.5.0",
-    "@useoptic/cli-config": "8.5.0",
-    "@useoptic/cli-scripts": "8.5.0",
-    "@useoptic/cli-server": "8.5.0",
-    "@useoptic/cli-shared": "8.5.0",
+    "@useoptic/analytics": "8.6.0-0",
+    "@useoptic/cli-client": "8.6.0-0",
+    "@useoptic/cli-config": "8.6.0-0",
+    "@useoptic/cli-scripts": "8.6.0-0",
+    "@useoptic/cli-server": "8.6.0-0",
+    "@useoptic/cli-shared": "8.6.0-0",
     "@useoptic/domain": "10.0.17",
     "analytics-node": "^3.4.0-beta.1",
     "cli-ux": "^5.4.1",

--- a/workspaces/local-cli/package.json
+++ b/workspaces/local-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/cli",
   "description": "The Optic CLI",
-  "version": "8.6.0-beta.2",
+  "version": "8.6.0-beta.3",
   "author": "@useoptic",
   "bin": {
     "api": "./bin/run"
@@ -18,12 +18,12 @@
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^2",
     "cli-table3": "^0.6.0",
-    "@useoptic/analytics": "8.6.0-beta.2",
-    "@useoptic/cli-client": "8.6.0-beta.2",
-    "@useoptic/cli-config": "8.6.0-beta.2",
-    "@useoptic/cli-scripts": "8.6.0-beta.2",
-    "@useoptic/cli-server": "8.6.0-beta.2",
-    "@useoptic/cli-shared": "8.6.0-beta.2",
+    "@useoptic/analytics": "8.6.0-beta.3",
+    "@useoptic/cli-client": "8.6.0-beta.3",
+    "@useoptic/cli-config": "8.6.0-beta.3",
+    "@useoptic/cli-scripts": "8.6.0-beta.3",
+    "@useoptic/cli-server": "8.6.0-beta.3",
+    "@useoptic/cli-shared": "8.6.0-beta.3",
     "@useoptic/domain": "10.0.17",
     "analytics-node": "^3.4.0-beta.1",
     "cli-ux": "^5.4.1",

--- a/workspaces/local-cli/package.json
+++ b/workspaces/local-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/cli",
   "description": "The Optic CLI",
-  "version": "8.6.0-beta.1",
+  "version": "8.6.0-beta.2",
   "author": "@useoptic",
   "bin": {
     "api": "./bin/run"
@@ -18,12 +18,12 @@
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^2",
     "cli-table3": "^0.6.0",
-    "@useoptic/analytics": "8.6.0-beta.1",
-    "@useoptic/cli-client": "8.6.0-beta.1",
-    "@useoptic/cli-config": "8.6.0-beta.1",
-    "@useoptic/cli-scripts": "8.6.0-beta.1",
-    "@useoptic/cli-server": "8.6.0-beta.1",
-    "@useoptic/cli-shared": "8.6.0-beta.1",
+    "@useoptic/analytics": "8.6.0-beta.2",
+    "@useoptic/cli-client": "8.6.0-beta.2",
+    "@useoptic/cli-config": "8.6.0-beta.2",
+    "@useoptic/cli-scripts": "8.6.0-beta.2",
+    "@useoptic/cli-server": "8.6.0-beta.2",
+    "@useoptic/cli-shared": "8.6.0-beta.2",
     "@useoptic/domain": "10.0.17",
     "analytics-node": "^3.4.0-beta.1",
     "cli-ux": "^5.4.1",

--- a/workspaces/local-cli/package.json
+++ b/workspaces/local-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/cli",
   "description": "The Optic CLI",
-  "version": "8.6.0-beta.0",
+  "version": "8.6.0-beta.1",
   "author": "@useoptic",
   "bin": {
     "api": "./bin/run"
@@ -18,12 +18,12 @@
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^2",
     "cli-table3": "^0.6.0",
-    "@useoptic/analytics": "8.6.0-beta.0",
-    "@useoptic/cli-client": "8.6.0-beta.0",
-    "@useoptic/cli-config": "8.6.0-beta.0",
-    "@useoptic/cli-scripts": "8.6.0-beta.0",
-    "@useoptic/cli-server": "8.6.0-beta.0",
-    "@useoptic/cli-shared": "8.6.0-beta.0",
+    "@useoptic/analytics": "8.6.0-beta.1",
+    "@useoptic/cli-client": "8.6.0-beta.1",
+    "@useoptic/cli-config": "8.6.0-beta.1",
+    "@useoptic/cli-scripts": "8.6.0-beta.1",
+    "@useoptic/cli-server": "8.6.0-beta.1",
+    "@useoptic/cli-shared": "8.6.0-beta.1",
     "@useoptic/domain": "10.0.17",
     "analytics-node": "^3.4.0-beta.1",
     "cli-ux": "^5.4.1",

--- a/workspaces/saas-types/package.json
+++ b/workspaces/saas-types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/saas-types",
   "description": "interfaces and types for Optic SaaS surface area",
-  "version": "8.6.0-beta.2",
+  "version": "8.6.0-beta.3",
   "main": "build/index.js",
   "files": [
     "build"

--- a/workspaces/saas-types/package.json
+++ b/workspaces/saas-types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/saas-types",
   "description": "interfaces and types for Optic SaaS surface area",
-  "version": "8.6.0-beta.1",
+  "version": "8.6.0-beta.2",
   "main": "build/index.js",
   "files": [
     "build"

--- a/workspaces/saas-types/package.json
+++ b/workspaces/saas-types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/saas-types",
   "description": "interfaces and types for Optic SaaS surface area",
-  "version": "8.6.0-beta.0",
+  "version": "8.6.0-beta.1",
   "main": "build/index.js",
   "files": [
     "build"

--- a/workspaces/saas-types/package.json
+++ b/workspaces/saas-types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/saas-types",
   "description": "interfaces and types for Optic SaaS surface area",
-  "version": "8.6.0-0",
+  "version": "8.6.0-beta.0",
   "main": "build/index.js",
   "files": [
     "build"

--- a/workspaces/saas-types/package.json
+++ b/workspaces/saas-types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/saas-types",
   "description": "interfaces and types for Optic SaaS surface area",
-  "version": "8.5.0",
+  "version": "8.6.0-0",
   "main": "build/index.js",
   "files": [
     "build"

--- a/workspaces/scripts/bump.js
+++ b/workspaces/scripts/bump.js
@@ -1,13 +1,24 @@
 // this script is meant to be run via `yarn bump <whatever version>`
 const path = require('path');
 const fs = require('fs-extra');
+const semver = require('semver');
+
+const semverIncrements = [
+  'minor',
+  'major',
+  'patch',
+  'premajor',
+  'preminor',
+  'prepatch',
+  'prerelease',
+];
 
 async function main(targetVersion) {
   const silentMode = JSON.parse(process.env.npm_config_argv).original.includes('--silent');
   const packageJson = await fs.readJson('./package.json');
   const { workspaces } = packageJson;
-  if ([undefined, "minor", "major", "patch"].includes(targetVersion)) {
-    bumpAllPackages(targetVersion, silentMode);
+  if (!targetVersion || semverIncrements.includes(targetVersion)) {
+    incrementAllPackages(targetVersion);
     return;
   } else {
     console.log(`setting workspace versions to ${targetVersion}`);
@@ -56,12 +67,12 @@ async function main(targetVersion) {
 }
 
 // this is called if there is no specified target version
-async function bumpAllPackages(type = "patch", silentMode) {
+async function incrementAllPackages(increment = "patch", silentMode) {
   let log = console.log;
   if (silentMode) {
     console.log = () => {} // disable logging
   }
-  console.log(`performing a ${type} bump`)
+  console.log(`performing a ${increment} bump`)
   const packageJson = await fs.readJson('./package.json');
   const { workspaces } = packageJson;
   const versions = {}
@@ -73,7 +84,7 @@ async function bumpAllPackages(type = "patch", silentMode) {
         const targetPackage = await fs.readJson(`./${workspace}/package.json`);
         const old = targetPackage.version;
 
-        targetPackage.version = bumpVersion(targetPackage.version, type);
+        targetPackage.version = semver.inc(targetPackage.version, increment);
         console.log(`bumping ${old} to ${targetPackage.version}`)
         versions[targetPackage.name] = targetPackage.version;
         version = targetPackage.version;
@@ -114,26 +125,6 @@ async function bumpAllPackages(type = "patch", silentMode) {
   });
   await Promise.all(updateVersionTasks);
   console.log(`Done!`);
-}
-
-function bumpVersion(current, type) {
-  console.log(current)
-  let [major, minor, patch] = current.split(".");
-  switch (type) {
-    case "major":
-      major = parseInt(major) + 1;
-      minor = patch = 0;
-      break;
-      case "minor":
-        minor = parseInt(minor) + 1;
-        patch = 0;
-        break;
-      case "patch":
-      default:
-        patch = parseInt(patch) + 1;
-        break;
-  }
-  return [major, minor, patch].join(".");
 }
 
 const [, , targetVersion] = process.argv;

--- a/workspaces/scripts/bump.js
+++ b/workspaces/scripts/bump.js
@@ -13,12 +13,12 @@ const semverIncrements = [
   'prerelease',
 ];
 
-async function main(targetVersion) {
+async function main(targetVersion, preId) {
   const silentMode = JSON.parse(process.env.npm_config_argv).original.includes('--silent');
   const packageJson = await fs.readJson('./package.json');
   const { workspaces } = packageJson;
   if (!targetVersion || semverIncrements.includes(targetVersion)) {
-    incrementAllPackages(targetVersion);
+    incrementAllPackages(targetVersion, preId);
     return;
   } else {
     console.log(`setting workspace versions to ${targetVersion}`);
@@ -67,7 +67,7 @@ async function main(targetVersion) {
 }
 
 // this is called if there is no specified target version
-async function incrementAllPackages(increment = "patch", silentMode) {
+async function incrementAllPackages(increment = "patch", preId, silentMode) {
   let log = console.log;
   if (silentMode) {
     console.log = () => {} // disable logging
@@ -84,7 +84,11 @@ async function incrementAllPackages(increment = "patch", silentMode) {
         const targetPackage = await fs.readJson(`./${workspace}/package.json`);
         const old = targetPackage.version;
 
-        targetPackage.version = semver.inc(targetPackage.version, increment);
+        targetPackage.version = semver.inc(
+          targetPackage.version,
+          increment,
+          preId
+        );
         console.log(`bumping ${old} to ${targetPackage.version}`)
         versions[targetPackage.name] = targetPackage.version;
         version = targetPackage.version;
@@ -127,5 +131,5 @@ async function incrementAllPackages(increment = "patch", silentMode) {
   console.log(`Done!`);
 }
 
-const [, , targetVersion] = process.argv;
-main(targetVersion);
+const [, , targetVersion, preId] = process.argv;
+main(targetVersion, preId);

--- a/workspaces/snapshot-tests/package.json
+++ b/workspaces/snapshot-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/snapshot-tests",
-  "version": "8.5.0",
+  "version": "8.6.0-0",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",

--- a/workspaces/snapshot-tests/package.json
+++ b/workspaces/snapshot-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/snapshot-tests",
-  "version": "8.6.0-0",
+  "version": "8.6.0-beta.0",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",

--- a/workspaces/snapshot-tests/package.json
+++ b/workspaces/snapshot-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/snapshot-tests",
-  "version": "8.6.0-beta.2",
+  "version": "8.6.0-beta.3",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",

--- a/workspaces/snapshot-tests/package.json
+++ b/workspaces/snapshot-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/snapshot-tests",
-  "version": "8.6.0-beta.0",
+  "version": "8.6.0-beta.1",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",

--- a/workspaces/snapshot-tests/package.json
+++ b/workspaces/snapshot-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/snapshot-tests",
-  "version": "8.6.0-beta.1",
+  "version": "8.6.0-beta.2",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",

--- a/workspaces/ui/package.json
+++ b/workspaces/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/ui",
-  "version": "8.6.0-beta.2",
+  "version": "8.6.0-beta.3",
   "files": [
     "build",
     "index.js",
@@ -15,9 +15,9 @@
     "@material-ui/core": "^4.9.7",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.46",
-    "@useoptic/cli-shared": "8.6.0-beta.2",
-    "@useoptic/cli-client": "8.6.0-beta.2",
-    "@useoptic/analytics": "8.6.0-beta.2",
+    "@useoptic/cli-shared": "8.6.0-beta.3",
+    "@useoptic/cli-client": "8.6.0-beta.3",
+    "@useoptic/analytics": "8.6.0-beta.3",
     "@useoptic/domain": "10.0.17",
     "@useoptic/domain-utilities": "10.0.17",
     "bottleneck": "^2.19.5",

--- a/workspaces/ui/package.json
+++ b/workspaces/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/ui",
-  "version": "8.6.0-beta.0",
+  "version": "8.6.0-beta.1",
   "files": [
     "build",
     "index.js",
@@ -15,9 +15,9 @@
     "@material-ui/core": "^4.9.7",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.46",
-    "@useoptic/cli-shared": "8.6.0-beta.0",
-    "@useoptic/cli-client": "8.6.0-beta.0",
-    "@useoptic/analytics": "8.6.0-beta.0",
+    "@useoptic/cli-shared": "8.6.0-beta.1",
+    "@useoptic/cli-client": "8.6.0-beta.1",
+    "@useoptic/analytics": "8.6.0-beta.1",
     "@useoptic/domain": "10.0.17",
     "@useoptic/domain-utilities": "10.0.17",
     "bottleneck": "^2.19.5",

--- a/workspaces/ui/package.json
+++ b/workspaces/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/ui",
-  "version": "8.6.0-beta.1",
+  "version": "8.6.0-beta.2",
   "files": [
     "build",
     "index.js",
@@ -15,9 +15,9 @@
     "@material-ui/core": "^4.9.7",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.46",
-    "@useoptic/cli-shared": "8.6.0-beta.1",
-    "@useoptic/cli-client": "8.6.0-beta.1",
-    "@useoptic/analytics": "8.6.0-beta.1",
+    "@useoptic/cli-shared": "8.6.0-beta.2",
+    "@useoptic/cli-client": "8.6.0-beta.2",
+    "@useoptic/analytics": "8.6.0-beta.2",
     "@useoptic/domain": "10.0.17",
     "@useoptic/domain-utilities": "10.0.17",
     "bottleneck": "^2.19.5",

--- a/workspaces/ui/package.json
+++ b/workspaces/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/ui",
-  "version": "8.8.0",
+  "version": "8.6.0-0",
   "files": [
     "build",
     "index.js",
@@ -15,9 +15,9 @@
     "@material-ui/core": "^4.9.7",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.46",
-    "@useoptic/cli-shared": "8.8.0",
-    "@useoptic/cli-client": "8.8.0",
-    "@useoptic/analytics": "8.8.0",
+    "@useoptic/cli-shared": "8.6.0-0",
+    "@useoptic/cli-client": "8.6.0-0",
+    "@useoptic/analytics": "8.6.0-0",
     "@useoptic/domain": "10.0.17",
     "@useoptic/domain-utilities": "10.0.17",
     "bottleneck": "^2.19.5",

--- a/workspaces/ui/package.json
+++ b/workspaces/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/ui",
-  "version": "8.6.0-0",
+  "version": "8.6.0-beta.0",
   "files": [
     "build",
     "index.js",
@@ -15,9 +15,9 @@
     "@material-ui/core": "^4.9.7",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.46",
-    "@useoptic/cli-shared": "8.6.0-0",
-    "@useoptic/cli-client": "8.6.0-0",
-    "@useoptic/analytics": "8.6.0-0",
+    "@useoptic/cli-shared": "8.6.0-beta.0",
+    "@useoptic/cli-client": "8.6.0-beta.0",
+    "@useoptic/analytics": "8.6.0-beta.0",
     "@useoptic/domain": "10.0.17",
     "@useoptic/domain-utilities": "10.0.17",
     "bottleneck": "^2.19.5",

--- a/workspaces/ui/package.json
+++ b/workspaces/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/ui",
-  "version": "8.5.0",
+  "version": "8.8.0",
   "files": [
     "build",
     "index.js",
@@ -15,9 +15,9 @@
     "@material-ui/core": "^4.9.7",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.46",
-    "@useoptic/cli-shared": "8.5.0",
-    "@useoptic/cli-client": "8.5.0",
-    "@useoptic/analytics": "8.5.0",
+    "@useoptic/cli-shared": "8.8.0",
+    "@useoptic/cli-client": "8.8.0",
+    "@useoptic/analytics": "8.8.0",
     "@useoptic/domain": "10.0.17",
     "@useoptic/domain-utilities": "10.0.17",
     "bottleneck": "^2.19.5",


### PR DESCRIPTION
We've built a release pipeline where part the building of binaries is part of the release + publishing to npm. During a new npm install, the pre-built binary must be able to be downloaded, or else it's install fails. Publishing a pre-release for a non-`latest` tag through this same pipeline is our best way of verifying this all works, while making sure nothing breaks for customers.

Due to [how semver treats prereleases](https://www.npmjs.com/package/semver#prerelease-tags) only users who explicitly opt-in to the pre-release will get it, and anyone who has will automatically get the full released version, eliminating the risk of users getting stuck on stale betas:

> If a version has a prerelease tag (for example, 1.2.3-alpha.3) then it will only be allowed to satisfy comparator sets if at least one comparator with the same [major, minor, patch]tuple also has a prerelease tag.
> 
> For example, the range >1.2.3-alpha.3 would be allowed to match the version 1.2.3-alpha.7, but it would not be satisfied by 3.4.5-alpha.9, even though 3.4.5-alpha.9 is technically "greater than" 1.2.3-alpha.3 according to the SemVer sort rules. The version range only accepts prerelease tags on the 1.2.3 version. The version 3.4.5 would satisfy the range, because it does not have a prerelease flag, and 3.4.5 is greater than 1.2.3-alpha.7.
> 
> The purpose for this behavior is twofold. First, prerelease versions frequently are updated very quickly, and contain many breaking changes that are (by the author's design) not yet fit for public consumption. Therefore, by default, they are excluded from range matching semantics.
> 
> Second, a user who has opted into using a prerelease version has clearly indicated the intent to use that specific set of alpha/beta/rc versions. By including a prerelease tag in the range, the user is indicating that they are aware of the risk. However, it is still not appropriate to assume that they have opted into taking a similar risk on the next set of prerelease versions.

Prereleases are only published to npm, since Homebrew and Debian registries don't work with semver in the same way. That's fine, since prereleases aren't for wide consumption in the first place. Requiring npm to use them should be fine.

This PR doesn't deal with trying to enable the feature flag: that's something we'll want to cover separately as we actually prepare the shipping of the new diff engine.