### PR TITLE
feat: containerize demo

### DIFF
--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -1,21 +1,20 @@
-name: Deploy Demo
+name: Build and deploy demo
+
 on:
   push:
     branches:
       - release
   pull_request:
     branches: [ 'develop' ]
+
 jobs:
   build-demo-and-push:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Set branch name
-        run: echo "BRANCH=$GITHUB_REF" >> $GITHUB_ENV
-
+      - run: echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
       - name: Set contextual vars
         run: |
-          if [ "$BRANCH" = "refs/heads/release" ]; then
+          if [ "$BRANCH" = "release" ]; then
             echo "BUCKET=optic-demo-website-production" >> $GITHUB_ENV
             echo "SITE_URL=https://demo.useoptic.com" >> $GITHUB_ENV
             echo "CLOUDFRONT_DIST=E1OKG70IUZ446Q" >> $GITHUB_ENV
@@ -24,7 +23,6 @@ jobs:
             echo "SITE_URL=https://demo.o3c.info" >> $GITHUB_ENV
             echo "CLOUDFRONT_DIST=E937BFTMG9NX3" >> $GITHUB_ENV
           fi
-
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@1417e62aeacec5e7fbe447bb7712d50847507342 # v1.5.4
         with:

--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -18,6 +18,7 @@ jobs:
       - run: |
           echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
       - run: |
+          echo "DEBUG ${GITHUB_REF} ${BRANCH}"
           if [ "$BRANCH" = "release" ]; then
             echo "BUCKET=optic-demo-website-production" >> $GITHUB_ENV
             echo "PUBLIC_URL=https://demo.useoptic.com" >> $GITHUB_ENV

--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -51,7 +51,7 @@ jobs:
       - run: task ui:demo:ci
       - uses: Ilshidur/action-slack@689ad44a9c9092315abd286d0e3a9a74d31ab78a # v2.1.0
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK: ${{ secrets.BUILD_BOT_SLACK_WEBHOOK_URL }}
         with:
           args: >
             {{ GITHUB_ACTOR }}: Pushed ${DOCKER_REGISTRY}/${REPO}:${TAG}

--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -47,6 +47,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@060516122e7b4cc1cc3d4614a998adbb93d3fbf2 # v1.2.2
       - run: |
           echo "DOCKER_REGISTRY=${{ steps.login-ecr.outputs.registry }}" >> $GITHUB_ENV
+          echo "REPO=demo" >> $GITHUB_ENV
           echo "TAG=${BRANCH}-b${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
       - run: task ui:demo:ci
       - uses: Ilshidur/action-slack@689ad44a9c9092315abd286d0e3a9a74d31ab78a # v2.1.0

--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - release
   pull_request:
-    branches: [ 'develop' ]
+    branches: [develop]
 
 jobs:
   build-and-push:

--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -20,11 +20,9 @@ jobs:
       - run: |
           if [ "$BRANCH" = "release" ]; then
             echo "BUCKET=optic-demo-website-production" >> $GITHUB_ENV
-            echo "PUBLIC_URL=https://demo.useoptic.com" >> $GITHUB_ENV
             echo "CLOUDFRONT_DIST=E1OKG70IUZ446Q" >> $GITHUB_ENV
           else
             echo "BUCKET=optic-demo-website-staging" >> $GITHUB_ENV
-            echo "PUBLIC_URL=https://demo.o3c.info" >> $GITHUB_ENV
             echo "CLOUDFRONT_DIST=E937BFTMG9NX3" >> $GITHUB_ENV
           fi
       - name: Install Task

--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -18,7 +18,7 @@ jobs:
       - run: |
           echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
       - run: |
-          echo "DEBUG ${GITHUB_REF} ${BRANCH}"
+          echo "DEBUG ${GITHUB_REF} ${BRANCH} ${GITHUB_HEAD_REF}"
           if [ "$BRANCH" = "release" ]; then
             echo "BUCKET=optic-demo-website-production" >> $GITHUB_ENV
             echo "PUBLIC_URL=https://demo.useoptic.com" >> $GITHUB_ENV

--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -16,9 +16,8 @@ jobs:
         with:
           token: ${{ github.token }}
       - run: |
-          echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
+          echo "BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
       - run: |
