### PR TITLE
Fix bug where Webpack couldn't build and bundle diff-engine-wasm

### DIFF
--- a/workspaces/diff-engine-wasm/webpack.plugin.js
+++ b/workspaces/diff-engine-wasm/webpack.plugin.js
@@ -3,11 +3,11 @@ const path = require('path');
 
 module.exports = function createDiffEnginePlugin() {
   return new WasmPackPlugin({
-    crateDirectory: path.resolve(__dirname),
+    crateDirectory: path.resolve(__dirname, 'engine'),
 
     watchDirectories: [path.resolve(__dirname, '..', 'diff-engine', 'src')],
 
-    outDir: path.resolve(__dirname, 'browser'),
+    outDir: path.resolve(__dirname, 'engine', 'browser'),
     outName: 'index',
   });
 };

--- a/workspaces/ui/src/services/diff/ExampleDiffService.ts
+++ b/workspaces/ui/src/services/diff/ExampleDiffService.ts
@@ -44,7 +44,7 @@ export class ExampleDiff {
     const diffingStream = (async function* (): AsyncIterable<
       Streams.DiffResults.DiffResult
     > {
-      for (let [i, interaction] of interactions.entries()) {
+      for (let interaction of interactions) {
         let results = DiffEngine.diff_interaction(
           JSON.stringify(interaction),
           spec
@@ -68,14 +68,7 @@ export class ExampleDiff {
     })();
 
     // Consume stream instantly for now, resulting in a Promise that resolves once exhausted
-    this.diffing = (async function (diffing) {
-      const diffs = [];
-      for await (let diff of diffing) {
-        diffs.push(diff);
-      }
-
-      return diffs;
-    })(diffingStream);
+    this.diffing = AsyncTools.toArray(diffingStream);
 
     return this.diffId;
   }


### PR DESCRIPTION
While all tests passed for #480, they don't cover the Webpack compilation! Sneaking in a tiny bit more clean up that I found stashed on my branch but forgot to pop as well.