### PR TITLE
display issues from the new diff engine on the review diff page

### DIFF
--- a/workspaces/ui/src/components/diff/review-diff/LoadingPage.js
+++ b/workspaces/ui/src/components/diff/review-diff/LoadingPage.js
@@ -9,6 +9,8 @@ import {
 import { Typography } from '@material-ui/core';
 import { useCaptureContext } from '../../../contexts/CaptureContext';
 import { useServices } from '../../../contexts/SpecServiceContext';
+import { CodeBlock } from '../../setup-page/setup-api/CodeBlock';
+import { MarkdownRender } from '../../docs/DocContribution';
 
 const pJson = require('../../../../package.json');
 export function LoadingReviewPage() {
@@ -53,6 +55,57 @@ export function LoadingReviewPage() {
             <Typography variant="caption" style={{ fontWeight: 200 }}>
               Diff Engine v{pJson.version}
             </Typography>
+          </div>
+        </Paper>
+      </Page.Body>
+    </Page>
+  );
+}
+
+export function ErrorLoadingReviewPage() {
+  const classes = useStyles();
+
+  const { specService } = useServices();
+
+  const { completed, skipped, processed, captureId } = useCaptureContext();
+  const [status, setStatus] = useState(null);
+
+  useEffect(() => {
+    specService.getCaptureStatus(captureId).then((i) => setStatus(i));
+  }, [captureId]);
+
+  const cursor = parseInt(processed) + parseInt(skipped);
+
+  const total = status && status.interactionsCount;
+
+  return (
+    <Page>
+      <Page.Navbar mini={true} />
+      <Page.Body
+        padded={false}
+        style={{
+          flexDirection: 'row',
+          height: '100vh',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Paper elevation={1} className={classes.loading}>
+          <div>
+            <Typography variant="h6" color="error" style={{ fontWeight: 200 }}>
+              Diff Could Not be Completed
+            </Typography>
+            <Typography variant="caption" style={{ fontWeight: 200 }}>
+              Diff Engine v{pJson.version}
+            </Typography>
+
+            <MarkdownRender
+              source={`
+- Share a debug capture with the Optic team on Slack (JSON values omitted)
+- Revert recent changes to specification.json to get unblocked`}
+            />
+
+            <CodeBlock lang="bash" code={`api debug:capture ${captureId}`} />
           </div>
         </Paper>
       </Page.Body>

--- a/workspaces/ui/src/components/diff/review-diff/ReviewDiffSession.js
+++ b/workspaces/ui/src/components/diff/review-diff/ReviewDiffSession.js
@@ -6,7 +6,7 @@ import { makeDiffRfcBaseState } from '../../../engine/interfaces/diff-rfc-base-s
 import { ReviewUI } from './ReviewUI';
 import { useDiffSessionMachine } from '../../../engine/hooks/session-hook';
 import { RfcContext } from '../../../contexts/RfcContext';
-import { LoadingReviewPage } from './LoadingPage';
+import { ErrorLoadingReviewPage, LoadingReviewPage } from './LoadingPage';
 import Page from '../../Page';
 import { useAnalyticsHook } from '../../../utilities/useAnalyticsHook';
 
@@ -70,7 +70,12 @@ export function DiffSessionMachineStore(props) {
     loadInteraction: captureService.loadInteraction.bind(captureService),
   });
 
-  const { completed, rawDiffs, unrecognizedUrlsRaw } = useCaptureContext();
+  const {
+    completed,
+    rawDiffs,
+    unrecognizedUrlsRaw,
+    didFail,
+  } = useCaptureContext();
 
   const [statedTime] = useState(Date.now());
 
@@ -112,6 +117,10 @@ export function DiffSessionMachineStore(props) {
       return captureService.loadInteraction(interactionPointer);
     },
   };
+
+  if (didFail) {
+    return <ErrorLoadingReviewPage />;
+  }
 
   return (
     <DiffSessionContext.Provider value={reactContext}>

--- a/workspaces/ui/src/contexts/CaptureContext.js
+++ b/workspaces/ui/src/contexts/CaptureContext.js
@@ -29,7 +29,7 @@ const initialState = (debouncer = null) => {
     completed: false,
     skipped: '0',
     processed: '0',
-
+    didFail: false,
     reloadDebounce: debouncer,
     unrecognizedUrls: [],
     endpointDiffs: [],
@@ -196,8 +196,8 @@ class _CaptureContextStore extends React.Component {
           this.state.reloadDebounce(data);
         } else if (type === 'error') {
           console.error(data);
+          this.setState({ didFail: true });
           notificationChannel.close();
-          debugger;
         }
       };
       notificationChannel.onerror = (e) => {
@@ -239,6 +239,7 @@ class _CaptureContextStore extends React.Component {
       diffService,
       captureService,
       completed,
+      didFail,
       skipped,
       processed,
       rawDiffs,
@@ -261,6 +262,7 @@ class _CaptureContextStore extends React.Component {
       unrecognizedUrls,
       diffService,
       captureService,
+      didFail,
       completed,
       skipped,
       processed,


### PR DESCRIPTION
this PR listens for error notifications from the diff engine and gracefully displays them on the UI with further instructions 

<img width="923" alt="Screen Shot 2021-01-14 at 8 00 21 AM" src="https://user-images.githubusercontent.com/5900338/104594172-c6e83580-563e-11eb-8c1a-bae903c9f6a8.png">
