### PR TITLE
init: clarify next step when `optic.yml` exists.

### DIFF
--- a/workspaces/local-cli/src/commands/init.ts
+++ b/workspaces/local-cli/src/commands/init.ts
@@ -48,7 +48,10 @@ export default class Init extends Command {
     ) {
       return this.log(
         colors.red(
-          `This directory already has an ${colors.bold('optic.yml')} file.`
+          `This directory already has an ${colors.bold('optic.yml')} file.\r\n`
+        ),
+        colors.yellow(
+          `You can see the current documentation for this project with ${colors.bold('api spec')}.`
         )
       );
     }


### PR DESCRIPTION
When optic.yml exists and you run `api init`, you get an error that the optic.yml file exists and init will not overwrite the existing structure. This change clarifies a next step: run `api spec` to open Optic and see the current documentation generated from the existing spec.