### PR TITLE
sourceme should not leak env

### DIFF
--- a/sourceme.sh
+++ b/sourceme.sh
@@ -18,7 +18,7 @@ optic_export_env() {
   fi
 
   VARS_TO_EXPORT=$(grep -v '^#' "$ENV_FILE")
-  VARS_WITHOUT_WHITESPACE=$(echo $VARS_TO_EXPORT | sed s/\n// | sed s/\ //)
+  VARS_WITHOUT_WHITESPACE=$(echo $VARS_TO_EXPORT | sed s/\ //)
   if [ "$VARS_WITHOUT_WHITESPACE" = "" ]
   then
     echo "'$ENV_FILE' is empty. You might want to put some variables there"


### PR DESCRIPTION
closes https://github.com/opticdev/issues/issues/55
## Why
We observed that sourceme.sh scripts would leak the entire host env when the .env file is "empty" (only whitespace after skipping lines starting with `#`)

## What
The only change in behavior is when the .env file is "empty". Previously it would result in exporting the entire host env, and now it will emit a warning message

## Validation
* [x] CI passes
* [x] Verified manually when .env is empty
* [x] Verified manually when .env is missing
