### PR TITLE
interaction iterator should stop when there are no more batches

### DIFF
--- a/workspaces/cli-shared/src/captures/avro/file-system/interaction-iterator.ts
+++ b/workspaces/cli-shared/src/captures/avro/file-system/interaction-iterator.ts
@@ -81,7 +81,6 @@ export async function* CaptureInteractionIterator(
     }
     const isBatchEmpty = index === 0;
     if (isBatchEmpty) {
-      debugger;
       yield {
         hasMoreInteractions: true,
         interaction: null,
@@ -91,7 +90,6 @@ export async function* CaptureInteractionIterator(
     }
     currentBatchId = currentBatchId + BigInt(1);
   }
-  debugger;
   yield {
     hasMoreInteractions: false,
     interaction: null,

--- a/workspaces/cli-shared/src/captures/avro/file-system/interaction-iterator.ts
+++ b/workspaces/cli-shared/src/captures/avro/file-system/interaction-iterator.ts
@@ -45,8 +45,7 @@ export async function* CaptureInteractionIterator(
     );
     if (!(await fs.pathExists(batchFilePath))) {
       //@TODO: determine if we should wait
-      shouldStop = true;
-      continue;
+      return;
     }
     console.log(batchFilePath + '\n\nxxx\n\n');
     let index = 0;
@@ -82,6 +81,7 @@ export async function* CaptureInteractionIterator(
     }
     const isBatchEmpty = index === 0;
     if (isBatchEmpty) {
+      debugger;
       yield {
         hasMoreInteractions: true,
         interaction: null,
@@ -91,7 +91,7 @@ export async function* CaptureInteractionIterator(
     }
     currentBatchId = currentBatchId + BigInt(1);
   }
-
+  debugger;
   yield {
     hasMoreInteractions: false,
     interaction: null,

--- a/workspaces/cli-shared/src/captures/avro/file-system/interaction-iterator.ts
+++ b/workspaces/cli-shared/src/captures/avro/file-system/interaction-iterator.ts
@@ -45,7 +45,8 @@ export async function* CaptureInteractionIterator(
     );
     if (!(await fs.pathExists(batchFilePath))) {
       //@TODO: determine if we should wait
-      return;
+      shouldStop = true;
+      continue;
     }
     console.log(batchFilePath + '\n\nxxx\n\n');
     let index = 0;

--- a/workspaces/cli-shared/src/diffs/diff-worker-rust.ts
+++ b/workspaces/cli-shared/src/diffs/diff-worker-rust.ts
@@ -189,6 +189,7 @@ export class DiffWorkerRust {
       const diffsSink = fs.createWriteStream(diffOutputPaths.diffsStream);
       diffsSink.once('finish', () => {
         hasMoreInteractions = false;
+        reportProgress();
         reportProgress.flush();
       });
 


### PR DESCRIPTION
This ensures the frontend will receive a notification with hasMoreInteractions: false when there are no more interactions. If we add support for tailing a live capture's interaction stream, we will have to change this or make another interaction-iterator. 