### PR TITLE
Fix installing of diff-engine

### DIFF
--- a/workspaces/agent-cli/package.json
+++ b/workspaces/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/agent-cli",
-  "version": "8.6.0-beta.4",
+  "version": "8.6.0-beta.5",
   "author": "@useoptic",
   "bin": {
     "optic-agent": "./bin/run"
@@ -15,7 +15,7 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^3",
-    "@useoptic/cli-shared": "8.6.0-beta.4",
+    "@useoptic/cli-shared": "8.6.0-beta.5",
     "dotenv": "^8.2.0",
     "jwt-decode": "^2.2.0",
     "tslib": "^1",

--- a/workspaces/analytics/package.json
+++ b/workspaces/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/analytics",
-  "version": "8.6.0-beta.4",
+  "version": "8.6.0-beta.5",
   "scripts": {
     "ws:build": "tsc -b --verbose",
     "ws:clean": "rm -rf build/*",

--- a/workspaces/ci-cli/package.json
+++ b/workspaces/ci-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/ci-cli",
-  "version": "8.6.0-beta.4",
+  "version": "8.6.0-beta.5",
   "author": "@useoptic",
   "bin": {
     "optic-ci": "./bin/run"
@@ -15,8 +15,8 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^3",
-    "@useoptic/cli-config": "8.6.0-beta.4",
-    "@useoptic/cli-shared": "8.6.0-beta.4",
+    "@useoptic/cli-config": "8.6.0-beta.5",
+    "@useoptic/cli-shared": "8.6.0-beta.5",
     "dotenv": "^8.2.0",
     "jwt-decode": "^2.2.0",
     "tslib": "^1",

--- a/workspaces/cli-client/package.json
+++ b/workspaces/cli-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-client",
-  "version": "8.6.0-beta.4",
+  "version": "8.6.0-beta.5",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",
@@ -14,9 +14,9 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "dependencies": {
-    "@useoptic/analytics": "8.6.0-beta.4",
-    "@useoptic/cli-config": "8.6.0-beta.4",
-    "@useoptic/client-utilities": "8.6.0-beta.4",
+    "@useoptic/analytics": "8.6.0-beta.5",
+    "@useoptic/cli-config": "8.6.0-beta.5",
+    "@useoptic/client-utilities": "8.6.0-beta.5",
     "bottleneck": "^2.19.5",
     "cross-fetch": "^3.0.4"
   },

--- a/workspaces/cli-config/package.json
+++ b/workspaces/cli-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-config",
-  "version": "8.6.0-beta.4",
+  "version": "8.6.0-beta.5",
   "scripts": {
     "ws:test": "jest",
     "ws:build": "yarn run tsc -b --verbose",

--- a/workspaces/cli-scripts/package.json
+++ b/workspaces/cli-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-scripts",
-  "version": "8.6.0-beta.4",
+  "version": "8.6.0-beta.5",
   "scripts": {
     "ws:test": "echo scripts",
     "ws:build": "yarn run tsc -b --verbose",
@@ -16,7 +16,7 @@
   "dependencies": {
     "node-notifier": "^7.0.0",
     "analytics-node": "^3.4.0-beta.1",
-    "@useoptic/cli-shared": "8.6.0-beta.4"
+    "@useoptic/cli-shared": "8.6.0-beta.5"
   },
   "devDependencies": {
     "@types/node-notifier": "^6.0.1"

--- a/workspaces/cli-server/package.json
+++ b/workspaces/cli-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-server",
-  "version": "8.6.0-beta.4",
+  "version": "8.6.0-beta.5",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",
@@ -14,12 +14,12 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "dependencies": {
-    "@useoptic/analytics": "8.6.0-beta.4",
-    "@useoptic/cli-client": "8.6.0-beta.4",
-    "@useoptic/cli-config": "8.6.0-beta.4",
-    "@useoptic/cli-scripts": "8.6.0-beta.4",
-    "@useoptic/cli-shared": "8.6.0-beta.4",
-    "@useoptic/ui": "8.6.0-beta.4",
+    "@useoptic/analytics": "8.6.0-beta.5",
+    "@useoptic/cli-client": "8.6.0-beta.5",
+    "@useoptic/cli-config": "8.6.0-beta.5",
+    "@useoptic/cli-scripts": "8.6.0-beta.5",
+    "@useoptic/cli-shared": "8.6.0-beta.5",
+    "@useoptic/ui": "8.6.0-beta.5",
     "avsc": "^5.4.18",
     "analytics-node": "^3.4.0-beta.2",
     "body-parser": "^1.19.0",

--- a/workspaces/cli-shared/package.json
+++ b/workspaces/cli-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-shared",
-  "version": "8.6.0-beta.4",
+  "version": "8.6.0-beta.5",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",
@@ -15,10 +15,10 @@
   "types": "build/index.d.ts",
   "dependencies": {
     "@oclif/command": "^1.6.1",
-    "@useoptic/cli-client": "8.6.0-beta.4",
-    "@useoptic/cli-config": "8.6.0-beta.4",
-    "@useoptic/client-utilities": "8.6.0-beta.4",
-    "@useoptic/diff-engine": "8.6.0-beta.4",
+    "@useoptic/cli-client": "8.6.0-beta.5",
+    "@useoptic/cli-config": "8.6.0-beta.5",
+    "@useoptic/client-utilities": "8.6.0-beta.5",
+    "@useoptic/diff-engine": "8.6.0-beta.5",
     "@useoptic/domain": "10.0.17",
     "@useoptic/domain-types": "10.0.17",
     "@useoptic/domain-utilities": "10.0.17",

--- a/workspaces/client-utilities/package.json
+++ b/workspaces/client-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/client-utilities",
-  "version": "8.6.0-beta.4",
+  "version": "8.6.0-beta.5",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",

--- a/workspaces/diff-engine/package.json
+++ b/workspaces/diff-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/diff-engine",
-  "version": "8.6.0-beta.4",
+  "version": "8.6.0-beta.5",
   "scripts": {
     "postinstall": "node scripts/install",
     "preuninstall": "node scripts/uninstall",

--- a/workspaces/diff-engine/package.json
+++ b/workspaces/diff-engine/package.json
@@ -2,8 +2,8 @@
   "name": "@useoptic/diff-engine",
   "version": "8.6.0-beta.4",
   "scripts": {
-    "postinstall": "echo 'Disabled for now' # node scripts/install",
-    "preuninstall": "ecoh 'Disabled for now' # node scripts/uninstall",
+    "postinstall": "node scripts/install",
+    "preuninstall": "node scripts/uninstall",
     "ws:build-binaries": "scripts/build-binaries.sh",
     "ws:clean": "rm -rf build/* && rm -rf target/*",
     "ws:test": "scripts/test.sh"
@@ -25,6 +25,7 @@
   },
   "devDependencies": {},
   "files": [
-    "/build"
+    "/build",
+    "/scripts"
   ]
 }

--- a/workspaces/diff-engine/package.json
+++ b/workspaces/diff-engine/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {},
   "files": [
-    "/build",
+    "/lib",
     "/scripts"
   ]
 }

--- a/workspaces/local-cli/package.json
+++ b/workspaces/local-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/cli",
   "description": "The Optic CLI",
-  "version": "8.6.0-beta.4",
+  "version": "8.6.0-beta.5",
   "author": "@useoptic",
   "bin": {
     "api": "./bin/run"
@@ -18,12 +18,12 @@
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^2",
     "cli-table3": "^0.6.0",
-    "@useoptic/analytics": "8.6.0-beta.4",
-    "@useoptic/cli-client": "8.6.0-beta.4",
-    "@useoptic/cli-config": "8.6.0-beta.4",
-    "@useoptic/cli-scripts": "8.6.0-beta.4",
-    "@useoptic/cli-server": "8.6.0-beta.4",
-    "@useoptic/cli-shared": "8.6.0-beta.4",
+    "@useoptic/analytics": "8.6.0-beta.5",
+    "@useoptic/cli-client": "8.6.0-beta.5",
+    "@useoptic/cli-config": "8.6.0-beta.5",
+    "@useoptic/cli-scripts": "8.6.0-beta.5",
+    "@useoptic/cli-server": "8.6.0-beta.5",
+    "@useoptic/cli-shared": "8.6.0-beta.5",
     "@useoptic/domain": "10.0.17",
     "analytics-node": "^3.4.0-beta.1",
     "cli-ux": "^5.4.1",

--- a/workspaces/saas-types/package.json
+++ b/workspaces/saas-types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/saas-types",
   "description": "interfaces and types for Optic SaaS surface area",
-  "version": "8.6.0-beta.4",
+  "version": "8.6.0-beta.5",
   "main": "build/index.js",
   "files": [
     "build"

--- a/workspaces/snapshot-tests/package.json
+++ b/workspaces/snapshot-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/snapshot-tests",
-  "version": "8.6.0-beta.4",
+  "version": "8.6.0-beta.5",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",

--- a/workspaces/ui/package.json
+++ b/workspaces/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/ui",
-  "version": "8.6.0-beta.4",
+  "version": "8.6.0-beta.5",
   "files": [
     "build",
     "index.js",
@@ -15,9 +15,9 @@
     "@material-ui/core": "^4.9.7",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.46",
-    "@useoptic/cli-shared": "8.6.0-beta.4",
-    "@useoptic/cli-client": "8.6.0-beta.4",
-    "@useoptic/analytics": "8.6.0-beta.4",
+    "@useoptic/cli-shared": "8.6.0-beta.5",
+    "@useoptic/cli-client": "8.6.0-beta.5",
+    "@useoptic/analytics": "8.6.0-beta.5",
     "@useoptic/domain": "10.0.17",
     "@useoptic/domain-utilities": "10.0.17",
     "bottleneck": "^2.19.5",


### PR DESCRIPTION
When installing the new diff engine, the prebuilt binary is downloaded through an installation script. We should make sure to actually include those scripts in the published package 😅.