### PR TITLE
set default daemon timeout to 10 mins for windows

### DIFF
--- a/workspaces/cli-server/src/server.ts
+++ b/workspaces/cli-server/src/server.ts
@@ -235,6 +235,8 @@ class CliServer {
         });
       });
 
+      this.server.setTimeout(600000);
+
       this.server.on('connection', (connection) => {
         console.log(`adding connection`);
         this.connections.push(connection);


### PR DESCRIPTION
@LouManglass and I finally discovered why some Windows users were seeing failures during Learn API. There is a Windows Specific Node timeout of 2 mins for HTTP requests. Some really large endpoints with 5-10MB bodies can take a long time. 

We overrode the flag across all platforms to a standard 10 min timeout. We plan to remove this when the Rust Endpoint Learners are released in a future cycle. Those should make learning initial bodies a "seconds" operation
