### PR TITLE
Publish new prereleases pushed to develop

### DIFF
--- a/.github/workflows/featurepeek.yml
+++ b/.github/workflows/featurepeek.yml
@@ -17,7 +17,7 @@ jobs:
     - name: "yarn install, post version changes"
       run: yarn install
     - name: "build workspaces"
-      run: yarn wsrun --stages --report --fast-exit ws:build
+      run: yarn wsrun --stages --report --fast-exit --exclude-missing ws:build
     - name: Install dependencies
       run: yarn install
     - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,51 @@ on:
       - develop
 
 jobs:
+  release_logic:
+    runs-on: ubuntu-latest
+    outputs:
+      should_publish: ${{ steps.should_publish.outputs.should_publish }}
+      is_prerelease: ${{ steps.release_type.outputs.is_prerelease }}
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # https://github.com/actions/checkout/releases/tag/v2.3.3
+      - uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d # https://github.com/actions/setup-node/releases/tag/v1.4.4
+        with:
+          node-version: 12
+      - name: Set version output
+        id: version
+        run: |
+          OPTIC_VERSION=$(node -e "console.log(require('./workspaces/local-cli/package.json').version)")
+          echo "OPTIC_VERSION=$OPTIC_VERSION" >> $GITHUB_ENV
+          echo "::set-output name=version::$OPTIC_VERSION"
+      - name: Set is_prerelease output
+        id: release_type
+        run: |
+          if [[ $OPTIC_VERSION == *'-'* ]]; then
+            echo "v$OPTIC_VERSION is a prerelease"
+            echo "::set-output name=is_prerelease::true"
+          else
+            echo "v$OPTIC_VERSION is not a prerelease"
+            echo "::set-output name=is_prerelease::false"
+          fi
+      - name: Set should_publish output
+        id: should_publish
+        run: |
+          echo Should we publish $OPTIC_VERSION from $GITHUB_REF?
+          RELEASED_VERSION=$(npm view @useoptic/cli@$OPTIC_VERSION version)
+          if ! [[ -z $RELEASED_VERSION ]]; then
+            echo "v$OPTIC_VERSION already published, should not publish again"
+            echo "::set-output name=should_publish::false"
+          elif [ "${{ steps.release_type.outputs.is_prerelease }}" = "false" ] && [ $GITHUB_REF != "refs/heads/release" ]; then
+            echo "Only prereleases should be published from branches other than release"
+            echo "::set-output name=should_publish::false"
+          else
+            echo "::set-output name=should_publish::true"
+          fi
+
   build-rust-binaries:
+    if: needs.release_logic.outputs.should_publish == 'true'
+    needs: release_logic
     strategy:
       matrix:
         include:
@@ -51,7 +95,7 @@ jobs:
       - name: 'Determine version and archive name'
         shell: bash
         run: |
-          OPTIC_VERSION=$(node -e "console.log(require('./workspaces/local-cli/package.json').version)")
+          OPTIC_VERSION=${{ needs.release_logic.outputs.version }}
           echo "OPTIC_VERSION=$OPTIC_VERSION" >> $GITHUB_ENV
           echo "ARCHIVE_NAME=optic_diff-v$OPTIC_VERSION-${{ matrix.platform_name }}" >> $GITHUB_ENV
       - name: 'Set CARGO_HOME and RUSTUP_HOME'
@@ -101,7 +145,7 @@ jobs:
           - platform_name: linux
             suffix: ''
     runs-on: ubuntu-latest
-    needs: build-rust-binaries
+    needs: [release_logic, build-rust-binaries]
     env:
       FILE_NAME: optic_diff${{ matrix.suffix }}
       BUCKET: optic-packages
@@ -112,7 +156,7 @@ jobs:
           node-version: 12
       - name: 'Determine version and archive name'
         run: |
-          OPTIC_VERSION=$(node -e "console.log(require('./workspaces/local-cli/package.json').version)")
+          OPTIC_VERSION=${{ needs.release_logic.outputs.version }}
           echo "OPTIC_VERSION=$OPTIC_VERSION" >> $GITHUB_ENV
           echo "ARCHIVE_NAME=optic_diff-v$OPTIC_VERSION-${{ matrix.platform_name }}" >> $GITHUB_ENV
       - name: Prepare directory structure
