### PR TITLE
WIP initial interface for changelog projection endpoint queries

### DIFF
--- a/workspaces/diff-engine/Cargo.toml
+++ b/workspaces/diff-engine/Cargo.toml
@@ -28,6 +28,7 @@ serde_json = "1.0.57"
 tokio = { version = "~1.1.1", features = ["full"], optional = true } 
 tokio-util = { version = "0.6.3", features = ["codec"], optional = true }
 tokio-stream = { version= "0.1.2", features = ["fs", "io-util"], optional = true }
+chrono = "0.4.19"
 
 [dev-dependencies]
 insta = "0.16.1"

--- a/workspaces/diff-engine/src/lib.rs
+++ b/workspaces/diff-engine/src/lib.rs
@@ -16,8 +16,10 @@ pub use events::{HttpInteraction, SpecChunkEvent, SpecEvent};
 pub use interactions::diff as diff_interaction;
 pub use interactions::result::InteractionDiffResult;
 pub use projections::{
-  EndpointProjection, ShapeProjection, SpecAssemblerProjection, SpecProjection,
+  EndpointProjection, ShapeProjection, SpecAssemblerProjection, 
+  SpecProjection, ChangelogProjection,
 };
+pub use queries::changelog::ChangelogQuery;
 pub use protos::shapehash;
 pub use shapes::diff as diff_shape;
 pub use state::body::BodyDescriptor;

--- a/workspaces/diff-engine/src/projections/changelog.rs
+++ b/workspaces/diff-engine/src/projections/changelog.rs
@@ -1,0 +1,37 @@
+use cqrs_core::{Aggregate, AggregateEvent};
+use chrono::{DateTime, Utc};
+use crate::events::{SpecEvent};
+use std::convert::From;
+
+#[derive(Debug)]
+pub struct Endpoint {
+  pub path: String,
+  pub happened_at: DateTime<Utc>
+}
+
+#[derive(Default, Debug)]
+pub struct ChangelogProjection {
+  pub endpoints: Vec<Endpoint>
+}
+
+impl Aggregate for ChangelogProjection {
+  fn aggregate_type() -> &'static str {
+    "changelog_projection"
+  }
+}
+
+impl AggregateEvent<ChangelogProjection> for SpecEvent {
+  fn apply_to(self, aggregate: &mut ChangelogProjection) {
+    match self { _ => {}};
+  }
+}
+
+impl From<Vec<SpecEvent>> for ChangelogProjection {
+  fn from(events: Vec<SpecEvent>) -> Self {
+    let mut changelog: ChangelogProjection = Default::default();
+    for event in events {
+      changelog.apply(event);
+    }
+    changelog
+  }
+}

--- a/workspaces/diff-engine/src/projections/mod.rs
+++ b/workspaces/diff-engine/src/projections/mod.rs
@@ -1,10 +1,12 @@
 pub mod endpoint;
 pub mod shape;
 pub mod spec_events;
+pub mod changelog;
 
 pub use endpoint::EndpointProjection;
 pub use shape::ShapeProjection;
 pub use spec_events::{SpecAssemblerError, SpecAssemblerProjection};
+pub use changelog::{ChangelogProjection};
 
 use crate::events::SpecEvent;
 use cqrs_core::{Aggregate, AggregateEvent};

--- a/workspaces/diff-engine/src/queries/changelog.rs
+++ b/workspaces/diff-engine/src/queries/changelog.rs
@@ -1,0 +1,16 @@
+use crate::projections::changelog::{ChangelogProjection, Endpoint};
+use chrono::{DateTime, Utc};
+
+pub struct ChangelogQuery {
+  pub changelog: ChangelogProjection
+}
+
+impl ChangelogQuery {
+  pub fn added(self, since: DateTime<Utc>) -> Vec<Endpoint> {
+    self.changelog.endpoints
+  }
+
+  pub fn changed(self, since: DateTime<Utc>) -> Vec<Endpoint> {
+    self.changelog.endpoints
+  }
+}

--- a/workspaces/diff-engine/src/queries/mod.rs
+++ b/workspaces/diff-engine/src/queries/mod.rs
@@ -1,2 +1,3 @@
 pub mod endpoint;
 pub mod shape;
+pub mod changelog;

--- a/workspaces/diff-engine/tests/changelog-projections.rs
+++ b/workspaces/diff-engine/tests/changelog-projections.rs
@@ -1,0 +1,26 @@
+use optic_diff_engine::{SpecEvent, ChangelogProjection, ChangelogQuery};
+use chrono::Utc;
+use insta::assert_debug_snapshot;
+
+#[test]
+fn empty_events_gives_empty_projection() {
+  let spec_events: Vec<SpecEvent> = Default::default();
+  let changelog_projection = ChangelogProjection::from(spec_events);
+  assert_debug_snapshot!(changelog_projection);
+}
+
+#[test]
+fn can_query_empty_projection_for_added_endpoints() {
+  let spec_events: Vec<SpecEvent> = Default::default();
+  let changelog_projection = ChangelogProjection::from(spec_events);
+  let changelog_query = ChangelogQuery{changelog: changelog_projection};
+  assert_debug_snapshot!(changelog_query.added(Utc::now()));
+}
+
+#[test]
+fn can_query_empty_projection_for_changed_endpoints() {
+  let spec_events: Vec<SpecEvent> = Default::default();
+  let changelog_projection = ChangelogProjection::from(spec_events);
+  let changelog_query = ChangelogQuery{changelog: changelog_projection};
+  assert_debug_snapshot!(changelog_query.changed(Utc::now()));
+}

--- a/workspaces/diff-engine/tests/snapshots/changelog_projections__can_query_empty_projection_for_added_endpoints.snap
+++ b/workspaces/diff-engine/tests/snapshots/changelog_projections__can_query_empty_projection_for_added_endpoints.snap
@@ -1,0 +1,5 @@
+---
+source: workspaces/diff-engine/tests/changelog-projections.rs
+expression: "changelog_query.added(Utc::now())"
+---
+[]

--- a/workspaces/diff-engine/tests/snapshots/changelog_projections__can_query_empty_projection_for_changed_endpoints.snap
+++ b/workspaces/diff-engine/tests/snapshots/changelog_projections__can_query_empty_projection_for_changed_endpoints.snap
@@ -1,0 +1,5 @@
+---
+source: workspaces/diff-engine/tests/changelog-projections.rs
+expression: "changelog_query.changed(Utc::now())"
+---
+[]

--- a/workspaces/diff-engine/tests/snapshots/changelog_projections__empty_events_gives_empty_projection.snap
+++ b/workspaces/diff-engine/tests/snapshots/changelog_projections__empty_events_gives_empty_projection.snap
@@ -1,0 +1,7 @@
+---
+source: workspaces/diff-engine/tests/changelog-projections.rs
+expression: changelog_projection
+---
+ChangelogProjection {
+    endpoints: [],
+}


### PR DESCRIPTION
## Why

Want to answer added and changed endpoint queries over changelog projection

## What

ChangelogProjection
ChangelogQuery#added
ChangelogQuery#changed

## Validation

Would like feedback if this interface is a good or bad approach