### PR TITLE
chore: dont run the release workflow needlessly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ on:
     branches:
       - release
       - develop
+    paths-ignore:
+      - website/**
+      - .github/**
 
 jobs:
   release_logic:


### PR DESCRIPTION
## Why
https://github.com/opticdev/optic/releases/tag/untagged-fa2b5e5cafc0ccedeb98 🙃 

## What
stops running the release workflow if the only changes are github workflow bits or the website