### PR TITLE
Unknown shapes should yield diffs

### DIFF
--- a/workspaces/diff-engine/src/queries/shape.rs
+++ b/workspaces/diff-engine/src/queries/shape.rs
@@ -57,7 +57,16 @@ impl<'a> ShapeQueries<'a> {
           _ => unreachable!("expected to be a core shape node"),
         };
         let trails: Vec<ChoiceOutput> = match core_shape_descriptor.kind {
-          ShapeKind::UnknownKind => vec![],
+          ShapeKind::UnknownKind => {
+            let output = vec![ChoiceOutput {
+              parent_trail: shape_trail.clone(),
+              additional_components: vec![ShapeTrailPathComponent::UnknownTrail {
+              }],
+              shape_id: shape_id.clone(),
+              core_shape_kind: core_shape_descriptor.kind.clone(),
+            }];
+            output
+          },
           ShapeKind::NullableKind => {
             let nullable_parameter_id = core_shape_descriptor
               .kind

--- a/workspaces/diff-engine/tests/shape_diff.rs
+++ b/workspaces/diff-engine/tests/shape_diff.rs
@@ -96,6 +96,66 @@ fn can_diff_primitive_json_and_yield_unspecified_shape() {
 }
 
 #[test]
+fn can_diff_empty_json_array() {
+  let events: Vec<SpecEvent> = serde_json::from_value(json!([
+      {"ShapeAdded":{"shapeId":"list_1","baseShapeId":"$list","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":""}},
+      {"ShapeAdded":{"shapeId":"number_shape_1","baseShapeId":"$number","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":""}},
+      {"ShapeParameterShapeSet":{"shapeDescriptor":{"ProviderInShape":{"shapeId":"list_1","providerDescriptor":{"ShapeProvider":{"shapeId":"number_shape_1"}},"consumingParameterId":"$listItem"}}}},
+  ])).expect("should be able to deserialize shape added events as spec events");
+  let shape_projection = ShapeProjection::from(events);
+
+  assert_debug_snapshot!(
+    "can_diff_empty_json_array__shape_projection_graph",
+    Dot::with_config(&shape_projection.graph, &[])
+  );
+  let array_body = json!([]);
+  let shape_id = String::from("list_1");
+  let results = diff_shape(
+    &shape_projection,
+    Some(BodyDescriptor::from(array_body)),
+    &shape_id,
+  );
+  let fingerprints = results
+      .iter()
+      .map(|result| result.fingerprint())
+      .collect::<Vec<_>>();
+
+  assert_debug_snapshot!("can_diff_empty_json_array__results", results);
+  assert_eq!(results.len(), 0);
+  assert_debug_snapshot!("can_diff_empty_json_array__fingerprints", fingerprints);
+}
+#[test]
+fn can_diff_list_of_unknown() {
+  let events: Vec<SpecEvent> = serde_json::from_value(json!([
+      {"ShapeAdded":{"shapeId":"list_1","baseShapeId":"$list","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":""}},
+      {"ShapeAdded":{"shapeId":"unknown_shape_1","baseShapeId":"$unknown","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":""}},
+      {"ShapeParameterShapeSet":{"shapeDescriptor":{"ProviderInShape":{"shapeId":"list_1","providerDescriptor":{"ShapeProvider":{"shapeId":"unknown_shape_1"}},"consumingParameterId":"$listItem"}}}},
+
+  ])).expect("should be able to deserialize shape added events as spec events");
+  let shape_projection = ShapeProjection::from(events);
+
+  assert_debug_snapshot!(
+    "can_diff_list_of_unknown__shape_projection_graph",
+    Dot::with_config(&shape_projection.graph, &[])
+  );
+  let array_body = json!(["a", 1, false]);
+  let shape_id = String::from("list_1");
+  let results = diff_shape(
+    &shape_projection,
+    Some(BodyDescriptor::from(array_body)),
+    &shape_id,
+  );
+  let fingerprints = results
+      .iter()
+      .map(|result| result.fingerprint())
+      .collect::<Vec<_>>();
+
+  assert_debug_snapshot!("can_diff_list_of_unknown__results", results);
+  assert_eq!(results.len(), 3);
+  assert_debug_snapshot!("can_diff_list_of_unknown__fingerprints", fingerprints);
+}
+
+#[test]
 fn can_match_array_json() {
   let events : Vec<SpecEvent> = serde_json::from_value(
     json!([

--- a/workspaces/diff-engine/tests/snapshots/bug_scenarios__scenario_32__results.snap
+++ b/workspaces/diff-engine/tests/snapshots/bug_scenarios__scenario_32__results.snap
@@ -70,4 +70,47 @@ expression: results
             },
         },
     ),
+    UnmatchedResponseBodyShape(
+        UnmatchedResponseBodyShape {
+            interaction_trail: InteractionTrail {
+                path: [
+                    ResponseBody {
+                        content_type: "application/json",
+                        status_code: 201,
+                    },
+                ],
+            },
+            requests_trail: SpecResponseBody(
+                SpecResponseBody {
+                    response_id: "response_Oq3x4otca8",
+                },
+            ),
+            shape_diff_result: UnmatchedShape {
+                json_trail: JsonTrail {
+                    path: [
+                        JsonObjectKey {
+                            key: "rating",
+                        },
+                    ],
+                },
+                shape_trail: ShapeTrail {
+                    root_shape_id: "shape_xjqKoYgnH6",
+                    path: [
+                        ObjectFieldTrail {
+                            field_id: "field_dcJtyX4lH0",
+                            field_shape_id: "shape_lhl794TnL5",
+                        },
+                        NullableTrail {
+                            shape_id: "shape_lhl794TnL5",
+                        },
+                        NullableItemTrail {
+                            shape_id: "shape_lhl794TnL5",
+                            inner_shape_id: "shape_p5uOLpFNK8",
+                        },
+                        UnknownTrail,
+                    ],
+                },
+            },
+        },
+    ),
 ]

--- a/workspaces/diff-engine/tests/snapshots/bug_scenarios__scenario_33__results.snap
+++ b/workspaces/diff-engine/tests/snapshots/bug_scenarios__scenario_33__results.snap
@@ -41,4 +41,47 @@ expression: results
             },
         },
     ),
