### PR TITLE
Fixes for setup page + check

### DIFF
--- a/workspaces/local-cli/src/shared/verify/recommended.ts
+++ b/workspaces/local-cli/src/shared/verify/recommended.ts
@@ -251,7 +251,7 @@ export async function getAssertionsFromCommandSession(
 
   const proxyCanStartAtInboundUrl: ProxyCanStartAtInboundUrl = {
     passed: inboundPortIsOpenAtStart && !tookProxyPort,
-    hostname: expected,
+    hostname: shouldNotTake,
   };
 
   return {

--- a/workspaces/ui/src/components/setup-page/CheckPassed.js
+++ b/workspaces/ui/src/components/setup-page/CheckPassed.js
@@ -51,13 +51,17 @@ export function CheckPassed(props) {
   const percentComplete = (count / target) * 100;
 
   return (
-    <Collapse in={props.passed}>
+    <Collapse in={props.passed} style={{ marginBottom: 300 }}>
       <Divider style={{ marginTop: 40, marginBottom: 20 }} />
       <div className={classes.root}>
-        <Typography variant="h5" style={{ marginBottom: 18 }}>
-          ✅ Check Passed! Your <Code>api start</Code> command is all set up.
-        </Typography>
-
+        {props.passed && (
+          <ScrollIntoViewIfNeeded>
+            <Typography variant="h5" style={{ marginBottom: 18 }}>
+              ✅ Check Passed! Your <Code>api start</Code> command is all set
+              up.
+            </Typography>
+          </ScrollIntoViewIfNeeded>
+        )}
         <Typography variant="h6" className={classes.copy}>
           Now run <Code>api start</Code>
         </Typography>

--- a/workspaces/ui/src/components/setup-page/HelperCard.js
+++ b/workspaces/ui/src/components/setup-page/HelperCard.js
@@ -61,7 +61,7 @@ const quickSummary = (mode) => {
   if (mode === 'recommended') {
     return {
       command: 'how your API is started',
-      inboundUrl: 'where the API usually starts locally localhost:PORT',
+      inboundUrl: 'where the API should listen locally',
     };
   } else if (mode === 'manual') {
     return {
@@ -96,22 +96,26 @@ export function HelperCard({ setting, mode, result, noChecks, value }) {
           variant="caption"
           style={{ color: '#999696', fontWeight: 100, paddingLeft: 2 }}
         >
+          <span style={{ fontWeight: 800 }}>{setting}</span>:{' '}
           {quickSummary(mode)[setting]}
         </Typography>
       </div>
-      <div className={classes.assertions}>
-        <Typography variant="caption" style={{ color: '#999696' }}>
-          The <strong>{setting}</strong> parameter:
-        </Typography>
-        {assertions.map((i, index) => (
-          <AssertionMini
-            issue={i.assertion}
-            noChecks={noChecks}
-            result={result && i.getStatus(result)}
-            key={'assertion' + index}
-          />
-        ))}
-      </div>
+      <Collapse in={!noChecks}>
+        <div className={classes.assertions}>
+          <Typography variant="caption" style={{ color: '#999696' }}>
+            The <strong>{setting}</strong> parameter:
+          </Typography>
+
+          {assertions.map((i, index) => (
+            <AssertionMini
+              issue={i.assertion}
+              noChecks={noChecks}
+              result={result && i.getStatus(result)}
+              key={'assertion' + index}
+            />
+          ))}
+        </div>
+      </Collapse>
     </Card>
   );
 }
@@ -177,8 +181,6 @@ const useStyles = makeStyles((theme) => ({
     justifyContent: 'center',
     paddingLeft: 9,
     padding: 7,
-    borderBottomColor: '#736d6d',
-    borderBottom: `1px solid`,
     marginBottom: 5,
   },
   error: {
@@ -199,5 +201,7 @@ const useStyles = makeStyles((theme) => ({
   assertions: {
     padding: 8,
     paddingTop: 0,
+    borderTopColor: '#736d6d',
+    borderTop: `1px solid`,
   },
 }));

--- a/workspaces/ui/src/components/setup-page/fetch-docs/loaded/common-issues.json
+++ b/workspaces/ui/src/components/setup-page/fetch-docs/loaded/common-issues.json
@@ -6,12 +6,12 @@
     },
     "commandHost": {
         "title": "Your `command` starts a long-running process on the host Optic assigns it",
-        "shortTitle": "starts a long-running process on the host Optic assigns it",
+        "shortTitle": "starts on the host Optic assigns it",
         "resolution": "By default when using the `command` parameter, Optic expects your API to be running on localhost alongside the Optic proxy. You shouldn't have to configure this in a recommended workflow.\n\n- If your API runs on localhost, but uses a different hostname: check your custom hostname mapping (such as in `/etc/hosts`) to assure it is properly resolving to localhost.\n- If your API doesn't run on localhost: Consider a [manual configuration](https://app.useoptic.com) which will let you target another host (such as a cloud-based API gateway).\n"
     },
     "commandPort": {
         "title": "Your `command` starts a long-running process on the port Optic assigns it",
-        "shortTitle": "starts a long-running process on the port Optic assigns it",
+        "shortTitle": "starts on the port Optic assigns it",
         "resolution": "Every time you run api start, Optic assigns your API a random port. If you get this error, it means that your command runs, but the API is not binding to the `$PORT` within 25 seconds of Optic running your command.\n\n- If you can set the port on which your API listens from the command line: make sure the `command` parameter of your task definition in `optic.yml` includes `$PORT`.\n  - For example, `rails -s` becomes `rails -s --port $PORT`.\n- If your development environment already uses `$PORT`, the value provided by Optic may be overridden. Instead, try `$OPTIC_API_PORT`.\n- If you can't set the port from the command line: update your code to bind to the port Optic provides via the `$PORT` environment variable.\n- If your application takes more than 25 seconds to warm up, the `api check` will always fail. As long as all other checks have passed, try using `api run` directly and wait for your application to warm up.\n"
     },
     "inboundUrlStart": {


### PR DESCRIPTION
@LouManglass I was making a user on-boarding video last night and damn -- the empathy one gets from being forced to think about a camera and an audience. love it -- may actually start using the 'ol glass eye to stay more honest. 

The first thing I noticed is that the inboundProxy check exits with the wrong port in its feedback. Can't start on 3005 (then under) could not start on 3997. Fixed that

I also realized the information overload factor of the initial UI was really high. There's stuff to read above, there's code, there's stuff to the right. I realized we could probably cut down on the feedback until after the first check runs. 

<img width="1254" alt="Screen Shot 2020-12-10 at 8 11 27 AM" src="https://user-images.githubusercontent.com/5900338/101776972-c7c9fc80-3abf-11eb-96bd-4c6652e256e4.png">
