### PR TITLE
feat[demo]: set correct content-type for wasm files during upload to s3

### DIFF
--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -55,11 +55,11 @@ jobs:
           aws s3 sync workspaces/ui/build/ "s3://$BUCKET/" \
             --sse=AES256 \
             --acl=public-read \
-            --exclude=*.wasm
+            --exclude=*.wasm \
             --delete
           aws s3 sync workspaces/ui/build/ "s3://$BUCKET/" \
             --sse=AES256 \
             --acl=public-read \
             --include=*.wasm \
-            --content-type=application/wasm
+            --content-type=application/wasm \
             --delete

--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -54,4 +54,12 @@ jobs:
         run: |
           aws s3 sync workspaces/ui/build/ "s3://$BUCKET/" \
             --sse=AES256 \
-            --acl=public-read
+            --acl=public-read \
+            --exclude=*.wasm
+            --delete
+          aws s3 sync workspaces/ui/build/ "s3://$BUCKET/" \
+            --sse=AES256 \
+            --acl=public-read \
+            --include=*.wasm \
+            --content-type=application/wasm
+            --delete


### PR DESCRIPTION
makes the demo site work

* fixes an issue where wasm is not served with the correct content-type
* adds `--delete` (back) to the s3 sync command after the permissions fixes from https://github.com/opticdev/monorail/pull/162

note that this still doesnt create a cloudfront invalidation—i figuring punting there is fine if we get this into docker soon, which is my plan.