### PR TITLE
Docs: Fix the yarn command in the Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,7 +34,7 @@
 Install Optic with npm or yarn"
 
 ```bash
-yarn add global @useoptic/cli
+yarn global add @useoptic/cli
 npm install @useoptic/cli -g
 ```
 Then run init command:


### PR DESCRIPTION
## Why
Because `yarn add global` would install the `global` package.

## What
Just a tiny doc change.

## Validation
* [ ] CI passes
* [ ] Verified in staging