@@ -147,17 +191,16 @@ jobs:
   # Deploys the current version to NPM, and also verifies that the version is correct in the process
   # All Jobs rely on this job because it verifies the version
   release-npm:
+    if: needs.release_logic.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
-    needs: publish-binaries
-    outputs: 
-      is_prerelease: ${{ steps.release_type.outputs.is_prerelease }}
+    needs: [publish-binaries, release_logic]
     steps:
     - run: | # TODO: remove this safety before merging this altered release flow
         echo "Hit safety exit"
         exit 1
     - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # https://github.com/actions/checkout/releases/tag/v2.3.3
-      with:
-        ref: release
+      # with:
+      #   ref: release
     - uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d # https://github.com/actions/setup-node/releases/tag/v1.4.4
       with:
         node-version: 12
@@ -168,23 +211,12 @@ jobs:
     - run: node ./workspaces/scripts/publish.js
       env:
         OPTIC_PUBLISH_SCOPE: public
-    - name: Set is_prerelease output
-      id: release_type
-      run: |
-        OPTIC_VERSION=$(node -e "console.log(require('./workspaces/local-cli/package.json').version)")
-        if [[ $OPTIC_VERSION == *'-'* ]]; then
-          echo "v$OPTIC_VERSION is a prerelease"
-          echo "::set-output name=is_prerelease::true"
-        else
-          echo "v$OPTIC_VERSION is not a prerelease"
-          echo "::set-output name=is_prerelease::false"
-        fi
 
   # Creates debian package for users to install, hosted on s3
   release-deb:
     runs-on: ubuntu-latest
-    needs: release-npm
-    if: needs.release-npm.outputs.is_prerelease == 'false'
+    needs: [release_logic, release-npm]
+    if: needs.release_logic.outputs.should_publish == 'true'
     steps:
       - run: |
           echo "determined as not a prerelease" 
@@ -205,8 +237,8 @@ jobs:
   # Requires Repository Access Token (https://github.com/peter-evans/repository-dispatch#token) with repo:write scope
   trigger-brew-release:
     runs-on: ubuntu-latest
-    needs: release-npm
-    if: needs.release-npm.outputs.is_prerelease == 'false'
+    needs: [release_logic, release-npm]
+    if: needs.release_logic.outputs.should_publish == 'true'
     steps:
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@95531d6358eb144ac65db1d7f39af794979ea97e # https://github.com/peter-evans/repository-dispatch/releases/tag/v1.1.2
@@ -219,14 +251,21 @@ jobs:
   # Tells slack a release has happened
   notify-slack:
     runs-on: ubuntu-latest
-    needs: release-npm
+    needs: [release_logic, release-npm]
     name: Message Slack that Release has happened
     steps:
       - uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d # https://github.com/actions/setup-node/releases/tag/v1.4.4
         name: Setup Node (to determine latest version of Optic)
         with:
             node-version: 12
-      - run: echo "MESSAGE=${{ github.event.pusher.name }} released version $(npm view @useoptic/cli version) \n Publish Release Notes <https://github.com/opticdev/optic/releases|here>" >> $GITHUB_ENV
+      - run: |
+          MESSAGE=${{ github.event.pusher.name }} released version ${{ needs.release_logic.outputs.version }}
+          if [[ "${needs.release_logic.outputs.is_prerelease}" == "true" ]]; then
+            MESSAGE="$MESSAGE \n This is a prerelease only published to npm. Only users who explicitly opted in by installing this or preceding prereleases in this set will be affected."
+          else
+            MESSAGE="$MESSAGE \n Publish Release Notes <https://github.com/opticdev/optic/releases|here>"            
+          fi
+          echo "MESSAGE=$MESSAGE" >> $GITHUB_ENV
       - name: Send message to Slack API
         run: |
           curl -X POST -H 'Content-type: application/json' --data '{"text":"${{ env.MESSAGE }}"}' ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,9 +84,6 @@ jobs:
     env:
       FILE_NAME: optic_diff${{ matrix.suffix }}
     steps:
