### PR TITLE
Fix bug where AsyncTools.lastBy would leak old results to new invocations

### DIFF
--- a/workspaces/cli-server/src/diffs/on-demand.ts
+++ b/workspaces/cli-server/src/diffs/on-demand.ts
@@ -240,13 +240,14 @@ export class DiffQueries implements DiffQueriesInterface {
   }
   undocumentedUrls(): Readable {
     if (fs.existsSync(this.paths.diffsStream)) {
-      let diffs = chain([
-        fs.createReadStream(this.paths.diffsStream),
-        jsonlParser(),
-        (data) => [data.value],
-      ]);
+      let diffResults = this.createDiffsStream(this.paths.diffsStream);
 
-      return Readable.from(this.countUndocumentedUrls(diffs));
+      let undocumentedUrls = Streams.UndocumentedUrls.fromDiffResults(
+        diffResults
+      );
+      let lastUnique = Streams.UndocumentedUrls.lastUnique(undocumentedUrls);
+
+      return Readable.from(lastUnique);
     } else {
       let reading = lockedRead<any>(this.paths.undocumentedUrls);
       let itemsGenerator = jsonStreamGenerator(reading);

--- a/workspaces/diff-engine-wasm/package.json
+++ b/workspaces/diff-engine-wasm/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "@types/tap": "^14.10.1",
     "@wasm-tool/wasm-pack-plugin": "^1.3.1",
+    "sinon": "^9.2.2",
     "tap": "^14.11.0",
     "typescript": "^3.8",
     "wasm-pack": "^0.9.1"

--- a/workspaces/diff-engine-wasm/src/async-tools.ts
+++ b/workspaces/diff-engine-wasm/src/async-tools.ts
@@ -8,24 +8,24 @@ import { Readable } from 'stream';
 export function lastBy<T>(
   predicate: (subject: T) => string
 ): (source: AsyncIterable<T>) => AsyncIterable<T> {
-  const findLastKey = reduce(
-    (
-      { lastByKey, keys }: { lastByKey: Map<string, T>; keys: Set<string> },
-      subject: T
-    ) => {
-      const key = predicate(subject);
-      // rely on insertion order guarantee from Set to yield final results by
-      // last key occurence
-      keys.delete(key);
-      keys.add(key);
-      lastByKey.set(key, subject);
-
-      return { lastByKey, keys };
-    },
-    { lastByKey: new Map(), keys: new Set<string>() }
-  );
-
   return async function* (source: AsyncIterable<T>) {
+    const findLastKey = reduce(
+      (
+        { lastByKey, keys }: { lastByKey: Map<string, T>; keys: Set<string> },
+        subject: T
+      ) => {
+        const key = predicate(subject);
+        // rely on insertion order guarantee from Set to yield final results by
+        // last key occurence
+        keys.delete(key);
+        keys.add(key);
+        lastByKey.set(key, subject);
+
+        return { lastByKey, keys };
+      },
+      { lastByKey: new Map(), keys: new Set<string>() }
+    );
+
     const { lastByKey, keys } = await findLastKey(source);
 
     for (let key of keys) {

--- a/workspaces/diff-engine-wasm/test/tests/async-tools.ts
+++ b/workspaces/diff-engine-wasm/test/tests/async-tools.ts
@@ -1,0 +1,52 @@
+import Tap from 'tap';
+import { spy } from 'sinon';
+
+import * as AT from '../../src/async-tools';
+
+Tap.test('AsyncTools.lastBy', async (t) => {
+  await t.test(
+    'will only emit the last occurence of each result by key returned by predicate, in order of last key occurence',
+    async (t) => {
+      interface Item {
+        name: string;
+        count: number;
+      }
+
+      const testInput: Item[] = [
+        { name: 'a', count: 1 },
+        { name: 'b', count: 1 },
+        { name: 'a', count: 2 },
+        { name: 'c', count: 1 },
+        { name: 'b', count: 5 },
+      ];
+
+      const predicate = spy((item: Item) => item.name);
+      const lastByName = AT.lastBy(predicate);
+
+      const lastInputsByName = lastByName(AT.from(testInput));
+
+      let results = await AT.toArray<Item>(lastInputsByName);
+
+      t.deepEqual(results, [
+        { name: 'a', count: 2 },
+        { name: 'c', count: 1 },
+        { name: 'b', count: 5 },
+      ]);
+      t.equal(predicate.callCount, testInput.length);
+
+      // verify last by generator is pure
+      predicate.resetHistory();
+      const otherTestInputs: Item[] = [
+        { name: 'd', count: 2 },
+        { name: 'e', count: 1 },
+        { name: 'f', count: 5 },
+      ];
+
+      const otherInputsByName = lastByName(AT.from(otherTestInputs));
+      results = await AT.toArray<Item>(otherInputsByName);
+
+      t.deepEqual(results, otherTestInputs);
+      t.equal(predicate.callCount, otherTestInputs.length);
+    }
+  );
+});

--- a/workspaces/ui/src/components/diff/review-diff/ReviewEndpoint.js
+++ b/workspaces/ui/src/components/diff/review-diff/ReviewEndpoint.js
@@ -57,6 +57,8 @@ export function ReviewEndpoint(props) {
           method,
           makeDiffActorHook,
           handled,
+          endpointQueries: queries,
+          endpointActions: actions,
           groupDiffsByLocation,
         }}
       />
@@ -84,11 +86,15 @@ export function ReviewEndpointInner(props) {
     makeDiffActorHook,
     groupDiffsByLocation,
     handled,
+    endpointQueries,
+    endpointActions,
   } = props;
+
+  const classes = useStyles();
 
   return (
     <Box display="flex" flexDirection="column" key={pathId + method}>
-     {!endpointQueries.allHandled() && (
+      {!endpointQueries.allHandled() && (
         <Paper
           key="bulk-actions"
           className={classNames(classes.sectionHeader, classes.bulkActions)}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2440,19 +2440,41 @@
   resolved "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
   integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
-"@sinonjs/commons@^1.7.0":
+"@sinonjs/commons@^1", "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.1":
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.1.tgz#e7df00f98a203324f6dc7cc606cad9d4a8ab2217"
   integrity sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==
   dependencies:
     type-detect "4.0.8"
 
-"@sinonjs/fake-timers@^6.0.1":
+"@sinonjs/fake-timers@^6.0.0", "@sinonjs/fake-timers@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz#293674fccb3262ac782c7aadfdeca86b10c75c40"
   integrity sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
+
+"@sinonjs/formatio@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-5.0.1.tgz#f13e713cb3313b1ab965901b01b0828ea6b77089"
+  integrity sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==
+  dependencies:
+    "@sinonjs/commons" "^1"
+    "@sinonjs/samsam" "^5.0.2"
+
+"@sinonjs/samsam@^5.0.2", "@sinonjs/samsam@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-5.3.0.tgz#1d2f0743dc54bf13fe9d508baefacdffa25d4329"
+  integrity sha512-hXpcfx3aq+ETVBwPlRFICld5EnrkexXuXDwqUNhDdr5L8VjvMeSRwyOa0qL7XFmR+jVWR4rUZtnxlG7RX72sBg==
+  dependencies:
+    "@sinonjs/commons" "^1.6.0"
+    lodash.get "^4.4.2"
+    type-detect "^4.0.8"
+
+"@sinonjs/text-encoding@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
+  integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
 "@storybook/addon-actions@^5.0.11":
   version "5.3.19"
@@ -7116,7 +7138,7 @@ diff@3.5.0:
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
-diff@^4.0.1:
+diff@^4.0.1, diff@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
@@ -11556,6 +11578,11 @@ jsx-ast-utils@^2.0.1:
     array-includes "^3.1.1"
     object.assign "^4.1.0"
 
+just-extend@^4.0.2:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.1.1.tgz#158f1fdb01f128c411dc8b286a7b4837b3545282"
+  integrity sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==
+
 jwt-decode@2.2.0, jwt-decode@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-2.2.0.tgz#7d86bd56679f58ce6a84704a657dd392bba81a79"
@@ -12691,6 +12718,17 @@ nice-try@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-2.1.0.tgz#d818aaf628993b4de39d11e9b53be224152b38c3"
   integrity sha512-ZR863POogZo2DpqQkqeUHM01Fg73CVSVoP2Gq7Wjn8AYv7R1rRkvXx4Bf6PsXhyBGDhsN6rKCPflGDjn3+flWg==
+
+nise@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-4.0.4.tgz#d73dea3e5731e6561992b8f570be9e363c4512dd"
+  integrity sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+    "@sinonjs/fake-timers" "^6.0.0"
+    "@sinonjs/text-encoding" "^0.7.1"
+    just-extend "^4.0.2"
+    path-to-regexp "^1.7.0"
 
 no-case@^2.2.0:
   version "2.3.2"
@@ -16136,6 +16174,19 @@ simplebar@^4.2.3:
     lodash.memoize "^4.1.2"
     lodash.throttle "^4.1.1"
     resize-observer-polyfill "^1.5.1"
+
+sinon@^9.2.2:
+  version "9.2.2"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-9.2.2.tgz#b83cf5d43838f99cfa3644453f4c7db23e7bd535"
+  integrity sha512-9Owi+RisvCZpB0bdOVFfL314I6I4YoRlz6Isi4+fr8q8YQsDPoCe5UnmNtKHRThX3negz2bXHWIuiPa42vM8EQ==
+  dependencies:
+    "@sinonjs/commons" "^1.8.1"
+    "@sinonjs/fake-timers" "^6.0.1"
+    "@sinonjs/formatio" "^5.0.1"
+    "@sinonjs/samsam" "^5.3.0"
+    diff "^4.0.2"
+    nise "^4.0.4"
+    supports-color "^7.1.0"
 
 sisteransi@^1.0.4:
   version "1.0.5"


### PR DESCRIPTION
This fixes a bug where to get the last stream items by some predicate wasn't pure per stream it was applied on. Instead, it would re-emit the last known entries for each stream it was ever called on. @acunniffe this fixes the issue you reported as regarding undocumented urls https://github.com/opticdev/optic/commit/3bffce1ebf90b6b997e358c22d309111e6b89bcb#r45483119 (turns out diffs more generally were affected).

The fix was fairly simple: make sure we use a new `Set` of seen keys for each stream, rather than using a single one per predicate. I added test coverage to reproduce the error and verify the fix.

Also: @acunniffe sneaked in a fix for some UI code which must have not gotten merged properly.