### PR TITLE
introducing optic debug command

### DIFF
--- a/workspaces/local-cli/src/commands/debug/capture.ts
+++ b/workspaces/local-cli/src/commands/debug/capture.ts
@@ -77,7 +77,9 @@ export default class DebugCapture extends Command {
       events,
       configJson,
       ignoreRules,
-      interactions: cleanedInteraction,
+      session: {
+        samples: cleanedInteraction,
+      },
       opticVersion: pJson.version,
       os: {
         arch: OS.arch(),

--- a/workspaces/local-cli/src/commands/debug/capture.ts
+++ b/workspaces/local-cli/src/commands/debug/capture.ts
@@ -1,0 +1,99 @@
+import { Command } from '@oclif/command';
+import { CaptureInteractionIterator } from '@useoptic/cli-shared/build/captures/avro/file-system/interaction-iterator';
+import { getPathsRelativeToConfig, readApiConfig } from '@useoptic/cli-config';
+import OS from 'os';
+import cli from 'cli-ux';
+import path from 'path';
+import fs from 'fs-extra';
+import { IgnoreFileHelper } from '@useoptic/cli-config/build/helpers/ignore-file-interface';
+import { getOrCreateAnonId } from '@useoptic/cli-config/build/opticrc/optic-rc';
+const pJson = require('../../../package.json');
+
+export default class DebugCapture extends Command {
+  static description =
+    'produce a debug file (full of shape hashed interactions) that can be shared with Optic maintainers';
+  static hidden: boolean = true;
+
+  static args = [
+    {
+      name: 'captureId',
+      description: 'the captureId, see the address bar /review/___{this id}___',
+      required: true,
+    },
+  ];
+
+  async run() {
+    const { args } = this.parse(DebugCapture);
+    const { captureId } = args;
+
+    cli.action.start('sanitizing json bodies...');
+
+    const {
+      capturesPath,
+      configPath,
+      basePath,
+      opticIgnorePath,
+      specStorePath,
+    } = await getPathsRelativeToConfig();
+    const configJson = await readApiConfig(configPath);
+    const events = await fs.readJson(specStorePath);
+    const ignoreRules = await new IgnoreFileHelper(
+      opticIgnorePath,
+      configPath
+    ).getCurrentIgnoreRules();
+
+    const interactionIterator = CaptureInteractionIterator(
+      {
+        captureId: captureId,
+        captureBaseDirectory: capturesPath,
+      },
+      (i) => true
+    );
+
+    const cleanedInteraction = [];
+
+    for await (const item of interactionIterator) {
+      if (!item.interaction) {
+        continue;
+      }
+      const { batchId, index } = item.interaction.context;
+
+      const itemValue = item.interaction.value;
+
+      cli.action.start(
+        'sanitizing json bodies...',
+        item.diffedInteractionsCounter.toString()
+      );
+      //question? do we want to fill in a similar quantity of bytes for non json?
+      itemValue.request.body.value.asJsonString = null;
+      itemValue.request.body.value.asText = null;
+      itemValue.response.body.value.asJsonString = null;
+      itemValue.response.body.value.asText = null;
+
+      cleanedInteraction.push(itemValue);
+    }
+
+    const result = {
+      events,
+      configJson,
+      ignoreRules,
+      interactions: cleanedInteraction,
+      opticVersion: pJson.version,
+      os: {
+        arch: OS.arch(),
+        cpus: OS.cpus(),
+        memory: OS.totalmem(),
+      },
+    };
+
+    cli.action.stop('Done!');
+    const anonId = await getOrCreateAnonId();
+    const savePath = path.join(
+      basePath,
+      '../',
+      `debug-optic-${Date.now().toString()}-${anonId}.json`
+    );
+    fs.writeJson(savePath, result);
+    this.log('saved to: ' + savePath);
+  }
+}


### PR DESCRIPTION
Ahead of Optic 9's pending release, we want to provide users with a means to send us really large debug captures (much bigger than what the browser can prepare) and a way for larger teams who have adopted Optic to sanitize and share example traffic we can put in our test suites -- a big way to invest in the overall stability of the project.

If you run `api debug:capture <captureId>` Optic will prepare a sharable file that removes all bodies, and shape hashes json. I've also included Optic version, system stats (but nothing identifiable) and the optic.yml + ignore config. 

The only non-obvious part of this work is how to treat bodies for non-json thing ie -- a text/html response or the bytes for an image. Right now, they are just omitted, but we may want to fill them with some repeating bytes that compress well so we can simulate the memory/data load. Open to ideas and happy to defer this last choice @LouManglass @devdoshi @JaapRood 

