### PR TITLE
frontend uses append batch commit pathway

### DIFF
--- a/workspaces/cli-client/src/spec-service-client.ts
+++ b/workspaces/cli-client/src/spec-service-client.ts
@@ -29,6 +29,7 @@ export interface ISpecService {
 
   saveEvents(eventStore: IEventStore, rfcId: RfcId): Promise<void>;
   saveEventsArray(serializedEvents: any[]): Promise<void>;
+  saveBatchCommit(serializedEvents: any[]): Promise<void>;
 
   listCaptures(): Promise<ListCapturesResponse>;
 
@@ -92,6 +93,16 @@ export class Client implements ISpecService {
   saveEventsArray(serializedEvents: any[]): Promise<void> {
     return JsonHttpClient.putJsonString(
       `${this.baseUrl}/specs/${this.specId}/events`,
+      JSON.stringify(serializedEvents)
+    ).then((x) => {
+      this.eventEmitter.emit('events-updated');
+      return x;
+    });
+  }
+
+  saveBatchCommit(serializedEvents: any[]): Promise<void> {
+    return JsonHttpClient.postJsonString(
+      `${this.baseUrl}/specs/${this.specId}/events/batch-commits`,
       JSON.stringify(serializedEvents)
     ).then((x) => {
       this.eventEmitter.emit('events-updated');

--- a/workspaces/ui/src/components/diff/review-diff/AskFinished.js
+++ b/workspaces/ui/src/components/diff/review-diff/AskFinished.js
@@ -74,14 +74,19 @@ export function AskFinished(props) {
   const isComplete = state.matches('completed');
   useEffect(() => {
     async function saveEvents() {
-      const { updatedEvents } = state.context;
+      const { newEvents, updatedEvents } = state.context;
       setSummary({
         // oasStats: state.context.oasStats,
         newEndpoints: patch.added.length,
         newEndpointsKnownPaths: patch.endpointsToDocument.length,
         endpointsWithChanges: endpointsWithChanges.length,
       });
-      await specService.saveEventsArray(updatedEvents);
+
+      if (process.env.REACT_APP_OPTIC_ASSEMBLED_SPEC_EVENTS) {
+        await specService.saveBatchCommit(newEvents);
+      } else {
+        await specService.saveEventsArray(updatedEvents);
+      }
       history.push(`${baseUrl}/documentation`);
     }
     if (isComplete) {

--- a/workspaces/ui/src/components/loaders/ApiLoader.js
+++ b/workspaces/ui/src/components/loaders/ApiLoader.js
@@ -267,6 +267,11 @@ export async function createExampleSpecServiceFactory(data) {
       eventEmitter.emit('events-updated');
       return Promise.resolve();
     },
+    saveBatchCommit: (serializedEvents) => {
+      events = JSON.stringify([...JSON.parse(events), ...serializedEvents]);
+      eventEmitter.emit('events-updated');
+      return Promise.resolve();
+    },
     listExamples: (requestId) => {
       return Promise.resolve({ examples: examples[requestId] || [] });
     },

--- a/workspaces/ui/src/engine/async-work/apply-changes-machine.ts
+++ b/workspaces/ui/src/engine/async-work/apply-changes-machine.ts
@@ -48,6 +48,7 @@ export interface ApplyChangesContext {
   newBodiesProgressLastLearned: string;
   newBodiesLearned: ILearnedBodies[] | undefined;
   approvedSuggestionsCommands: any[];
+  newEvents: any[];
   updatedEvents: any[];
   oasStats: IOasStats | undefined;
   error: string;
@@ -77,6 +78,7 @@ export const newApplyChangesMachine = (
       newBodiesProgressLastLearned: '',
       newBodiesLearned: undefined,
       approvedSuggestionsCommands: [],
+      newEvents: [],
       updatedEvents: [],
       oasStats: undefined,
       error: '',
@@ -165,13 +167,15 @@ export const newApplyChangesMachine = (
                   console.log(`learning started for ${pathId} ${method}`);
                   let promise;
                   batchHandler.doWork(async ({ rfcService, rfcId }) => {
-                    promise = diffService.learnInitial(
-                      rfcService,
-                      rfcId,
-                      pathId,
-                      method,
-                      services.rfcBaseState.domainIdGenerator
-                    ).catch(() => null);
+                    promise = diffService
+                      .learnInitial(
+                        rfcService,
+                        rfcId,
+                        pathId,
+                        method,
+                        services.rfcBaseState.domainIdGenerator
+                      )
+                      .catch(() => null);
                   });
 
                   promise.finally(() => {
@@ -182,7 +186,7 @@ export const newApplyChangesMachine = (
                     });
                   });
 
-                  return await promise
+                  return await promise;
                 });
               }
             );
@@ -300,7 +304,8 @@ export const newApplyChangesMachine = (
           onDone: {
             target: 'completed',
             actions: assign({
-              updatedEvents: (context, event) => event.data,
+              newEvents: (context, event) => event.data.newEvents,
+              updatedEvents: (context, event) => event.data.updatedEvents,
             }),
           },
           onError: {

--- a/workspaces/ui/src/engine/async-work/handle-commands-worker.ts
+++ b/workspaces/ui/src/engine/async-work/handle-commands-worker.ts
@@ -13,7 +13,7 @@ function handleCommands(
   clientSessionId: string,
   clientId: string,
   commitMessage: string
-): any[] {
+): { newEvents: any[]; updatedEvents: any[] } {
   const {
     universeFromEventsAndAdditionalCommands,
   } = require('@useoptic/domain-utilities');
@@ -33,18 +33,23 @@ function handleCommands(
     batchId
   );
 
+  const parsedEvents = JSON.parse(eventString);
+
   const {
     rfcId,
     eventStore,
-  } = universeFromEventsAndAdditionalCommands(
-    JSON.parse(eventString),
-    commandContext,
-    [
-      StartBatchCommit(batchId, commitMessage),
-      ...inputCommands,
-      EndBatchCommit(batchId),
-    ]
-  );
+  } = universeFromEventsAndAdditionalCommands(parsedEvents, commandContext, [
+    StartBatchCommit(batchId, commitMessage),
+    ...inputCommands,
+    EndBatchCommit(batchId),
+  ]);
 
-  return JSON.parse(eventStore.serializeEvents(rfcId));
+  const parsedNewEvents = JSON.parse(eventStore.serializeEvents(rfcId));
+
+  const onlyNewEvents = parsedNewEvents.slice(parsedEvents.length);
+
+  return {
+    newEvents: onlyNewEvents,
+    updatedEvents: parsedNewEvents,
+  };
 }


### PR DESCRIPTION
These changes should get the frontend saving events using the new pathway, if, and only if, `REACT_APP_OPTIC_ASSEMBLED_SPEC_EVENTS` is enabled 