### PR TITLE
hotfix: scroll fix for docs

### DIFF
--- a/workspaces/agent-cli/package.json
+++ b/workspaces/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/agent-cli",
-  "version": "8.6.3-beta.3",
+  "version": "8.6.3-beta.4",
   "author": "@useoptic",
   "bin": {
     "optic-agent": "./bin/run"
@@ -15,7 +15,7 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^3",
-    "@useoptic/cli-shared": "8.6.3-beta.3",
+    "@useoptic/cli-shared": "8.6.3-beta.4",
     "dotenv": "^8.2.0",
     "jwt-decode": "^2.2.0",
     "tslib": "^1",

--- a/workspaces/analytics/package.json
+++ b/workspaces/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/analytics",
-  "version": "8.6.3-beta.3",
+  "version": "8.6.3-beta.4",
   "scripts": {
     "ws:build": "tsc -b --verbose",
     "ws:clean": "rm -rf build/*",

--- a/workspaces/ci-cli/package.json
+++ b/workspaces/ci-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/ci-cli",
-  "version": "8.6.3-beta.3",
+  "version": "8.6.3-beta.4",
   "author": "@useoptic",
   "bin": {
     "optic-ci": "./bin/run"
@@ -15,8 +15,8 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^3",
-    "@useoptic/cli-config": "8.6.3-beta.3",
-    "@useoptic/cli-shared": "8.6.3-beta.3",
+    "@useoptic/cli-config": "8.6.3-beta.4",
+    "@useoptic/cli-shared": "8.6.3-beta.4",
     "dotenv": "^8.2.0",
     "jwt-decode": "^2.2.0",
     "tslib": "^1",

--- a/workspaces/cli-client/package.json
+++ b/workspaces/cli-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-client",
-  "version": "8.6.3-beta.3",
+  "version": "8.6.3-beta.4",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",
@@ -14,9 +14,9 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "dependencies": {
-    "@useoptic/analytics": "8.6.3-beta.3",
-    "@useoptic/cli-config": "8.6.3-beta.3",
-    "@useoptic/client-utilities": "8.6.3-beta.3",
+    "@useoptic/analytics": "8.6.3-beta.4",
+    "@useoptic/cli-config": "8.6.3-beta.4",
+    "@useoptic/client-utilities": "8.6.3-beta.4",
     "bottleneck": "^2.19.5",
     "cross-fetch": "^3.0.4"
   },

--- a/workspaces/cli-config/package.json
+++ b/workspaces/cli-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-config",
-  "version": "8.6.3-beta.3",
+  "version": "8.6.3-beta.4",
   "scripts": {
     "ws:test": "jest",
     "ws:build": "yarn run tsc -b --verbose",

--- a/workspaces/cli-scripts/package.json
+++ b/workspaces/cli-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-scripts",
-  "version": "8.6.3-beta.3",
+  "version": "8.6.3-beta.4",
   "scripts": {
     "ws:test": "echo scripts",
     "ws:build": "yarn run tsc -b --verbose",
@@ -18,8 +18,8 @@
     "@sentry/tracing": "^5.28.0",
     "node-notifier": "^7.0.0",
     "analytics-node": "^3.4.0-beta.1",
-    "@useoptic/cli-config": "8.6.3-beta.3",
-    "@useoptic/cli-shared": "8.6.3-beta.3"
+    "@useoptic/cli-config": "8.6.3-beta.4",
+    "@useoptic/cli-shared": "8.6.3-beta.4"
   },
   "devDependencies": {
     "@types/node-notifier": "^6.0.1"

--- a/workspaces/cli-server/package.json
+++ b/workspaces/cli-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-server",
-  "version": "8.6.3-beta.3",
+  "version": "8.6.3-beta.4",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",
@@ -16,13 +16,13 @@
   "dependencies": {
     "@sentry/node": "^5.28.0",
     "@sentry/tracing": "^5.28.0",
-    "@useoptic/analytics": "8.6.3-beta.3",
-    "@useoptic/cli-client": "8.6.3-beta.3",
-    "@useoptic/cli-config": "8.6.3-beta.3",
-    "@useoptic/cli-scripts": "8.6.3-beta.3",
-    "@useoptic/cli-shared": "8.6.3-beta.3",
-    "@useoptic/diff-engine-wasm": "8.6.3-beta.3",
-    "@useoptic/ui": "8.6.3-beta.3",
+    "@useoptic/analytics": "8.6.3-beta.4",
+    "@useoptic/cli-client": "8.6.3-beta.4",
+    "@useoptic/cli-config": "8.6.3-beta.4",
+    "@useoptic/cli-scripts": "8.6.3-beta.4",
+    "@useoptic/cli-shared": "8.6.3-beta.4",
+    "@useoptic/diff-engine-wasm": "8.6.3-beta.4",
+    "@useoptic/ui": "8.6.3-beta.4",
     "analytics-node": "^3.4.0-beta.2",
     "avsc": "^5.4.18",
     "body-parser": "^1.19.0",

--- a/workspaces/cli-shared/package.json
+++ b/workspaces/cli-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-shared",
-  "version": "8.6.3-beta.3",
+  "version": "8.6.3-beta.4",
   "scripts": {
     "test": "cd test && tap tests",
     "ws:build": "yarn run tsc -b --verbose",
@@ -16,10 +16,10 @@
   "types": "build/index.d.ts",
   "dependencies": {
     "@oclif/command": "^1.6.1",
-    "@useoptic/cli-client": "8.6.3-beta.3",
-    "@useoptic/cli-config": "8.6.3-beta.3",
-    "@useoptic/client-utilities": "8.6.3-beta.3",
-    "@useoptic/diff-engine": "8.6.3-beta.3",
+    "@useoptic/cli-client": "8.6.3-beta.4",
+    "@useoptic/cli-config": "8.6.3-beta.4",
+    "@useoptic/client-utilities": "8.6.3-beta.4",
+    "@useoptic/diff-engine": "8.6.3-beta.4",
     "@useoptic/domain": "10.0.50",
     "@useoptic/domain-types": "10.0.50",
     "@useoptic/domain-utilities": "10.0.50",

--- a/workspaces/client-utilities/package.json
+++ b/workspaces/client-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/client-utilities",
-  "version": "8.6.3-beta.3",
+  "version": "8.6.3-beta.4",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",

--- a/workspaces/diff-engine-wasm/package.json
+++ b/workspaces/diff-engine-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/diff-engine-wasm",
-  "version": "8.6.3-beta.3",
+  "version": "8.6.3-beta.4",
   "scripts": {
     "build:lib": "tsc -b --verbose",
     "build:node": "cd engine && wasm-pack build --target nodejs --out-dir build --out-name index",

--- a/workspaces/diff-engine/package.json
+++ b/workspaces/diff-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/diff-engine",
-  "version": "8.6.3-beta.3",
+  "version": "8.6.3-beta.4",
   "scripts": {
     "postinstall": "node scripts/install",
     "preuninstall": "node scripts/uninstall",

--- a/workspaces/local-cli/package.json
+++ b/workspaces/local-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/cli",
   "description": "The Optic CLI",
-  "version": "8.6.3-beta.3",
+  "version": "8.6.3-beta.4",
   "author": "@useoptic",
   "bin": {
     "api": "./bin/run"
@@ -18,12 +18,12 @@
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^2",
     "cli-table3": "^0.6.0",
-    "@useoptic/analytics": "8.6.3-beta.3",
-    "@useoptic/cli-client": "8.6.3-beta.3",
-    "@useoptic/cli-config": "8.6.3-beta.3",
-    "@useoptic/cli-scripts": "8.6.3-beta.3",
-    "@useoptic/cli-server": "8.6.3-beta.3",
-    "@useoptic/cli-shared": "8.6.3-beta.3",
+    "@useoptic/analytics": "8.6.3-beta.4",
+    "@useoptic/cli-client": "8.6.3-beta.4",
+    "@useoptic/cli-config": "8.6.3-beta.4",
+    "@useoptic/cli-scripts": "8.6.3-beta.4",
+    "@useoptic/cli-server": "8.6.3-beta.4",
+    "@useoptic/cli-shared": "8.6.3-beta.4",
     "@useoptic/domain": "10.0.50",
     "analytics-node": "^3.4.0-beta.1",
     "cli-ux": "^5.4.1",

--- a/workspaces/saas-types/package.json
+++ b/workspaces/saas-types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/saas-types",
   "description": "interfaces and types for Optic SaaS surface area",
-  "version": "8.6.3-beta.3",
+  "version": "8.6.3-beta.4",
   "main": "build/index.js",
   "files": [
     "build"

--- a/workspaces/snapshot-tests/package.json
+++ b/workspaces/snapshot-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/snapshot-tests",
-  "version": "8.6.3-beta.3",
+  "version": "8.6.3-beta.4",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",
@@ -15,8 +15,8 @@
     "@useoptic/domain": "10.0.50",
     "@useoptic/domain-types": "10.0.50",
     "@useoptic/domain-utilities": "10.0.50",
-    "@useoptic/client-utilities": "8.6.3-beta.3",
-    "@useoptic/cli-shared": "8.6.3-beta.3",
+    "@useoptic/client-utilities": "8.6.3-beta.4",
+    "@useoptic/cli-shared": "8.6.3-beta.4",
     "dataloader": "^2.0.0",
     "eventsource": "^1.0.7",
     "fs-extra": "^9.0.0"

--- a/workspaces/ui/package.json
+++ b/workspaces/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/ui",
-  "version": "8.6.3-beta.3",
+  "version": "8.6.3-beta.4",
   "files": [
     "build",
     "index.js",
@@ -15,10 +15,10 @@
     "@material-ui/core": "^4.9.7",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.46",
-    "@useoptic/cli-shared": "8.6.3-beta.3",
-    "@useoptic/cli-client": "8.6.3-beta.3",
-    "@useoptic/analytics": "8.6.3-beta.3",
-    "@useoptic/diff-engine-wasm": "8.6.3-beta.3",
+    "@useoptic/cli-shared": "8.6.3-beta.4",
+    "@useoptic/cli-client": "8.6.3-beta.4",
+    "@useoptic/analytics": "8.6.3-beta.4",
+    "@useoptic/diff-engine-wasm": "8.6.3-beta.4",
     "@useoptic/domain": "10.0.50",
     "@useoptic/domain-utilities": "10.0.50",
     "bottleneck": "^2.19.5",

--- a/workspaces/ui/src/components/docs/DocsPage.js
+++ b/workspaces/ui/src/components/docs/DocsPage.js
@@ -195,9 +195,8 @@ export const DocumentationToc = () => {
                               to={`documentation/paths/${endpointDescriptor.pathId}/methods/${endpointDescriptor.method}`}
                               size="medium"
                               color="primary"
-                              endIcon={<ExpandMoreIcon />}
                             >
-                              Full Documentation
+                              Full Documentation ➔
                             </Button>
                             <div style={{ flex: 1 }} />
 

--- a/workspaces/ui/src/components/docs/DocsPage.js
+++ b/workspaces/ui/src/components/docs/DocsPage.js
@@ -28,6 +28,7 @@ import EmptyState from '../support/EmptyState';
 import { AddOpticLink, DocumentingYourApi } from '../support/Links';
 import { trackUserEvent } from '../../Analytics';
 import { UpdateContribution } from '@useoptic/analytics/lib/events/diffs';
+import ScrollIntoViewIfNeeded from 'react-scroll-into-view-if-needed';
 const useStyles = makeStyles((theme) => ({
   maxWidth: {
     width: '100%',
@@ -300,20 +301,22 @@ export const EndpointDocs = (props) => {
 
             return (
               <div>
-                <HeadingContribution
-                  value={getContribution(endpointId, PURPOSE)}
-                  label="What does this endpoint do?"
-                  onChange={(value) => {
-                    updateContribution(endpointId, PURPOSE, value);
-                    trackUserEvent(
-                      UpdateContribution.withProps({
-                        id: endpointId,
-                        purpose: PURPOSE,
-                        value,
-                      })
-                    );
-                  }}
-                />
+                <ScrollIntoViewIfNeeded options={{ scrollMode: 'if-needed' }}>
+                  <HeadingContribution
+                    value={getContribution(endpointId, PURPOSE)}
+                    label="What does this endpoint do?"
+                    onChange={(value) => {
+                      updateContribution(endpointId, PURPOSE, value);
+                      trackUserEvent(
+                        UpdateContribution.withProps({
+                          id: endpointId,
+                          purpose: PURPOSE,
+                          value,
+                        })
+                      );
+                    }}
+                  />
+                </ScrollIntoViewIfNeeded>
                 <MarkdownContribution
                   value={getContribution(endpointId, DESCRIPTION)}
                   label="Detailed Description"


### PR DESCRIPTION
When users have dozens of endpoints documented, and click "Full Documentation", some browsers don't scroll back to the top of the page. This makes it appear that the page hasn't loaded. 

A simple fix has been made, to scroll to the top of the docs page when it loads. 

A new design for the docs page is on the roadmap and we'll likely be retiring most of this code as a part of it. 