### PR TITLE
Fix bug where diffing would yield double results and sometimes crash at the end

### DIFF
--- a/workspaces/cli-shared/src/diffs/diff-worker-rust.ts
+++ b/workspaces/cli-shared/src/diffs/diff-worker-rust.ts
@@ -214,9 +214,6 @@ export class DiffWorkerRust {
       const diffEngineLog = fs.createWriteStream(diffEngineLogFilePath);
       diffEngine.error.pipe(diffEngineLog);
 
-      // provide diffEngine's stdin:
-      interactionsStream.pipe(diffEngine.input);
-
       // write initial output
       await Promise.all([
         safeWriteJson(diffOutputPaths.stats, {


### PR DESCRIPTION
A slightly embarrassing one, where in fixing https://github.com/opticdev/optic/pull/441 we introduced a nasty little bug due to a bad cherry-picking. 

We started picking up on the diffs sometimes not finishing, especially on Windows. Using a local test setup, I isolated it to a stream being written to while it had already closed. The intermittent behaviour pointed at a race condition, and the removal of the `fork` of input interactions fixed the issue, so I started looking at `stream-fork`'s implementation, hunting for a condition in there. 

However, going deeper and deeper (including Node.js source for Streams), I realised every ending mechanic was working as designed. Yet, for some reason writes were queued up while the writable had already been ended by its source.

![Screenshot 2020-11-30 at 13 22 49](https://user-images.githubusercontent.com/857549/100610904-cc98ee80-3310-11eb-9f42-a16a58e6f17f.png)

And then I spotted the actual issue: **the interactions were piped to the diff engine twice**. Once forked, once straight up. And there's your race condition. In the end, it would have shown up on Windows as there the downstream I/O is blocking rather than async as macOS and Linux, meaning it was unlikely for messages to get buffered and any get written after end. Both streams would have still called `stream.end`, but that's perfectly legal. 