### PR TITLE
daemon should retry acquiring lock when the lock is stale.

### DIFF
--- a/workspaces/cli-server/src/daemon.ts
+++ b/workspaces/cli-server/src/daemon.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import lockfile from 'proper-lockfile';
 import { ICliDaemonState, userDebugLogger } from '@useoptic/cli-shared';
-import { CliServer, log, shutdownRequested } from './server';
+import { CliServer, shutdownRequested } from './server';
 
 export interface ICliDaemonConfig {
   lockFilePath: string;
@@ -17,17 +17,19 @@ class CliDaemon {
   async start() {
     await this.acquireInstanceLock();
     const output = await this.startApiServer();
-    log.write(JSON.stringify(output) + '\n');
+    console.log(JSON.stringify(output));
     return output;
   }
 
   async acquireInstanceLock() {
-    log.write(`acquiring lock\n`);
-    this.releaseLock = await lockfile.lock(this.config.lockFilePath);
-    log.write(`acquired lock\n`);
+    console.log(`acquiring lock`);
+    this.releaseLock = await lockfile.lock(this.config.lockFilePath, {
+      retries: 3,
+    });
+    console.log(`acquired lock`);
     const fileExists = await fs.pathExists(this.config.lockFilePath);
     if (fileExists) {
-      log.write(`something exists at lock, deleting\n`);
+      console.log(`something exists at lock, deleting`);
       await fs.unlink(this.config.lockFilePath);
     }
   }

--- a/workspaces/cli-server/src/main.ts
+++ b/workspaces/cli-server/src/main.ts
@@ -1,6 +1,6 @@
 import { CliDaemon } from './daemon';
 import fs from 'fs-extra';
-import { isEnvTrue, userDebugLogger } from '@useoptic/cli-shared';
+import { userDebugLogger } from '@useoptic/cli-shared';
 import dotenv from 'dotenv';
 import path from 'path';
 import Config from './config';
@@ -14,8 +14,11 @@ dotenv.config({
 });
 
 if (Config.errors.sentry) {
+  console.log('Sentry is enabled');
   Errors.trackWithSentry(Config.errors.sentry);
   console.log('Remote error tracking with Sentry enabled');
+} else {
+  console.log('Sentry is disabled');
 }
 
 console.log('starting daemon', process.argv, process.env.DEBUG);

--- a/workspaces/cli-server/src/server.ts
+++ b/workspaces/cli-server/src/server.ts
@@ -1,9 +1,7 @@
 import {
   getPathsRelativeToCwd,
   IApiCliConfig,
-  IOpticTaskRunnerConfig,
   IPathMapping,
-  readApiConfig,
 } from '@useoptic/cli-config';
 import { EventEmitter } from 'events';
 import express from 'express';
@@ -11,9 +9,7 @@ import getPort from 'get-port';
 import bodyParser from 'body-parser';
 import http from 'http';
 import { Socket } from 'net';
-import os from 'os';
 import path from 'path';
-import fs from 'fs-extra';
 import {
   CapturesHelpers,
   ExampleRequestsHelpers,
@@ -28,10 +24,6 @@ import { IgnoreFileHelper } from '@useoptic/cli-config/build/helpers/ignore-file
 import { Session, SessionsManager } from './sessions';
 
 const pJson = require('../package.json');
-
-const logFilePath = path.join(os.homedir(), '.optic', 'optic-daemon.log');
-fs.ensureDirSync(path.dirname(logFilePath));
-export const log = fs.createWriteStream(logFilePath);
 
 export interface ICliServerConfig {
   cloudApiBaseUrl: string;
@@ -245,10 +237,10 @@ class CliServer {
       });
 
       this.server.on('connection', (connection) => {
-        log.write(`adding connection\n`);
+        console.log(`adding connection`);
         this.connections.push(connection);
         connection.on('close', () => {
-          log.write(`removing connection\n`);
+          console.log(`removing connection`);
           this.connections = this.connections.filter((c) => c !== connection);
         });
       });
@@ -258,22 +250,21 @@ class CliServer {
   async stop() {
     if (this.server) {
       await new Promise((resolve) => {
-        log.write(`server closing ${this.connections.length} open\n`);
+        console.log(`server closing ${this.connections.length} open`);
         this.connections.forEach((connection) => {
-          log.write(`destroying existing connection\n`);
+          console.log(`destroying existing connection`);
           connection.end();
           connection.destroy();
         });
         this.server.close((err) => {
-          log.write(`server closed\n`);
+          console.log(`server closed`);
           this.connections.forEach((connection) => {
-            log.write(`destroying existing connection\n`);
+            console.log(`destroying existing connection`);
             connection.end();
             connection.destroy();
           });
           if (err) {
             console.error(err);
-            log.write(`${err.message}\n`);
           }
           resolve();
         });

--- a/workspaces/local-cli/src/commands/daemon/start.ts
+++ b/workspaces/local-cli/src/commands/daemon/start.ts
@@ -2,12 +2,18 @@ import { Command } from '@oclif/command';
 import { ensureDaemonStarted } from '@useoptic/cli-server';
 import { lockFilePath } from '../../shared/paths';
 import { Config } from '../../config';
+import { cleanupAndExit } from '@useoptic/cli-shared';
 export default class DaemonStop extends Command {
   static description = 'ensures the Optic daemon has been started';
   static hidden: boolean = true;
 
   async run() {
-    await ensureDaemonStarted(lockFilePath, Config.apiBaseUrl);
-    this.log('Done!');
+    try {
+      await ensureDaemonStarted(lockFilePath, Config.apiBaseUrl);
+      this.log('Done!');
+      cleanupAndExit();
+    } catch (e) {
+      this.error(e);
+    }
   }
 }


### PR DESCRIPTION
per proper-lockfile's documentation:
stale: Duration in milliseconds in which the lock is considered stale, defaults to 10000 (minimum value is 5000)
update: The interval in milliseconds in which the lockfile's mtime will be updated, defaults to stale/2 (minimum value is 1000, maximum value is stale/2)

So, when a daemon terminates non-gracefully, there's a window in which a new daemon will think the lock is still being held by the old daemon and will fail to acquire it.