### PR TITLE
Prevent VC++ redist packages requirement for diff-engine's prebuilt windows binary

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,6 @@
+# Note: this config is only loaded when running `cargo <command>` from **the workspace root**,
+# e.g. when the prebuilt binaries get compiled during the release workflow.
+
+[target.x86_64-pc-windows-msvc]
+# prevent Visual C++ Redistributable from having to be installed
+rustflags = ["-Ctarget-feature=+crt-static"]


### PR DESCRIPTION
Installation of the `@useoptic/diff-engine` would fail on Windows machines that didn't have the Visual C++ Redistributable packages installed. While it's unlikely for developers to be in that position, we can link the C-runtime that's required by Rust statically for prebuilt binaries, removing the requirement all together.