### PR TITLE
hotfix: properly store query parameters in captures

### DIFF
--- a/workspaces/cli-shared/src/httptoolkit-capturing-proxy.ts
+++ b/workspaces/cli-shared/src/httptoolkit-capturing-proxy.ts
@@ -146,13 +146,16 @@ export class HttpToolkitCapturingProxy {
         }
 
         developerDebugLogger(req);
+
+        const path = url.parse(req.url).pathname!;
+
         const sample: IHttpInteraction = {
           tags: [],
           uuid: res.id,
           request: {
             host: req.hostname || '',
             method: req.method,
-            path: req.path,
+            path,
             headers: {
               asJsonString: null,
               asText: null,


### PR DESCRIPTION
It seems that after the HttpToolkit upgrade query parameters were being included in `req.path`. This PR uses `url.parse` to isolate the `pathname` and save the `query` in the proper part of the capture