### PR TITLE
added websocket passthrough for forwarding proxy

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -173,6 +173,15 @@
       "contributions": [
         "review"
       ]
+    },
+    {
+      "login": "pimterry",
+      "name": "Tim Perry",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1526883?v=4",
+      "profile": "https://tim.fyi/",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/Contributors.md
+++ b/Contributors.md
@@ -24,6 +24,7 @@
     <td align="center"><a href="https://viljami.io/"><img src="https://avatars3.githubusercontent.com/u/6105650?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Viljami Kuosmanen</b></sub></a><br /><a href="#ideas-anttiviljami" title="Ideas, Planning, & Feedback">🤔</a> <a href="#content-anttiviljami" title="Content">🖋</a></td>
     <td align="center"><a href="http://rcrowley.org/"><img src="https://avatars0.githubusercontent.com/u/11151?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Richard Crowley</b></sub></a><br /><a href="#research-rcrowley" title="Research">🔬</a> <a href="#ideas-rcrowley" title="Ideas, Planning, & Feedback">🤔</a></td>
     <td align="center"><a href="https://github.com/danMateer"><img src="https://avatars2.githubusercontent.com/u/34169713?v=4?s=100" width="100px;" alt=""/><br /><sub><b>dnmtr</b></sub></a><br /><a href="https://github.com/opticdev/Optic/pulls?q=is%3Apr+reviewed-by%3AdanMateer" title="Reviewed Pull Requests">👀</a></td>
+    <td align="center"><a href="https://tim.fyi/"><img src="https://avatars.githubusercontent.com/u/1526883?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Tim Perry</b></sub></a><br /><a href="https://github.com/opticdev/Optic/commits?author=pimterry" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/Readme.md
+++ b/Readme.md
@@ -152,7 +152,7 @@ MIT
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-17-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-18-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->
@@ -180,6 +180,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://viljami.io/"><img src="https://avatars3.githubusercontent.com/u/6105650?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Viljami Kuosmanen</b></sub></a><br /><a href="#ideas-anttiviljami" title="Ideas, Planning, & Feedback">🤔</a> <a href="#content-anttiviljami" title="Content">🖋</a></td>
     <td align="center"><a href="http://rcrowley.org/"><img src="https://avatars0.githubusercontent.com/u/11151?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Richard Crowley</b></sub></a><br /><a href="#research-rcrowley" title="Research">🔬</a> <a href="#ideas-rcrowley" title="Ideas, Planning, & Feedback">🤔</a></td>
     <td align="center"><a href="https://github.com/danMateer"><img src="https://avatars2.githubusercontent.com/u/34169713?v=4?s=100" width="100px;" alt=""/><br /><sub><b>dnmtr</b></sub></a><br /><a href="https://github.com/opticdev/Optic/pulls?q=is%3Apr+reviewed-by%3AdanMateer" title="Reviewed Pull Requests">👀</a></td>
+    <td align="center"><a href="https://tim.fyi/"><img src="https://avatars.githubusercontent.com/u/1526883?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Tim Perry</b></sub></a><br /><a href="https://github.com/opticdev/Optic/commits?author=pimterry" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/workspaces/cli-shared/package.json
+++ b/workspaces/cli-shared/package.json
@@ -31,7 +31,7 @@
     "fs-extra": "^9.0.0",
     "keymirror": "^0.1.1",
     "lodash.throttle": "^4.1.1",
-    "mockttp": "^1.0.3",
+    "mockttp": "^1.1.0",
     "oboe": "^2.1.5",
     "ora": "^4.0.4",
     "proper-lockfile": "^4.1.1",

--- a/workspaces/cli-shared/src/httptoolkit-capturing-proxy.ts
+++ b/workspaces/cli-shared/src/httptoolkit-capturing-proxy.ts
@@ -3,7 +3,6 @@ import path from 'path';
 import os from 'os';
 import * as mockttp from 'mockttp';
 import fs from 'fs-extra';
-import { CallbackResponseResult } from 'mockttp/dist/rules/handlers';
 import { CompletedRequest, MockRuleData } from 'mockttp';
 import mime from 'whatwg-mimetype';
 import {
@@ -16,6 +15,7 @@ import { toBytes } from 'shape-hash';
 import { developerDebugLogger } from './index';
 import url from 'url';
 import { IQueryParser } from './query/query-parser-interfaces';
+import { CallbackResponseResult } from 'mockttp/dist/rules/requests/request-handlers';
 
 export interface IHttpToolkitCapturingProxyConfig {
   proxyTarget?: string;
@@ -105,6 +105,17 @@ export class HttpToolkitCapturingProxy {
           },
         }),
       });
+
+      const websocketRule = {
+        matchers: [new mockttp.matchers.WildcardMatcher()],
+        handler: new mockttp.webSocketHandlers.PassThroughWebSocketHandler({
+          forwarding: {
+            targetHost: config.proxyTarget,
+          },
+        }),
+      };
+
+      await proxy.addWebSocketRules(websocketRule);
     } else {
       rules.push({
         matchers: [new mockttp.matchers.WildcardMatcher()],

--- a/yarn.lock
+++ b/yarn.lock
@@ -12578,10 +12578,10 @@ mock-stdin@^1.0.0:
   resolved "https://registry.yarnpkg.com/mock-stdin/-/mock-stdin-1.0.0.tgz#efcfaf4b18077e14541742fd758b9cae4e5365ea"
   integrity sha512-tukRdb9Beu27t6dN+XztSRHq9J0B/CoAOySGzHfn8UTfmqipA5yNT/sDUEyYdAV3Hpka6Wx6kOMxuObdOex60Q==
 
-mockttp@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.npmjs.org/mockttp/-/mockttp-1.0.3.tgz#f8b4388816e60e136289a92ed3987580fe7601bf"
-  integrity sha512-pVRm4lSGGBY6+q3bGkPAz3JsrK/zMtRw7NMQzHuF2GaVt1ru4uLEBBLRNWplFsVuvDxI02dlbyHHYR2qpPZynA==
+mockttp@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/mockttp/-/mockttp-1.1.0.tgz#e37f1333926606a16a0acdc76a914314a493e29c"
+  integrity sha512-SuglRYryHsTMPy63KZugtDjHGg8bowPmKIxEIXxRsdZMuuvvTp2eki1ScO9PujiW33Mj+yQyjPVlYbZvlTU7nQ==
   dependencies:
     "@graphql-tools/schema" "^6.0.18"
     "@graphql-tools/utils" "^6.0.18"


### PR DESCRIPTION
## Why
Many APIs have a combination of REST endpoints and some websockets. We don't  help teams document their WebSocket messages (yet), but those should at least be passed through the proxy

- Recent Issue: https://github.com/opticdev/optic/issues/545
- This has been around for a while and I remember it being reported before in a user session

## What
Tim from Mockttp released v 1.1.0 which allows us to forward websockets through the proxy. In previous versions, this worked in transparent mode, but not forwarding mode. 


## Validation
* [x] CI passes
* [x] Verified against https://github.com/acunniffe/repo-socket-issue
* [x] Verified against test projects -- default forwarding behavior for normal interactions not affected. 