### PR TITLE
dump_capture_saver can now repeat samples to generate large captures

### DIFF
--- a/debugsourceme.sh
+++ b/debugsourceme.sh
@@ -5,7 +5,7 @@ export OPTIC_SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && p
 debug_to_capture() {
   (
     set -o errexit
-    node "$OPTIC_SRC_DIR/workspaces/cli-shared/build/captures/avro/file-system/dump-capture-saver.js" $1 .
+    node "$OPTIC_SRC_DIR/workspaces/cli-shared/build/captures/avro/file-system/dump-capture-saver.js" $1 . ${2:-1}
   )
 }
 

--- a/workspaces/cli-shared/src/captures/avro/file-system/dump-capture-saver.ts
+++ b/workspaces/cli-shared/src/captures/avro/file-system/dump-capture-saver.ts
@@ -8,10 +8,12 @@ import { CaptureSaver } from './capture-saver';
 async function main(
   inputFilePath: string,
   outputBaseDirectory: string,
-  captureId: string = 'ccc'
+  repeatSampleTimes: string = '1',
+  captureId: string = 'ccc',
 ) {
   console.log({ inputFilePath });
   const input = fs.createReadStream(inputFilePath);
+  const repeatSampleCount = isNaN(parseInt(repeatSampleTimes))? 1 : parseInt(repeatSampleTimes);
   const events: any[] = [];
   const captureBaseDirectory = path.join(
     outputBaseDirectory,
@@ -33,9 +35,11 @@ async function main(
           events.push(event);
         },
         'session.samples.*': function (sample: IHttpInteraction) {
-          console.count('sample');
-          //console.log({ sample });
-          captureSaver.save(sample);
+          for (var i = 0; i < repeatSampleCount; i++) {
+            console.count('sample');
+            //console.log({ sample });
+            captureSaver.save(sample);
+          }
         },
       })
       .on('done', function () {
@@ -91,5 +95,5 @@ async function main(
   );
 }
 
-const [, , inputFilePath, outputBaseDirectory, captureId] = process.argv;
-main(inputFilePath, outputBaseDirectory, captureId);
+const [, , inputFilePath, outputBaseDirectory, repeatSampleTimes, captureId] = process.argv;
+main(inputFilePath, outputBaseDirectory, repeatSampleTimes, captureId);


### PR DESCRIPTION
Debugging tool now takes an optional value (default 1) to multiply the number of times it uses a sample in a dump capture conversion. This allows us to increase the size of a capture dump for performance testing without having to generate more traffic.