### PR TITLE
fix: don't exit 1 when the env file doesnt exist

### DIFF
--- a/sourceme.sh
+++ b/sourceme.sh
@@ -10,20 +10,14 @@ alias cidev="$OPTIC_SRC_DIR/workspaces/ci-cli/bin/run"
 alias agentdev="$OPTIC_SRC_DIR/workspaces/agent-cli/bin/run"
 
 optic_export_env() {
-  ENV_FILE=$1
-  if [ ! -f "$ENV_FILE" ]
-  then
-    echo "could not find env file '$ENV_FILE'"
-    exit 1
-  fi
+  set -u
 
-  VARS_TO_EXPORT=$(grep -v '^#' "$ENV_FILE")
-  VARS_WITHOUT_WHITESPACE=$(echo $VARS_TO_EXPORT | sed s/\ //)
-  if [ "$VARS_WITHOUT_WHITESPACE" = "" ]
+  ENV_FILE=$1
+  if [ -f "$ENV_FILE" ]
   then
-    echo "'$ENV_FILE' is empty. You might want to put some variables there"
+    export "$(grep -v '^#' $ENV_FILE | xargs)"
   else
-    export $VARS_TO_EXPORT
+    echo "Could not find env file '$ENV_FILE'."
   fi
 }
 

--- a/sourceme.sh
+++ b/sourceme.sh
@@ -15,7 +15,7 @@ optic_export_env() {
   ENV_FILE=$1
   if [ -f "$ENV_FILE" ]
   then
-    export "$(grep -v '^#' $ENV_FILE | xargs)"
+    export "$(grep -v '^#' $ENV_FILE)"
   else
     echo "Could not find env file '$ENV_FILE'."
   fi


### PR DESCRIPTION
## Why
follow up to https://github.com/opticdev/optic/pull/595 with a couple things that came out of a follow up conversation

## What
* our readme and developer-setup make no mention of populating a .env file, so this PR changes the task to not exit 1 when the env file is missing.
* removes the sed to replace spaces in the file. the intention behind that was to detect non-empty strings of only whitespace. as long as the value we pass to `export` is quoted, we wont leak the env. if we choose to, we can validate the sanity of the exports differently. i opted to not bother and allow export to display its own error.

## Validation
empty file:
```
nate@robot-hell optic % touch /tmp/empty.env
nate@robot-hell optic % optic_export_env /tmp/empty.env
optic_export_env:export:6: not valid in this context:
```

non-existent file:
```
nate@robot-hell optic % optic_export_env /tmp/kdhjkfjdfh
Could not find env file '/tmp/kdhjkfjdfh'.
```

existing env file:
```
nate@robot-hell optic % env | grep OPTIC
OPTIC_SRC_DIR=/Users/nate/code/optic/optic
OPTIC_DEBUG_ENV_FILE=/Users/nate/code/optic/optic/.env

nate@robot-hell optic % optic_export_env .env.beta

nate@robot-hell optic % env | egrep "(OPTIC|REACT|GITFLOW)"
OPTIC_SRC_DIR=/Users/nate/code/optic/optic
OPTIC_DEBUG_ENV_FILE=/Users/nate/code/optic/optic/.env
OPTIC_ASSEMBLED_SPEC_EVENTS=false
OPTIC_RUST_DIFF_ENGINE=true
REACT_APP_LEARN_API_MODE=true
REACT_APP_DIFF_REVIEW_PAGE=true
GITFLOW_CAPTURE=true
OPTIC__CLI_SCRIPTS__SENTRY__ENABLED=yes
OPTIC__CLI_SERVER__SENTRY__ENABLED=yes
```