+    UnmatchedResponseBodyShape(
+        UnmatchedResponseBodyShape {
+            interaction_trail: InteractionTrail {
+                path: [
+                    ResponseBody {
+                        content_type: "application/json",
+                        status_code: 201,
+                    },
+                ],
+            },
+            requests_trail: SpecResponseBody(
+                SpecResponseBody {
+                    response_id: "response_Oq3x4otca8",
+                },
+            ),
+            shape_diff_result: UnmatchedShape {
+                json_trail: JsonTrail {
+                    path: [
+                        JsonObjectKey {
+                            key: "rating",
+                        },
+                    ],
+                },
+                shape_trail: ShapeTrail {
+                    root_shape_id: "shape_xjqKoYgnH6",
+                    path: [
+                        ObjectFieldTrail {
+                            field_id: "field_dcJtyX4lH0",
+                            field_shape_id: "shape_lhl794TnL5",
+                        },
+                        NullableTrail {
+                            shape_id: "shape_lhl794TnL5",
+                        },
+                        NullableItemTrail {
+                            shape_id: "shape_lhl794TnL5",
+                            inner_shape_id: "shape_p5uOLpFNK8",
+                        },
+                        UnknownTrail,
+                    ],
+                },
+            },
+        },
+    ),
 ]

--- a/workspaces/diff-engine/tests/snapshots/e2e_scenarios__scenario_3__results.snap
+++ b/workspaces/diff-engine/tests/snapshots/e2e_scenarios__scenario_3__results.snap
@@ -2,4 +2,41 @@
 source: workspaces/diff-engine/tests/e2e-scenarios.rs
 expression: results
 ---
-[]
+[
+    UnmatchedResponseBodyShape(
+        UnmatchedResponseBodyShape {
+            interaction_trail: InteractionTrail {
+                path: [
+                    ResponseBody {
+                        content_type: "application/json",
+                        status_code: 200,
+                    },
+                ],
+            },
+            requests_trail: SpecResponseBody(
+                SpecResponseBody {
+                    response_id: "response_1",
+                },
+            ),
+            shape_diff_result: UnmatchedShape {
+                json_trail: JsonTrail {
+                    path: [
+                        JsonArrayItem {
+                            index: 0,
+                        },
+                    ],
+                },
+                shape_trail: ShapeTrail {
+                    root_shape_id: "shape_3",
+                    path: [
+                        ListItemTrail {
+                            list_shape_id: "shape_3",
+                            item_shape_id: "shape_2",
+                        },
+                        UnknownTrail,
+                    ],
+                },
+            },
+        },
+    ),
+]

