### PR TITLE
Remove oas projection from Learn API Mode

### DIFF
--- a/workspaces/agent-cli/package.json
+++ b/workspaces/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/agent-cli",
-  "version": "8.6.0-beta.26",
+  "version": "8.6.0-beta.27",
   "author": "@useoptic",
   "bin": {
     "optic-agent": "./bin/run"
@@ -15,7 +15,7 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^3",
-    "@useoptic/cli-shared": "8.6.0-beta.26",
+    "@useoptic/cli-shared": "8.6.0-beta.27",
     "dotenv": "^8.2.0",
     "jwt-decode": "^2.2.0",
     "tslib": "^1",

--- a/workspaces/analytics/package.json
+++ b/workspaces/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/analytics",
-  "version": "8.6.0-beta.26",
+  "version": "8.6.0-beta.27",
   "scripts": {
     "ws:build": "tsc -b --verbose",
     "ws:clean": "rm -rf build/*",

--- a/workspaces/ci-cli/package.json
+++ b/workspaces/ci-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/ci-cli",
-  "version": "8.6.0-beta.26",
+  "version": "8.6.0-beta.27",
   "author": "@useoptic",
   "bin": {
     "optic-ci": "./bin/run"
@@ -15,8 +15,8 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^3",
-    "@useoptic/cli-config": "8.6.0-beta.26",
-    "@useoptic/cli-shared": "8.6.0-beta.26",
+    "@useoptic/cli-config": "8.6.0-beta.27",
+    "@useoptic/cli-shared": "8.6.0-beta.27",
     "dotenv": "^8.2.0",
     "jwt-decode": "^2.2.0",
     "tslib": "^1",

--- a/workspaces/cli-client/package.json
+++ b/workspaces/cli-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-client",
-  "version": "8.6.0-beta.26",
+  "version": "8.6.0-beta.27",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",
@@ -14,9 +14,9 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "dependencies": {
-    "@useoptic/analytics": "8.6.0-beta.26",
-    "@useoptic/cli-config": "8.6.0-beta.26",
-    "@useoptic/client-utilities": "8.6.0-beta.26",
+    "@useoptic/analytics": "8.6.0-beta.27",
+    "@useoptic/cli-config": "8.6.0-beta.27",
+    "@useoptic/client-utilities": "8.6.0-beta.27",
     "bottleneck": "^2.19.5",
     "cross-fetch": "^3.0.4"
   },

--- a/workspaces/cli-config/package.json
+++ b/workspaces/cli-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-config",
-  "version": "8.6.0-beta.26",
+  "version": "8.6.0-beta.27",
   "scripts": {
     "ws:test": "jest",
     "ws:build": "yarn run tsc -b --verbose",

--- a/workspaces/cli-scripts/package.json
+++ b/workspaces/cli-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-scripts",
-  "version": "8.6.0-beta.26",
+  "version": "8.6.0-beta.27",
   "scripts": {
     "ws:test": "echo scripts",
     "ws:build": "yarn run tsc -b --verbose",
@@ -18,7 +18,7 @@
     "@sentry/tracing": "^5.28.0",
     "node-notifier": "^7.0.0",
     "analytics-node": "^3.4.0-beta.1",
-    "@useoptic/cli-shared": "8.6.0-beta.26"
+    "@useoptic/cli-shared": "8.6.0-beta.27"
   },
   "devDependencies": {
     "@types/node-notifier": "^6.0.1"

--- a/workspaces/cli-server/package.json
+++ b/workspaces/cli-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-server",
-  "version": "8.6.0-beta.26",
+  "version": "8.6.0-beta.27",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",
@@ -16,12 +16,12 @@
   "dependencies": {
     "@sentry/node": "^5.28.0",
     "@sentry/tracing": "^5.28.0",
-    "@useoptic/analytics": "8.6.0-beta.26",
-    "@useoptic/cli-client": "8.6.0-beta.26",
-    "@useoptic/cli-config": "8.6.0-beta.26",
-    "@useoptic/cli-scripts": "8.6.0-beta.26",
-    "@useoptic/cli-shared": "8.6.0-beta.26",
-    "@useoptic/ui": "8.6.0-beta.26",
+    "@useoptic/analytics": "8.6.0-beta.27",
+    "@useoptic/cli-client": "8.6.0-beta.27",
+    "@useoptic/cli-config": "8.6.0-beta.27",
+    "@useoptic/cli-scripts": "8.6.0-beta.27",
+    "@useoptic/cli-shared": "8.6.0-beta.27",
+    "@useoptic/ui": "8.6.0-beta.27",
     "analytics-node": "^3.4.0-beta.2",
     "avsc": "^5.4.18",
     "body-parser": "^1.19.0",

--- a/workspaces/cli-shared/package.json
+++ b/workspaces/cli-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-shared",
-  "version": "8.6.0-beta.26",
+  "version": "8.6.0-beta.27",
   "scripts": {
     "test": "cd test && tap .",
     "ws:build": "yarn run tsc -b --verbose",
@@ -16,10 +16,10 @@
   "types": "build/index.d.ts",
   "dependencies": {
     "@oclif/command": "^1.6.1",
-    "@useoptic/cli-client": "8.6.0-beta.26",
-    "@useoptic/cli-config": "8.6.0-beta.26",
-    "@useoptic/client-utilities": "8.6.0-beta.26",
-    "@useoptic/diff-engine": "8.6.0-beta.26",
+    "@useoptic/cli-client": "8.6.0-beta.27",
+    "@useoptic/cli-config": "8.6.0-beta.27",
+    "@useoptic/client-utilities": "8.6.0-beta.27",
+    "@useoptic/diff-engine": "8.6.0-beta.27",
     "@useoptic/domain": "10.0.17",
     "@useoptic/domain-types": "10.0.17",
     "@useoptic/domain-utilities": "10.0.17",

--- a/workspaces/client-utilities/package.json
+++ b/workspaces/client-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/client-utilities",
-  "version": "8.6.0-beta.26",
+  "version": "8.6.0-beta.27",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",

--- a/workspaces/diff-engine/package.json
+++ b/workspaces/diff-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/diff-engine",
-  "version": "8.6.0-beta.26",
+  "version": "8.6.0-beta.27",
   "scripts": {
     "postinstall": "node scripts/install",
     "preuninstall": "node scripts/uninstall",

--- a/workspaces/local-cli/package.json
+++ b/workspaces/local-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/cli",
   "description": "The Optic CLI",
-  "version": "8.6.0-beta.26",
+  "version": "8.6.0-beta.27",
   "author": "@useoptic",
   "bin": {
     "api": "./bin/run"
@@ -18,12 +18,12 @@
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^2",
     "cli-table3": "^0.6.0",
-    "@useoptic/analytics": "8.6.0-beta.26",
-    "@useoptic/cli-client": "8.6.0-beta.26",
-    "@useoptic/cli-config": "8.6.0-beta.26",
-    "@useoptic/cli-scripts": "8.6.0-beta.26",
-    "@useoptic/cli-server": "8.6.0-beta.26",
-    "@useoptic/cli-shared": "8.6.0-beta.26",
+    "@useoptic/analytics": "8.6.0-beta.27",
+    "@useoptic/cli-client": "8.6.0-beta.27",
+    "@useoptic/cli-config": "8.6.0-beta.27",
+    "@useoptic/cli-scripts": "8.6.0-beta.27",
+    "@useoptic/cli-server": "8.6.0-beta.27",
+    "@useoptic/cli-shared": "8.6.0-beta.27",
     "@useoptic/domain": "10.0.17",
     "analytics-node": "^3.4.0-beta.1",
     "cli-ux": "^5.4.1",

--- a/workspaces/saas-types/package.json
+++ b/workspaces/saas-types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/saas-types",
   "description": "interfaces and types for Optic SaaS surface area",
-  "version": "8.6.0-beta.26",
+  "version": "8.6.0-beta.27",
   "main": "build/index.js",
   "files": [
     "build"

--- a/workspaces/snapshot-tests/package.json
+++ b/workspaces/snapshot-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/snapshot-tests",
-  "version": "8.6.0-beta.26",
+  "version": "8.6.0-beta.27",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",
@@ -15,8 +15,8 @@
     "@useoptic/domain": "10.0.18",
     "@useoptic/domain-types": "10.0.18",
     "@useoptic/domain-utilities": "10.0.18",
-    "@useoptic/client-utilities": "8.6.0-beta.26",
-    "@useoptic/cli-shared": "8.6.0-beta.26",
+    "@useoptic/client-utilities": "8.6.0-beta.27",
+    "@useoptic/cli-shared": "8.6.0-beta.27",
     "dataloader": "^2.0.0",
     "eventsource": "^1.0.7",
     "fs-extra": "^9.0.0"

--- a/workspaces/ui/package.json
+++ b/workspaces/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/ui",
-  "version": "8.6.0-beta.26",
+  "version": "8.6.0-beta.27",
   "files": [
     "build",
     "index.js",
@@ -15,9 +15,9 @@
     "@material-ui/core": "^4.9.7",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.46",
-    "@useoptic/cli-shared": "8.6.0-beta.26",
-    "@useoptic/cli-client": "8.6.0-beta.26",
-    "@useoptic/analytics": "8.6.0-beta.26",
+    "@useoptic/cli-shared": "8.6.0-beta.27",
+    "@useoptic/cli-client": "8.6.0-beta.27",
+    "@useoptic/analytics": "8.6.0-beta.27",
     "@useoptic/domain": "10.0.17",
     "@useoptic/domain-utilities": "10.0.17",
     "bottleneck": "^2.19.5",

--- a/workspaces/ui/src/components/diff/v2/learn-api/InProgressFullScreen.js
+++ b/workspaces/ui/src/components/diff/v2/learn-api/InProgressFullScreen.js
@@ -187,25 +187,11 @@ export default function InProgressFullScreen({ type }) {
         );
 
         updatedAdditionalCommands([]); // clear these
-        const oas = OasProjectionHelper.fromEventString(
-          newEventStore.serializeEvents(rfcId)
-        );
-
         setStats({
-          fields: asJs.reduce(
-            (sum, command) => (command.AddField ? sum + 1 : sum),
-            0
-          ),
-          requests: asJs.reduce(
-            (sum, command) => (command.AddRequest ? sum + 1 : sum),
-            0
-          ),
-          responses: asJs.reduce(
-            (sum, command) =>
-              command.AddResponseByPathAndMethod ? sum + 1 : sum,
-            0
-          ),
-          oasLineCount: JSON.stringify(oas, null, 4).split('\n').length,
+          fields: 0,
+          requests: 0,
+          responses: 0,
+          oasLineCount: 0,
         });
         await specService.saveEvents(newEventStore, rfcId);
         setDone(true);
@@ -307,30 +293,30 @@ export default function InProgressFullScreen({ type }) {
             </Collapse>
             <Collapse in={done}>
               <div style={{ textAlign: 'center', marginTop: 19 }}>
-                {stats && !isManual ? (
-                  <Typography variant="body1" color="primary">
-                    <Typography variant="h6" color="textPrimary">
-                      That's <Stat number={stats.oasLineCount} label="line" />{' '}
-                      of OpenAPI that Optic will continue to keep up-to-date for
-                      your team!
-                    </Typography>
+                {/*{stats && !isManual ? (*/}
+                {/*  <Typography variant="body1" color="primary">*/}
+                {/*    <Typography variant="h6" color="textPrimary">*/}
+                {/*      That's <Stat number={stats.oasLineCount} label="line" />{' '}*/}
+                {/*      of OpenAPI that Optic will continue to keep up-to-date for*/}
+                {/*      your team!*/}
+                {/*    </Typography>*/}
 
-                    <div
-                      style={{
-                        display: 'flex',
-                        margin: '0 auto',
-                        justifyContent: 'space-around',
-                        maxWidth: 320,
-                      }}
-                    >
-                      <StatMini number={stats.requests} label="new request" />
-                      <StatMini number={stats.responses} label="new response" />
-                      <StatMini number={stats.fields} label="new field" />
-                    </div>
-                    <div></div>
-                    <div></div>
-                  </Typography>
-                ) : null}
+                {/*    <div*/}
+                {/*      style={{*/}
+                {/*        display: 'flex',*/}
+                {/*        margin: '0 auto',*/}
+                {/*        justifyContent: 'space-around',*/}
+                {/*        maxWidth: 320,*/}
+                {/*      }}*/}
+                {/*    >*/}
+                {/*      <StatMini number={stats.requests} label="new request" />*/}
+                {/*      <StatMini number={stats.responses} label="new response" />*/}
+                {/*      <StatMini number={stats.fields} label="new field" />*/}
+                {/*    </div>*/}
+                {/*    <div></div>*/}
+                {/*    <div></div>*/}
+                {/*  </Typography>*/}
+                {/*) : null}*/}
                 <Button
                   variant="contained"
                   color="primary"


### PR DESCRIPTION
The current IMPL of OAS Projection isn't suitable for the browser. When you get into the hundreds of endpoints the memory, and stack requirements break most users. Learn API Mode is much more stable without it and the only function it was serving was telling you how many lines of OpenAPI Optic is managing for you -- cool, but not worth the stability hit.

A user with a huge API is blocked by this right now (see slack), getting this through to a beta channel will unblock them