### PR TITLE
Fix Setup page YAML editor validation

### DIFF
--- a/workspaces/agent-cli/package.json
+++ b/workspaces/agent-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/agent-cli",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "author": "@useoptic",
   "bin": {
     "optic-agent": "./bin/run"
@@ -15,7 +15,7 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^3",
-    "@useoptic/cli-shared": "9.0.3",
+    "@useoptic/cli-shared": "9.0.4",
     "dotenv": "^8.2.0",
     "jwt-decode": "^2.2.0",
     "tslib": "^1",

--- a/workspaces/analytics/package.json
+++ b/workspaces/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/analytics",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "scripts": {
     "ws:build": "tsc -b --verbose",
     "ws:clean": "rm -rf build/*",

--- a/workspaces/ci-cli/package.json
+++ b/workspaces/ci-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/ci-cli",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "author": "@useoptic",
   "bin": {
     "optic-ci": "./bin/run"
@@ -15,8 +15,8 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^3",
-    "@useoptic/cli-config": "9.0.3",
-    "@useoptic/cli-shared": "9.0.3",
+    "@useoptic/cli-config": "9.0.4",
+    "@useoptic/cli-shared": "9.0.4",
     "dotenv": "^8.2.0",
     "jwt-decode": "^2.2.0",
     "tslib": "^1",

--- a/workspaces/cli-client/package.json
+++ b/workspaces/cli-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-client",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",
@@ -14,9 +14,9 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "dependencies": {
-    "@useoptic/analytics": "9.0.3",
-    "@useoptic/cli-config": "9.0.3",
-    "@useoptic/client-utilities": "9.0.3",
+    "@useoptic/analytics": "9.0.4",
+    "@useoptic/cli-config": "9.0.4",
+    "@useoptic/client-utilities": "9.0.4",
     "bottleneck": "^2.19.5",
     "cross-fetch": "^3.0.4"
   },

--- a/workspaces/cli-config/package.json
+++ b/workspaces/cli-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-config",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "scripts": {
     "ws:test": "jest",
     "ws:build": "yarn run tsc -b --verbose",

--- a/workspaces/cli-scripts/package.json
+++ b/workspaces/cli-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-scripts",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "scripts": {
     "ws:test": "echo scripts",
     "ws:build": "yarn run tsc -b --verbose",
@@ -18,8 +18,8 @@
     "@sentry/tracing": "^5.28.0",
     "node-notifier": "^7.0.0",
     "analytics-node": "^3.4.0-beta.1",
-    "@useoptic/cli-config": "9.0.3",
-    "@useoptic/cli-shared": "9.0.3"
+    "@useoptic/cli-config": "9.0.4",
+    "@useoptic/cli-shared": "9.0.4"
   },
   "devDependencies": {
     "@types/node-notifier": "^6.0.1"

--- a/workspaces/cli-server/package.json
+++ b/workspaces/cli-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-server",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",
@@ -16,13 +16,13 @@
   "dependencies": {
     "@sentry/node": "^5.28.0",
     "@sentry/tracing": "^5.28.0",
-    "@useoptic/analytics": "9.0.3",
-    "@useoptic/cli-client": "9.0.3",
-    "@useoptic/cli-config": "9.0.3",
-    "@useoptic/cli-scripts": "9.0.3",
-    "@useoptic/cli-shared": "9.0.3",
-    "@useoptic/diff-engine-wasm": "9.0.3",
-    "@useoptic/ui": "9.0.3",
+    "@useoptic/analytics": "9.0.4",
+    "@useoptic/cli-client": "9.0.4",
+    "@useoptic/cli-config": "9.0.4",
+    "@useoptic/cli-scripts": "9.0.4",
+    "@useoptic/cli-shared": "9.0.4",
+    "@useoptic/diff-engine-wasm": "9.0.4",
+    "@useoptic/ui": "9.0.4",
     "analytics-node": "^3.4.0-beta.2",
     "avsc": "^5.4.18",
     "body-parser": "^1.19.0",

--- a/workspaces/cli-shared/package.json
+++ b/workspaces/cli-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli-shared",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "scripts": {
     "test": "cd test && tap tests",
     "ws:build": "yarn run tsc -b --verbose",
@@ -16,11 +16,11 @@
   "types": "build/index.d.ts",
   "dependencies": {
     "@oclif/command": "^1.6.1",
-    "@useoptic/cli-client": "9.0.3",
-    "@useoptic/cli-config": "9.0.3",
-    "@useoptic/client-utilities": "9.0.3",
-    "@useoptic/diff-engine": "9.0.3",
-    "@useoptic/diff-engine-wasm": "9.0.3",
+    "@useoptic/cli-client": "9.0.4",
+    "@useoptic/cli-config": "9.0.4",
+    "@useoptic/client-utilities": "9.0.4",
+    "@useoptic/diff-engine": "9.0.4",
+    "@useoptic/diff-engine-wasm": "9.0.4",
     "@useoptic/domain": "10.0.64",
     "@useoptic/domain-types": "10.0.64",
     "@useoptic/domain-utilities": "10.0.64",

--- a/workspaces/client-utilities/package.json
+++ b/workspaces/client-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/client-utilities",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",

--- a/workspaces/diff-engine-wasm/package.json
+++ b/workspaces/diff-engine-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/diff-engine-wasm",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "scripts": {
     "build:lib": "tsc -b --verbose",
     "build:node": "cd engine && wasm-pack build --target nodejs --out-dir build --out-name index",

--- a/workspaces/diff-engine/package.json
+++ b/workspaces/diff-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/diff-engine",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "scripts": {
     "postinstall": "node scripts/install",
     "preuninstall": "node scripts/uninstall",

--- a/workspaces/local-cli/package.json
+++ b/workspaces/local-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/cli",
   "description": "The Optic CLI",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "author": "@useoptic",
   "bin": {
     "api": "./bin/run"
@@ -18,12 +18,12 @@
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^2",
     "cli-table3": "^0.6.0",
-    "@useoptic/analytics": "9.0.3",
-    "@useoptic/cli-client": "9.0.3",
-    "@useoptic/cli-config": "9.0.3",
-    "@useoptic/cli-scripts": "9.0.3",
-    "@useoptic/cli-server": "9.0.3",
-    "@useoptic/cli-shared": "9.0.3",
+    "@useoptic/analytics": "9.0.4",
+    "@useoptic/cli-client": "9.0.4",
+    "@useoptic/cli-config": "9.0.4",
+    "@useoptic/cli-scripts": "9.0.4",
+    "@useoptic/cli-server": "9.0.4",
+    "@useoptic/cli-shared": "9.0.4",
     "@useoptic/domain": "10.0.64",
     "analytics-node": "^3.4.0-beta.1",
     "cli-ux": "^5.4.1",

--- a/workspaces/saas-types/package.json
+++ b/workspaces/saas-types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/saas-types",
   "description": "interfaces and types for Optic SaaS surface area",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "main": "build/index.js",
   "files": [
     "build"

--- a/workspaces/snapshot-tests/package.json
+++ b/workspaces/snapshot-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/snapshot-tests",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "scripts": {
     "ws:build": "yarn run tsc -b --verbose",
     "ws:clean": "rm -rf build/*",
@@ -15,8 +15,8 @@
     "@useoptic/domain": "10.0.64",
     "@useoptic/domain-types": "10.0.64",
     "@useoptic/domain-utilities": "10.0.64",
-    "@useoptic/client-utilities": "9.0.3",
-    "@useoptic/cli-shared": "9.0.3",
+    "@useoptic/client-utilities": "9.0.4",
+    "@useoptic/cli-shared": "9.0.4",
     "dataloader": "^2.0.0",
     "eventsource": "^1.0.7",
     "fs-extra": "^9.0.0"

--- a/workspaces/ui/package.json
+++ b/workspaces/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/ui",
-  "version": "9.0.3",
+  "version": "9.0.4",
   "files": [
     "build",
     "index.js",
@@ -15,10 +15,10 @@
     "@material-ui/core": "^4.9.7",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.46",
-    "@useoptic/cli-shared": "9.0.3",
-    "@useoptic/cli-client": "9.0.3",
-    "@useoptic/analytics": "9.0.3",
-    "@useoptic/diff-engine-wasm": "9.0.3",
+    "@useoptic/cli-shared": "9.0.4",
+    "@useoptic/cli-client": "9.0.4",
+    "@useoptic/analytics": "9.0.4",
+    "@useoptic/diff-engine-wasm": "9.0.4",
     "@useoptic/domain": "10.0.64",
     "@useoptic/domain-utilities": "10.0.64",
     "bottleneck": "^2.19.5",

--- a/workspaces/ui/src/components/setup-page/SetupPage.js
+++ b/workspaces/ui/src/components/setup-page/SetupPage.js
@@ -277,20 +277,11 @@ function PortAssumption(props) {
         title={
           <div>
             <Typography variant="overline">examples:</Typography>
-            {docs && (
-              <MarkdownRender
-                source={
-                  docs.data.preamble + '\n\n```' + docs.data.after + '\n```'
-                }
-              />
-            )}
-            {!docs && (
               <MarkdownRender
                 source={
                   "\n```\n//when your starts and binds to a port...\napi.listen(env['PORT'])\n```"
                 }
               />
-            )}
           </div>
         }
       >

--- a/workspaces/ui/src/components/setup-page/setup-and-check-machine.ts
+++ b/workspaces/ui/src/components/setup-page/setup-and-check-machine.ts
@@ -3,6 +3,7 @@ import { ISpecService } from '@useoptic/cli-client/build/spec-service-client';
 import { CheckAssertionsResult } from '@useoptic/analytics/lib/interfaces/ApiCheck';
 import { rangesFromOpticYaml, RangesFromYaml } from './yaml/YamlHelper';
 import { integrationDocsOptions } from './fetch-docs/IntegrationDocs';
+import {load} from "yaml-ast-parser";
 
 export interface SetupAndCheckMachineSchema {
   states: {
@@ -72,6 +73,12 @@ export const newSetupAndCheckMachine = (
       saving: {
         invoke: {
           src: async (context, event) => {
+            const isValid = load(context.stagedConfig).errors.length === 0;
+
+            if (!isValid) {
+              return Promise.resolve()
+            }
+
             return await specService.saveConfig(context.stagedConfig);
           },
           onDone: {


### PR DESCRIPTION
Invalid YAML (from incremental user input) was allowed to persist to disk breaking the UI. This was missed in testing because of the save debouncer which plastered over the issue since it would not try to save anything until 2 seconds of no typing. If you input changes slowly the issue pops up immediately. 

