### PR TITLE
[Draft] explore local-cli diff error handling

### DIFF
--- a/workspaces/cli-scripts/src/emit-diff-projections-rust.ts
+++ b/workspaces/cli-scripts/src/emit-diff-projections-rust.ts
@@ -9,6 +9,7 @@ async function run(config: IDiffProjectionEmitterConfig) {
 
 const [, , configJsonString] = process.argv;
 const config: IDiffProjectionEmitterConfig = JSON.parse(configJsonString);
+debugger;
 console.log({ config });
 run(config).catch((e) => {
   console.error(e);

--- a/workspaces/cli-scripts/src/index.ts
+++ b/workspaces/cli-scripts/src/index.ts
@@ -19,12 +19,16 @@ export function runManagedScript(modulePath: string, ...args: string[]) {
   const isDebuggingEnabled =
     process.env.OPTIC_DAEMON_ENABLE_DEBUGGING === 'yes';
   // const execArgv = isDebuggingEnabled ? ['--inspect=63694'] : []; // not in spawn
-  const child = cp.spawn(process.argv0, [modulePath, ...args], {
-    windowsHide: true,
-    // make sure stdout and stderr are consumed (by piping to process.stdout & process.stderr)
-    // execution may block, otherwise.
-    stdio: ['ignore', 'inherit', 'inherit', 'ipc'],
-  });
+  const child = cp.spawn(
+    process.argv0,
+    ['--inspect-brk=63694', modulePath, ...args],
+    {
+      windowsHide: true,
+      // make sure stdout and stderr are consumed (by piping to process.stdout & process.stderr)
+      // execution may block, otherwise.
+      stdio: ['ignore', 'inherit', 'inherit', 'ipc'],
+    }
+  );
   return child;
 }
 

--- a/workspaces/cli-server/src/diffs/on-demand.ts
+++ b/workspaces/cli-server/src/diffs/on-demand.ts
@@ -71,11 +71,14 @@ export class OnDemandDiff implements Diff {
       additionalCommandsFilePath: outputPaths.additionalCommands,
       filtersFilePath: outputPaths.filters,
     };
-    console.log(JSON.stringify(scriptConfig));
-    const child = runManagedScriptByName(
+    const scriptName =
       process.env.OPTIC_RUST_DIFF_ENGINE === 'true'
         ? 'emit-diff-projections-rust'
-        : 'emit-diff-projections',
+        : 'emit-diff-projections';
+    console.log(scriptName, JSON.stringify(scriptConfig));
+    debugger;
+    const child = runManagedScriptByName(
+      scriptName,
       JSON.stringify(scriptConfig)
     );
 
@@ -86,14 +89,17 @@ export class OnDemandDiff implements Diff {
       this.events.emit(x.type, x.data);
     };
     const onError = (err: Error) => {
+      debugger;
       cleanup();
       this.events.emit('error', err);
+      debugger;
     };
     const onExit = (code: number, signal: string | null) => {
       cleanup();
       if (code !== 0) {
         // @TODO: wonder how we'll ever find out about this happening.
         console.error(`Diff Worker exited with non-zero exit code ${code}`);
+        debugger;
       } else {
         this.finished = true;
         this.events.emit('finish');
@@ -114,6 +120,7 @@ export class OnDemandDiff implements Diff {
 
     return new Promise((resolve, reject) => {
       function onErr(err: Error) {
+        debugger;
         cleanup();
         reject(err);
       }
@@ -153,6 +160,7 @@ export class OnDemandDiff implements Diff {
     stream.write({ type: 'progress', data: this.latestProgress() });
 
     if (this.finished) {
+      debugger;
       stream.end();
     } else {
       let resume = () => {
@@ -165,14 +173,18 @@ export class OnDemandDiff implements Diff {
 
         let end = () => {
           stopListening();
-          stream.end();
+          debugger;
+          //ending the stream here doesn't seem to flush
+          //stream.end({ type: 'idk', data: { finished: true } });
         };
 
         function onProgress(data: any) {
           write({ type: 'progress', data });
         }
         function onErr(data: any) {
+          debugger;
           write({ type: 'error', data });
+
           end();
         }
         function onFinish() {

--- a/workspaces/cli-server/src/routers/capture-router.ts
+++ b/workspaces/cli-server/src/routers/capture-router.ts
@@ -77,12 +77,17 @@ export function makeRouter(dependencies: ICaptureRouterDependencies) {
     '/diffs',
     bodyParser.json({ limit: '100mb' }),
     async (req, res) => {
+      debugger;
       const { captureId } = req.params;
       const { ignoreRequests, events, additionalCommands, filters } = req.body;
 
       let diffId;
       try {
-        diffId = await req.optic.session.diffCapture(captureId, events, filters);
+        diffId = await req.optic.session.diffCapture(
+          captureId,
+          events,
+          filters
+        );
       } catch (e) {
         return res.status(500).json({ message: e.message });
       }
@@ -134,7 +139,7 @@ export function makeRouter(dependencies: ICaptureRouterDependencies) {
     const notifications = chain([
       progress,
       ({ type, data }) => {
-        if (type === 'progress') type = 'message';
+        debugger;
         return [`data: ${JSON.stringify({ type, data })}\n\n`];
       },
     ]);

--- a/workspaces/cli-server/src/sessions.ts
+++ b/workspaces/cli-server/src/sessions.ts
@@ -122,11 +122,13 @@ class SessionDiffs {
     this.diffsById.set(diffId, newDiff);
 
     newDiff.events.once('finish', () => {
+      debugger;
       this.activeDiffsByCaptureId.delete(captureId);
     });
     newDiff.events.once('error', (err) => {
       console.error(err);
-      throw err;
+      debugger;
+      //throw err; // if we throw here after newDiff.start() succeeds, this error does not get caught
     });
 
     await newDiff.start();

--- a/workspaces/diff-engine/lib/index.d.ts
+++ b/workspaces/diff-engine/lib/index.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="node" />
 
 import { Duplex } from 'stream';
+import { ExecaChildProcess } from 'execa';
 
 export function spawn({
   specPath: string,
@@ -8,4 +9,5 @@ export function spawn({
   input: Duplex;
   output: Duplex;
   error: Duplex;
+  child: ExecaChildProcess;
 };

--- a/workspaces/diff-engine/scripts/install.js
+++ b/workspaces/diff-engine/scripts/install.js
@@ -1,4 +1,4 @@
-const { install } = require('../lib');
+const { install, dryRun } = require('../lib');
 const dotenv = require('dotenv');
 const path = require('path');
 
@@ -23,6 +23,8 @@ if (process.env.OPTIC_RUST_DIFF_ENGINE !== 'true') {
 install()
   .then(({ archiveName }) => {
     console.log(`Installed binaries for diff-engine: ${archiveName}`);
+    console.log('Verifying binary can actualy run...');
+    return dryRun();
   })
   .catch((err) => {
     console.error('Could not install diff-engine:', err);

--- a/workspaces/diff-engine/src/main.rs
+++ b/workspaces/diff-engine/src/main.rs
@@ -16,6 +16,8 @@ use tokio::stream::StreamExt;
 use tokio::sync::{mpsc, Semaphore};
 
 fn main() {
+  process::exit(1);
+
   let cli = App::new("Optic Diff engine")
     .version(crate_version!())
     .author("Optic Labs Corporation")


### PR DESCRIPTION
This PR explores what happens when the rust binary is missing or terminates with a non-zero exit code. It seems like there are a few issues stopping the error from reaching the frontend. One appears to be related to the SSE notifications channel not flushing the final write()s. Another is the daemon crashing due to uncaught errors. Another is execa's output seeming to be ignored