### PR TITLE
Fixes Issue where HTML is parsed as a JSON Object

### DIFF
--- a/workspaces/cli-shared/src/httptoolkit-capturing-proxy.ts
+++ b/workspaces/cli-shared/src/httptoolkit-capturing-proxy.ts
@@ -227,7 +227,7 @@ export class HttpToolkitCapturingProxy {
   ): IBody {
     if (req.headers['content-type'] || req.headers['transfer-encoding']) {
       const contentType = mime.parse(req.headers['content-type'] || '');
-      const json = req.body.json || req.body.formData || null;
+      const json = req.body.json || null;
       return {
         contentType: (req.body.text && contentType?.essence) || null,
         value: {


### PR DESCRIPTION
Some users have noticed that their `text/html` bodies -- most often seen in the context of 4xxs parse as an object with the page data as the key:

```
extracting body text/html;charset=utf-8 json: undefined formData: {"<h1>Hello Express!</h1>":""} 
```

The blame goes to the line that was changed, we took req.body.json or req.body.formData -- the way bodyparser handles form-data though made that a field in an object, which gets stringified to JSON. This chain of coercion is confusing. 

I think the intent behind `json || formData` was to support both, but we've said explicitly Optic only handles JSON and Text today. All this does is add buggy surface area. It's not clear that formData and Json map 1:1 anyway so it's best, I think, to document this hole in the product, and remove the pathway. 

In the future, we can properly support formData with its own "asFormData", its own diff, and (possibly) UI tweaks to accommodate these kinds of shapes. 

> One could argue this change results in a break. We could absolutely add more logic to extract body so that it only tries to JSON-ify formData when you use certain content types. Thoughts?