### PR TITLE
feat: parallelize ui builds

### DIFF
--- a/workspaces/ui/Taskfile.yml
+++ b/workspaces/ui/Taskfile.yml
@@ -1,5 +1,7 @@
 version: "3"
 
+output: prefix
+
 tasks:
   clean:
     desc: Removes UI's build directories

--- a/workspaces/ui/Taskfile.yml
+++ b/workspaces/ui/Taskfile.yml
@@ -23,7 +23,6 @@ tasks:
     - task: ci:setup
     - task: ci:build
 
-
   #
   # docker namespace
   #

--- a/workspaces/ui/Taskfile.yml
+++ b/workspaces/ui/Taskfile.yml
@@ -6,10 +6,21 @@ tasks:
     cmds:
       - rm -rf build build-demo build-apidocs
 
-  ci:
+  #
+  # ci namespace
+  #
+  ci:setup:
+    - task: :workspaces:build
+
+  ci:build:
     deps:
       - task: demo:ci
       - task: apidocs:ci
+
+  ci:
+    - task: ci:setup
+    - task: ci:build
+
 
   #
   # docker namespace
@@ -45,7 +56,6 @@ tasks:
   demo:build:
     desc: Build demo site
     cmds:
-      - task: :workspaces:build
       - >
         BUILD_DIR=build-demo
         CI=false
@@ -79,7 +89,6 @@ tasks:
 
   demo:ci:
     desc: CI workflow
-    deps: [":workspaces:setup"]
     cmds:
       - task: demo:docker:build
       - task: demo:docker:push
@@ -127,7 +136,6 @@ tasks:
 
   apidocs:ci:
     desc: CI workflow
-    deps: [":workspaces:setup"]
     cmds:
       - task: apidocs:docker:build
       - task: apidocs:docker:push

--- a/workspaces/ui/Taskfile.yml
+++ b/workspaces/ui/Taskfile.yml
@@ -1,6 +1,6 @@
 version: "3"
 
-output: prefix
+output: prefixed
 
 tasks:
   clean:

--- a/workspaces/ui/Taskfile.yml
+++ b/workspaces/ui/Taskfile.yml
@@ -7,8 +7,9 @@ tasks:
       - rm -rf build build-demo build-apidocs
 
   ci:
-    - task: demo:ci
-    - task: apidocs:ci
+    deps:
+      - task: demo:ci
+      - task: apidocs:ci
 
   #
   # docker namespace


### PR DESCRIPTION
## Why
the UI builds are some of the slower workflows because they build the world first. before digging into not building the world, we can build demo and apidocs in parallel.

## What
builds demo and apidocs in parallel

## Validation
* [ ] CI passes
