### PR TITLE
Fix handling of stderr and stdout preventing diffing to hang on Windows

### DIFF
--- a/.github/workflows/regression-suites.yml
+++ b/.github/workflows/regression-suites.yml
@@ -1,0 +1,87 @@
+name: Test Regression Scenarios
+
+on: push
+
+jobs:
+
+  local-cli-regression-:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ windows-latest, macos-latest, ubuntu-latest ]
+        interaction-count: [0, 1, 100, 1000, 10000]
+        rust-diff-engine: ["true"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d # https://github.com/actions/setup-node/releases/tag/v1.4.4
+        with:
+          node-version: 12
+
+      - name: 'Set CARGO_HOME and RUSTUP_HOME'
+        run: |
+          echo "RUSTUP_HOME=$HOME/.rustup" >> $GITHUB_ENV
+          echo "CARGO_HOME=$HOME/.cargo" >> $GITHUB_ENV
+
+      - name: 'Checkout source'
+        uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b # https://github.com/actions/checkout/commits/v2
+      - name: restore cached node_modules
+        id: workspace-node-modules
+        uses: actions/cache@d1255ad9362389eac595a9ae406b8e8cb3331f16 # v2.1.2
+        with:
+          path: |
+            node_modules/
+          key: workspace-node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}-v1
+      - name: 'Install test dependencies'
+        shell: bash
+        run: |
+          set -x
+          set -v
+          source sourceme.sh
+          optic_build_for_release
+      - name: 'display yarn error log'
+        shell: bash
+        run: cat yarn-error.log
+        if: ${{ failure() }}
+
+      - name: 'restore cached cargo registry'
+        uses: actions/cache@d1255ad9362389eac595a9ae406b8e8cb3331f16 # https://github.com/actions/cache/commits/v2
+        with:
+          path: |
+            ${{ env.CARGO_HOME }}/registry
+            ${{ env.CARGO_HOME }}/git
+            target
+          key: '${{ runner.os }}-cargo-${{ hashFiles(''**/Cargo.lock'') }}-v4'
+      - name: 'Rust toolchain'
+        uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # https://github.com/actions-rs/toolchain/commits/v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      # @TODO: build and use the release binary as opposed to the debug binary
+      - name: 'Build'
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # https://github.com/actions-rs/cargo/commits/v1
+        with:
+          command: build
+          args: --workspace --all-features
+      - name: 'Test'
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # https://github.com/actions-rs/cargo/commits/v1
+        with:
+          command: test
+      - name: 'Flush Cargo cache to disk on macOS'
+        if: runner.os == 'macOS'
+        run: sudo /usr/sbin/purge
+
+      - name: 'run scenario'
+        shell: bash
+        timeout-minutes: 2
+        run: |
+          source sourceme.sh
+          optic_ci_standard_streams_regression ${{ matrix.interaction-count }} ${{ matrix.rust-diff-engine }}
+
+
+      - name: 'display diff output'
+        shell: bash
+        run: |
+          source sourceme.sh
+          optic_ci_standard_streams_regression__on_failure
+        if: ${{ always() }}

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,2 @@
+network-timeout 600000
+

--- a/workspaces/cli-scripts/src/index.ts
+++ b/workspaces/cli-scripts/src/index.ts
@@ -21,7 +21,9 @@ export function runManagedScript(modulePath: string, ...args: string[]) {
   // const execArgv = isDebuggingEnabled ? ['--inspect=63694'] : []; // not in spawn
   const child = cp.spawn(process.argv0, [modulePath, ...args], {
     windowsHide: true,
-    stdio: ['ipc'],
+    // make sure stdout and stderr are consumed (by piping to process.stdout & process.stderr)
+    // execution may block, otherwise.
+    stdio: ['ignore', 'inherit', 'inherit', 'ipc'],
   });
   return child;
 }

--- a/workspaces/cli-shared/src/captures/avro/file-system/replicated-interactions-capture-saver.ts
+++ b/workspaces/cli-shared/src/captures/avro/file-system/replicated-interactions-capture-saver.ts
@@ -1,0 +1,109 @@
+import fs from 'fs-extra';
+import path from 'path';
+import { IHttpInteraction } from '@useoptic/domain-types';
+//@ts-ignore
+import oboe from 'oboe';
+import { CaptureSaver } from './capture-saver';
+
+async function main(
+  inputFilePaths: {
+    events: string;
+    interactions: string;
+  },
+  outputBaseDirectory: string,
+  captureId: string,
+  replicaCount: number
+) {
+  console.log({ inputFilePaths });
+  const events: any[] = await fs.readJson(inputFilePaths.events);
+  const captureBaseDirectory = path.join(
+    outputBaseDirectory,
+    '.optic',
+    'captures'
+  );
+  const captureSaver = new CaptureSaver({
+    captureBaseDirectory,
+    captureId,
+  });
+  const input = fs.createReadStream(inputFilePaths.interactions);
+  await captureSaver.init();
+  await new Promise((resolve, reject) => {
+    oboe(input)
+      .on('node', {
+        // @ts-ignore
+        '!.*': function (sample: IHttpInteraction) {
+          console.count('sample');
+          console.log({ sample });
+          Array.from({ length: replicaCount }).forEach(() => {
+            captureSaver.save(sample);
+          });
+        },
+      })
+      .on('done', function () {
+        console.log('done');
+        resolve();
+      })
+      .on('fail', function (e: any) {
+        console.error(e);
+        reject(e);
+      });
+  });
+
+  const files = [
+    {
+      location: path.join(outputBaseDirectory, 'optic.yml'),
+      contents: `name: ${JSON.stringify(path.basename(inputFilePaths.events))}`,
+    },
+    {
+      location: path.join(
+        outputBaseDirectory,
+        '.optic',
+        'api',
+        'specification.json'
+      ),
+      contents: JSON.stringify(events),
+    },
+    {
+      location: path.join(
+        outputBaseDirectory,
+        '.optic',
+        'captures',
+        captureId,
+        'optic-capture-state.json'
+      ),
+      contents: JSON.stringify({
+        captureId,
+        status: 'completed',
+        metadata: {
+          startedAt: new Date().toISOString(),
+          taskConfig: null,
+          lastInteraction: null,
+        },
+      }),
+    },
+  ];
+
+  await Promise.all(
+    files.map(async (x) => {
+      const { location, contents } = x;
+      await fs.ensureDir(path.dirname(location));
+      return fs.writeFile(location, contents);
+    })
+  );
+}
+
+const [
+  ,
+  ,
+  inputEventsFilePath,
+  inputInteractionsFilePath,
+  outputBaseDirectory,
+  captureId,
+  replicaCount,
+] = process.argv;
+main(
+  { interactions: inputInteractionsFilePath, events: inputEventsFilePath },
+  outputBaseDirectory,
+  captureId,
+  parseInt(replicaCount, 10)
+);


### PR DESCRIPTION
Captures on Windows that were larger than about 200 interactions would hang and never finish.

The problem lied in that `stdout` and `stderr` streams not being consumed when the cli-server spawned them as children processes. On POSIX this was fine, as the I/O is asynchronous and the writes to the streams (not consumed, with content being buffered) didn't block. On Windows, however, where Node's pipes are blocking, once the buffers of the unconsumed streams filled up, blocked further execution.

We concluded that a reasonable fix was to perform the `ipc` over a separate file descriptor instead of `stdin` and explicitly ignoring or cosuming the rest for running managed scripts. That allows debug output to make it all the way down to the cli-server's output (and eventually do aggregated logging from a single point), but prevents tasks from getting blocked.