### PR TITLE
Fix: Add conventions for Production vs Development log levels

### DIFF
--- a/workspaces/local-cli/bin/run
+++ b/workspaces/local-cli/bin/run
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
-process.removeAllListeners('warning');
+if (process.env.OPTIC_DEVELOPMENT !== 'yes') {
+  process.removeAllListeners('warning')
+}
+
 require('../lib')
 .run()
 .then(require('@oclif/command/flush'))


### PR DESCRIPTION
Optic recently updated our version of mockttp, the latest of which comes with a [known issue](https://github.com/httptoolkit/mockttp/issues/41) where an inner dependency uses a deprecated stream processor. While non-breaking, the node community has not been able to [fully shift away from this deprecated functionality yet.](https://github.com/nodejs/node/issues/34296). 

We want to make sure Optic contributors, and non-stable build users see every warning, because future warnings may indeed matter. But we also don't want to pollute production CLIs will warnings that those users don't need to worry about. 

This PR starts looking for `OPTIC_DEVELOPMENT` in the environment. When you are developing Optic with the `sourceme.sh` aliases on your path, that variable is present in the environment, the effect of which is that you see all warnings. When this is missing (production builds) you won't see the node deprecation warnings. 

There may well be other kinds of warnings we want to add to development only Optic builds,  we will likely continue using `OPTIC_DEVELOPMENT` as the flag to turn this feedback on and off. 

We'll continue tracking the mockttp issue and hope to move away from the deprecated functionality the dependencies rely on soon. 

