### PR TITLE
Stop publishing ARM build to Debian

### DIFF
--- a/.github/deployDebian/entrypoint.sh
+++ b/.github/deployDebian/entrypoint.sh
@@ -26,6 +26,4 @@ echo "Installing Ruby"
 apt install ruby-full -y
 gem install deb-s3
 export PATH_TO_DEB_AMD="/tmp/optic/workspaces/local-cli/dist/deb/api_$(npm view $INPUT_NPM_PACKAGE_NAME version)-1_amd64.deb"
-export PATH_TO_DEB_ARM="/tmp/optic/workspaces/local-cli/dist/deb/api_$(npm view $INPUT_NPM_PACKAGE_NAME version)-1_armel.deb"
 deb-s3 upload -e --access-key-id=$INPUT_AWS_ACCESS_KEY_ID --secret-access-key=$INPUT_AWS_SECRET_ACCESS_KEY --bucket $INPUT_BUCKET_NAME --prefix $INPUT_PREFIX_NAME --codename $INPUT_PACKAGE_NAME --preserve-versions $PATH_TO_DEB_AMD
-deb-s3 upload -e --access-key-id=$INPUT_AWS_ACCESS_KEY_ID --secret-access-key=$INPUT_AWS_SECRET_ACCESS_KEY --bucket $INPUT_BUCKET_NAME --prefix $INPUT_PREFIX_NAME --codename $INPUT_PACKAGE_NAME --preserve-versions $PATH_TO_DEB_ARM


### PR DESCRIPTION
As we work with pre-built binaries but don't include ARM compilation yet, the ARM build for Debian would fail installation. Rather than going through the trouble of building the cross compilation workflows required for this (the current setup requires host-native builds), we will stop publishing the ARM build to Debian for now.

We can make this call as we have little proof of the ARM package being used, nor sufficient information on why it was included in the first place. We'll rely on customers or other indicators telling us that ARM deployments _are_ worth investing the development time for.