### PR TITLE
Finish macOS workflows in some reasonable amount of time

### DIFF
--- a/.github/workflows/regression-suites.yml
+++ b/.github/workflows/regression-suites.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ windows-latest, macos-latest, ubuntu-latest ]
-        interaction-count: [0, 1, 100, 1000, 10000]
+        interaction-count: [ 10000 ]
         rust-diff-engine: ["true"]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Multiple instances of waiting for a release to make it from a new version being pushed to `develop`, prompted me to look into why the workflows take such a long time to complete (I was waiting anyway!). macOS runners must be expensive, as Github seems to limit the amount that can run at any given time for the repo. We should treat that as the limited resource it seems to be, so we don't have to wait 30 minutes for workflows to eventually complete.