### PR TITLE
Learn initial body performance fix

### DIFF
--- a/workspaces/cli-server/src/routers/capture-router.ts
+++ b/workspaces/cli-server/src/routers/capture-router.ts
@@ -119,9 +119,10 @@ export function makeRouter(dependencies: ICaptureRouterDependencies) {
         method,
       });
 
+      console.time('learn ' + pathId + method);
       const result = initialBodyGenerator.run();
-
       result.then((learnedBodies: ILearnedBodies) => {
+        console.timeEnd('learn ' + pathId + method);
         res.json(learnedBodies);
       });
       result.catch((e) => {

--- a/workspaces/cli-shared/src/diffs/initial-bodies-worker.ts
+++ b/workspaces/cli-shared/src/diffs/initial-bodies-worker.ts
@@ -196,7 +196,6 @@ export class InitialBodiesWorker {
       });
 
       await fs.ensureDir(outputPaths.base);
-      await flush();
 
       for await (const item of interactionIterator) {
         hasMoreInteractions = item.hasMoreInteractions;
@@ -214,8 +213,6 @@ export class InitialBodiesWorker {
         );
 
         LearnAPIHelper.learnBody(deserializedInteraction, shapeBuilderMap);
-
-        batcher.add(null);
       }
       hasMoreInteractions = false;
       batcher.add(null);


### PR DESCRIPTION
Commands were being flushed to disk every batch, instead of once, at the end. That created a lot of IO, esp for large captures