### PR TITLE
Add support for installing the Rust Diff engine on Macs with an M1 (Apple Silicon) natively

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,15 @@ env:
   BUCKET_NAME: optic-packages
   PACKAGE_NAME: api
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-  RELEASE_WORKFLOW_DRY_RUN: false
+  RELEASE_WORKFLOW_DRY_RUN: true
 
 on:
   push:
     branches:
       - release
+      - develop
+  pull_request:
+    branches:
       - develop
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,14 +84,22 @@ jobs:
           - os: macos-latest
             target: x86_64-apple-darwin
             platform_name: macos
+            rustup_channel: stable
+            suffix: ''
+          - os: macos-11.0
+            target: aarch64-apple-darwin
+            platform_name: macos-aarch64
+            rustup_channel: beta
             suffix: ''
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             platform_name: win64
+            rustup_channel: stable
             suffix: .exe
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             platform_name: linux
+            rustup_channel: stable
             suffix: ''
     runs-on: ${{ matrix.os }}
     env:
@@ -127,7 +135,8 @@ jobs:
       - name: 'Rust toolchain'
         uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # https://github.com/actions-rs/toolchain/releases/tag/v1.0.6
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.rustup_channel }}
+          target: ${{ matrix.target }}
           profile: minimal
           override: true
       - name: 'Build'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,15 +8,12 @@ env:
   BUCKET_NAME: optic-packages
   PACKAGE_NAME: api
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-  RELEASE_WORKFLOW_DRY_RUN: true
+  RELEASE_WORKFLOW_DRY_RUN: false
 
 on:
   push:
     branches:
       - release
-      - develop
-  pull_request:
-    branches:
       - develop
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,12 +126,12 @@ jobs:
           path: |
             ${{ env.CARGO_HOME }}/registry
             ${{ env.CARGO_HOME }}/git
-          key: "${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-vendor-v1"
+          key: "${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}-vendor-v1"
       - name: 'Cache build target'
         uses: actions/cache@d1255ad9362389eac595a9ae406b8e8cb3331f16 # https://github.com/actions/cache/releases/tag/v2.1.2
         with:
           path: target
-          key: "${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-release-target-v1"
+          key: "${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}-release-target-v1"
       - name: 'Rust toolchain'
         uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # https://github.com/actions-rs/toolchain/releases/tag/v1.0.6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,6 +159,8 @@ jobs:
         include:
           - platform_name: macos
             suffix: ''
+          - platform_name: macos-aarch64
+            suffix: ''
           - platform_name: win64
             suffix: .exe
           - platform_name: linux

--- a/workspaces/diff-engine/lib/config.js
+++ b/workspaces/diff-engine/lib/config.js
@@ -35,5 +35,11 @@ module.exports = {
       name: 'macos',
       suffix: '',
     },
+    {
+      type: 'Darwin',
+      arch: 'arm64',
+      name: 'macos-aarch64',
+      suffix: '',
+    },
   ],
 };


### PR DESCRIPTION
While there's a way to install optic with the new Rust diff engine on Macs with M1 (through running a x86 version of Node and relying on Rosetta 2 to translate), running a native binary would be far preferred. This PR provides this pre-built binary as part of the release workflow.

It uses the macOS 11 runner featuring the latest version of Xcode combined with the `1.49-beta.2` of the Rust compiler (we should set ourselves a reminder to move back to stable once 1.49 is stable). It then cross-compiles to `aarch64`, since there aren't any native runners yet.