### PR TITLE
Fix bug where feature flags not present during install script of diff-engine

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,6 +224,7 @@ jobs:
             cp $FLAGS_FILE workspaces/agent-cli/.env
             cp $FLAGS_FILE workspaces/ci-cli/.env
             cp $FLAGS_FILE workspaces/local-cli/.env
+            cp $FLAGS_FILE workspaces/diff-engine/.env
           fi
         fi
 

--- a/workspaces/diff-engine/package.json
+++ b/workspaces/diff-engine/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@iarna/toml": "^2.2.5",
     "bent": "^7.3.12",
+    "dotenv": "^8.2.0",
     "execa": "^4.0.3",
     "read-package-json": "^3.0.0",
     "rimraf": "^3.0.2",

--- a/workspaces/diff-engine/scripts/install.js
+++ b/workspaces/diff-engine/scripts/install.js
@@ -1,4 +1,13 @@
 const { install } = require('../lib');
+const dotenv = require('dotenv');
+const path = require('path');
+
+const envPath =
+  process.env.OPTIC_DEBUG_ENV_FILE || path.join(__dirname, '..', '.env');
+
+dotenv.config({
+  path: envPath,
+});
 
 if (process.env.OPTIC_SKIP_PREBUILT_INSTALLS === 'true') {
   console.log(


### PR DESCRIPTION
Installing `8.6.0-beta.7` revealed that, while feature flags are shipped for use in the cli's, it was not present during the install. Since we're doing conditional installs (prevent diff engine from installing / failing installs while feature flag is disabled), we need that in place, too.