### PR TITLE
fix: sanitize git branch name for use in docker image tags

### DIFF
--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -48,9 +48,7 @@ jobs:
           echo "DOCKER_REGISTRY=${{ steps.login-ecr.outputs.registry }}" >> $GITHUB_ENV
           echo "REPO=demo" >> $GITHUB_ENV
           echo "TAG=${BRANCH}-b${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
+          echo "USER=${GITHUB_ACTOR}" >> $GITHUB_ENV
       - run: task ui:demo:ci
-      - uses: Ilshidur/action-slack@689ad44a9c9092315abd286d0e3a9a74d31ab78a # v2.1.0
         env:
           SLACK_WEBHOOK: ${{ secrets.BUILD_BOT_SLACK_WEBHOOK_URL }}
-        with:
-          args: "{{ GITHUB_ACTOR }}: `{{ REPO }}:{{ TAG }}` was pushed to our Docker registry."

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -58,4 +58,23 @@ tasks:
     status:
       - uname -a | grep -qv Darwin
 
+  docker:slack-notifier:
+    desc: Posts a message to Slack
+    summary: |
+      Posts a docker build announcement to Slack. To disable announcements
+      unset SLACK_WEBHOOK.
 
+      Expected env:
+        * REPO — the Docker image repository
+        * SLACK_WEBHOOK — a Slack webhook URL
+        * TAG — the Docker image tag
+        * USER — the user to direct the message at
+    vars:
+      MESSAGE: "{{.USER}}: `{{.REPO}}:{{.TAG}}` was pushed to our Docker registry."
+    env:
+      DATA: '{"text":"{{.MESSAGE}}"}'
+    cmds:
+      - echo $DATA
+      - 'curl -X POST -H "Content-type: application/json" --data "$DATA" $SLACK_WEBHOOK'
+    status:
+      - test -z $SLACK_WEBHOOK

--- a/bin/clean-docker-tag
+++ b/bin/clean-docker-tag
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -eu
+# replaces character that aren't valid om Docker image tags with hyphens
+echo $TAG | sed 's/\//-/g'

--- a/bin/clean-docker-tag
+++ b/bin/clean-docker-tag
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -eu
-# replaces character that aren't valid om Docker image tags with hyphens
-echo $TAG | sed 's/\//-/g'
+# replaces character that aren't valid in Docker image tags with hyphens
+echo $1 | sed 's/\//-/g'

--- a/workspaces/ui/Taskfile.yml
+++ b/workspaces/ui/Taskfile.yml
@@ -18,7 +18,7 @@ tasks:
     desc: Build and package demo site as a Docker container
     vars:
       TAG:
-        sh: echo $(../../bin/clean-docker-tag)
+        sh: echo $(../../bin/clean-docker-tag $TAG)
     cmds:
       - task: demo:build
       - docker build . -f Dockerfile_demo -t $DOCKER_REGISTRY/$REPO:{{.TAG}}
@@ -26,7 +26,7 @@ tasks:
   demo:docker:push:
     vars:
       TAG:
-        sh: echo $(../../bin/clean-docker-tag)
+        sh: echo $(../../bin/clean-docker-tag $TAG)
     cmds:
       - docker push $DOCKER_REGISTRY/$REPO:{{.TAG}}
       - |

--- a/workspaces/ui/Taskfile.yml
+++ b/workspaces/ui/Taskfile.yml
@@ -36,6 +36,8 @@ tasks:
           docker push $DOCKER_REGISTRY/$REPO:latest
         fi
       - task: :docker:slack-notifier
+        vars:
+          TAG: "{{.TAG}}"
 
   demo:ci:
     desc: CI workflow

--- a/workspaces/ui/Taskfile.yml
+++ b/workspaces/ui/Taskfile.yml
@@ -35,6 +35,7 @@ tasks:
           docker tag $DOCKER_REGISTRY/$REPO:{{.TAG}} $DOCKER_REGISTRY/$REPO:latest
           docker push $DOCKER_REGISTRY/$REPO:latest
         fi
+      - task: :docker:slack-notifier
 
   demo:ci:
     desc: CI workflow
@@ -43,4 +44,3 @@ tasks:
       - task: :workspaces:clean
       - task: demo:docker:build
       - task: demo:docker:push
-      - task: :docker:slack-notifier

--- a/workspaces/ui/Taskfile.yml
+++ b/workspaces/ui/Taskfile.yml
@@ -1,8 +1,8 @@
 version: "3"
 
 env:
-  REPO: demo
   DOCKER_REGISTRY: 513974440343.dkr.ecr.us-east-1.amazonaws.com
+  REPO: '{{default .Env.REPO "demo" }}'
 
 tasks:
   demo:build:
@@ -16,18 +16,25 @@ tasks:
 
   demo:docker:build:
     desc: Build and package demo site as a Docker container
-    deps: ["demo:build"]
+    vars:
+      TAG:
+        sh: echo $(../../bin/clean-docker-tag)
     cmds:
-      - docker build . -f Dockerfile_demo -t $DOCKER_REGISTRY/$REPO:$TAG
+      - task: demo:build
+      - docker build . -f Dockerfile_demo -t $DOCKER_REGISTRY/$REPO:{{.TAG}}
 
   demo:docker:push:
-    - docker push $DOCKER_REGISTRY/$REPO:$TAG
-    - |
-      if [[ "$TAG" =~ ^release-b ]]
-      then
-        docker tag $DOCKER_REGISTRY/$REPO:$TAG $DOCKER_REGISTRY/$REPO:latest
-        docker push $DOCKER_REGISTRY/$REPO:latest
-      fi
+    vars:
+      TAG:
+        sh: echo $(../../bin/clean-docker-tag)
+    cmds:
+      - docker push $DOCKER_REGISTRY/$REPO:{{.TAG}}
+      - |
+        if [[ "{{.TAG}}" =~ ^release-b ]]
+        then
+          docker tag $DOCKER_REGISTRY/$REPO:{{.TAG}} $DOCKER_REGISTRY/$REPO:latest
+          docker push $DOCKER_REGISTRY/$REPO:latest
+        fi
 
   demo:ci:
     desc: CI workflow
@@ -36,3 +43,4 @@ tasks:
       - task: :workspaces:clean
       - task: demo:docker:build
       - task: demo:docker:push
+      - task: :docker:slack-notifier


### PR DESCRIPTION
works on this branch,
<img width="502" alt="image" src="https://user-images.githubusercontent.com/672246/106936213-28954000-66d1-11eb-8a94-cadb32aac744.png">

only handles forward slashes for now, but easy to modify later.

this also replaces using  `Ilshidur/action-slack` with a task, `docker:slack-notifier`. doing the slack notification ourselves means that we can sanitize the tag within Task and not worry about exposing it back to the gha workflow for consumption in other steps.