### PR TITLE
don't build UI on PRs

### DIFF
--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -9,16 +9,9 @@ on:
       - website/**
       - .github/**
       - "**.md"
-  pull_request:
-    branches: [develop]
-    paths-ignore:
-      - website/**
-      #- .github/**
-      - "**.md"
 
 jobs:
   build:
-    if: github.repository == 'opticdev/optic'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -13,11 +13,12 @@ on:
     branches: [develop]
     paths-ignore:
       - website/**
-      - .github/**
+      #- .github/**
       - "**.md"
 
 jobs:
   build:
+    if: github.repository == 'opticdev/optic'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -9,6 +9,7 @@ on:
       - website/**
       - .github/**
       - "**.md"
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
## Why
the `build ui` workflow is running on PRs opened from forks, and forks do not have access to the repo secrets which causes the workflow to fail. thinking through this, we don't want to build UI at all on PRs, since we'd never want to actually deploy those resultant images inside of our infra.
 
## What
* removes `on:pull_request` from the workflow
* adds `on:workflow_disptach` so we can internally produce builds from arbitrary branches if we choose
