### PR TITLE
New Diff UX -- collapse extra rows

### DIFF
--- a/workspaces/ui/public/example-sessions/todos-big.json
+++ b/workspaces/ui/public/example-sessions/todos-big.json
@@ -1,0 +1,3068 @@
+{
+  "events": [
+    {
+      "BatchCommitStarted": {
+        "batchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+        "commitMessage": "added",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.040Z"
+        }
+      }
+    },
+    {
+      "PathComponentAdded": {
+        "pathId": "path_mm0bIE3sps",
+        "parentPathId": "root",
+        "name": "api",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.045Z"
+        }
+      }
+    },
+    {
+      "PathComponentAdded": {
+        "pathId": "path_CYRR1KoF7s",
+        "parentPathId": "path_mm0bIE3sps",
+        "name": "response",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.046Z"
+        }
+      }
+    },
+    {
+      "RequestParameterAddedByPathAndMethod": {
+        "parameterId": "request-parameter_X1fBUXp4ZK",
+        "pathId": "path_CYRR1KoF7s",
+        "httpMethod": "GET",
+        "parameterLocation": "query",
+        "name": "queryString",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.046Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_clNjL2mSEJ",
+        "baseShapeId": "$object",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.046Z"
+        }
+      }
+    },
+    {
+      "RequestParameterShapeSet": {
+        "parameterId": "request-parameter_X1fBUXp4ZK",
+        "parameterDescriptor": {
+          "shapeId": "shape_clNjL2mSEJ",
+          "isRemoved": false
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.046Z"
+        }
+      }
+    },
+    {
+      "RequestAdded": {
+        "requestId": "request_pQGaZpox3D",
+        "pathId": "path_CYRR1KoF7s",
+        "httpMethod": "GET",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.046Z"
+        }
+      }
+    },
+    {
+      "ResponseAddedByPathAndMethod": {
+        "responseId": "response_SRTBbx4LPq",
+        "pathId": "path_CYRR1KoF7s",
+        "httpMethod": "GET",
+        "httpStatusCode": 200,
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.049Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_86Xr4QQ79v",
+        "baseShapeId": "$object",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.050Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_yAMU5q8cUc",
+        "baseShapeId": "$object",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.050Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_eDrlfKeMrP",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.050Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_bDaJJJhmnS",
+        "shapeId": "shape_yAMU5q8cUc",
+        "name": "created_at",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_bDaJJJhmnS",
+            "shapeId": "shape_eDrlfKeMrP"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.050Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_k4ZejAUqdR",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.051Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_p1CJhRqnRy",
+        "shapeId": "shape_yAMU5q8cUc",
+        "name": "description",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_p1CJhRqnRy",
+            "shapeId": "shape_k4ZejAUqdR"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.051Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_eyac78TLPq",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.052Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_YvgTSKNvTy",
+        "baseShapeId": "$list",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.052Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_NO5whDCIqZ",
+        "shapeId": "shape_yAMU5q8cUc",
+        "name": "events",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_NO5whDCIqZ",
+            "shapeId": "shape_YvgTSKNvTy"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.052Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_JTfWXDl8Rg",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.052Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_j01BoftQvx",
+        "shapeId": "shape_yAMU5q8cUc",
+        "name": "external_url",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_j01BoftQvx",
+            "shapeId": "shape_JTfWXDl8Rg"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.052Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_1Jy5WKd729",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.053Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_jZ8i9rLNsH",
+        "shapeId": "shape_yAMU5q8cUc",
+        "name": "html_url",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_jZ8i9rLNsH",
+            "shapeId": "shape_1Jy5WKd729"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.053Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_6OPL5goYx0",
+        "baseShapeId": "$number",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.053Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_0NtI4NOUq1",
+        "shapeId": "shape_yAMU5q8cUc",
+        "name": "id",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_0NtI4NOUq1",
+            "shapeId": "shape_6OPL5goYx0"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.053Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_HhUTJz31Sf",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.053Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_LUhjgZEWFp",
+        "shapeId": "shape_yAMU5q8cUc",
+        "name": "name",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_LUhjgZEWFp",
+            "shapeId": "shape_HhUTJz31Sf"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.053Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_dfA0a24Y4D",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.054Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_f8wuBgWGXd",
+        "shapeId": "shape_yAMU5q8cUc",
+        "name": "node_id",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_f8wuBgWGXd",
+            "shapeId": "shape_dfA0a24Y4D"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.054Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_0lhzUs4IGY",
+        "baseShapeId": "$object",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.054Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_XUvuJH0TV6",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.054Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_atDVU3y0Hn",
+        "shapeId": "shape_0lhzUs4IGY",
+        "name": "avatar_url",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_atDVU3y0Hn",
+            "shapeId": "shape_XUvuJH0TV6"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.054Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_901kqowT8I",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.054Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_AVGdRaATci",
+        "shapeId": "shape_0lhzUs4IGY",
+        "name": "events_url",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_AVGdRaATci",
+            "shapeId": "shape_901kqowT8I"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.054Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_7OWGdkJgiE",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.055Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_UenRgkIQSL",
+        "shapeId": "shape_0lhzUs4IGY",
+        "name": "followers_url",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_UenRgkIQSL",
+            "shapeId": "shape_7OWGdkJgiE"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.055Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_SOSvVpi77d",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.055Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_qBBYBRy0ad",
+        "shapeId": "shape_0lhzUs4IGY",
+        "name": "following_url",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_qBBYBRy0ad",
+            "shapeId": "shape_SOSvVpi77d"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.055Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_CDRl8Ij2H5",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.055Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_aY8mPxbffi",
+        "shapeId": "shape_0lhzUs4IGY",
+        "name": "gists_url",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_aY8mPxbffi",
+            "shapeId": "shape_CDRl8Ij2H5"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.056Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_7Y2hdtoV8n",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.056Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_oQb6idnUXq",
+        "shapeId": "shape_0lhzUs4IGY",
+        "name": "gravatar_id",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_oQb6idnUXq",
+            "shapeId": "shape_7Y2hdtoV8n"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.056Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_d6qgwuAi0p",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.056Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_4f4HUeeQXN",
+        "shapeId": "shape_0lhzUs4IGY",
+        "name": "html_url",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_4f4HUeeQXN",
+            "shapeId": "shape_d6qgwuAi0p"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.056Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_RPOabrwhy0",
+        "baseShapeId": "$number",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.056Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_9vDmoSUW8C",
+        "shapeId": "shape_0lhzUs4IGY",
+        "name": "id",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_9vDmoSUW8C",
+            "shapeId": "shape_RPOabrwhy0"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.057Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_miIPxcII2m",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.057Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_N0qNkmjAae",
+        "shapeId": "shape_0lhzUs4IGY",
+        "name": "login",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_N0qNkmjAae",
+            "shapeId": "shape_miIPxcII2m"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.057Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_jgjQD4upOx",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.057Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_68k1DudRK6",
+        "shapeId": "shape_0lhzUs4IGY",
+        "name": "node_id",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_68k1DudRK6",
+            "shapeId": "shape_jgjQD4upOx"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.057Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_6Tfb3ECenX",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.057Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_evA67V2uCt",
+        "shapeId": "shape_0lhzUs4IGY",
+        "name": "organizations_url",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_evA67V2uCt",
+            "shapeId": "shape_6Tfb3ECenX"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.058Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_NTERrZf9UQ",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.058Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_YaB52UxiXe",
+        "shapeId": "shape_0lhzUs4IGY",
+        "name": "received_events_url",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_YaB52UxiXe",
+            "shapeId": "shape_NTERrZf9UQ"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.058Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_UWDHOyopoP",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.058Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_kE9o8dAagF",
+        "shapeId": "shape_0lhzUs4IGY",
+        "name": "repos_url",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_kE9o8dAagF",
+            "shapeId": "shape_UWDHOyopoP"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.058Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_fGcZ8DCuo5",
+        "baseShapeId": "$boolean",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.058Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_HYaDq8tdSo",
+        "shapeId": "shape_0lhzUs4IGY",
+        "name": "site_admin",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_HYaDq8tdSo",
+            "shapeId": "shape_fGcZ8DCuo5"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.059Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_vifbgnONA1",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.059Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_Gn6NmdGsq8",
+        "shapeId": "shape_0lhzUs4IGY",
+        "name": "starred_url",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_Gn6NmdGsq8",
+            "shapeId": "shape_vifbgnONA1"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.059Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_90g5uM8qwH",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.059Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_Ul3sISJKGP",
+        "shapeId": "shape_0lhzUs4IGY",
+        "name": "subscriptions_url",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_Ul3sISJKGP",
+            "shapeId": "shape_90g5uM8qwH"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.059Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_7cPCgYNU4D",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.059Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_UsbbqBWdd5",
+        "shapeId": "shape_0lhzUs4IGY",
+        "name": "type",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_UsbbqBWdd5",
+            "shapeId": "shape_7cPCgYNU4D"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.060Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_51gycomxjJ",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.060Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_pnzQkNAv2N",
+        "shapeId": "shape_0lhzUs4IGY",
+        "name": "url",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_pnzQkNAv2N",
+            "shapeId": "shape_51gycomxjJ"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.060Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_HlT9FGwzqP",
+        "shapeId": "shape_yAMU5q8cUc",
+        "name": "owner",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_HlT9FGwzqP",
+            "shapeId": "shape_0lhzUs4IGY"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.060Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_euOM49nJNr",
+        "baseShapeId": "$object",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.060Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_H3QF8qBN4d",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.060Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_DXbJMO3Cja",
+        "shapeId": "shape_euOM49nJNr",
+        "name": "contents",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_DXbJMO3Cja",
+            "shapeId": "shape_H3QF8qBN4d"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.061Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_gUt41bHdfS",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.061Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_Ar0uvO9oBr",
+        "shapeId": "shape_euOM49nJNr",
+        "name": "issues",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_Ar0uvO9oBr",
+            "shapeId": "shape_gUt41bHdfS"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.061Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_StiT2zwJ51",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.061Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_YO67Bbd7md",
+        "shapeId": "shape_euOM49nJNr",
+        "name": "metadata",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_YO67Bbd7md",
+            "shapeId": "shape_StiT2zwJ51"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.061Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_EYOUT66AXg",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.065Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_9WtEGJw2Nt",
+        "shapeId": "shape_euOM49nJNr",
+        "name": "single_file",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_9WtEGJw2Nt",
+            "shapeId": "shape_EYOUT66AXg"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.065Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_CN43vgyEfp",
+        "shapeId": "shape_yAMU5q8cUc",
+        "name": "permissions",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_CN43vgyEfp",
+            "shapeId": "shape_euOM49nJNr"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.066Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_G5eeoYW2IK",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.067Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_0J6HOKBb1p",
+        "shapeId": "shape_yAMU5q8cUc",
+        "name": "slug",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_0J6HOKBb1p",
+            "shapeId": "shape_G5eeoYW2IK"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.067Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_JWCauidfug",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.067Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_a5X6vnbPPL",
+        "shapeId": "shape_yAMU5q8cUc",
+        "name": "updated_at",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_a5X6vnbPPL",
+            "shapeId": "shape_JWCauidfug"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.067Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_6mefPDJ2VU",
+        "shapeId": "shape_86Xr4QQ79v",
+        "name": "app",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_6mefPDJ2VU",
+            "shapeId": "shape_yAMU5q8cUc"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.067Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_34ZO3G27DJ",
+        "baseShapeId": "$object",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.068Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_wk1LVXr5ab",
+        "baseShapeId": "$number",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.068Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_CwFqsw4WLx",
+        "shapeId": "shape_34ZO3G27DJ",
+        "name": "id",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_CwFqsw4WLx",
+            "shapeId": "shape_wk1LVXr5ab"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.068Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_DYraXzkSgv",
+        "shapeId": "shape_86Xr4QQ79v",
+        "name": "check_suite",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_DYraXzkSgv",
+            "shapeId": "shape_34ZO3G27DJ"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.068Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_QYR9BekSuv",
+        "baseShapeId": "$unknown",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.068Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_0C1VDmxIrS",
+        "baseShapeId": "$nullable",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.069Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_D6A0TOU3PI",
+        "shapeId": "shape_86Xr4QQ79v",
+        "name": "completed_at",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_D6A0TOU3PI",
+            "shapeId": "shape_0C1VDmxIrS"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.069Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_U3EcJ3l8L2",
+        "baseShapeId": "$unknown",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.069Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_dA0TmEgW1b",
+        "baseShapeId": "$nullable",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.069Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_HMzQ4uUH0J",
+        "shapeId": "shape_86Xr4QQ79v",
+        "name": "conclusion",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_HMzQ4uUH0J",
+            "shapeId": "shape_dA0TmEgW1b"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.069Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_2xTejnTDGF",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.069Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_rnsbzNJYT3",
+        "shapeId": "shape_86Xr4QQ79v",
+        "name": "details_url",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_rnsbzNJYT3",
+            "shapeId": "shape_2xTejnTDGF"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.069Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_uUL3S757SV",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.070Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_23Fw66wKjK",
+        "shapeId": "shape_86Xr4QQ79v",
+        "name": "external_id",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_23Fw66wKjK",
+            "shapeId": "shape_uUL3S757SV"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.071Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_EwuU0ghFCY",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.071Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_XRxuVE5TwY",
+        "shapeId": "shape_86Xr4QQ79v",
+        "name": "head_sha",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_XRxuVE5TwY",
+            "shapeId": "shape_EwuU0ghFCY"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.071Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_N18zZRLU5g",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.072Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_Sc0Z3oykpq",
+        "shapeId": "shape_86Xr4QQ79v",
+        "name": "html_url",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_Sc0Z3oykpq",
+            "shapeId": "shape_N18zZRLU5g"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.072Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_k88pUpTk74",
+        "baseShapeId": "$number",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.072Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_WWrJ22xcdI",
+        "shapeId": "shape_86Xr4QQ79v",
+        "name": "id",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_WWrJ22xcdI",
+            "shapeId": "shape_k88pUpTk74"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.072Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_9XiFBcDVA1",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.073Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_pxWoZyzfCq",
+        "shapeId": "shape_86Xr4QQ79v",
+        "name": "name",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_pxWoZyzfCq",
+            "shapeId": "shape_9XiFBcDVA1"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.073Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_pHZl75MDSY",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.073Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_nUvRJlkyvc",
+        "shapeId": "shape_86Xr4QQ79v",
+        "name": "node_id",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_nUvRJlkyvc",
+            "shapeId": "shape_pHZl75MDSY"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.073Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_IgZ2uNyWP6",
+        "baseShapeId": "$object",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.074Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_UE8UthG1Ia",
+        "baseShapeId": "$number",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.074Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_GWkVYoERSb",
+        "shapeId": "shape_IgZ2uNyWP6",
+        "name": "annotations_count",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_GWkVYoERSb",
+            "shapeId": "shape_UE8UthG1Ia"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.074Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_xXmvX5wX1g",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.075Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_TgOW0zfYCQ",
+        "shapeId": "shape_IgZ2uNyWP6",
+        "name": "annotations_url",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_TgOW0zfYCQ",
+            "shapeId": "shape_xXmvX5wX1g"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.075Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_IWgiTp6FzD",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.075Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_51NhUAHEh5",
+        "shapeId": "shape_IgZ2uNyWP6",
+        "name": "summary",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_51NhUAHEh5",
+            "shapeId": "shape_IWgiTp6FzD"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.075Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_hAJbSqCGmK",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.076Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_GeXhTNQ5Iu",
+        "shapeId": "shape_IgZ2uNyWP6",
+        "name": "text",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_GeXhTNQ5Iu",
+            "shapeId": "shape_hAJbSqCGmK"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.076Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_2QGbv1w1gv",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.076Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_FGUbGzdzQg",
+        "shapeId": "shape_IgZ2uNyWP6",
+        "name": "title",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_FGUbGzdzQg",
+            "shapeId": "shape_2QGbv1w1gv"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.076Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_tRoezeUehM",
+        "shapeId": "shape_86Xr4QQ79v",
+        "name": "output",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_tRoezeUehM",
+            "shapeId": "shape_IgZ2uNyWP6"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.077Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_tf77g8Tp64",
+        "baseShapeId": "$object",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.077Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_u1MCoId2wy",
+        "baseShapeId": "$object",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.078Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_GUCXCZNILs",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.079Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_dik1qhEOWC",
+        "shapeId": "shape_u1MCoId2wy",
+        "name": "ref",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_dik1qhEOWC",
+            "shapeId": "shape_GUCXCZNILs"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.079Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_DO0rsMXnYC",
+        "baseShapeId": "$object",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.080Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_ZTSC5FupOQ",
+        "baseShapeId": "$number",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.081Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_7te91RulFj",
+        "shapeId": "shape_DO0rsMXnYC",
+        "name": "id",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_7te91RulFj",
+            "shapeId": "shape_ZTSC5FupOQ"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.082Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_SBzg61AMoy",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.082Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_kL4ub6Xc3I",
+        "shapeId": "shape_DO0rsMXnYC",
+        "name": "name",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_kL4ub6Xc3I",
+            "shapeId": "shape_SBzg61AMoy"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.082Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_CiW3HWpGOg",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.082Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_WWnSjJzWk0",
+        "shapeId": "shape_DO0rsMXnYC",
+        "name": "url",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_WWnSjJzWk0",
+            "shapeId": "shape_CiW3HWpGOg"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.082Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_ic88D8pZI8",
+        "shapeId": "shape_u1MCoId2wy",
+        "name": "repo",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_ic88D8pZI8",
+            "shapeId": "shape_DO0rsMXnYC"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.083Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_JdEImWLrYh",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.083Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_cwHWgvlB7I",
+        "shapeId": "shape_u1MCoId2wy",
+        "name": "sha",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_cwHWgvlB7I",
+            "shapeId": "shape_JdEImWLrYh"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.083Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_TI3iH0XjHw",
+        "shapeId": "shape_tf77g8Tp64",
+        "name": "base",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_TI3iH0XjHw",
+            "shapeId": "shape_u1MCoId2wy"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.083Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_hhKwfjEnWQ",
+        "baseShapeId": "$object",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.083Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_wlilchRUY4",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.084Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_nDpIW9zjXZ",
+        "shapeId": "shape_hhKwfjEnWQ",
+        "name": "ref",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_nDpIW9zjXZ",
+            "shapeId": "shape_wlilchRUY4"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.084Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_rvllQ3TBmx",
+        "baseShapeId": "$object",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.084Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_WE3fD84mL9",
+        "baseShapeId": "$number",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.084Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_3KS64fNtPZ",
+        "shapeId": "shape_rvllQ3TBmx",
+        "name": "id",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_3KS64fNtPZ",
+            "shapeId": "shape_WE3fD84mL9"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.084Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_bIqLZZvgSV",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.084Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_yBOQcLXvcD",
+        "shapeId": "shape_rvllQ3TBmx",
+        "name": "name",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_yBOQcLXvcD",
+            "shapeId": "shape_bIqLZZvgSV"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.084Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_Py3duCGHxk",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.085Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_9PRBJFAtH8",
+        "shapeId": "shape_rvllQ3TBmx",
+        "name": "url",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_9PRBJFAtH8",
+            "shapeId": "shape_Py3duCGHxk"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.085Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_UcfdCJt1Qy",
+        "shapeId": "shape_hhKwfjEnWQ",
+        "name": "repo",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_UcfdCJt1Qy",
+            "shapeId": "shape_rvllQ3TBmx"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.085Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_OM2IeEOACN",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.085Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_mHQ5ZZQ17S",
+        "shapeId": "shape_hhKwfjEnWQ",
+        "name": "sha",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_mHQ5ZZQ17S",
+            "shapeId": "shape_OM2IeEOACN"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.085Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_KldglYtjRB",
+        "shapeId": "shape_tf77g8Tp64",
+        "name": "head",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_KldglYtjRB",
+            "shapeId": "shape_hhKwfjEnWQ"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.085Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_cCxSJ0pJoq",
+        "baseShapeId": "$number",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.086Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_8MeZeS4uDG",
+        "shapeId": "shape_tf77g8Tp64",
+        "name": "id",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_8MeZeS4uDG",
+            "shapeId": "shape_cCxSJ0pJoq"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.086Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_MfNDnPFpgY",
+        "baseShapeId": "$number",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.086Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_WIGmyLvoXs",
+        "shapeId": "shape_tf77g8Tp64",
+        "name": "number",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_WIGmyLvoXs",
+            "shapeId": "shape_MfNDnPFpgY"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.086Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_sgNfCPBRDr",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.086Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_P4iqPR2xPo",
+        "shapeId": "shape_tf77g8Tp64",
+        "name": "url",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_P4iqPR2xPo",
+            "shapeId": "shape_sgNfCPBRDr"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.086Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_HHFfTP5SoL",
+        "baseShapeId": "$list",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.087Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_xPKm7kagIM",
+        "shapeId": "shape_86Xr4QQ79v",
+        "name": "pull_requests",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_xPKm7kagIM",
+            "shapeId": "shape_HHFfTP5SoL"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.087Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_cvWoHtXlQk",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.087Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_8uoPX1Uo3d",
+        "shapeId": "shape_86Xr4QQ79v",
+        "name": "started_at",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_8uoPX1Uo3d",
+            "shapeId": "shape_cvWoHtXlQk"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.087Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_bGL4lv1i88",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.087Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_dvKP5BUyy3",
+        "shapeId": "shape_86Xr4QQ79v",
+        "name": "status",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_dvKP5BUyy3",
+            "shapeId": "shape_bGL4lv1i88"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.087Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_VNIPqvTFoT",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.088Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_e9pGD45pZq",
+        "shapeId": "shape_86Xr4QQ79v",
+        "name": "url",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_e9pGD45pZq",
+            "shapeId": "shape_VNIPqvTFoT"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.088Z"
+        }
+      }
+    },
+    {
+      "ShapeParameterShapeSet": {
+        "shapeDescriptor": {
+          "ProviderInShape": {
+            "shapeId": "shape_YvgTSKNvTy",
+            "providerDescriptor": {
+              "ShapeProvider": {
+                "shapeId": "shape_eyac78TLPq"
+              }
+            },
+            "consumingParameterId": "$listItem"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.088Z"
+        }
+      }
+    },
+    {
+      "ShapeParameterShapeSet": {
+        "shapeDescriptor": {
+          "ProviderInShape": {
+            "shapeId": "shape_0C1VDmxIrS",
+            "providerDescriptor": {
+              "ShapeProvider": {
+                "shapeId": "shape_QYR9BekSuv"
+              }
+            },
+            "consumingParameterId": "$nullableInner"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.088Z"
+        }
+      }
+    },
+    {
+      "ShapeParameterShapeSet": {
+        "shapeDescriptor": {
+          "ProviderInShape": {
+            "shapeId": "shape_dA0TmEgW1b",
+            "providerDescriptor": {
+              "ShapeProvider": {
+                "shapeId": "shape_U3EcJ3l8L2"
+              }
+            },
+            "consumingParameterId": "$nullableInner"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.089Z"
+        }
+      }
+    },
+    {
+      "ShapeParameterShapeSet": {
+        "shapeDescriptor": {
+          "ProviderInShape": {
+            "shapeId": "shape_HHFfTP5SoL",
+            "providerDescriptor": {
+              "ShapeProvider": {
+                "shapeId": "shape_tf77g8Tp64"
+              }
+            },
+            "consumingParameterId": "$listItem"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.089Z"
+        }
+      }
+    },
+    {
+      "ResponseBodySet": {
+        "responseId": "response_SRTBbx4LPq",
+        "bodyDescriptor": {
+          "httpContentType": "application/json",
+          "shapeId": "shape_86Xr4QQ79v",
+          "isRemoved": false
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.089Z"
+        }
+      }
+    },
+    {
+      "BatchCommitEnded": {
+        "batchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a41c425a-bbff-4006-911f-fb2348251d7b",
+          "clientCommandBatchId": "95edddbb-9e0d-4084-9854-e4533a81eb63",
+          "createdAt": "2020-12-17T21:17:28.089Z"
+        }
+      }
+    }
+  ],
+  "session": {
+    "samples": [
+      {
+        "uuid": "8eff95b1-4f6d-4d3c-ba71-5e3792780ce4",
+        "request": {
+          "host": "localhost",
+          "method": "GET",
+          "path": "/api/response",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": "{\n  \"id\": 4,\n  \"head_sha\": \"ce587453ced02b1526dfb4cb910479d431683101\",\n  \"node_id\": \"MDg6Q2hlY2tSdW40\",\n  \"external_id\": \"42\",\n  \"url\": \"https://api.github.com/repos/github/hello-world/check-runs/4\",\n  \"html_url\": \"https://github.com/github/hello-world/runs/4\",\n  \"details_url\": \"https://example.com\",\n  \"status\": \"in_progress\",\n  \"conclusion\": null,\n  \"started_at\": \"2018-05-04T01:14:52Z\",\n  \"completed_at\": null,\n  \"output\": {\n    \"title\": \"Mighty Readme Report\",\n    \"summary\": \"\",\n    \"text\": \"\",\n    \"annotations_count\": 1,\n    \"annotations_url\": \"https://api.github.com/repos/github/hello-world/check-runs/4/annotations\"\n  },\n  \"name\": \"mighty_readme\",\n  \"check_suite\": {\n    \"id\": 5\n  },\n  \"app\": {\n    \"id\": 1,\n    \"slug\": \"octoapp\",\n    \"node_id\": \"MDExOkludGVncmF0aW9uMQ==\",\n    \"owner\": {\n      \"login\": \"github\",\n      \"id\": 1,\n      \"node_id\": \"MDEyOk9yZ2FuaXphdGlvbjE=\",\n      \"url\": \"https://api.github.com/orgs/github\",\n      \"repos_url\": \"https://api.github.com/orgs/github/repos\",\n      \"events_url\": \"https://api.github.com/orgs/github/events\",\n      \"avatar_url\": \"https://github.com/images/error/octocat_happy.gif\",\n      \"gravatar_id\": \"\",\n      \"html_url\": \"https://github.com/octocat\",\n      \"followers_url\": \"https://api.github.com/users/octocat/followers\",\n      \"following_url\": \"https://api.github.com/users/octocat/following{/other_user}\",\n      \"gists_url\": \"https://api.github.com/users/octocat/gists{/gist_id}\",\n      \"starred_url\": \"https://api.github.com/users/octocat/starred{/owner}{/repo}\",\n      \"organizations_url\": [\"https://api.github.com/users/octocat/orgs\"],\n      \"received_events_url\": \"https://api.github.com/users/octocat/received_events\",\n      \"type\": \"User\",\n      \"site_admin\": true\n    },\n    \"name\": \"Octocat App\",\n    \"description\": \"\",\n    \"external_url\": \"https://example.com\",\n    \"html_url\": \"https://github.com/apps/octoapp\",\n    \"created_at\": \"2017-07-08T16:18:44-04:00\",\n    \"updated_at\": \"2017-07-08T16:18:44-04:00\",\n    \"permissions\": {\n      \"metadata\": \"read\",\n      \"contents\": \"read\",\n      \"issues\": \"write\",\n      \"single_file\": \"write\"\n    },\n    \"events\": [\n      \"push\",\n      \"pull_request\"\n    ]\n  },\n  \"pull_requests\": [\n    {\n      \"url\": \"https://api.github.com/repos/github/hello-world/pulls/1\",\n      \"id\": 1934,\n      \"number\": 3956,\n      \"head\": {\n        \"ref\": \"say-hello\",\n        \"sha\": \"3dca65fa3e8d4b3da3f3d056c59aee1c50f41390\",\n        \"repo\": {\n          \"id\": 526,\n          \"url\": \"https://api.github.com/repos/github/hello-world\",\n          \"name\": \"hello-world\"\n        }\n      },\n      \"base\": {\n        \"ref\": \"master\",\n        \"sha\": \"e7fdf7640066d71ad16a86fbcbb9c6a10a18af4f\",\n        \"repo\": {\n          \"id\": 526,\n          \"url\": \"https://api.github.com/repos/github/hello-world\",\n          \"name\": \"hello-world\"\n        }\n      }\n    }\n  ]\n}",
+              "asText": null
+            }
+          }
+        },
+        "tags": []
+      }
+    ],
+    "metadata": {}
+  },
+  "examples": {}
+}