-          echo "DEBUG ${GITHUB_REF} ${BRANCH} ${GITHUB_HEAD_REF}"
           if [ "$BRANCH" = "release" ]; then
             echo "BUCKET=optic-demo-website-production" >> $GITHUB_ENV
             echo "PUBLIC_URL=https://demo.useoptic.com" >> $GITHUB_ENV

--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -1,4 +1,4 @@
-name: Build and deploy demo
+name: Deploy Optic Demo
 
 on:
   push:
@@ -8,48 +8,44 @@ on:
     branches: [ 'develop' ]
 
 jobs:
-  build-demo-and-push:
+  build-and-push:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
-      - name: Set contextual vars
-        run: |
+      - name: Checkout
+        uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # v2.3.3
+        with:
+          token: ${{ github.token }}
+      - run: |
+          echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
+      - run: |
           if [ "$BRANCH" = "release" ]; then
             echo "BUCKET=optic-demo-website-production" >> $GITHUB_ENV
-            echo "SITE_URL=https://demo.useoptic.com" >> $GITHUB_ENV
+            echo "PUBLIC_URL=https://demo.useoptic.com" >> $GITHUB_ENV
             echo "CLOUDFRONT_DIST=E1OKG70IUZ446Q" >> $GITHUB_ENV
           else
             echo "BUCKET=optic-demo-website-staging" >> $GITHUB_ENV
-            echo "SITE_URL=https://demo.o3c.info" >> $GITHUB_ENV
+            echo "PUBLIC_URL=https://demo.o3c.info" >> $GITHUB_ENV
             echo "CLOUDFRONT_DIST=E937BFTMG9NX3" >> $GITHUB_ENV
           fi
+      - name: Install Task
+        uses: Arduino/actions/setup-taskfile@9d04a51fc17daddb0eb127933aaa950af1e3ff97 # they dont give us any tags :\
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Configure Node
+        uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d # v1.4.4
+        with:
+          node-version: 12
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@1417e62aeacec5e7fbe447bb7712d50847507342 # v1.5.4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: "us-east-1"
-      - uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d # v1.4.4
-        with:
-          node-version: 12
-      - name: Checkout Optic Repository
-        uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # v2.3.3
-        with:
-            token: ${{ github.token }}
-      - name: Install Dependencies and Build Optic
-        run:  |
-          source ./sourceme.sh
-          optic_build_for_release
-      - name: Build Demo Site
-        run: yarn build-demo
-        env:
-          PUBLIC_URL: ${{ env.SITE_URL }}
-          CI: false # required since otherwise the warnings in react cause a fail to compile
-
-      # `--acl=public-read` is neceesary because the prod account is uploading the files to the staging bucket,
-      # which prevents the default bucket policy from applying to these objects
-      - name: Upload to S3
-        run: |
-          aws s3 sync workspaces/ui/build/ "s3://$BUCKET/" \
-            --sse=AES256 \
-            --acl=public-read
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@060516122e7b4cc1cc3d4614a998adbb93d3fbf2 # v1.2.2
+      - run: |
+          echo "DOCKER_REGISTRY=${{ steps.login-ecr.outputs.registry }}" >> $GITHUB_ENV
+          echo "TAG=${BRANCH}-b${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
+      - run: task ui:demo:ci

--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -49,3 +49,9 @@ jobs:
           echo "DOCKER_REGISTRY=${{ steps.login-ecr.outputs.registry }}" >> $GITHUB_ENV
           echo "TAG=${BRANCH}-b${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
       - run: task ui:demo:ci
+      - uses: Ilshidur/action-slack@689ad44a9c9092315abd286d0e3a9a74d31ab78a # v2.1.0
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          args: >
+            {{ GITHUB_ACTOR }}: Pushed ${DOCKER_REGISTRY}/${REPO}:${TAG}

--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -53,5 +53,4 @@ jobs:
         env:
           SLACK_WEBHOOK: ${{ secrets.BUILD_BOT_SLACK_WEBHOOK_URL }}
         with:
-          args: >
-            {{ GITHUB_ACTOR }}: Pushed ${DOCKER_REGISTRY}/${REPO}:${TAG}
+          args: "{{ GITHUB_ACTOR }}: `{{ REPO }}:{{ TAG }}` was pushed to our Docker registry."

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -25,14 +25,6 @@ tasks:
       # - workspace/diff-engine-wasm/engine/target/**/* # do we need this?
       - workspaces/*/build/**/*
 
