### PR TITLE
added $PORT flag to API Check

### DIFF
--- a/workspaces/local-cli/src/shared/verify/recommended.ts
+++ b/workspaces/local-cli/src/shared/verify/recommended.ts
@@ -154,6 +154,7 @@ export async function getAssertionsFromCommandSession(
   const servicePort = serviceConfig.port;
   const serviceHost = serviceConfig.host;
   const opticServiceConfig = {
+    PORT: servicePort.toString(),
     OPTIC_API_PORT: servicePort.toString(),
     OPTIC_API_HOST: serviceHost.toString(),
   };

--- a/workspaces/local-cli/src/shared/verify/recommended.ts
+++ b/workspaces/local-cli/src/shared/verify/recommended.ts
@@ -60,7 +60,7 @@ export async function verifyRecommended(
     },
     {
       title: `On the host Optic assigns it ${colors.bold(
-        '$OPTIC_API_HOST'
+        '$HOST'
       )} (current: ${colors.bold(startConfig.serviceConfig.host)})`,
       task: async () => {
         const results = await commandSessionPromise;
@@ -74,14 +74,14 @@ export async function verifyRecommended(
     },
     {
       title: `On the port Optic assigns it ${colors.bold(
-        '$OPTIC_API_PORT'
+        '$PORT'
       )} (current: ${colors.bold(startConfig.serviceConfig.port.toString())})`,
       task: async () => {
         const results = await commandSessionPromise;
         assert(
           results.startOnPortAssertion.passed,
           `Your command did not start the API on ${colors.bold(
-            '$OPTIC_API_PORT'
+            '$PORT'
           )} after 25 seconds`
         );
       },


### PR DESCRIPTION
Going forward, the new Optic documentation is going to advise users to set up their APIs to listen on `$PORT` not `$OPTIC_API_PORT` -- although both will continue to be added to the environment. 

The reason being -- a lot of frameworks and a lot of APIs are already set up to look for that port. Lou has shifted the language towards, 'make sure your API starts of provided $PORT' and away from 'make you API look for this other port that Optic configures'. 

It's subtle, but it's a change worth making. @LouManglass  -- we tested this for start, but it wasn't in the API Check code before now. Can you make sure it works as expected and aligns with the new docs? 

 