### PR TITLE
Give user instant feedback when trying to install diff-engine on unsupported platform

### DIFF
--- a/workspaces/diff-engine/lib/index.js
+++ b/workspaces/diff-engine/lib/index.js
@@ -85,12 +85,18 @@ function getPrebuiltPath(platform) {
 
 async function install(options) {
   let platform = getSupportedPlatform();
-  if (!platform)
+  if (!platform) {
+    let issueTitle = `Support for platform (os.type=${OS.type()} os.arch=${OS.arch()})`;
+    let issueLabels = 'feature request';
+    let issueUrl = encodeURI(
+      `https://github.com/opticdev/optic/issues/new?title=${issueTitle}&labels=${issueLabels}`
+    );
     throw new Error(
       `Unsupported platform. Cannot install pre-built ${
         Config.binaryName
-      } for os.type=${OS.type()} os.arch=${OS.arch()}`
+      } for os.type=${OS.type()} os.arch=${OS.arch()}. You can request support by opening a Github Issue at ${issueUrl}`
     );
+  }
 
   const installDir = Config.prebuilt.installPath;
   if (!Fs.existsSync(installDir)) {

--- a/workspaces/diff-engine/lib/index.js
+++ b/workspaces/diff-engine/lib/index.js
@@ -86,7 +86,7 @@ function getPrebuiltPath(platform) {
 async function install(options) {
   let platform = getSupportedPlatform();
   if (!platform)
-    new Error(
+    throw new Error(
       `Unsupported platform. Cannot install pre-built ${
         Config.binaryName
       } for os.type=${OS.type()} os.arch=${OS.arch()}`


### PR DESCRIPTION
Small bug, where we didn't interrupt the installation of diff-engine's prebuilt binaries when the platform turned out to be unsupported.