### PR TITLE
build tooling should have tools to make one-off artifacts simple

### DIFF
--- a/workspaces/scripts/list-workspace-packages.js
+++ b/workspaces/scripts/list-workspace-packages.js
@@ -1,0 +1,25 @@
+// this script is meant to be run via ` node workspaces/scripts/list-workspace-packages.js`
+const path = require('path');
+const fs = require('fs-extra');
+
+async function main() {
+  const packageJson = await fs.readJson('./package.json');
+  const { workspaces } = packageJson;
+  
+  const tasks = workspaces.map((workspace) => {
+    const task = new Promise(async (resolve, reject) => {
+      try {
+        const targetPackage = await fs.readJson(`./${workspace}/package.json`);
+        resolve(targetPackage.name.substring('@useoptic/'.length));
+      } catch (e) {
+        reject(e)
+      }
+    })
+    return task;
+  });
+  
+  const packages = await Promise.all(tasks)
+  console.log(packages.join(','))
+}
+
+main()

--- a/workspaces/scripts/list-workspaces.js
+++ b/workspaces/scripts/list-workspaces.js
@@ -1,0 +1,11 @@
+// this script is meant to be run via ` node workspaces/scripts/list-workspaces.js`
+const path = require('path');
+const fs = require('fs-extra');
+
+async function main() {
+  const packageJson = await fs.readJson('./package.json');
+  const { workspaces } = packageJson;
+  console.log(workspaces.join(','))
+}
+
+main()

--- a/workspaces/scripts/use-s3-dependencies.js
+++ b/workspaces/scripts/use-s3-dependencies.js
@@ -1,0 +1,61 @@
+// this script is meant to be run via `S3_HTTPS_URL=https://xyz.com VERSION=1.2.3-beta.4 node workspaces/scripts/use-s3-dependencies.js`
+const path = require('path');
+const fs = require('fs-extra');
+
+async function main(input) {
+  const {baseUrl, packageVersion} = input;
+  const packageJson = await fs.readJson('./package.json');
+  const { workspaces } = packageJson;
+  
+  console.log(workspaces.map((x) => ` - ${x}\n`).join(''));
+  const tasks = workspaces.map((workspace) => {
+    const task = new Promise(async (resolve, reject) => {
+      try {
+        const targetPackage = await fs.readJson(`./${workspace}/package.json`);
+        targetPackage.version = packageVersion;
+        resolve({
+          workspace,
+          package: targetPackage,
+        });
+      } catch (e) {
+        reject(e);
+      }
+    });
+    return task;
+  });
+  const results = await Promise.all(tasks);
+  const packageNames = results.map((result) => result.package.name);
+  console.log(packageNames.map((x) => ` - ${x}\n`).join(''));
+  const updateVersionTasks = results.map((result) => {
+    const task = new Promise(async (resolve, reject) => {
+      try {
+        packageNames.map((packageName) => {
+          if (result.package.dependencies[packageName]) {
+            const name = packageName.substring('@useoptic/'.length);
+            const url = `${baseUrl}/${packageVersion}/${name}-${packageVersion}.tgz`
+            result.package.dependencies[packageName] = url;
+          }
+        });
+        await fs.writeJson(
+          `./${result.workspace}/package.json`,
+          result.package,
+          { spaces: 2 }
+        );
+      } catch (e) {
+        reject(e);
+      }
+    });
+    return task;
+  });
+  await Promise.all(updateVersionTasks);
+  console.log(`Done!`);
+}
+
+const {
+  S3_HTTPS_URL,
+  VERSION
+} = process.env;
+main({
+  baseUrl: S3_HTTPS_URL,
+  packageVersion: VERSION
+})


### PR DESCRIPTION

## Why
Publishing artifacts to s3 requires modifying the package.json files to point to a s3 url. These scripts give the building blocks to achieve this in future work

## What
Nothing affecting the product changes. This adds scripts available to developer tooling

## Validation
* [x] CI passes
