### PR TITLE
Hide node deprecation warning on CLI commands

### DIFF
--- a/workspaces/local-cli/bin/run
+++ b/workspaces/local-cli/bin/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --no-warnings
 require('../lib')
 .run()
 .then(require('@oclif/command/flush'))

--- a/workspaces/local-cli/bin/run.cmd
+++ b/workspaces/local-cli/bin/run.cmd
@@ -1,3 +1,3 @@
 @echo off
 
-node "%~dp0\run" %* --no-warnings
+node --no-warnings "%~dp0\run" %*

--- a/workspaces/local-cli/bin/run.cmd
+++ b/workspaces/local-cli/bin/run.cmd
@@ -1,3 +1,3 @@
 @echo off
 
-node "%~dp0\run" %*
+node "%~dp0\run" %* --no-warnings


### PR DESCRIPTION
There's an open issue in the latest mockttp (recently updated) where an intermediate deprecation warning is being emitted. https://github.com/httptoolkit/mockttp/issues/41

This change hides those to clean up the DX of the CLI. 