### PR TITLE
Fix ignore confusion

### DIFF
--- a/workspaces/ui/src/components/diff/review-diff/learn-api/LearnAPIPageInner.js
+++ b/workspaces/ui/src/components/diff/review-diff/learn-api/LearnAPIPageInner.js
@@ -30,6 +30,7 @@ import Button from '@material-ui/core/Button';
 import Box from '@material-ui/core/Box';
 import { DiffLoadingOverview } from '../DiffLoading';
 import { MethodRenderLarge } from '../PathAndMethod';
+import { Link } from '@material-ui/core';
 
 export function LearnAPIPageInner(props) {
   const { urls, undocumentedEndpoints, setAskFinish } = props;
@@ -456,10 +457,22 @@ function UndocumentedRow(props) {
               <Box
                 display="flex"
                 flexDirection="row"
-                alignItems="center"
+                alignItems="flex-start"
                 onClick={(e) => e.stopPropagation()}
               >
-                Mark this path and method as ignored?{' '}
+                <div style={{ paddingRight: 35 }}>
+                  Mark this path and method as ignored?
+                  <div>
+                    <Link
+                      href="http://useoptic.com/docs/using/advanced-configuration#ignoring-api-paths"
+                      color="primary"
+                      target="_blank"
+                      component="a"
+                    >
+                      Learn about adding advanced ignore rules here
+                    </Link>
+                  </div>
+                </div>
                 <Button
                   color="secondary"
                   onClick={() => {
@@ -475,7 +488,7 @@ function UndocumentedRow(props) {
             }
             interactive
           >
-            <IconButton size="small">
+            <IconButton size="small" onClick={(e) => e.stopPropagation()}>
               <RemoveCircleIcon
                 fontSizeAdjust="small"
                 style={{ width: '.8rem', height: '.8rem' }}

--- a/workspaces/ui/src/components/diff/review-diff/learn-api/LearnAPIPageInner.js
+++ b/workspaces/ui/src/components/diff/review-diff/learn-api/LearnAPIPageInner.js
@@ -460,7 +460,15 @@ function UndocumentedRow(props) {
                 onClick={(e) => e.stopPropagation()}
               >
                 Mark this path and method as ignored?{' '}
-                <Button color="secondary" onClick={() => setIgnore(row)}>
+                <Button
+                  color="secondary"
+                  onClick={() => {
+                    setIgnore(row);
+                    if (isItemSelected) {
+                      toggleRow(row);
+                    }
+                  }}
+                >
                   Confirm
                 </Button>
               </Box>


### PR DESCRIPTION
## Why
@LouManglass and I noticed some interesting ways the ignore button was being used. 

1.  some users were creating path patterns in the UI, then clicking ignore -- pointing towards a lack of knowledge about how to use the `ignore` file. 
2. sometimes users would start documenting a path, then choose to ignore it. these paths were still being documented by Optic. 

## What
1. There are now [links and documentation to explain the `ignore` file in the UI](https://github.com/opticdev/optic/pull/577)
2. whenever a path is ignored, it is also removed from the `toDocument` queue

## Validation
* [x] CI passes
* [x] manual testing
* [x] making sure new links work before release 
