### PR TITLE
use dbg instead of stderr when possible

### DIFF
--- a/workspaces/diff-engine/src/interactions/visitors/diff.rs
+++ b/workspaces/diff-engine/src/interactions/visitors/diff.rs
@@ -113,11 +113,8 @@ impl RequestBodyVisitor<InteractionDiffResult> for DiffRequestBodyVisitor {
     if let Some(operation) = context.operation {
       let actual_content_type = &interaction.request.body.content_type;
       let (request_id, request_body_descriptor) = operation;
-      eprintln!("actual request content type {:?}", actual_content_type);
-      eprintln!(
-        "expecting request content type {:?}",
-        &request_body_descriptor
-      );
+      dbg!( actual_content_type);
+      dbg!(&request_body_descriptor);
       match (&request_body_descriptor.body, actual_content_type) {
         (None, None) => {
           self
@@ -218,17 +215,17 @@ impl InteractionVisitor<InteractionDiffResult> for DiffResponseBodyVisitor {
 }
 impl ResponseBodyVisitor<InteractionDiffResult> for DiffResponseBodyVisitor {
   fn begin(&mut self) {
-    eprintln!("begin response body visitor");
+    dbg!("begin response body visitor");
   }
 
   fn visit(&mut self, interaction: &HttpInteraction, context: &ResponseBodyVisitorContext) {
-    eprintln!("visit response body");
+    dbg!("visit response body");
     if let Some(response) = context.response {
       let actual_content_type = &interaction.response.body.content_type;
       let (response_id, response_body_descriptor) = response;
-      eprintln!("actual response content type {:?}", actual_content_type);
-      eprintln!(
-        "expecting response content type {:?}",
+      dbg!("actual response content type", actual_content_type);
+      dbg!(
+        "expecting response content type",
         &response_body_descriptor
       );
       match (&response_body_descriptor.body, actual_content_type) {

--- a/workspaces/diff-engine/src/shapes/mod.rs
+++ b/workspaces/diff-engine/src/shapes/mod.rs
@@ -21,25 +21,11 @@ pub fn diff(
   let shape_traverser = traverser::Traverser::new(&shapes_queries);
   let mut diff_visitors = visitors::diff::DiffVisitors::new();
 
-  eprintln!(
-    "shape-diff: diffing body with shape id {},  {:?}",
-    shape_id, body
+  dbg!(
+    &shape_id, &body
   );
 
   shape_traverser.traverse_root_shape(body, shape_id, &mut diff_visitors);
 
   diff_visitors.take_results().unwrap()
 }
-
-// pub fn diff(
-//   endpoint_projection: &EndpointProjection,
-//   http_interaction: HttpInteraction,
-// ) -> Vec<InteractionDiffResult> {
-//   let endpoint_queries = EndpointQueries::new(endpoint_projection);
-//   let interaction_traverser = traverser::Traverser::new(&endpoint_queries);
-//   let mut diff_visitors = visitors::diff::DiffVisitors::new();
-
-//   interaction_traverser.traverse(http_interaction, &mut diff_visitors);
-
-//   diff_visitors.take_results().unwrap()
-// }

--- a/workspaces/diff-engine/src/shapes/traverser.rs
+++ b/workspaces/diff-engine/src/shapes/traverser.rs
@@ -165,14 +165,14 @@ impl<'a> Traverser<'a> {
           let field_choices = matching_choices
             .iter()
             .flat_map(|choice| {
-              eprintln!("shape-traverser: object choice {:?}", choice);
+              dbg!("shape-traverser: object choice", choice);
               if let ShapeKind::ObjectKind = &choice.core_shape_kind {
                 // - find field node by key in object's field node edges
                 let field_id_option = self
                   .shape_queries
                   .resolve_field_id(&choice.shape_id, &field_key);
                 if let None = field_id_option {
-                  eprintln!("shape-traverser: no field id could be resolved");
+                  dbg!("shape-traverser: no field id could be resolved");
                   return vec![];
                 }
 
@@ -181,7 +181,7 @@ impl<'a> Traverser<'a> {
                   .shape_queries
                   .resolve_field_shape_node(&field_id)
                   .expect("field node should have an edge to a shape node describing its value");
-                eprintln!("shape-traverser: field_shape_id {:?}", field_shape_id);
+                dbg!("shape-traverser: field_shape_id", &field_shape_id);
 
                 let field_trail =
                   choice


### PR DESCRIPTION
all output that should not be displayed to end users should use dbg! instead of eprintln! (at least as a short term measure). The release build of the cli will then spend less time flushing stderr