-      - run: | # TODO: remove this safety before merging this altered release flow
-          echo "Hit safety exit"
-          exit 1
       - name: 'Checkout source'
         uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # https://github.com/actions/checkout/releases/tag/v2.3.3
       - uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d # https://github.com/actions/setup-node/releases/tag/v1.4.4
@@ -185,6 +182,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: 'us-east-1'
       - name: 'Upload to S3'
+        if: false # TODO: remove this before merging
         run: |
           aws s3 cp dist/$ARCHIVE_NAME.tar.gz s3://$BUCKET/dists/optic_diff/v$OPTIC_VERSION/$ARCHIVE_NAME.tar.gz --sse=AES256 --acl=public-read
 
@@ -195,9 +193,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [publish-binaries, release_logic]
     steps:
-    - run: | # TODO: remove this safety before merging this altered release flow
-        echo "Hit safety exit"
-        exit 1
     - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # https://github.com/actions/checkout/releases/tag/v2.3.3
       # with:
       #   ref: release
@@ -209,6 +204,7 @@ jobs:
         source ./sourceme.sh && optic_build_for_release
     - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.PUBLISH_NPM_OPTIC_BOT }}" > ~/.npmrc
     - run: node ./workspaces/scripts/publish.js
+      if: false # TODO: remove this safety measure before merging
       env:
         OPTIC_PUBLISH_SCOPE: public
 
@@ -216,7 +212,7 @@ jobs:
   release-deb:
     runs-on: ubuntu-latest
     needs: [release_logic, release-npm]
-    if: needs.release_logic.outputs.should_publish == 'true'
+    if: needs.release_logic.outputs.is_prerelease == 'false'
     steps:
       - run: |
           echo "determined as not a prerelease" 
@@ -225,6 +221,7 @@ jobs:
         with:
           ref: release
       - uses: ./.github/deployDebian/ # locally defined action
+        if: false # TODO: remove this safety measure before merging
         with:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -238,10 +235,11 @@ jobs:
   trigger-brew-release:
     runs-on: ubuntu-latest
     needs: [release_logic, release-npm]
-    if: needs.release_logic.outputs.should_publish == 'true'
+    if: needs.release_logic.outputs.is_prerelease == 'false'
     steps:
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@95531d6358eb144ac65db1d7f39af794979ea97e # https://github.com/peter-evans/repository-dispatch/releases/tag/v1.1.2
+        if: false # TODO: remove this safety measure before merging
         with:
           token: ${{ secrets.HOMEBREW_UTILITY_ACCOUNT }}
           repository: opticdev/homebrew-optic
@@ -259,8 +257,8 @@ jobs:
         with:
             node-version: 12
       - run: |
-          MESSAGE=${{ github.event.pusher.name }} released version ${{ needs.release_logic.outputs.version }}
-          if [[ "${needs.release_logic.outputs.is_prerelease}" == "true" ]]; then
+          MESSAGE="${{ github.event.pusher.name }} released version ${{ needs.release_logic.outputs.version }}"
+          if [[ "${{ needs.release_logic.outputs.is_prerelease }}" == "true" ]]; then
             MESSAGE="$MESSAGE \n This is a prerelease only published to npm. Only users who explicitly opted in by installing this or preceding prereleases in this set will be affected."
           else
             MESSAGE="$MESSAGE \n Publish Release Notes <https://github.com/opticdev/optic/releases|here>"            

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,6 @@ on:
     branches:
       - release
       - develop
-  # TODO: remove this debug trigger before merging
-  pull_request:
-    branches:
-      - develop
 
 jobs:
   release_logic:
@@ -182,7 +178,6 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: 'us-east-1'
       - name: 'Upload to S3'
-        if: false # TODO: remove this before merging
         run: |
           aws s3 cp dist/$ARCHIVE_NAME.tar.gz s3://$BUCKET/dists/optic_diff/v$OPTIC_VERSION/$ARCHIVE_NAME.tar.gz --sse=AES256 --acl=public-read
 
@@ -204,7 +199,6 @@ jobs:
         source ./sourceme.sh && optic_build_for_release
     - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.PUBLISH_NPM_OPTIC_BOT }}" > ~/.npmrc
     - run: node ./workspaces/scripts/publish.js
