### PR TITLE
fix for Optic updates -- client side caching

### DIFF
--- a/workspaces/cli-server/src/server.ts
+++ b/workspaces/cli-server/src/server.ts
@@ -80,7 +80,12 @@ class CliServer {
     const resourceRoot = path.resolve(basePath);
     const reactRoot = path.join(resourceRoot, 'build');
     const indexHtmlPath = path.join(reactRoot, 'index.html');
-    app.use(express.static(reactRoot));
+    app.use(
+      express.static(reactRoot, {
+        etag: false,
+        maxAge: '5000',
+      })
+    );
     app.use(bodyParser.json({ limit: '1mb' }));
     app.get('*', (req, res) => {
       res.sendFile(indexHtmlPath);


### PR DESCRIPTION
Express static serves the Optic UX -- users have reported that upon updating to new Optic versions (hurray! people are doing this a lot more), the UI won't load. This appears to be caused by client-side caching of index.html, which then cannot resolves the .js and css assets it needs. 

This fix disables the two caching mechanisms at fault -- etag and maxAge