### PR TITLE
[Experiment] use cross-spawn for optic tasks

### DIFF
--- a/workspaces/cli-shared/src/command-session.ts
+++ b/workspaces/cli-shared/src/command-session.ts
@@ -1,7 +1,9 @@
-import { ChildProcess, spawn, SpawnOptions } from 'child_process';
+import { ChildProcess, SpawnOptions } from 'child_process';
 import { EventEmitter } from 'events';
 import treeKill from 'tree-kill';
 import { developerDebugLogger } from './index';
+//@ts-ignore
+import { spawn } from 'cross-spawn';
 
 export interface ICommandSessionConfig {
   command: string;
@@ -31,7 +33,8 @@ class CommandSession {
     this.events.once('stopped', (e) => {
       this.isRunning = false;
     });
-    this.child.on('exit', (code, signal) => {
+    // @ts-ignore
+    this.child.on('exit', (code: number, signal) => {
       developerDebugLogger(
         `command process exited with code ${code} and signal ${signal}`
       );

--- a/workspaces/local-cli/package.json
+++ b/workspaces/local-cli/package.json
@@ -28,6 +28,7 @@
     "cli-table3": "^0.6.0",
     "cli-ux": "^5.4.1",
     "colors": "^1.4.0",
+    "cross-spawn": "^7.0.3",
     "dotenv": "^8.2.0",
     "eventsource": "^1.0.7",
     "find-process": "^1.4.3",

--- a/workspaces/local-cli/src/shared/spawn-process.ts
+++ b/workspaces/local-cli/src/shared/spawn-process.ts
@@ -19,7 +19,7 @@ export async function spawnProcess(
   const child = spawn(command, taskOptions);
 
   return await new Promise((resolve) => {
-    child.on('exit', (code) => {
+    child.on('exit', (code: number) => {
       resolve(code === 0);
     });
   });

--- a/workspaces/local-cli/src/shared/spawn-process.ts
+++ b/workspaces/local-cli/src/shared/spawn-process.ts
@@ -1,4 +1,6 @@
-import { spawn, SpawnOptions } from 'child_process';
+import { SpawnOptions } from 'child_process';
+// @ts-ignore
+import { spawn } from 'cross-spawn';
 
 export async function spawnProcess(
   command: string,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6512,7 +6512,7 @@ cross-spawn@^4:
     lru-cache "^4.0.1"
     which "^1.2.9"
 
-cross-spawn@^7.0.0:
+cross-spawn@^7.0.0, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
## Why
We've found a surprising mix of shells, operating systems on teams -- making it hard to share commands in their optic.yml files. We expected on the individual team level there'd be homogeneity. There is not. The lesson of the ages. 

## What
To make it easier to collaborate with people using different shells this PR introduces [cross-spawn](https://www.npmjs.com/package/cross-spawn) under the hood when you run `api run <task>`

In theory, this will allow commands in `optic.yml` files to be more portable/robust across environments so it's easier for teams to use the tool together. 

## Validation
* [ ] CI passes
* [ ] @LouManglass tests cross platform and known use cases, approves 
* [ ] @devdoshi approves 
* [ ] it's been 3 days -- Feb 13th
