### PR TITLE
avoid running app ci workflows when unrelated things are changed

### DIFF
--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -8,11 +8,13 @@ on:
     paths-ignore:
       - website/**
       - .github/**
+      - "**.md"
   pull_request:
     branches: [develop]
     paths-ignore:
       - website/**
       - .github/**
+      - "**.md"
 
 jobs:
   build-and-push:

--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - release
       - develop
+    paths-ignore:
+      - website/**
+      - .github/**
   pull_request:
     branches: [develop]
 

--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -10,6 +10,9 @@ on:
       - .github/**
   pull_request:
     branches: [develop]
+    paths-ignore:
+      - website/**
+      - .github/**
 
 jobs:
   build-and-push:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -5,6 +5,9 @@ name: Run Tests
 on:
   push:
     branches: [ 'develop' ]
+    paths-ignore:
+      - website/**
+      - .github/**
   pull_request:
     branches: [ 'develop' ]
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -8,11 +8,13 @@ on:
     paths-ignore:
       - website/**
       - .github/**
+      - "**.md"
   pull_request:
     branches: [ 'develop' ]
     paths-ignore:
       - website/**
       - .github/**
+      - "**.md"
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -10,6 +10,9 @@ on:
       - .github/**
   pull_request:
     branches: [ 'develop' ]
+    paths-ignore:
+      - website/**
+      - .github/**
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
## Why
aidan said, "hey nate, wouldnt it be cool if..."

## What
prevents the tests and demo gha workflows from running when unrelated files are changed. id rather describe this inclusively but this is faster and easier for the moment.

## Validation
* [x] "run tests"and "demo" workflows dont run against this pr
