### PR TITLE
build linux binaries with musl libc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
             rustup_channel: stable
             suffix: .exe
           - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
+            target: x86_64-unknown-linux-musl
             platform_name: linux
             rustup_channel: stable
             suffix: ''

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,14 +8,13 @@ env:
   BUCKET_NAME: optic-packages
   PACKAGE_NAME: api
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-  RELEASE_WORKFLOW_DRY_RUN: true
+  RELEASE_WORKFLOW_DRY_RUN: false
 
 on:
   push:
     branches:
       - release
       - develop
-      - linux-musl
 
 jobs:
   release_logic:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,13 +8,14 @@ env:
   BUCKET_NAME: optic-packages
   PACKAGE_NAME: api
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-  RELEASE_WORKFLOW_DRY_RUN: false
+  RELEASE_WORKFLOW_DRY_RUN: true
 
 on:
   push:
     branches:
       - release
       - develop
+      - linux-musl
 
 jobs:
   release_logic:


### PR DESCRIPTION
## Why
the dynamically linked linux binary doesnt run on systems with versions of glibc prior to whats present in out build system.

## What
builds the linux diff-engine binary with the `86_64-unknown-linux-musl` target for improved compatibility

## Validation
binary artifact: https://github.com/opticdev/optic/suites/1993372398/artifacts/39753863 

```
➜ file /tmp/optic_diff
/tmp/optic_diff: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, BuildID[sha1]=fed8019e1dc4ffcd923300a10e6a320e1cfebbb6, with debug_info, not stripped
```

```
➜ docker run --rm -it -v /tmp/optic_diff:/optic_diff:ro centos:7 /optic_diff --help
Optic Diff engine 0.1.0
Optic Labs Corporation
Detects differences between API spec and captured interactions

USAGE:
    optic_diff <spec-file-path>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:


ARGS:
    <spec-file-path>    Sets the specification file that describes the API spec
```

closes https://github.com/opticdev/issues/issues/53