-  demo:build:
-    dir: workspaces/ui
-    env:
-      PUBLIC_URL: "https://demo.o3c.info"
-      CI: "false"
-    cmds:
-      - yarn build-demo
-
   spec:build:
     dir: workspaces/ui
     env:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,5 +1,8 @@
 version: "3"
 
+dotenv:
+  - .env
+
 includes:
   diff-engine:
     taskfile: workspaces/diff-engine/Taskfile.yml
@@ -8,12 +11,15 @@ includes:
     dir: workspaces/ui
 
 tasks:
-  setup:
+  workspaces:setup:
+    env:
+      OPTIC_SKIP_PREBUILT_INSTALLS: "true"
     cmds:
       - yarn install
 
   workspaces:build:
-    deps: [setup]
+    desc: Build Yarn workspaces
+    deps: ["workspaces:setup"]
     cmds:
       - yarn wsrun --stages --report --fast-exit --exclude-missing ws:build
     sources:
@@ -24,6 +30,11 @@ tasks:
       - workspaces/diff-engine-wasm/engine/build/**/*
       # - workspace/diff-engine-wasm/engine/target/**/* # do we need this?
       - workspaces/*/build/**/*
+
+  workspaces:clean:
+    desc: Remove previous build artifacts
+    cmds:
+      - yarn wsrun --stages --report --fast-exit ws:clean
 
   spec:build:
     dir: workspaces/ui

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,6 +3,9 @@ version: "3"
 includes:
   diff-engine:
     taskfile: workspaces/diff-engine/Taskfile.yml
+  ui:
+    taskfile: workspaces/ui/Taskfile.yml
+    dir: workspaces/ui
 
 tasks:
   setup:

--- a/workspaces/ui/Dockerfile_demo
+++ b/workspaces/ui/Dockerfile_demo
@@ -1,4 +1,5 @@
 FROM library/nginx:alpine
 COPY build/ /usr/share/nginx/html/
-COPY config/nginx/ /etc/nginx/
+COPY config/nginx/demo.nginx.conf /etc/nginx/nginx.conf
+COPY config/nginx/mime.types /etc/nginx/
 EXPOSE 80

--- a/workspaces/ui/Dockerfile_demo
+++ b/workspaces/ui/Dockerfile_demo
@@ -1,0 +1,4 @@
+FROM library/nginx:alpine
+COPY build/ /usr/share/nginx/html/
+COPY config/nginx/ /etc/nginx/
+EXPOSE 80

--- a/workspaces/ui/README.md
+++ b/workspaces/ui/README.md
@@ -1,74 +1,14 @@
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
-## Available Scripts
+# UI
 
-In the project directory, you can run:
+This directory builds several projects, see `yarn run` or `task -l` for available options
 
-### `npm start`
+## Demo
 