--- a/workspaces/diff-engine/tests/snapshots/e2e_scenarios__scenario_7__results.snap
+++ b/workspaces/diff-engine/tests/snapshots/e2e_scenarios__scenario_7__results.snap
@@ -48,4 +48,54 @@ expression: results
             },
         },
     ),
+    UnmatchedResponseBodyShape(
+        UnmatchedResponseBodyShape {
+            interaction_trail: InteractionTrail {
+                path: [
+                    ResponseBody {
+                        content_type: "application/json",
+                        status_code: 200,
+                    },
+                ],
+            },
+            requests_trail: SpecResponseBody(
+                SpecResponseBody {
+                    response_id: "baseline-response_1",
+                },
+            ),
+            shape_diff_result: UnmatchedShape {
+                json_trail: JsonTrail {
+                    path: [
+                        JsonArrayItem {
+                            index: 0,
+                        },
+                        JsonObjectKey {
+                            key: "price",
+                        },
+                    ],
+                },
+                shape_trail: ShapeTrail {
+                    root_shape_id: "baseline-shape_9",
+                    path: [
+                        ListItemTrail {
+                            list_shape_id: "baseline-shape_9",
+                            item_shape_id: "baseline-shape_8",
+                        },
+                        ObjectFieldTrail {
+                            field_id: "baseline-field_4",
+                            field_shape_id: "baseline-shape_7",
+                        },
+                        NullableTrail {
+                            shape_id: "baseline-shape_7",
+                        },
+                        NullableItemTrail {
+                            shape_id: "baseline-shape_7",
+                            inner_shape_id: "baseline-shape_6",
+                        },
+                        UnknownTrail,
+                    ],
+                },
+            },
+        },
+    ),
 ]

--- a/workspaces/diff-engine/tests/snapshots/shape_diff__can_diff_empty_json_array__fingerprints.snap
+++ b/workspaces/diff-engine/tests/snapshots/shape_diff__can_diff_empty_json_array__fingerprints.snap
@@ -1,0 +1,5 @@
+---
+source: workspaces/diff-engine/tests/shape_diff.rs
+expression: fingerprints
+---
+[]

--- a/workspaces/diff-engine/tests/snapshots/shape_diff__can_diff_empty_json_array__results.snap
+++ b/workspaces/diff-engine/tests/snapshots/shape_diff__can_diff_empty_json_array__results.snap
@@ -1,0 +1,5 @@
+---
+source: workspaces/diff-engine/tests/shape_diff.rs
+expression: results
+---
+[]