--- a/workspaces/ui/src/components/diff/v2/shape_viewers/InteractionBodyViewerAllJS.js
+++ b/workspaces/ui/src/components/diff/v2/shape_viewers/InteractionBodyViewerAllJS.js
@@ -64,6 +64,7 @@ export function Row(props) {
     diffDetails,
     indent,
     index,
+    fieldsHidden,
     seqIndex,
     fieldName,
     fieldValue,
@@ -76,7 +77,10 @@ export function Row(props) {
       if (!collapsed) return;
       e.preventDefault();
       if (type === 'array_item_collapsed') {
-        dispatch({ type: 'unfold', payload: index });
+        dispatch({ type: 'unfold-index', payload: index });
+      }
+      if (type === 'object_keys_collapsed') {
+        dispatch({ type: 'unfold-fields', payload: index });
       }
     },
     [index, type, dispatch]
@@ -113,6 +117,7 @@ export function Row(props) {
         <RowValue
           isRoot={indent === 0}
           type={type}
+          fieldsHidden={fieldsHidden}
           value={fieldValue}
           compliant={compliant}
           changeDescription={diffDetails && diffDetails.changeDescription}
@@ -138,6 +143,7 @@ function RowValue({
   changeDescription,
   trailsAreCorrect,
   isRoot,
+  fieldsHidden,
 }) {
   const generalClasses = useShapeViewerStyles();
   const classes = useStyles();
@@ -179,6 +185,14 @@ function RowValue({
         ) : (
           ''
         )}
+      </span>
+    );
+  }
+
+  if (type === 'object_keys_collapsed') {
+    return (
+      <span className={classes.collapsedObjectSymbol}>
+        {`...expand ${fieldsHidden} additional fields`}
       </span>
     );
   }
@@ -390,6 +404,32 @@ const useStyles = makeStyles((theme) => ({
     },
   },
 
+  collapsedObjectSymbol: {
+    paddingRight: theme.spacing(1),
+    paddingTop: 3,
+    color: '#8f8f8f',
+    fontSize: 10,
+    borderRadius: 12,
+    '$isCollapsedIncompliant$requiresAddition &': {
+      backgroundColor: theme.palette.added.background,
+      color: theme.palette.added.main,
+    },
+
+    '$isCollapsedIncompliant$requiresRemoval &': {
+      backgroundColor: theme.palette.removed.background,
+      color: theme.palette.removed.main,
+    },
+
+    '$isCollapsedIncompliant$requiresUpdate &': {
+      backgroundColor: theme.palette.changed.background,
+      color: theme.palette.changed.main,
+    },
+    '$trailsAreCorrect &': {
+      backgroundColor: theme.palette.added.background,
+      color: theme.palette.added.main,
+    },
+  },
+
   collapsedWarning: {
     width: 10,
     height: 10,
@@ -558,10 +598,12 @@ function createInitialState({ diff, jsonTrails, description, body }) {
 }
 
 function updateState(state, action) {
+  const index = action.payload;
   switch (action.type) {
-    case 'unfold':
-      let index = action.payload;
+    case 'unfold-index':
       return unfoldRows(state, index);
+    case 'unfold-fields':
+      return unfoldObjectRows(state, index);
     default:
       throw new Error(
         `State cannot be updated through action of type '${action.type}'`
@@ -602,6 +644,59 @@ function unfoldRows(currentState, index) {
   };
 }
 
+function unfoldObjectRows(currentState, index) {
+  const row = currentState.rows[index];
+  if (row.type !== 'object_keys_collapsed') return currentState;
+
+  const updatedRows = [...currentState.rows];
+
+  const startIndex = updatedRows.findIndex(
+    (i) => i.type === 'object_open' && _isEqual(i.trail, row.trail)
+  );
+
+  const open = updatedRows[startIndex];
+  const collapsedShape = _get(currentState.body, open.trail, currentState.body);
+  const rowField = {
+    fieldValue: open.fieldValue,
+    fieldName: open.fieldName,
+    seqIndex: open.seqIndex,
+    trail: [...open.trail],
+  };
+
+  const [replacementRows, newCollapsedTrails] = shapeRows(
+    collapsedShape,
+    currentState.diffTrails,
+    [],
+    [],
+    row.indent - 1,
+    rowField,
+    row.trail
+  );
+
+  const endIndex =
+    updatedRows.findIndex(
+      (i, index) =>
+        i.type === 'object_close' &&
+        index > startIndex &&
+        _isEqual(i.trail, row.trail)
+    ) + 1;
+
+  const offset = endIndex - startIndex;
+
+  debugger;
+
+  updatedRows.splice(startIndex, offset, ...replacementRows);
+  const updatedCollapsedTrails = currentState.collapsedTrails
+    .filter((trail) => !_isEqual(trail, row.trail))
+    .concat(newCollapsedTrails);
+
+  return {
+    ...currentState,
+    rows: updatedRows,
+    collapsedTrails: updatedCollapsedTrails,
+  };
+}
+
 // Since we've run into performance issue before traversing entire shapes, we're doing this
 // the mutative way to prevent a lot of re-alloctions for big bodies.
 function shapeRows(
@@ -615,18 +710,35 @@ function shapeRows(
     fieldValue: undefined,
     seqIndex: undefined,
     trail: [],
-  }
+  },
+  expandObjectWithTrail = null
 ) {
   const typeString = Object.prototype.toString.call(shape);
 
   switch (typeString) {
     case '[object Object]':
       // debugger;
-      objectRows(shape, diffTrails, rows, collapsedTrails, indent, field);
+      objectRows(
+        shape,
+        diffTrails,
+        rows,
+        collapsedTrails,
+        indent,
+        field,
+        expandObjectWithTrail
+      );
       break;
     case '[object Array]':
       // debugger;
-      listRows(shape, diffTrails, rows, collapsedTrails, indent, field);
+      listRows(
+        shape,
+        diffTrails,
+        rows,
+        collapsedTrails,
+        indent,
+        field,
+        expandObjectWithTrail
+      );
       break;
     default:
       // debugger
@@ -648,7 +760,8 @@ function objectRows(
   rows,
   collapsedTrails,
   indent,
-  field
+  field,
+  expandObjectWithTrail
 ) {
   const { trail } = field;
 
@@ -668,20 +781,61 @@ function objectRows(
   const nestedDiffs = diffTrails.filter((diffTrail) =>
     trail.every((trailComponent, n) => trailComponent === diffTrail[n])
   );
+
+  function hasNestedDiff(trail) {
+    return nestedDiffs.some((i) => _isEqual(i.slice(0, trail.length), trail));
+  }
+
   const keysWithDiffs = nestedDiffs
     .filter((nestedDiff) => nestedDiff.length === trail.length + 1)
     .map((diff) => diff[diff.length - 1]);
+
   const objectKeys = _uniq([...Object.keys(objectShape), ...keysWithDiffs]);
+  let collapsedCount = 0;
+
+  const collapseAt = 9;
+
+  const shouldCollapse =
+    objectKeys.length > collapseAt && !_isEqual(expandObjectWithTrail, trail);
+
+  if (shouldCollapse) {
+    collapsedTrails.push(trail);
+    rows.push(
+      createRow({
+        type: 'object_keys_collapsed',
+        collapsed: true,
+        indent: indent + 1,
+        fieldsHidden: objectKeys.filter(
+          (key) =>
+            !(keysWithDiffs.includes(key) || hasNestedDiff([...trail, key]))
+        ).length,
+        trail: trail,
+      })
+    );
+  }
 
   objectKeys.sort(alphabetizeCaseInsensitve).forEach((key) => {
     const fieldName = key;
+    const fieldTrail = [...trail, fieldName];
     const value = objectShape[key];
 
-    return shapeRows(value, nestedDiffs, rows, collapsedTrails, indent + 1, {
-      fieldName,
-      fieldValue: value,
-      trail: [...trail, fieldName],
-    });
+    if (shouldCollapse) {
+      if (keysWithDiffs.includes(key) || hasNestedDiff(fieldTrail)) {
+        shapeRows(value, nestedDiffs, rows, collapsedTrails, indent + 1, {
+          fieldName,
+          fieldValue: value,
+          trail: fieldTrail,
+        });
+      } else {
+        collapsedCount++;
+      }
+    } else {
+      shapeRows(value, nestedDiffs, rows, collapsedTrails, indent + 1, {
+        fieldName,
+        fieldValue: value,
+        trail: fieldTrail,
+      });
+    }
   });
 
   rows.push(createRow({ type: 'object_close', indent, trail }));

--- a/workspaces/ui/src/components/diff/v2/shape_viewers/InteractionBodyViewerAllJS.js
+++ b/workspaces/ui/src/components/diff/v2/shape_viewers/InteractionBodyViewerAllJS.js
@@ -796,7 +796,9 @@ function objectRows(
   const collapseAt = 9;
 
   const shouldCollapse =
-    objectKeys.length > collapseAt && !_isEqual(expandObjectWithTrail, trail);
+    objectKeys.length > collapseAt &&
+    !_isEqual(expandObjectWithTrail, trail) &&
+    keysWithDiffs.length === 0;
 
   if (shouldCollapse) {
     collapsedTrails.push(trail);


### PR DESCRIPTION
In the new Diff UX Optic shows all the diffs for an endpoint on the same page. This has been frequently requested, but it also leads to some problematic UI elements. It's not always obvious where the diff actually is -- esp for large bodies. 

We added collapsedTrails for arrays which helped a lot. With this PR we can also collapse (then expand when needed) fields and + their children that aren't relevant to the diff in question. 

<img width="1480" alt="Screen Shot 2020-12-17 at 6 20 38 PM" src="https://user-images.githubusercontent.com/5900338/102555644-2af5f900-4095-11eb-9254-837ada8c0a18.png">

We may still find that we want to bring back the diff compass, but that can come later. Let's see how people like this first. 

Re: performance, in keeping with the established pattern, this UI doesn't try to render any of the hidden fields until you choose to unhide them. 