### PR TITLE
Add test path for empty spec against default http interaction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 .task/
 *.swp
 .DS_Store
+.vscode
 
 #Added by cargo
 

--- a/workspaces/diff-engine/src/events/http_interaction.rs
+++ b/workspaces/diff-engine/src/events/http_interaction.rs
@@ -12,7 +12,7 @@ use std::iter::FromIterator;
 
 // TODO: consider whether these aren't actually Events and the Traverser not an Aggregator
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Default)]
 pub struct HttpInteraction {
   pub uuid: String,
   pub request: Request,
@@ -26,7 +26,7 @@ pub struct HttpInteractionTag {
   value: String,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Default)]
 pub struct Request {
   pub host: String,
   pub method: String,
@@ -36,7 +36,7 @@ pub struct Request {
   pub body: Body,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Response {
   pub status_code: u16,
@@ -45,7 +45,7 @@ pub struct Response {
   pub body: Body,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Body {
   pub content_type: Option<String>,
@@ -53,7 +53,7 @@ pub struct Body {
   pub value: ArbitraryData,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ArbitraryData {
   shape_hash_v1_base64: Option<String>,

--- a/workspaces/diff-engine/src/lib.rs
+++ b/workspaces/diff-engine/src/lib.rs
@@ -1,12 +1,12 @@
 #![allow(dead_code, unused_imports, unused_variables)]
 
-mod events;
-mod interactions;
-mod projections;
-mod protos;
-mod queries;
-mod shapes;
-mod state;
+pub mod events;
+pub mod interactions;
+pub mod projections;
+pub mod protos;
+pub mod queries;
+pub mod shapes;
+pub mod state;
 
 #[cfg(feature = "streams")]
 pub mod streams;

--- a/workspaces/diff-engine/tests/interaction_diff.rs
+++ b/workspaces/diff-engine/tests/interaction_diff.rs
@@ -7,6 +7,12 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio_stream::wrappers::LinesStream;
 use tokio_stream::StreamExt;
 
+#[test]
+fn can_diff_default_projection_against_default_interaction() {
+  let results = diff_interaction(&Default::default(), Default::default());
+  assert_debug_snapshot!(results);
+}
+
 #[tokio::main]
 #[test]
 async fn can_yield_interactive_diff_result() {

--- a/workspaces/diff-engine/tests/snapshots/interaction_diff__can_diff_default_projection_against_default_interaction.snap
+++ b/workspaces/diff-engine/tests/snapshots/interaction_diff__can_diff_default_projection_against_default_interaction.snap
@@ -1,0 +1,44 @@
+---
+source: workspaces/diff-engine/tests/interaction_diff.rs
+expression: results
+---
+[
+    UnmatchedRequestBodyContentType(
+        UnmatchedRequestBodyContentType {
+            interaction_trail: InteractionTrail {
+                path: [
+                    Url {
+                        path: "",
+                    },
+                    Method {
+                        method: "",
+                    },
+                ],
+            },
+            requests_trail: SpecPath(
+                SpecPath {
+                    path_id: "root",
+                },
+            ),
+        },
+    ),
+    UnmatchedResponseBodyContentType(
+        UnmatchedResponseBodyContentType {
+            interaction_trail: InteractionTrail {
+                path: [
+                    Method {
+                        method: "",
+                    },
+                    ResponseStatusCode {
+                        status_code: 0,
+                    },
+                ],
+            },
+            requests_trail: SpecPath(
+                SpecPath {
+                    path_id: "root",
+                },
+            ),
+        },
+    ),
+]


### PR DESCRIPTION
## Why

Improve test coverage of diff_interaction by adding a test for a case that isn't currently covered, that of diffing an empty spec projection (from empty events) against a generic http interaction. What is covered already are spec projections that always have events.

## What

Add a default http interaction for ease of use as there is no way to create ArbitraryData due to its private fields. There is no need to manually create since None values for the fields are fine for the path under test, so a derive default will do. 

Add the test using the defaults for spec projection and http interaction against saved snapshot of result.

## Validation

* cargo test works and runs the test case
* the snapshot result looks correct to me