--- a/workspaces/diff-engine/tests/snapshots/shape_diff__can_diff_empty_json_array__shape_projection_graph.snap
+++ b/workspaces/diff-engine/tests/snapshots/shape_diff__can_diff_empty_json_array__shape_projection_graph.snap
@@ -1,0 +1,27 @@
+---
+source: workspaces/diff-engine/tests/shape_diff.rs
+expression: "Dot::with_config(&shape_projection.graph, &[])"
+---
+digraph {
+    0 [ label = "CoreShape(\l    CoreShapeNode(\l        \"$string\",\l        CoreShapeNodeDescriptor {\l            kind: StringKind,\l        },\l    ),\l)\l" ]
+    1 [ label = "CoreShape(\l    CoreShapeNode(\l        \"$number\",\l        CoreShapeNodeDescriptor {\l            kind: NumberKind,\l        },\l    ),\l)\l" ]
+    2 [ label = "CoreShape(\l    CoreShapeNode(\l        \"$boolean\",\l        CoreShapeNodeDescriptor {\l            kind: BooleanKind,\l        },\l    ),\l)\l" ]
+    3 [ label = "CoreShape(\l    CoreShapeNode(\l        \"$list\",\l        CoreShapeNodeDescriptor {\l            kind: ListKind,\l        },\l    ),\l)\l" ]
+    4 [ label = "ShapeParameter(\l    ShapeParameterNode(\l        \"$listItem\",\l        ShapeParameterNodeDescriptor,\l    ),\l)\l" ]
+    5 [ label = "CoreShape(\l    CoreShapeNode(\l        \"$object\",\l        CoreShapeNodeDescriptor {\l            kind: ObjectKind,\l        },\l    ),\l)\l" ]
+    6 [ label = "CoreShape(\l    CoreShapeNode(\l        \"$nullable\",\l        CoreShapeNodeDescriptor {\l            kind: NullableKind,\l        },\l    ),\l)\l" ]
+    7 [ label = "ShapeParameter(\l    ShapeParameterNode(\l        \"$nullableInner\",\l        ShapeParameterNodeDescriptor,\l    ),\l)\l" ]
+    8 [ label = "CoreShape(\l    CoreShapeNode(\l        \"$unknown\",\l        CoreShapeNodeDescriptor {\l            kind: UnknownKind,\l        },\l    ),\l)\l" ]
+    9 [ label = "CoreShape(\l    CoreShapeNode(\l        \"$optional\",\l        CoreShapeNodeDescriptor {\l            kind: OptionalKind,\l        },\l    ),\l)\l" ]
+    10 [ label = "ShapeParameter(\l    ShapeParameterNode(\l        \"$optionalInner\",\l        ShapeParameterNodeDescriptor,\l    ),\l)\l" ]
+    11 [ label = "CoreShape(\l    CoreShapeNode(\l        \"$oneOf\",\l        CoreShapeNodeDescriptor {\l            kind: OneOfKind,\l        },\l    ),\l)\l" ]
+    12 [ label = "Shape(\l    ShapeNode(\l        \"list_1\",\l        ShapeNodeDescriptor,\l    ),\l)\l" ]
+    13 [ label = "Shape(\l    ShapeNode(\l        \"number_shape_1\",\l        ShapeNodeDescriptor,\l    ),\l)\l" ]
+    4 -> 3 [ label = "IsParameterOf\l" ]
+    7 -> 6 [ label = "IsParameterOf\l" ]
+    10 -> 9 [ label = "IsParameterOf\l" ]
+    12 -> 3 [ label = "IsDescendantOf\l" ]
+    13 -> 1 [ label = "IsDescendantOf\l" ]
+    12 -> 4 [ label = "HasBinding(\l    ShapeParameterBinding {\l        shape_id: \"number_shape_1\",\l    },\l)\l" ]
+}
+

--- a/workspaces/diff-engine/tests/snapshots/shape_diff__can_diff_list_of_unknown__fingerprints.snap
+++ b/workspaces/diff-engine/tests/snapshots/shape_diff__can_diff_list_of_unknown__fingerprints.snap
@@ -1,0 +1,9 @@
+---
+source: workspaces/diff-engine/tests/shape_diff.rs
+expression: fingerprints
+---
+[
+    "1db406dd0c46798",
+    "1db406dd0c46798",
+    "1db406dd0c46798",
+]

--- a/workspaces/diff-engine/tests/snapshots/shape_diff__can_diff_list_of_unknown__results.snap
+++ b/workspaces/diff-engine/tests/snapshots/shape_diff__can_diff_list_of_unknown__results.snap
@@ -1,0 +1,63 @@
+---
+source: workspaces/diff-engine/tests/shape_diff.rs
+expression: results
+---
+[
+    UnmatchedShape {
+        json_trail: JsonTrail {
+            path: [
+                JsonArrayItem {
+                    index: 0,
+                },
+            ],
+        },
+        shape_trail: ShapeTrail {
+            root_shape_id: "list_1",
+            path: [
+                ListItemTrail {
+                    list_shape_id: "list_1",
+                    item_shape_id: "unknown_shape_1",
+                },
+                UnknownTrail,
+            ],
+        },
+    },
+    UnmatchedShape {
+        json_trail: JsonTrail {
+            path: [
+                JsonArrayItem {
+                    index: 1,
+                },
+            ],
+        },
+        shape_trail: ShapeTrail {
+            root_shape_id: "list_1",
+            path: [
+                ListItemTrail {
+                    list_shape_id: "list_1",
+                    item_shape_id: "unknown_shape_1",
+                },
+                UnknownTrail,
+            ],
+        },
+    },
+    UnmatchedShape {
+        json_trail: JsonTrail {
+            path: [
+                JsonArrayItem {
+                    index: 2,
+                },
+            ],
+        },
+        shape_trail: ShapeTrail {
+            root_shape_id: "list_1",
+            path: [
+                ListItemTrail {
+                    list_shape_id: "list_1",
+                    item_shape_id: "unknown_shape_1",
+                },
+                UnknownTrail,
+            ],
+        },
+    },
+]