-      if: false # TODO: remove this safety measure before merging
       env:
         OPTIC_PUBLISH_SCOPE: public
 
@@ -221,7 +215,6 @@ jobs:
         with:
           ref: release
       - uses: ./.github/deployDebian/ # locally defined action
-        if: false # TODO: remove this safety measure before merging
         with:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -239,7 +232,6 @@ jobs:
     steps:
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@95531d6358eb144ac65db1d7f39af794979ea97e # https://github.com/peter-evans/repository-dispatch/releases/tag/v1.1.2
-        if: false # TODO: remove this safety measure before merging
         with:
           token: ${{ secrets.HOMEBREW_UTILITY_ACCOUNT }}
           repository: opticdev/homebrew-optic

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,7 +259,7 @@ jobs:
       - run: |
           MESSAGE="${{ github.event.pusher.name }} released version ${{ needs.release_logic.outputs.version }}"
           if [[ "${{ needs.release_logic.outputs.is_prerelease }}" == "true" ]]; then
-            MESSAGE="$MESSAGE \n This is a prerelease only published to npm. Only users who explicitly opted in by installing this or preceding prereleases in this set will be affected."
+            MESSAGE="$MESSAGE \n This is a prerelease only <https://www.npmjs.com/package/@useoptic/cli/v/${{ needs.release_logic.outputs.version }}|published to npm>. Only users who explicitly opted in by installing this or preceding prereleases in this set will be affected. "
           else
             MESSAGE="$MESSAGE \n Publish Release Notes <https://github.com/opticdev/optic/releases|here>"            
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,11 @@ on:
   push:
     branches:
       - release
+      - develop
+  # TODO: remove this debug trigger before merging
+  pull_request:
+    branches:
+      - develop
 
 jobs:
   build-rust-binaries:
@@ -35,6 +40,9 @@ jobs:
     env:
       FILE_NAME: optic_diff${{ matrix.suffix }}
     steps:
+      - run: | # TODO: remove this safety before merging this altered release flow
+          echo "Hit safety exit"
+          exit 1
       - name: 'Checkout source'
         uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # https://github.com/actions/checkout/releases/tag/v2.3.3
       - uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d # https://github.com/actions/setup-node/releases/tag/v1.4.4
@@ -144,6 +152,9 @@ jobs:
     outputs: 
       is_prerelease: ${{ steps.release_type.outputs.is_prerelease }}
     steps:
+    - run: | # TODO: remove this safety before merging this altered release flow
+        echo "Hit safety exit"
+        exit 1
     - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # https://github.com/actions/checkout/releases/tag/v2.3.3
       with:
         ref: release

