### PR TITLE
fix: during gha docker build workflows select branch names based on the triggering gh event

### DIFF
--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -25,11 +25,12 @@ jobs:
         with:
           token: ${{ github.token }}
       - run: |
-          echo "GITHUB_REF $GITHUB_REF"
-          echo "GITHUB_HEAD_REF $GITHUB_HEAD_REF"
-          echo "GITHUB_BASE_REF $GITHUB_BASE_REF"
-          echo "GITHUB_EVENT_NAME $GITHUB_EVENT_NAME"
-          echo "BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]
+          then
+            echo "BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+          else
+            echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
+          fi
       - run: |
           if [ "$BRANCH" = "release" ]; then
             echo "BUCKET=optic-demo-website-production" >> $GITHUB_ENV

--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -28,6 +28,7 @@ jobs:
           echo "GITHUB_REF $GITHUB_REF"
           echo "GITHUB_HEAD_REF $GITHUB_HEAD_REF"
           echo "GITHUB_BASE_REF $GITHUB_BASE_REF"
+          echo "GITHUB_EVENT_NAME $GITHUB_EVENT_NAME"
           echo "BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
       - run: |
           if [ "$BRANCH" = "release" ]; then

--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -13,7 +13,7 @@ on:
     branches: [develop]
     paths-ignore:
       - website/**
-      - .github/**
+      # - .github/**
       - "**.md"
 
 jobs:
@@ -25,6 +25,9 @@ jobs:
         with:
           token: ${{ github.token }}
       - run: |
+          echo "GITHUB_REF $GITHUB_REF"
+          echo "GITHUB_HEAD_REF $GITHUB_HEAD_REF"
+          echo "GITHUB_BASE_REF $GITHUB_BASE_REF"
           echo "BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
       - run: |
           if [ "$BRANCH" = "release" ]; then

--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -31,6 +31,12 @@ jobs:
           else
             echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
           fi
+
+          echo "branch debugging bits:"
+          echo "GITHUB_REF $GITHUB_REF"
+          echo "GITHUB_HEAD_REF $GITHUB_HEAD_REF"
+          echo "GITHUB_BASE_REF $GITHUB_BASE_REF"
+          echo "GITHUB_EVENT_NAME $GITHUB_EVENT_NAME"
       - run: |
           if [ "$BRANCH" = "release" ]; then
             echo "BUCKET=optic-demo-website-production" >> $GITHUB_ENV


### PR DESCRIPTION
## Why
for demo builds (but ultimately every docker build we'll do) we need to select the branch differently based on the type of event triggering the workflow.

## What
for the demo build, gets the branch from GITHUB_HEAD_REF if this is a PR event, or GITHUB_REF if its not (which would be a push event)

## Validation
hard to tell before merging to develop and release. i added some debugging in case this doesnt fix things
