### PR TITLE
update doc links printed in errors.

### DIFF
--- a/website/src/components/HomePageHero.js
+++ b/website/src/components/HomePageHero.js
@@ -41,7 +41,7 @@ const useStyles = makeStyles({
     alignItems: 'center',
     justifyContent: 'flex-start',
     overflow: 'hidden',
-    backgroundImage: `url('/svg-bg.svg')`,
+    backgroundImage: `url('/img/svg-bg.svg')`,
     backgroundRepeat: 'no-repeat',
     backgroundPosition: '95% 34%',
     backgroundAttachment: 'local',

--- a/workspaces/diff-engine-wasm/engine/Cargo.lock
+++ b/workspaces/diff-engine-wasm/engine/Cargo.lock
@@ -79,9 +79,9 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "bytes"
-version = "0.5.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cfg-if"

--- a/workspaces/local-cli/package.json
+++ b/workspaces/local-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/cli",
-  "description": "The Optic CLI",
+  "description": "API CLI from Optic. Document and test your APIs as you build them.",
   "version": "9.0.9",
   "author": "@useoptic",
   "bin": {

--- a/workspaces/local-cli/src/commands/check.ts
+++ b/workspaces/local-cli/src/commands/check.ts
@@ -2,7 +2,8 @@ import { Command } from '@oclif/command';
 import { verifyTask } from '../shared/verify/verify';
 
 export default class Check extends Command {
-  static description = 'Validate the correctness of a task in your optic.yml';
+  static description =
+    'verify that Optic can run your tasks and monitor traffic';
 
   static args = [
     {

--- a/workspaces/local-cli/src/commands/init.ts
+++ b/workspaces/local-cli/src/commands/init.ts
@@ -30,7 +30,7 @@ import { Client } from '@useoptic/cli-client';
 import openBrowser from 'react-dev-utils/openBrowser';
 
 export default class Init extends Command {
-  static description = 'Add Optic to your API';
+  static description = 'add Optic to your API';
 
   static flags = {
     inboundUrl: flags.string({}),

--- a/workspaces/local-cli/src/commands/login.ts
+++ b/workspaces/local-cli/src/commands/login.ts
@@ -18,6 +18,7 @@ import { trackUserEvent } from '../shared/analytics';
 export default class Login extends Command {
   static description = 'Login to Optic from the CLI';
 
+  static hidden = true;
   async run() {
     const { flags } = this.parse(Login);
     try {

--- a/workspaces/local-cli/src/commands/logout.ts
+++ b/workspaces/local-cli/src/commands/logout.ts
@@ -4,7 +4,7 @@ import colors from 'colors';
 
 export default class Logout extends Command {
   static description = 'Logout from Optic';
-
+  static hidden = true;
   async run() {
     try {
       await deleteCredentials();

--- a/workspaces/local-cli/src/commands/run.ts
+++ b/workspaces/local-cli/src/commands/run.ts
@@ -6,7 +6,7 @@ import {
 import { cleanupAndExit } from '@useoptic/cli-shared';
 
 export default class Run extends Command {
-  static description = 'Run a task from your optic.yml';
+  static description = 'run tasks from your optic.yml';
 
   static flags = runCommandFlags;
 

--- a/workspaces/local-cli/src/commands/scripts.ts
+++ b/workspaces/local-cli/src/commands/scripts.ts
@@ -12,7 +12,8 @@ import { fromOptic } from '@useoptic/cli-shared';
 import { generateOas } from './generate/oas';
 import { spawnProcess } from '../shared/spawn-process';
 export default class Scripts extends Command {
-  static description = 'Run one of the scripts in your optic.yml file';
+  static description =
+    'run one of the scripts in optic.yml with the current specification';
 
   static args = [
     {

--- a/workspaces/local-cli/src/commands/spec.ts
+++ b/workspaces/local-cli/src/commands/spec.ts
@@ -20,7 +20,7 @@ import {
 import { getUser } from '../shared/analytics';
 import { Config } from '../config';
 export default class Spec extends Command {
-  static description = 'Open your Optic API specification';
+  static description = 'open your current API specification';
 
   async run() {
     let paths: IPathMapping;

--- a/workspaces/local-cli/src/commands/start.ts
+++ b/workspaces/local-cli/src/commands/start.ts
@@ -5,7 +5,7 @@ import {
 } from '../shared/local-cli-task-runner';
 
 export default class Start extends Command {
-  static description = 'starts your API process behind an Optic proxy';
+  static description = 'alias for "api run start"';
 
   static flags = runCommandFlags;
 

--- a/workspaces/local-cli/src/shared/verify/verify.ts
+++ b/workspaces/local-cli/src/shared/verify/verify.ts
@@ -193,7 +193,7 @@ export async function verifyTask(
           '\n' +
             fromOptic(
               colors.red.bold(
-                `Some checks failed. Steps to fix can be found here: useoptic.com/docs/check-fail`
+                `Some checks failed. Review the documentation here: https://useoptic.com/docs/get-started/config`
               )
             )
         );

--- a/workspaces/ui/src/__tests__/yaml-helper.test.ts
+++ b/workspaces/ui/src/__tests__/yaml-helper.test.ts
@@ -3,7 +3,7 @@ import { rangesFromOpticYaml } from '../components/setup-page/yaml/YamlHelper';
 const opticyaml = `name: Todo API
 tasks:
   # The default task, invoke using \`api run start\`
-  # Learn how to set up and use Optic at https://app.useoptic.com
+  # Learn how to set up and use Optic at https://useoptic.com/docs/
   start:
     command: npm run server-start
     inboundUrl: http://localhost:3005

--- a/workspaces/ui/src/components/DemoModal.js
+++ b/workspaces/ui/src/components/DemoModal.js
@@ -41,7 +41,7 @@ export const DemoModal = (props) => {
               autoFocus={false}
               type="submit"
               onClick={() => {
-                window.open('https://auth.useoptic.com/login');
+                window.open('https://useoptic.com/docs');
               }}
               color="secondary"
               endIcon={<NavigateNextIcon />}

--- a/workspaces/ui/src/components/support/Links.js
+++ b/workspaces/ui/src/components/support/Links.js
@@ -1,8 +1,8 @@
 const docsBaseLink = 'https://www.useoptic.com/docs';
 
 export const OpticDocs = docsBaseLink + '/';
-export const AddOpticLink = docsBaseLink + '/getting-started/setup/';
-export const DocumentingYourApi = docsBaseLink + '/building-the-documentation/';
+export const AddOpticLink = docsBaseLink + '/get-started/config';
+export const DocumentingYourApi = docsBaseLink + '/using/baseline';
 
 export const Contact = (subject) =>
   `mailto:aidan@useoptic.com?subject=${subject}`;


### PR DESCRIPTION
## Why
We noticed some dead links that weren't updated during the cutover to the new documentation. It sucks to have something go wrong, get a link to 'fix the problem' and have that be a dead link

## What
- Updated links
- Updated copy for each command
- Hid old CLI commands that aren't recommended -- login/logout

## Validation
* [x] CI passes
* [x] Verified in staging
