### PR TITLE
docs init: updated documentation, init help, for Windows

### DIFF
--- a/website/docs/get-started/config.mdx
+++ b/website/docs/get-started/config.mdx
@@ -53,8 +53,12 @@ For the start task:
 
 :::tip Make sure your API starts on $PORT
 Optic assumes your API can be started on a specific port, which Optic assigns. To do this, Optic provides $PORT as an environment variable. You'll either need to map this variable to a flag your API framework looks for, or modify your code to look for the $PORT variable when starting up.
+:::
 
-If you're using optic from within a non-bash environment (such as PowerShell), $PORT may need to be replaced with %PORT%
+:::tip on Windows, optic.yml commands are interpreted by the Command shell
+By default, Node uses the built-in Command shell on Windows when asked to start a child process. This interprets commands differently from bash. Tools like [cross-env](https://www.npmjs.com/package/cross-env) help manage this for cross-platform projects. On Windows only projects, you can target Command shells directly. Here's a few Windows tips:
+- To expand an environment variable such as `PORT`, use `%PORT%` instead of `$PORT`
+- When invoking a program or script, use Command shell format (for example, `./application` on Linux/MacOS would be `application` on Windows.)
 :::
 
 ---

--- a/website/docs/get-started/quickstart.mdx
+++ b/website/docs/get-started/quickstart.mdx
@@ -38,7 +38,9 @@ brew install opticdev/optic/api
   </TabItem>
 </Tabs>
 
-
+:::note
+Optic requires Node v12+, and we'll install a compatible version as a requirement via your package manager of choice. Depending on your installation method and node version management process, it's possible to get into a state where an incompatible version of Node is running. If you need to check, `api --version` will tell you both the Optic CLI and Node version running. If you run into an issue here, please [let us know](https://github.com/opticdev/optic/issues/new?title=Node%20Version%20Incompatibility%20Issue:).
+:::
 
 #### While that’s downloading 👇
 

--- a/workspaces/ui/src/components/setup-page/SetupPage.js
+++ b/workspaces/ui/src/components/setup-page/SetupPage.js
@@ -277,7 +277,7 @@ function PortAssumption(props) {
 
   const LookFor = (
     <span style={{ fontWeight: 600 }}>
-      look for the <Code>$PORT</Code> variable when starting up
+      look for the <Code>$PORT</Code> variable when starting up (<Code>%PORT%</Code> on Windows)
       <LightTooltip
         interactive
         title={


### PR DESCRIPTION
## Why
Based on community feedback and input, this changeset beefs up our (1) minimum node requirements as a note with some troubleshooting tips and (2) clarifies how to expand environment variables such as `PORT` on Windows. It expands on our `api init` tip as well.

## What

- Quick Start > [Download the CLI](https://o3c.info/docs/#1-download-the-cli)
- New note under Configure > [API Start alias](https://o3c.info/docs/get-started/config#configure-api-start-alias)
- api init (attached)
![image](https://user-images.githubusercontent.com/241059/107781781-49cfdf00-6d16-11eb-9cdc-33daaa250585.png)


## Validation
* [x] CI passes
* [x] PR approval/second set of eyes
