### PR TITLE
Learn API Mode was not cleaning up its child threads

### DIFF
--- a/workspaces/cli-server/src/tasks/on-demand-initial-body.ts
+++ b/workspaces/cli-server/src/tasks/on-demand-initial-body.ts
@@ -97,6 +97,7 @@ export class OnDemandInitialBody {
       this.events.once('completed', onCompleted);
       function onCompleted(data: any) {
         cleanup();
+        child.kill(0);
         resolve(data.results);
       }
       const cleanup = () => {


### PR DESCRIPTION
Child processes weren't exiting after documenting initial bodies. If you documented 50 endpoints, you'd have 50 new node processes that remained idle

Adding an explicit child.exit on cleanup works, but I don't know if it's the best approach. I know there are learnings from the other IPC work I may not be privy to