### PR TITLE
ignore rule: added .ico files to default ignore rules

### DIFF
--- a/workspaces/cli-config/src/helpers/default-ignore-rules.ts
+++ b/workspaces/cli-config/src/helpers/default-ignore-rules.ts
@@ -3,6 +3,7 @@ export const defaultIgnoreRules = [
   'HEAD *',
   'GET (.*).htm',
   'GET (.*).html',
+  'GET (.*).ico',
   'GET (.*).css',
   'GET (.*).js',
   'GET (.*).woff',


### PR DESCRIPTION
One-liner to update default ignore rules. Chose to ignore all .icos since there shouldn't be a reason to document GETting those ever, but this is inspired specifically by favicon.ico and we can dial that in if preferred.