--- a/workspaces/diff-engine/tests/snapshots/shape_diff__can_diff_list_of_unknown__shape_projection_graph.snap
+++ b/workspaces/diff-engine/tests/snapshots/shape_diff__can_diff_list_of_unknown__shape_projection_graph.snap
@@ -1,0 +1,27 @@
+---
+source: workspaces/diff-engine/tests/shape_diff.rs
+expression: "Dot::with_config(&shape_projection.graph, &[])"
+---
+digraph {
+    0 [ label = "CoreShape(\l    CoreShapeNode(\l        \"$string\",\l        CoreShapeNodeDescriptor {\l            kind: StringKind,\l        },\l    ),\l)\l" ]
+    1 [ label = "CoreShape(\l    CoreShapeNode(\l        \"$number\",\l        CoreShapeNodeDescriptor {\l            kind: NumberKind,\l        },\l    ),\l)\l" ]
+    2 [ label = "CoreShape(\l    CoreShapeNode(\l        \"$boolean\",\l        CoreShapeNodeDescriptor {\l            kind: BooleanKind,\l        },\l    ),\l)\l" ]
+    3 [ label = "CoreShape(\l    CoreShapeNode(\l        \"$list\",\l        CoreShapeNodeDescriptor {\l            kind: ListKind,\l        },\l    ),\l)\l" ]
+    4 [ label = "ShapeParameter(\l    ShapeParameterNode(\l        \"$listItem\",\l        ShapeParameterNodeDescriptor,\l    ),\l)\l" ]
+    5 [ label = "CoreShape(\l    CoreShapeNode(\l        \"$object\",\l        CoreShapeNodeDescriptor {\l            kind: ObjectKind,\l        },\l    ),\l)\l" ]
+    6 [ label = "CoreShape(\l    CoreShapeNode(\l        \"$nullable\",\l        CoreShapeNodeDescriptor {\l            kind: NullableKind,\l        },\l    ),\l)\l" ]
+    7 [ label = "ShapeParameter(\l    ShapeParameterNode(\l        \"$nullableInner\",\l        ShapeParameterNodeDescriptor,\l    ),\l)\l" ]
+    8 [ label = "CoreShape(\l    CoreShapeNode(\l        \"$unknown\",\l        CoreShapeNodeDescriptor {\l            kind: UnknownKind,\l        },\l    ),\l)\l" ]
+    9 [ label = "CoreShape(\l    CoreShapeNode(\l        \"$optional\",\l        CoreShapeNodeDescriptor {\l            kind: OptionalKind,\l        },\l    ),\l)\l" ]
+    10 [ label = "ShapeParameter(\l    ShapeParameterNode(\l        \"$optionalInner\",\l        ShapeParameterNodeDescriptor,\l    ),\l)\l" ]
+    11 [ label = "CoreShape(\l    CoreShapeNode(\l        \"$oneOf\",\l        CoreShapeNodeDescriptor {\l            kind: OneOfKind,\l        },\l    ),\l)\l" ]
+    12 [ label = "Shape(\l    ShapeNode(\l        \"list_1\",\l        ShapeNodeDescriptor,\l    ),\l)\l" ]
+    13 [ label = "Shape(\l    ShapeNode(\l        \"unknown_shape_1\",\l        ShapeNodeDescriptor,\l    ),\l)\l" ]
+    4 -> 3 [ label = "IsParameterOf\l" ]
+    7 -> 6 [ label = "IsParameterOf\l" ]
+    10 -> 9 [ label = "IsParameterOf\l" ]
+    12 -> 3 [ label = "IsDescendantOf\l" ]
+    13 -> 8 [ label = "IsDescendantOf\l" ]
+    12 -> 4 [ label = "HasBinding(\l    ShapeParameterBinding {\l        shape_id: \"unknown_shape_1\",\l    },\l)\l" ]
+}
+


### PR DESCRIPTION
When a value is only observed as an empty list or null, it is defined as a List of Unknown or a Nullable of Unknown. When presented with a non-empty list or non-null value, it should yield a diff so the Unknown can be set based on the newly observed shape.