### PR TITLE
Fix publishing of diff-engine

### DIFF
--- a/workspaces/diff-engine/.npmignore
+++ b/workspaces/diff-engine/.npmignore
@@ -1,0 +1,4 @@
+src
+binaries
+tests
+**/*.rs

--- a/workspaces/diff-engine/package.json
+++ b/workspaces/diff-engine/package.json
@@ -23,9 +23,5 @@
     "rimraf": "^3.0.2",
     "tar": "^6.0.5"
   },
-  "devDependencies": {},
-  "files": [
-    "/lib",
-    "/scripts"
-  ]
+  "devDependencies": {}
 }


### PR DESCRIPTION
As this is the second time this donkey hurts himself on this stone, I've opted to choose which files we choose to _ignore_ when publishing to NPM, rather than explicitly stating which make it through.