--- a/workspaces/agent-cli/package.json
+++ b/workspaces/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/agent-cli",
-  "version": "8.6.0-beta.3",
+  "version": "8.6.0-beta.4",
   "author": "@useoptic",
   "bin": {
     "optic-agent": "./bin/run"
@@ -15,7 +15,7 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^3",
-    "@useoptic/cli-shared": "8.6.0-beta.3",
+    "@useoptic/cli-shared": "8.6.0-beta.4",
     "dotenv": "^8.2.0",
     "jwt-decode": "^2.2.0",
     "tslib": "^1",

--- a/workspaces/analytics/package.json
+++ b/workspaces/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/analytics",
-  "version": "8.6.0-beta.3",
+  "version": "8.6.0-beta.4",
   "scripts": {
     "ws:build": "tsc -b --verbose",
     "ws:clean": "rm -rf build/*",

--- a/workspaces/ci-cli/package.json
+++ b/workspaces/ci-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/ci-cli",
-  "version": "8.6.0-beta.3",
+  "version": "8.6.0-beta.4",
   "author": "@useoptic",
   "bin": {
     "optic-ci": "./bin/run"
@@ -15,8 +15,8 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^3",
-    "@useoptic/cli-config": "8.6.0-beta.3",
-    "@useoptic/cli-shared": "8.6.0-beta.3",
+    "@useoptic/cli-config": "8.6.0-beta.4",
+    "@useoptic/cli-shared": "8.6.0-beta.4",
     "dotenv": "^8.2.0",
     "jwt-decode": "^2.2.0",
     "tslib": "^1",

--- a/workspaces/cli-client/package.json
+++ b/workspaces/cli-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-client",
-  "version": "8.6.0-beta.3",
+  "version": "8.6.0-beta.4",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",
@@ -14,9 +14,9 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "dependencies": {
-    "@useoptic/analytics": "8.6.0-beta.3",
-    "@useoptic/cli-config": "8.6.0-beta.3",
-    "@useoptic/client-utilities": "8.6.0-beta.3",
+    "@useoptic/analytics": "8.6.0-beta.4",
+    "@useoptic/cli-config": "8.6.0-beta.4",
+    "@useoptic/client-utilities": "8.6.0-beta.4",
     "bottleneck": "^2.19.5",
     "cross-fetch": "^3.0.4"
   },

--- a/workspaces/cli-config/package.json
+++ b/workspaces/cli-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-config",
-  "version": "8.6.0-beta.3",
+  "version": "8.6.0-beta.4",
   "scripts": {
     "ws:test": "jest",
     "ws:build": "yarn run tsc -b --verbose",

--- a/workspaces/cli-scripts/package.json
+++ b/workspaces/cli-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-scripts",
-  "version": "8.6.0-beta.3",
+  "version": "8.6.0-beta.4",
   "scripts": {
     "ws:test": "echo scripts",
     "ws:build": "yarn run tsc -b --verbose",
@@ -16,7 +16,7 @@
   "dependencies": {
     "node-notifier": "^7.0.0",
     "analytics-node": "^3.4.0-beta.1",
-    "@useoptic/cli-shared": "8.6.0-beta.3"
+    "@useoptic/cli-shared": "8.6.0-beta.4"
   },
   "devDependencies": {
     "@types/node-notifier": "^6.0.1"

--- a/workspaces/cli-server/package.json
+++ b/workspaces/cli-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-server",
-  "version": "8.6.0-beta.3",
+  "version": "8.6.0-beta.4",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",
@@ -14,12 +14,12 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "dependencies": {
-    "@useoptic/analytics": "8.6.0-beta.3",
-    "@useoptic/cli-client": "8.6.0-beta.3",
-    "@useoptic/cli-config": "8.6.0-beta.3",
-    "@useoptic/cli-scripts": "8.6.0-beta.3",
-    "@useoptic/cli-shared": "8.6.0-beta.3",
-    "@useoptic/ui": "8.6.0-beta.3",
+    "@useoptic/analytics": "8.6.0-beta.4",
+    "@useoptic/cli-client": "8.6.0-beta.4",
+    "@useoptic/cli-config": "8.6.0-beta.4",
+    "@useoptic/cli-scripts": "8.6.0-beta.4",
+    "@useoptic/cli-shared": "8.6.0-beta.4",
+    "@useoptic/ui": "8.6.0-beta.4",
     "avsc": "^5.4.18",
     "analytics-node": "^3.4.0-beta.2",
     "body-parser": "^1.19.0",

--- a/workspaces/cli-shared/package.json
+++ b/workspaces/cli-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-shared",
-  "version": "8.6.0-beta.3",
+  "version": "8.6.0-beta.4",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",
@@ -15,10 +15,10 @@
   "types": "build/index.d.ts",
   "dependencies": {
     "@oclif/command": "^1.6.1",
-    "@useoptic/cli-client": "8.6.0-beta.3",
-    "@useoptic/cli-config": "8.6.0-beta.3",
-    "@useoptic/client-utilities": "8.6.0-beta.3",
-    "@useoptic/diff-engine": "8.6.0-beta.3",
+    "@useoptic/cli-client": "8.6.0-beta.4",
+    "@useoptic/cli-config": "8.6.0-beta.4",
+    "@useoptic/client-utilities": "8.6.0-beta.4",
+    "@useoptic/diff-engine": "8.6.0-beta.4",
     "@useoptic/domain": "10.0.17",
     "@useoptic/domain-types": "10.0.17",
     "@useoptic/domain-utilities": "10.0.17",

--- a/workspaces/client-utilities/package.json
+++ b/workspaces/client-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/client-utilities",
-  "version": "8.6.0-beta.3",
+  "version": "8.6.0-beta.4",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",

--- a/workspaces/diff-engine/package.json
+++ b/workspaces/diff-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/diff-engine",
-  "version": "8.6.0-beta.3",
+  "version": "8.6.0-beta.4",
   "scripts": {
     "postinstall": "echo 'Disabled for now' # node scripts/install",
     "preuninstall": "ecoh 'Disabled for now' # node scripts/uninstall",

--- a/workspaces/local-cli/package.json
+++ b/workspaces/local-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/cli",
   "description": "The Optic CLI",
-  "version": "8.6.0-beta.3",
+  "version": "8.6.0-beta.4",
   "author": "@useoptic",
   "bin": {
     "api": "./bin/run"
@@ -18,12 +18,12 @@
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^2",
     "cli-table3": "^0.6.0",
-    "@useoptic/analytics": "8.6.0-beta.3",
-    "@useoptic/cli-client": "8.6.0-beta.3",
-    "@useoptic/cli-config": "8.6.0-beta.3",
-    "@useoptic/cli-scripts": "8.6.0-beta.3",
-    "@useoptic/cli-server": "8.6.0-beta.3",
-    "@useoptic/cli-shared": "8.6.0-beta.3",
+    "@useoptic/analytics": "8.6.0-beta.4",
+    "@useoptic/cli-client": "8.6.0-beta.4",
+    "@useoptic/cli-config": "8.6.0-beta.4",
+    "@useoptic/cli-scripts": "8.6.0-beta.4",
+    "@useoptic/cli-server": "8.6.0-beta.4",
+    "@useoptic/cli-shared": "8.6.0-beta.4",
     "@useoptic/domain": "10.0.17",
     "analytics-node": "^3.4.0-beta.1",
     "cli-ux": "^5.4.1",

--- a/workspaces/saas-types/package.json
+++ b/workspaces/saas-types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/saas-types",
   "description": "interfaces and types for Optic SaaS surface area",
-  "version": "8.6.0-beta.3",
+  "version": "8.6.0-beta.4",
   "main": "build/index.js",
   "files": [
     "build"

--- a/workspaces/snapshot-tests/package.json
+++ b/workspaces/snapshot-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/snapshot-tests",
-  "version": "8.6.0-beta.3",
+  "version": "8.6.0-beta.4",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",

--- a/workspaces/ui/package.json
+++ b/workspaces/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/ui",
-  "version": "8.6.0-beta.3",
+  "version": "8.6.0-beta.4",
   "files": [
     "build",
     "index.js",
@@ -15,9 +15,9 @@
     "@material-ui/core": "^4.9.7",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.46",
-    "@useoptic/cli-shared": "8.6.0-beta.3",
-    "@useoptic/cli-client": "8.6.0-beta.3",
-    "@useoptic/analytics": "8.6.0-beta.3",
+    "@useoptic/cli-shared": "8.6.0-beta.4",
+    "@useoptic/cli-client": "8.6.0-beta.4",
+    "@useoptic/analytics": "8.6.0-beta.4",
     "@useoptic/domain": "10.0.17",
     "@useoptic/domain-utilities": "10.0.17",
     "bottleneck": "^2.19.5",


### PR DESCRIPTION
I realised that for prereleases it's fine if we do that straight from pull requests getting merged to `develop`.

In figuring out how to allow publish a new prerelease after merging #410 it stood out to me how that was still unnecessarily clunky: 

- make a manual bump pull request
- get bump merged
- make a pull request to release
- get that merged.

This pull request amends the `release` workflow to publish any versions with a prerelease tag when pushed to `develop`. That means, we simplify the above workflow to:

- manually bump prerelease as part of any pull request that should be then published in a prerelease (like #410, could eventually be automated through use of PR labels, but not bothering with that now)
- merge said pull request

This is implemented through a new `release_logic` job, that runs before anything else and outputs `should_publish` as well as `is_prerelease`. To determine if a publish should happen, it's verified it hasn't been published yet, and when triggered from the `develop` branch we're publishing a pre-release.