-Runs the app in the development mode.<br>
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
-
-The page will reload if you make edits.<br>
-You will also see any lint errors in the console.
-
-### `npm test`
-
-Launches the test runner in the interactive watch mode.<br>
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
-
-### `npm run build`
-
-Builds the app for production to the `build` folder.<br>
-It correctly bundles React in production mode and optimizes the build for the best performance.
-
-The build is minified and the filenames include the hashes.<br>
-Your app is ready to be deployed!
-
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-### `npm run eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
-
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (Webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
-
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
-
-### Code Splitting
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/code-splitting
-
-### Analyzing the Bundle Size
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size
-
-### Making a Progressive Web App
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app
-
-### Advanced Configuration
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/advanced-configuration
-
-### Deployment
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/deployment
-
-### `npm run build` fails to minify
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify
+Demo runs in K8s and deploys from [monorail](https://github.com/opticdev/monorail/tree/master/projects/demo).
 
 ## Contributors ✨
 

--- a/workspaces/ui/Taskfile.yml
+++ b/workspaces/ui/Taskfile.yml
@@ -7,8 +7,7 @@ env:
 tasks:
   demo:build:
     desc: Build demo site
-    deps:
-      - :workspaces:clean
+    deps: [":workspaces:setup"]
     env:
       PUBLIC_URL: "https://demo.o3c.info"
       CI: "false"
@@ -27,6 +26,8 @@ tasks:
 
   demo:ci:
     desc: CI workflow
+    deps: [":workspaces:setup"]
     cmds:
+      - task: :workspaces:clean
       - task: demo:docker:build
       - task: demo:docker:push

--- a/workspaces/ui/Taskfile.yml
+++ b/workspaces/ui/Taskfile.yml
@@ -1,0 +1,14 @@
+version: "3"
+
+tasks:
+  demo:build:
+    desc: Builds static demo site
+    cmds:
+      - source ../../sourceme.sh && optic_build_for_release
+      - yarn build-demo
+
+  demo:docker:
+    desc: Build and package demo site as a Docker container
+    deps: ["demo:build"]
+    cmds:
+      - docker build . -f Dockerfile_demo -t some-dumb-image

--- a/workspaces/ui/Taskfile.yml
+++ b/workspaces/ui/Taskfile.yml
@@ -10,7 +10,7 @@ tasks:
     cmds:
       - task: :workspaces:build
       # required due to the way env inheritance winds up working. setting this in
-      # the env block will _not_ stock, at in gha
+      # the env block on this task will not work.
       - CI=false yarn build-demo
 
   demo:docker:build:
@@ -18,15 +18,20 @@ tasks:
     deps: ["demo:build"]
     cmds:
       - docker build . -f Dockerfile_demo -t $DOCKER_REGISTRY/$REPO:$TAG
-      # TODO(nate): add a 'latest' tag when this is a develop build
 
   demo:docker:push:
     - docker push $DOCKER_REGISTRY/$REPO:$TAG
+    - |
+      if [[ "$TAG" =~ ^release-b ]]
+      then
+        docker tag $DOCKER_REGISTRY/$REPO:$TAG $DOCKER_REGISTRY/$REPO:latest
+        docker push $DOCKER_REGISTRY/$REPO:latest
+      fi
 
   demo:ci:
     desc: CI workflow
     deps: [":workspaces:setup"]
     cmds:
-      #- task: :workspaces:clean
+      - task: :workspaces:clean
       - task: demo:docker:build
       - task: demo:docker:push

--- a/workspaces/ui/Taskfile.yml
+++ b/workspaces/ui/Taskfile.yml
@@ -2,13 +2,25 @@ version: "3"
 
 tasks:
   demo:build:
-    desc: Builds static demo site
+    desc: Build demo site
     cmds:
       - source ../../sourceme.sh && optic_build_for_release
       - yarn build-demo
 
-  demo:docker:
+  demo:docker:build:
     desc: Build and package demo site as a Docker container
     deps: ["demo:build"]
     cmds:
       - docker build . -f Dockerfile_demo -t some-dumb-image
+
+  # demo:docker:push:
+  #   - docker push blah
+
+  # demo:ci:
+  #   desc: CI workflow
+  #   cmds:
+  #     - task: demo:docker:build
+  #     - task: demo:docker:push
+  #     - task: :announce-build
+  #       vars:
+  #         MESSAGE: "Did something"

--- a/workspaces/ui/Taskfile.yml
+++ b/workspaces/ui/Taskfile.yml
@@ -7,13 +7,13 @@ env:
 tasks:
   demo:build:
     desc: Build demo site
-    deps: [":workspaces:setup"]
     env:
       PUBLIC_URL: "https://demo.o3c.info"
-      CI: "false"
+      CI: false
     cmds:
+      - echo "DEBUG: $CI"
       - task: :workspaces:build
-      - yarn build-demo
+      - CI=false yarn build-demo
 
   demo:docker:build:
     desc: Build and package demo site as a Docker container
@@ -28,6 +28,6 @@ tasks:
     desc: CI workflow
     deps: [":workspaces:setup"]
     cmds:
-      - task: :workspaces:clean
+      #- task: :workspaces:clean
       - task: demo:docker:build
       - task: demo:docker:push

--- a/workspaces/ui/Taskfile.yml
+++ b/workspaces/ui/Taskfile.yml
@@ -1,26 +1,37 @@
 version: "3"
 
+env:
+  REPO: demo
+  DOCKER_REGISTRY: 513974440343.dkr.ecr.us-east-1.amazonaws.com
+
 tasks:
   demo:build:
     desc: Build demo site
+    deps: [":setup"]
+    env:
+      PUBLIC_URL: "https://demo.o3c.info"
+      CI: "false"
     cmds:
-      - source ../../sourceme.sh && optic_build_for_release
+      # TODO(nate): unpack this
+      - |
+        source ../../sourceme.sh
+        optic_build_for_release
       - yarn build-demo
 
   demo:docker:build:
     desc: Build and package demo site as a Docker container
     deps: ["demo:build"]
     cmds:
-      - docker build . -f Dockerfile_demo -t some-dumb-image
+      - docker build . -f Dockerfile_demo -t $DOCKER_REGISTRY/$REPO:$TAG
 
-  # demo:docker:push:
-  #   - docker push blah
+  demo:docker:push:
+    - docker push $DOCKER_REGISTRY/$REPO:$TAG
 
-  # demo:ci:
-  #   desc: CI workflow
-  #   cmds:
-  #     - task: demo:docker:build
-  #     - task: demo:docker:push
-  #     - task: :announce-build
-  #       vars:
-  #         MESSAGE: "Did something"
+  demo:ci:
+    desc: CI workflow
+    cmds:
+      - task: demo:docker:build
+      - task: demo:docker:push
+      # - task: :announce-build
+      #   vars:
+      #     MESSAGE: "Did something"

--- a/workspaces/ui/Taskfile.yml
+++ b/workspaces/ui/Taskfile.yml
@@ -32,6 +32,3 @@ tasks:
     cmds:
       - task: demo:docker:build
       - task: demo:docker:push
-      # - task: :announce-build
-      #   vars:
-      #     MESSAGE: "Did something"

--- a/workspaces/ui/Taskfile.yml
+++ b/workspaces/ui/Taskfile.yml
@@ -9,8 +9,9 @@ tasks:
     desc: Build demo site
     cmds:
       - task: :workspaces:build
-      # required due to the way env inheritance winds up working. setting this in
-      # the env block on this task will not work.
+      # setting $CI directly on the build command is required due to the way env
+      # inheritance winds up working here. setting this in the env block on this
+      # task will not work.
       - CI=false yarn build-demo
 
   demo:docker:build:

--- a/workspaces/ui/Taskfile.yml
+++ b/workspaces/ui/Taskfile.yml
@@ -21,6 +21,7 @@ tasks:
     deps: ["demo:build"]
     cmds:
       - docker build . -f Dockerfile_demo -t $DOCKER_REGISTRY/$REPO:$TAG
+      # TODO(nate): add a 'latest' tag when this is a develop build
 
   demo:docker:push:
     - docker push $DOCKER_REGISTRY/$REPO:$TAG

--- a/workspaces/ui/Taskfile.yml
+++ b/workspaces/ui/Taskfile.yml
@@ -11,9 +11,9 @@ tasks:
       PUBLIC_URL: "https://demo.o3c.info"
       CI: false
     cmds:
-      - echo "DEBUG: $CI"
+      - echo "DEBUG ${CI}"
       - task: :workspaces:build
-      - CI=false yarn build-demo
+      - yarn build-demo
 
   demo:docker:build:
     desc: Build and package demo site as a Docker container

--- a/workspaces/ui/Taskfile.yml
+++ b/workspaces/ui/Taskfile.yml
@@ -7,15 +7,13 @@ env:
 tasks:
   demo:build:
     desc: Build demo site
-    deps: [":setup"]
+    deps:
+      - :workspaces:clean
     env:
       PUBLIC_URL: "https://demo.o3c.info"
       CI: "false"
     cmds:
-      # TODO(nate): unpack this
-      - |
-        source ../../sourceme.sh
-        optic_build_for_release
+      - task: :workspaces:build
       - yarn build-demo
 
   demo:docker:build:

--- a/workspaces/ui/Taskfile.yml
+++ b/workspaces/ui/Taskfile.yml
@@ -7,9 +7,6 @@ env:
 tasks:
   demo:build:
     desc: Build demo site
-    env:
-      PUBLIC_URL: "https://demo.o3c.info"
-      CI: "false"
     cmds:
       - task: :workspaces:build
       # required due to the way env inheritance winds up working. setting this in

--- a/workspaces/ui/Taskfile.yml
+++ b/workspaces/ui/Taskfile.yml
@@ -9,11 +9,12 @@ tasks:
     desc: Build demo site
     env:
       PUBLIC_URL: "https://demo.o3c.info"
-      CI: false
+      CI: "false"
     cmds:
-      - echo "DEBUG ${CI}"
       - task: :workspaces:build
-      - yarn build-demo
+      # required due to the way env inheritance winds up working. setting this in
+      # the env block will _not_ stock, at in gha
+      - CI=false yarn build-demo
 
   demo:docker:build:
     desc: Build and package demo site as a Docker container

--- a/workspaces/ui/config/nginx/demo.nginx.conf
+++ b/workspaces/ui/config/nginx/demo.nginx.conf
@@ -35,7 +35,7 @@ http {
         add_header x-frame-options SAMEORIGIN;
         add_header x-xss-protection "1; mode=block";
         add_header referrer-policy same-origin;
-        add_header content-security-policy "frame-ancestors https://*.useoptic.com https://useoptic.com https://*.o3c.info https://o3c.info; default-src 'self' 'unsafe-inline' data: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; object-src 'none'; font-src 'self' https://fonts.gstatic.com; connect-src 'self' 'unsafe-inline' wss://*.intercom.io https:"
+        add_header content-security-policy "frame-ancestors https://*.useoptic.com https://useoptic.com https://*.o3c.info https://o3c.info; default-src 'self' 'unsafe-inline' data: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; object-src 'none'; font-src 'self' https://fonts.gstatic.com; connect-src 'self' 'unsafe-inline' wss://*.intercom.io https:";
 
         location / {
             root /usr/share/nginx/html;

--- a/workspaces/ui/config/nginx/demo.nginx.conf
+++ b/workspaces/ui/config/nginx/demo.nginx.conf
@@ -23,19 +23,19 @@ http {
 
     keepalive_timeout  65;
 
-    #gzip  on;
-
-    add_header strict-transport-security "max-age=63072000; includeSubdomains; preload";
-    add_header x-content-type-options nosniff;
-    add_header x-frame-options DENY;
-    add_header x-xss-protection "1; mode=block";
-    add_header referrer-policy same-origin;
-    add_header content-security-policy "default-src 'self' 'unsafe-inline' wss: data: https:; connect-src 'self' 'unsafe-inline' wss: data: https: http://localhost:6782 http://localhost:34444; script-src 'self' 'unsafe-inline' 'unsafe-eval' https:; style-src 'self' 'unsafe-inline' 'unsafe-eval' https://fonts.googleapis.com; object-src 'none'; font-src 'self' https://fonts.gstatic.com";
+    gzip  on;
 
     server {
         listen 80;
         listen [::]:80;
         server_name localhost;
+
+        add_header strict-transport-security "max-age=63072000; includeSubdomains; preload";
+        add_header x-content-type-options nosniff;
+        add_header x-frame-options SAMEORIGIN;
+        add_header x-xss-protection "1; mode=block";
+        add_header referrer-policy same-origin;
+        add_header content-security-policy "frame-ancestors https://*.useoptic.com https://useoptic.com https://*.o3c.info https://o3c.info; default-src 'self' 'unsafe-inline' data: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; object-src 'none'; font-src 'self' https://fonts.gstatic.com; connect-src 'self' 'unsafe-inline' wss://*.intercom.io https:"
 
         location / {
             root /usr/share/nginx/html;

--- a/workspaces/ui/config/nginx/mime.types
+++ b/workspaces/ui/config/nginx/mime.types
@@ -1,0 +1,98 @@
+types {
+    text/html                                        html htm shtml;
+    text/css                                         css;
+    text/xml                                         xml;
+    image/gif                                        gif;
+    image/jpeg                                       jpeg jpg;
+    application/javascript                           js;
+    application/atom+xml                             atom;
+    application/rss+xml                              rss;
+
+    text/mathml                                      mml;
+    text/plain                                       txt;
+    text/vnd.sun.j2me.app-descriptor                 jad;
+    text/vnd.wap.wml                                 wml;
+    text/x-component                                 htc;
+
+    image/png                                        png;
+    image/svg+xml                                    svg svgz;
+    image/tiff                                       tif tiff;
+    image/vnd.wap.wbmp                               wbmp;
+    image/webp                                       webp;
+    image/x-icon                                     ico;
+    image/x-jng                                      jng;
+    image/x-ms-bmp                                   bmp;
+
+    font/woff                                        woff;
+    font/woff2                                       woff2;
+
+    application/java-archive                         jar war ear;
+    application/json                                 json;
+    application/mac-binhex40                         hqx;
+    application/msword                               doc;
+    application/pdf                                  pdf;
+    application/postscript                           ps eps ai;
+    application/rtf                                  rtf;
+    application/vnd.apple.mpegurl                    m3u8;
+    application/vnd.google-earth.kml+xml             kml;
+    application/vnd.google-earth.kmz                 kmz;
+    application/vnd.ms-excel                         xls;
+    application/vnd.ms-fontobject                    eot;
+    application/vnd.ms-powerpoint                    ppt;
+    application/vnd.oasis.opendocument.graphics      odg;
+    application/vnd.oasis.opendocument.presentation  odp;
+    application/vnd.oasis.opendocument.spreadsheet   ods;
+    application/vnd.oasis.opendocument.text          odt;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation
+                                                     pptx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+                                                     xlsx;
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document
+                                                     docx;
+    application/vnd.wap.wmlc                         wmlc;
+    application/x-7z-compressed                      7z;
+    application/x-cocoa                              cco;
+    application/x-java-archive-diff                  jardiff;
+    application/x-java-jnlp-file                     jnlp;
+    application/x-makeself                           run;
+    application/x-perl                               pl pm;
+    application/x-pilot                              prc pdb;
+    application/x-rar-compressed                     rar;
+    application/x-redhat-package-manager             rpm;
+    application/x-sea                                sea;
+    application/x-shockwave-flash                    swf;
+    application/x-stuffit                            sit;
+    application/x-tcl                                tcl tk;
+    application/x-x509-ca-cert                       der pem crt;
+    application/x-xpinstall                          xpi;
+    application/xhtml+xml                            xhtml;
+    application/xspf+xml                             xspf;
+    application/zip                                  zip;
+
+    application/octet-stream                         bin exe dll;
+    application/octet-stream                         deb;
+    application/octet-stream                         dmg;
+    application/octet-stream                         iso img;
+    application/octet-stream                         msi msp msm;
+
+    audio/midi                                       mid midi kar;
+    audio/mpeg                                       mp3;
+    audio/ogg                                        ogg;
+    audio/x-m4a                                      m4a;
+    audio/x-realaudio                                ra;
+
+    video/3gpp                                       3gpp 3gp;
+    video/mp2t                                       ts;
+    video/mp4                                        mp4;
+    video/mpeg                                       mpeg mpg;
+    video/quicktime                                  mov;
+    video/webm                                       webm;
+    video/x-flv                                      flv;
+    video/x-m4v                                      m4v;
+    video/x-mng                                      mng;
+    video/x-ms-asf                                   asx asf;
+    video/x-ms-wmv                                   wmv;
+    video/x-msvideo                                  avi;
+
+    application/wasm                                 wasm;
+}

--- a/workspaces/ui/config/nginx/nginx.conf
+++ b/workspaces/ui/config/nginx/nginx.conf
@@ -1,0 +1,51 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    add_header strict-transport-security "max-age=63072000; includeSubdomains; preload";
+    add_header x-content-type-options nosniff;
+    add_header x-frame-options DENY;
+    add_header x-xss-protection "1; mode=block";
+    add_header referrer-policy same-origin;
+    add_header content-security-policy "default-src 'self' 'unsafe-inline' wss: data: https:; connect-src 'self' 'unsafe-inline' wss: data: https: http://localhost:6782 http://localhost:34444; script-src 'self' 'unsafe-inline' 'unsafe-eval' https:; style-src 'self' 'unsafe-inline' 'unsafe-eval' https://fonts.googleapis.com; object-src 'none'; font-src 'self' https://fonts.gstatic.com";
+
+    server {
+        listen 80;
+        listen [::]:80;
+        server_name localhost;
+
+        location / {
+            root /usr/share/nginx/html;
+            index index.html index.htm;
+        }
+
+        error_page 404 =200 /index.html;
+        error_page 500 502 503 504 /50x.html;
+        location = /50x.html {
+            root /usr/share/nginx/html;
+        }
+    }
+}


### PR DESCRIPTION
containerizes demo. it will still be built in the same situations as today, but CI will only push a Docker image and report the result to `#builds` (while name-dropping the triggering GH user, so it might be wise to add your GH name as a watched keyword in Slack). k8s and deploy bits live in https://github.com/opticdev/monorail/pull/164

couple things of note:
* adds a taskfile to `workspaces/ui` with tasks to build/use with ci. doesn't address the other bits built from the ui workspace yet.
* there's no quality of life improvements to the gha workflow around caching or artifact reuse. i'll circle back on these bits a little further down the road.