### PR TITLE
Fix building of optic during release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,15 @@ env:
   BUCKET_NAME: optic-packages
   PACKAGE_NAME: api
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-  RELEASE_WORKFLOW_DRY_RUN: false
+  RELEASE_WORKFLOW_DRY_RUN: true
 
 on:
   push:
     branches:
       - release
+      - develop
+  pull_request: # TODO: remove this debug trigger before merging
+    branches:
       - develop
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ jobs:
       - name: Set version output
         id: version
         run: |
+          rustc -V
+          cargo -V
           OPTIC_VERSION=$(node -e "console.log(require('./workspaces/local-cli/package.json').version)")
           echo "OPTIC_VERSION=$OPTIC_VERSION" >> $GITHUB_ENV
           echo "::set-output name=version::$OPTIC_VERSION"
@@ -231,6 +233,8 @@ jobs:
         key: "${{ runner.os }}-npm-${{ hashFiles('**/yarn.lock') }}-vendor-v1"
     - name: Install Dependencies and Build Optic
       run:  |
+        rustc -V
+        cargo -V
         if [ "${{ needs.release_logic.outputs.is_prerelease }}" == "true" ] && [ -n "${{ needs.release_logic.outputs.prerelease_tag }}" ]; then
           echo "Prelease with a tag detected. Staging any feature flags for '${{ needs.release_logic.outputs.prerelease_tag }}'."
           RELEASE_CHANNEL=${{ needs.release_logic.outputs.prerelease_tag }}


### PR DESCRIPTION
With the inclusion of `diff-engine-wasm`, we now require the Rust toolchain to be installed for building Optic. The release workflow require updates to make sure that toolchain is installed before trying to build and publish new packages.