### PR TITLE
Run in-browser diffs with Rust diff engine

### DIFF
--- a/workspaces/ui/src/components/loaders/ApiLoader.js
+++ b/workspaces/ui/src/components/loaders/ApiLoader.js
@@ -1,43 +1,35 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useMockData } from '../../contexts/MockDataContext';
 import { SpecServiceStore } from '../../contexts/SpecServiceContext';
 import { LinearProgress } from '@material-ui/core';
 import { LocalRfcStore, RfcStore } from '../../contexts/RfcContext';
 import { InitialRfcCommandsStore } from '../../contexts/InitialRfcCommandsContext';
 import EventEmitter from 'events';
+import { RfcCommandContext } from '@useoptic/domain';
+import { cachingResolversAndRfcStateFromEventsAndAdditionalCommands } from '@useoptic/domain-utilities';
 
 export function ApiSpecServiceLoader(props) {
-  const { diffServiceFactory, captureServiceFactory } = props;
   const debugData = useMockData();
 
-  const [service, setService] = useState(null);
+  const specService = useSpecService(debugData);
   const [events, setEvents] = useState(null);
+  const loadingExampleDiff = useLoadExampleDiff(specService);
+
   useEffect(() => {
-    if (debugData.available && debugData.loading) return;
-
-    const serviceFactory = () =>
-      createExampleSpecServiceFactory(debugData.data);
-
-    const task = async () => {
-      const { specService } = await serviceFactory();
-      setService(specService);
-      specService.eventEmitter.on('events-updated', async () => {
+    if (specService) {
+      const task = async () => {
         const events = await specService.listEvents();
         setEvents(events);
-      });
-    };
-    task();
-  }, [debugData.available, debugData.loading]);
-
-  useEffect(() => {
-    if (service) {
-      const task = async () => {
-        const events = await service.listEvents();
-        setEvents(events);
       };
+      specService.eventEmitter.on('events-updated', () => {
+        task();
+      });
       task();
     }
-  }, [service]);
+  }, [specService]);
+
+  const captureServiceFactory = useCaptureServiceFactory(loadingExampleDiff);
+  const diffServiceFactory = useDiffServiceFactory(loadingExampleDiff);
 
   if (!events) {
     return <LinearProgress />;
@@ -45,8 +37,8 @@ export function ApiSpecServiceLoader(props) {
 
   return (
     <SpecServiceStore
-      specService={service}
-      specServiceEvents={service.eventEmitter}
+      specService={specService}
+      specServiceEvents={specService.eventEmitter}
       diffServiceFactory={diffServiceFactory}
       captureServiceFactory={captureServiceFactory}
     >
@@ -55,7 +47,7 @@ export function ApiSpecServiceLoader(props) {
         rfcId="testRfcId"
         instance="the one in ApiSpecServiceLoader"
       >
-        <RfcStore specService={service}>{props.children}</RfcStore>
+        <RfcStore specService={specService}>{props.children}</RfcStore>
       </InitialRfcCommandsStore>
     </SpecServiceStore>
   );
@@ -107,6 +99,108 @@ export function LocalCliSpecServiceLoader(props) {
       </InitialRfcCommandsStore>
     </SpecServiceStore>
   );
+}
+
+function useSpecService(debugData) {
+  const [service, setService] = useState(null);
+  useEffect(() => {
+    if (debugData.available && debugData.loading) return;
+
+    const serviceFactory = () =>
+      createExampleSpecServiceFactory(debugData.data);
+
+    const task = async () => {
+      const { specService } = await serviceFactory();
+      setService(specService);
+    };
+    task();
+  }, [debugData.available, debugData.loading]);
+
+  return service;
+}
+
+function useLoadExampleDiff() {
+  // produce a Promise that resolves with example diff instance
+  const resolveExampleDiff = useRef(null);
+
+  const loadingRef = useRef(
+    !resolveExampleDiff.current
+      ? new Promise((resolve) => {
+          resolveExampleDiff.current = resolve;
+        })
+      : null
+  );
+
+  useEffect(() => {
+    let createExampleDiff = async () => {
+      const { ExampleDiff } = await import(
+        '../../services/diff/ExampleDiffService'
+      );
+      let diff = new ExampleDiff();
+
+      resolveExampleDiff.current(diff);
+      resolveExampleDiff.current = null;
+    };
+
+    createExampleDiff();
+  }, []);
+
+  return loadingRef.current;
+}
+
+function useCaptureServiceFactory(loadingExampleDiff) {
+  const factoryRef = useRef(async (specService) => {
+    const [{ ExampleCaptureService }, exampleDiff] = await Promise.all([
+      import('../../services/diff/ExampleDiffService'),
+      loadingExampleDiff,
+    ]);
+
+    return new ExampleCaptureService(specService, exampleDiff);
+  });
+
+  return factoryRef.current;
+}
+
+function useDiffServiceFactory(loadingExampleDiff) {
+  const factoryRef = useRef(
+    async (
+      specService,
+      captureService,
+      _events,
+      _rfcState,
+      additionalCommands,
+      config
+    ) => {
+      const commandContext = new RfcCommandContext(
+        'simulated',
+        'simulated',
+        'simulated'
+      );
+      const {
+        rfcState,
+      } = cachingResolversAndRfcStateFromEventsAndAdditionalCommands(
+        _events,
+        commandContext,
+        additionalCommands
+      );
+
+      const [{ ExampleDiffService }, exampleDiff] = await Promise.all([
+        import('../../services/diff/ExampleDiffService'),
+        loadingExampleDiff,
+      ]);
+
+      return new ExampleDiffService(
+        exampleDiff,
+        specService,
+        captureService,
+        config,
+        [],
+        rfcState
+      );
+    }
+  );
+
+  return factoryRef.current;
 }
 
 export const captureId = 'example-session';

--- a/workspaces/ui/src/entrypoints/demo-sessions.js
+++ b/workspaces/ui/src/entrypoints/demo-sessions.js
@@ -7,12 +7,6 @@ import {
 } from '../contexts/MockDataContext';
 import { ApiRoutes } from '../routes';
 import { Provider as BaseUrlContext } from '../contexts/BaseUrlContext';
-// import {
-//   ExampleCaptureService,
-//   ExampleDiffService,
-// } from '../services/diff/ExampleDiffService';
-import { DiffHelpers, JsonHelper, RfcCommandContext } from '@useoptic/domain';
-import { cachingResolversAndRfcStateFromEventsAndAdditionalCommands } from '@useoptic/domain-utilities';
 import { Snackbar, makeStyles } from '@material-ui/core';
 import { analyticsEvents } from '../Analytics';
 import * as DiffEvents from '@useoptic/analytics/lib/events/diffs';
@@ -68,55 +62,6 @@ export default function DemoSessions(props) {
     sessionId: sessionId,
     exampleSessionCollection: 'demos',
   });
-
-  let exampleDiff;
-
-  const captureServiceFactory = async (specService, captureId) => {
-    const { ExampleDiff, ExampleCaptureService } = await import(
-      '../services/diff/ExampleDiffService'
-    );
-
-    if (!exampleDiff) exampleDiff = new ExampleDiff();
-
-    return new ExampleCaptureService(specService, exampleDiff);
-  };
-
-  const diffServiceFactory = async (
-    specService,
-    captureService,
-    _events,
-    _rfcState,
-    additionalCommands,
-    config
-  ) => {
-    const commandContext = new RfcCommandContext(
-      'simulated',
-      'simulated',
-      'simulated'
-    );
-    const {
-      rfcState,
-    } = cachingResolversAndRfcStateFromEventsAndAdditionalCommands(
-      _events,
-      commandContext,
-      additionalCommands
-    );
-
-    const { ExampleDiff, ExampleDiffService } = await import(
-      '../services/diff/ExampleDiffService'
-    );
-
-    if (!exampleDiff) exampleDiff = new ExampleDiff();
-
-    return new ExampleDiffService(
-      exampleDiff,
-      specService,
-      captureService,
-      config,
-      [],
-      rfcState
-    );
-  };
 
   // info boxes / guides for the demo
   const [message, setMessage] = useState({
@@ -357,10 +302,7 @@ export default function DemoSessions(props) {
     <>
       <BaseUrlContext value={{ path: match.path, url: match.url }}>
         <DebugSessionContextProvider value={session}>
-          <ApiSpecServiceLoader
-            captureServiceFactory={captureServiceFactory}
-            diffServiceFactory={diffServiceFactory}
-          >
+          <ApiSpecServiceLoader>
             <ApiRoutes getDefaultRoute={(options) => options.diffsRoot} />
 
             <Snackbar

--- a/workspaces/ui/src/entrypoints/private-sessions.js
+++ b/workspaces/ui/src/entrypoints/private-sessions.js
@@ -7,11 +7,6 @@ import {
 } from '../contexts/MockDataContext';
 import { ApiRoutes } from '../routes';
 import { Provider as BaseUrlContext } from '../contexts/BaseUrlContext';
-import { DiffHelpers, JsonHelper, RfcCommandContext } from '@useoptic/domain';
-import {
-  cachingResolversAndRfcStateFromEventsAndAdditionalCommands,
-  normalizedDiffFromRfcStateAndInteractions,
-} from '@useoptic/domain-utilities';
 
 export default function PrivateSessions(props) {
   const match = useRouteMatch();
@@ -21,62 +16,11 @@ export default function PrivateSessions(props) {
     sessionId: sessionId,
     exampleSessionCollection: 'private-sessions',
   });
-  let exampleDiff;
-
-  const captureServiceFactory = async (specService, captureId) => {
-    const { ExampleDiff, ExampleCaptureService } = await import(
-      '../services/diff/ExampleDiffService'
-    );
-
-    if (!exampleDiff) exampleDiff = new ExampleDiff();
-
-    return new ExampleCaptureService(specService, exampleDiff);
-  };
-
-  const diffServiceFactory = async (
-    specService,
-    captureService,
-    _events,
-    _rfcState,
-    additionalCommands,
-    config
-  ) => {
-    const commandContext = new RfcCommandContext(
-      'simulated',
-      'simulated',
-      'simulated'
-    );
-    const {
-      rfcState,
-    } = cachingResolversAndRfcStateFromEventsAndAdditionalCommands(
-      _events,
-      commandContext,
-      additionalCommands
-    );
-
-    const { ExampleDiff, ExampleDiffService } = await import(
-      '../services/diff/ExampleDiffService'
-    );
-
-    if (!exampleDiff) exampleDiff = new ExampleDiff();
-
-    return new ExampleDiffService(
-      exampleDiff,
-      specService,
-      captureService,
-      config,
-      [],
-      rfcState
-    );
-  };
 
   return (
     <BaseUrlContext value={{ path: match.path, url: match.url }}>
       <DebugSessionContextProvider value={session}>
-        <ApiSpecServiceLoader
-          captureServiceFactory={captureServiceFactory}
-          diffServiceFactory={diffServiceFactory}
-        >
+        <ApiSpecServiceLoader>
           <ApiRoutes />
         </ApiSpecServiceLoader>
       </DebugSessionContextProvider>

--- a/workspaces/ui/src/entrypoints/private-sessions.js
+++ b/workspaces/ui/src/entrypoints/private-sessions.js
@@ -21,12 +21,16 @@ export default function PrivateSessions(props) {
     sessionId: sessionId,
     exampleSessionCollection: 'private-sessions',
   });
+  let exampleDiff;
 
   const captureServiceFactory = async (specService, captureId) => {
-    const { ExampleCaptureService } = await import(
+    const { ExampleDiff, ExampleCaptureService } = await import(
       '../services/diff/ExampleDiffService'
     );
-    return new ExampleCaptureService(specService);
+
+    if (!exampleDiff) exampleDiff = new ExampleDiff();
+
+    return new ExampleCaptureService(specService, exampleDiff);
   };
 
   const diffServiceFactory = async (
@@ -35,52 +39,33 @@ export default function PrivateSessions(props) {
     _events,
     _rfcState,
     additionalCommands,
-    config,
-    captureId
+    config
   ) => {
-    const { ExampleDiffService } = await import(
+    const commandContext = new RfcCommandContext(
+      'simulated',
+      'simulated',
+      'simulated'
+    );
+    const {
+      rfcState,
+    } = cachingResolversAndRfcStateFromEventsAndAdditionalCommands(
+      _events,
+      commandContext,
+      additionalCommands
+    );
+
+    const { ExampleDiff, ExampleDiffService } = await import(
       '../services/diff/ExampleDiffService'
     );
-    async function computeInitialDiff() {
-      const capture = await specService.listCapturedSamples(captureId);
-      const commandContext = new RfcCommandContext(
-        'simulated',
-        'simulated',
-        'simulated'
-      );
 
-      const {
-        resolvers,
-        rfcState,
-      } = cachingResolversAndRfcStateFromEventsAndAdditionalCommands(
-        _events,
-        commandContext,
-        additionalCommands
-      );
-      let diffs = DiffHelpers.emptyInteractionPointersGroupedByDiff();
-      for (const interaction of capture.samples) {
-        diffs = DiffHelpers.groupInteractionPointerByDiffs(
-          resolvers,
-          rfcState,
-          JsonHelper.fromInteraction(interaction),
-          interaction.uuid,
-          diffs
-        );
-      }
-      return {
-        diffs,
-        rfcState,
-        resolvers,
-      };
-    }
-
-    const { diffs, rfcState } = await computeInitialDiff();
+    if (!exampleDiff) exampleDiff = new ExampleDiff();
 
     return new ExampleDiffService(
+      exampleDiff,
       specService,
       captureService,
       config,
-      diffs,
+      [],
       rfcState
     );
   };

--- a/workspaces/ui/src/entrypoints/spec-viewer.js
+++ b/workspaces/ui/src/entrypoints/spec-viewer.js
@@ -21,11 +21,16 @@ export default function SpecViewer(props) {
 
   const session = useSpecSession(specId);
 
+  let exampleDiff;
+
   const captureServiceFactory = async (specService, captureId) => {
-    const { ExampleCaptureService } = await import(
+    const { ExampleDiff, ExampleCaptureService } = await import(
       '../services/diff/ExampleDiffService'
     );
-    return new ExampleCaptureService(specService);
+
+    if (!exampleDiff) exampleDiff = new ExampleDiff();
+
+    return new ExampleCaptureService(specService, exampleDiff);
   };
 
   const diffServiceFactory = async (
@@ -34,52 +39,33 @@ export default function SpecViewer(props) {
     _events,
     _rfcState,
     additionalCommands,
-    config,
-    captureId
+    config
   ) => {
-    const { ExampleDiffService } = await import(
+    const commandContext = new RfcCommandContext(
+      'simulated',
+      'simulated',
+      'simulated'
+    );
+    const {
+      rfcState,
+    } = cachingResolversAndRfcStateFromEventsAndAdditionalCommands(
+      _events,
+      commandContext,
+      additionalCommands
+    );
+
+    const { ExampleDiff, ExampleDiffService } = await import(
       '../services/diff/ExampleDiffService'
     );
-    async function computeInitialDiff() {
-      const capture = await specService.listCapturedSamples(captureId);
-      const commandContext = new RfcCommandContext(
-        'simulated',
-        'simulated',
-        'simulated'
-      );
 
-      const {
-        resolvers,
-        rfcState,
-      } = cachingResolversAndRfcStateFromEventsAndAdditionalCommands(
-        _events,
-        commandContext,
-        additionalCommands
-      );
-      let diffs = DiffHelpers.emptyInteractionPointersGroupedByDiff();
-      for (const interaction of capture.samples) {
-        diffs = DiffHelpers.groupInteractionPointerByDiffs(
-          resolvers,
-          rfcState,
-          JsonHelper.fromInteraction(interaction),
-          interaction.uuid,
-          diffs
-        );
-      }
-      return {
-        diffs,
-        rfcState,
-        resolvers,
-      };
-    }
-
-    const { diffs, rfcState } = await computeInitialDiff();
+    if (!exampleDiff) exampleDiff = new ExampleDiff();
 
     return new ExampleDiffService(
+      exampleDiff,
       specService,
       captureService,
       config,
-      diffs,
+      [],
       rfcState
     );
   };

--- a/workspaces/ui/src/entrypoints/spec-viewer.js
+++ b/workspaces/ui/src/entrypoints/spec-viewer.js
@@ -5,15 +5,6 @@ import { useSpecSession } from '../contexts/SpecViewerContext';
 import { Provider as DebugSessionContextProvider } from '../contexts/MockDataContext';
 import { ApiRoutes } from '../routes';
 import { Provider as BaseUrlContext } from '../contexts/BaseUrlContext';
-// import {
-//   ExampleCaptureService,
-//   ExampleDiffService,
-// } from '../services/diff/ExampleDiffService';
-import { DiffHelpers, JsonHelper, RfcCommandContext } from '@useoptic/domain';
-import {
-  cachingResolversAndRfcStateFromEventsAndAdditionalCommands,
-  normalizedDiffFromRfcStateAndInteractions,
-} from '@useoptic/domain-utilities';
 
 export default function SpecViewer(props) {
   const match = useRouteMatch();
@@ -21,62 +12,10 @@ export default function SpecViewer(props) {
 
   const session = useSpecSession(specId);
 
-  let exampleDiff;
-
-  const captureServiceFactory = async (specService, captureId) => {
-    const { ExampleDiff, ExampleCaptureService } = await import(
-      '../services/diff/ExampleDiffService'
-    );
-
-    if (!exampleDiff) exampleDiff = new ExampleDiff();
-
-    return new ExampleCaptureService(specService, exampleDiff);
-  };
-
-  const diffServiceFactory = async (
-    specService,
-    captureService,
-    _events,
-    _rfcState,
-    additionalCommands,
-    config
-  ) => {
-    const commandContext = new RfcCommandContext(
-      'simulated',
-      'simulated',
-      'simulated'
-    );
-    const {
-      rfcState,
-    } = cachingResolversAndRfcStateFromEventsAndAdditionalCommands(
-      _events,
-      commandContext,
-      additionalCommands
-    );
-
-    const { ExampleDiff, ExampleDiffService } = await import(
-      '../services/diff/ExampleDiffService'
-    );
-
-    if (!exampleDiff) exampleDiff = new ExampleDiff();
-
-    return new ExampleDiffService(
-      exampleDiff,
-      specService,
-      captureService,
-      config,
-      [],
-      rfcState
-    );
-  };
-
   return (
     <BaseUrlContext value={{ path: match.path, url: match.url }}>
       <DebugSessionContextProvider value={session}>
-        <ApiSpecServiceLoader
-          captureServiceFactory={captureServiceFactory}
-          diffServiceFactory={diffServiceFactory}
-        >
+        <ApiSpecServiceLoader>
           <ApiRoutes defaultRoute={(options) => options.docsRoot} />
         </ApiSpecServiceLoader>
       </DebugSessionContextProvider>

--- a/workspaces/ui/src/entrypoints/testing-sessions.js
+++ b/workspaces/ui/src/entrypoints/testing-sessions.js
@@ -22,62 +22,59 @@ export default function TestingSessions(props) {
     exampleSessionCollection: 'example-sessions',
   });
 
-  let exampleDiff;
+  // let exampleDiff;
 
-  const captureServiceFactory = async (specService, captureId) => {
-    const { ExampleDiff, ExampleCaptureService } = await import(
-      '../services/diff/ExampleDiffService'
-    );
+  // const captureServiceFactory = async (specService, captureId) => {
+  //   const { ExampleDiff, ExampleCaptureService } = await import(
+  //     '../services/diff/ExampleDiffService'
+  //   );
 
-    if (!exampleDiff) exampleDiff = new ExampleDiff();
+  //   if (!exampleDiff) exampleDiff = new ExampleDiff();
 
-    return new ExampleCaptureService(specService, exampleDiff);
-  };
+  //   return new ExampleCaptureService(specService, exampleDiff);
+  // };
 
-  const diffServiceFactory = async (
-    specService,
-    captureService,
-    _events,
-    _rfcState,
-    additionalCommands,
-    config
-  ) => {
-    const commandContext = new RfcCommandContext(
-      'simulated',
-      'simulated',
-      'simulated'
-    );
-    const {
-      rfcState,
-    } = cachingResolversAndRfcStateFromEventsAndAdditionalCommands(
-      _events,
-      commandContext,
-      additionalCommands
-    );
+  // const diffServiceFactory = async (
+  //   specService,
+  //   captureService,
+  //   _events,
+  //   _rfcState,
+  //   additionalCommands,
+  //   config
+  // ) => {
+  //   const commandContext = new RfcCommandContext(
+  //     'simulated',
+  //     'simulated',
+  //     'simulated'
+  //   );
+  //   const {
+  //     rfcState,
+  //   } = cachingResolversAndRfcStateFromEventsAndAdditionalCommands(
+  //     _events,
+  //     commandContext,
+  //     additionalCommands
+  //   );
 
-    const { ExampleDiff, ExampleDiffService } = await import(
-      '../services/diff/ExampleDiffService'
-    );
+  //   const { ExampleDiff, ExampleDiffService } = await import(
+  //     '../services/diff/ExampleDiffService'
+  //   );
 
-    if (!exampleDiff) exampleDiff = new ExampleDiff();
+  //   if (!exampleDiff) exampleDiff = new ExampleDiff();
 
-    return new ExampleDiffService(
-      exampleDiff,
-      specService,
-      captureService,
-      config,
-      [],
-      rfcState
-    );
-  };
+  //   return new ExampleDiffService(
+  //     exampleDiff,
+  //     specService,
+  //     captureService,
+  //     config,
+  //     [],
+  //     rfcState
+  //   );
+  // };
 
   return (
     <BaseUrlContext value={{ path: match.path, url: match.url }}>
       <DebugSessionContextProvider value={session}>
-        <ApiSpecServiceLoader
-          captureServiceFactory={captureServiceFactory}
-          diffServiceFactory={diffServiceFactory}
-        >
+        <ApiSpecServiceLoader>
           <ApiRoutes />
         </ApiSpecServiceLoader>
       </DebugSessionContextProvider>

--- a/workspaces/ui/src/entrypoints/testing-sessions.js
+++ b/workspaces/ui/src/entrypoints/testing-sessions.js
@@ -22,11 +22,16 @@ export default function TestingSessions(props) {
     exampleSessionCollection: 'example-sessions',
   });
 
+  let exampleDiff;
+
   const captureServiceFactory = async (specService, captureId) => {
-    const { ExampleCaptureService } = await import(
+    const { ExampleDiff, ExampleCaptureService } = await import(
       '../services/diff/ExampleDiffService'
     );
-    return new ExampleCaptureService(specService);
+
+    if (!exampleDiff) exampleDiff = new ExampleDiff();
+
+    return new ExampleCaptureService(specService, exampleDiff);
   };
 
   const diffServiceFactory = async (

--- a/workspaces/ui/src/entrypoints/testing-sessions.js
+++ b/workspaces/ui/src/entrypoints/testing-sessions.js
@@ -40,44 +40,8 @@ export default function TestingSessions(props) {
     _events,
     _rfcState,
     additionalCommands,
-    config,
-    captureId
+    config
   ) => {
-    // async function computeInitialDiff() {
-    //   const capture = await specService.listCapturedSamples(captureId);
-    //   const commandContext = new RfcCommandContext(
-    //     'simulated',
-    //     'simulated',
-    //     'simulated'
-    //   );
-
-    //   const {
-    //     resolvers,
-    //     rfcState,
-    //   } = cachingResolversAndRfcStateFromEventsAndAdditionalCommands(
-    //     _events,
-    //     commandContext,
-    //     additionalCommands
-    //   );
-    //   const a = DiffHelpers;
-    //   let diffs = DiffHelpers.emptyInteractionPointersGroupedByDiff();
-    //   for (const interaction of capture.samples) {
-    //     diffs = DiffHelpers.groupInteractionPointerByDiffs(
-    //       resolvers,
-    //       rfcState,
-    //       JsonHelper.fromInteraction(interaction),
-    //       interaction.uuid,
-    //       diffs
-    //     );
-    //   }
-    //   return {
-    //     diffs,
-    //     rfcState,
-    //     resolvers,
-    //   };
-    // }
-
-    // const { diffs, rfcState } = await computeInitialDiff();
     const commandContext = new RfcCommandContext(
       'simulated',
       'simulated',

--- a/workspaces/ui/src/entrypoints/testing-sessions.js
+++ b/workspaces/ui/src/entrypoints/testing-sessions.js
@@ -43,50 +43,66 @@ export default function TestingSessions(props) {
     config,
     captureId
   ) => {
-    async function computeInitialDiff() {
-      const capture = await specService.listCapturedSamples(captureId);
-      const commandContext = new RfcCommandContext(
-        'simulated',
-        'simulated',
-        'simulated'
-      );
+    // async function computeInitialDiff() {
+    //   const capture = await specService.listCapturedSamples(captureId);
+    //   const commandContext = new RfcCommandContext(
+    //     'simulated',
+    //     'simulated',
+    //     'simulated'
+    //   );
 
-      const {
-        resolvers,
-        rfcState,
-      } = cachingResolversAndRfcStateFromEventsAndAdditionalCommands(
-        _events,
-        commandContext,
-        additionalCommands
-      );
-      const a = DiffHelpers;
-      let diffs = DiffHelpers.emptyInteractionPointersGroupedByDiff();
-      for (const interaction of capture.samples) {
-        diffs = DiffHelpers.groupInteractionPointerByDiffs(
-          resolvers,
-          rfcState,
-          JsonHelper.fromInteraction(interaction),
-          interaction.uuid,
-          diffs
-        );
-      }
-      return {
-        diffs,
-        rfcState,
-        resolvers,
-      };
-    }
+    //   const {
+    //     resolvers,
+    //     rfcState,
+    //   } = cachingResolversAndRfcStateFromEventsAndAdditionalCommands(
+    //     _events,
+    //     commandContext,
+    //     additionalCommands
+    //   );
+    //   const a = DiffHelpers;
+    //   let diffs = DiffHelpers.emptyInteractionPointersGroupedByDiff();
+    //   for (const interaction of capture.samples) {
+    //     diffs = DiffHelpers.groupInteractionPointerByDiffs(
+    //       resolvers,
+    //       rfcState,
+    //       JsonHelper.fromInteraction(interaction),
+    //       interaction.uuid,
+    //       diffs
+    //     );
+    //   }
+    //   return {
+    //     diffs,
+    //     rfcState,
+    //     resolvers,
+    //   };
+    // }
 
-    const { diffs, rfcState } = await computeInitialDiff();
-    const { ExampleDiffService } = await import(
+    // const { diffs, rfcState } = await computeInitialDiff();
+    const commandContext = new RfcCommandContext(
+      'simulated',
+      'simulated',
+      'simulated'
+    );
+    const {
+      rfcState,
+    } = cachingResolversAndRfcStateFromEventsAndAdditionalCommands(
+      _events,
+      commandContext,
+      additionalCommands
+    );
+
+    const { ExampleDiff, ExampleDiffService } = await import(
       '../services/diff/ExampleDiffService'
     );
 
+    if (!exampleDiff) exampleDiff = new ExampleDiff();
+
     return new ExampleDiffService(
+      exampleDiff,
       specService,
       captureService,
       config,
-      diffs,
+      [],
       rfcState
     );
   };

--- a/workspaces/ui/src/services/diff/ExampleDiffService.ts
+++ b/workspaces/ui/src/services/diff/ExampleDiffService.ts
@@ -41,15 +41,18 @@ export class ExampleDiff {
     this.diffing = (async function* () {
       for (let [i, interaction] of interactions.entries()) {
         let results = DiffEngine.diff_interaction(
-          JSON.stringify([interaction, [`${interaction.uuid}`]]),
+          JSON.stringify(interaction),
           spec
         );
 
         let parsedResults = JSON.parse(results);
-        let taggedResults = (parsedResults = parsedResults.map((diffResult) => [
-          diffResult,
-          [interaction.uuid],
-        ]));
+        let taggedResults = (parsedResults = parsedResults.map(
+          ([diffResult, fingerprint]) => [
+            diffResult,
+            [interaction.uuid],
+            fingerprint,
+          ]
+        ));
 
         diffResults.push(...taggedResults);
 
@@ -63,49 +66,49 @@ export class ExampleDiff {
 
     // TODO: remove this when we get the undocumented urls in order. Need this now
     // as async generators are lazy!
-    (async function (diffing) {
-      for await (let diff of diffing) {
-        console.log('diff yielded');
-      }
-    })(this.diffing);
+    // (async function (diffing) {
+    //   for await (let diff of diffing) {
+    //     console.log('diff yielded');
+    //   }
+    // })(this.diffing);
 
     // counting undocumented urls
     // TODO: we already have this for the cli-server side, perhaps we can re-use that logic
     // somehow.
-    // (async function (diffing) {
-    //   let countsByFingerprint: Map<String, number> = new Map();
-    //   let undocumentedUrls: Array<{
-    //     path: string;
-    //     method: string;
-    //     fingerprint: string;
-    //   }> = [];
+    (async function (diffing) {
+      let countsByFingerprint: Map<String, number> = new Map();
+      let undocumentedUrls: Array<{
+        path: string;
+        method: string;
+        fingerprint: string;
+      }> = [];
 
-    //   for await (let [diff, _, fingerprint] of diffing) {
-    //     let urlDiff = diff['UnmatchedRequestUrl'];
-    //     if (!urlDiff || !fingerprint) continue;
+      for await (let [diff, _, fingerprint] of diffing) {
+        let urlDiff = diff['UnmatchedRequestUrl'];
+        if (!urlDiff || !fingerprint) continue;
 
-    //     let existingCount = countsByFingerprint.get(fingerprint) || 0;
-    //     if (existingCount < 1) {
-    //       let path = urlDiff.interactionTrail.path.find(
-    //         (interactionComponent: any) =>
-    //           interactionComponent.Url && interactionComponent.Url.path
-    //       ).Url.path as string;
-    //       let method = urlDiff.interactionTrail.path.find(
-    //         (interactionComponent: any) =>
-    //           interactionComponent.Method && interactionComponent.Method.method
-    //       ).Method.method as string;
+        let existingCount = countsByFingerprint.get(fingerprint) || 0;
+        if (existingCount < 1) {
+          let path = urlDiff.interactionTrail.path.find(
+            (interactionComponent: any) =>
+              interactionComponent.Url && interactionComponent.Url.path
+          ).Url.path as string;
+          let method = urlDiff.interactionTrail.path.find(
+            (interactionComponent: any) =>
+              interactionComponent.Method && interactionComponent.Method.method
+          ).Method.method as string;
 
-    //       undocumentedUrls.push({ path, method, fingerprint });
-    //     }
-    //     countsByFingerprint.set(fingerprint, existingCount + 1);
-    //   }
+          undocumentedUrls.push({ path, method, fingerprint });
+        }
+        countsByFingerprint.set(fingerprint, existingCount + 1);
+      }
 
-    //   for (let { path, method, fingerprint } of undocumentedUrls) {
-    //     let count = countsByFingerprint.get(fingerprint);
-    //     if (!count) throw new Error('unreachable');
-    //     unrecognizedUrls.push({ path, method, count });
-    //   }
-    // })(diffing);
+      for (let { path, method, fingerprint } of undocumentedUrls) {
+        let count = countsByFingerprint.get(fingerprint);
+        if (!count) throw new Error('unreachable');
+        unrecognizedUrls.push({ path, method, count });
+      }
+    })(this.diffing);
 
     return this.diffId;
   }
@@ -170,7 +173,9 @@ export class ExampleDiffService implements IDiffService {
   }
 
   async listDiffs(): Promise<IListDiffsResponse> {
-    const diffsJson = this.exampleDiff.getResults();
+    const diffsJson = this.exampleDiff
+      .getResults()
+      .map(([diff, tags, _fingerprint]) => [diff, tags]);
 
     const diffs = opticEngine.DiffWithPointersJsonDeserializer.fromJs(
       diffsJson

--- a/workspaces/ui/tsconfig.json
+++ b/workspaces/ui/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "strict": false,
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "downlevelIteration": true
   }
 }


### PR DESCRIPTION
There are various scenarios where diffs are run in-browser, feeding a spec and interactions and handling results in a mostly in-memory way. Mostly, this is for development / and private debug sessions. This PR allows that to be achieved against the same diff engine as we're on the cusp of releasing.

It implements an `ExampleDiff` that interacts with the WASM diff engine and using `async generators` to diff the example interactions one by on, yielding results over time and storing them. A shared instance of `ExampleDiff` is then inserted into `ExampleDiffService` and `ExampleCaptureService`, starting it through the normal `captureService.startDiff` like it happens for the local-cli versions of those services.

It intentionally **doesn't** hide this behind a feature flag. This is a PR in a set of ones that is supposed to _reduce_ the amount of technical debt, and especially in the ui package are we faced with lots of old and stale code. So, since this is mostly used for debugging and other non-core areas of the experience, going straight over to the Rust implementation is the desired step to take. 