### PR TITLE
docs: added integrations

### DIFF
--- a/website/Taskfile.yml
+++ b/website/Taskfile.yml
@@ -1,0 +1,61 @@
+# https://taskfile.dev
+
+version: '3'
+
+tasks:
+  default:
+    cmds:
+      - task --list
+    silent: true
+
+  check-credentials:
+    cmds:
+      - aws-mfa --profile parent
+    silent: true
+
+  deploy:
+    desc: Deploys the web site (see --summary for detailed usage)
+    summary: |
+      Deploys the web site. Depends on having your AWS profiles set up properly with aws-mfa. This task deploys:
+
+      - to environment AWS_PROFILE, default is {{.AWS_PROFILE}}
+      - when DRY_RUN is false, default is {{.DRY_RUN}}
+    cmds:
+      - AWS_PROFILE={{.AWS_PROFILE}} DRY_RUN={{.DRY_RUN}} bin/deploy
+    deps:
+      - check-credentials
+    vars:
+      AWS_PROFILE: '{{default "staging" .AWS_PROFILE}}'
+      DRY_RUN: '{{default "true" .DRY_RUN}}'
+
+  deploy:staging:
+    desc: Dry run of a deploy to staging
+    cmds: 
+      - task: deploy
+        vars:
+          AWS_PROFILE: staging
+          DRY_RUN: true
+
+  deploy:staging:doit:
+    desc: Deploy to staging
+    cmds: 
+      - task: deploy
+        vars:
+          AWS_PROFILE: staging
+          DRY_RUN: false  
+
+  deploy:prod:
+    desc: Dry run of a deploy to production
+    cmds: 
+      - task: deploy
+        vars:
+          AWS_PROFILE: production
+          DRY_RUN: true
+
+  deploy:prod:doit:
+    desc: Deploy to production
+    cmds: 
+      - task: deploy
+        vars:
+          AWS_PROFILE: production
+          DRY_RUN: false  

--- a/website/Taskfile.yml
+++ b/website/Taskfile.yml
@@ -21,10 +21,10 @@ tasks:
       - to environment AWS_PROFILE, default is {{.AWS_PROFILE}}
       - when DRY_RUN is false, default is {{.DRY_RUN}}
     cmds:
-      - AWS_PROFILE={{.AWS_PROFILE}} DRY_RUN={{.DRY_RUN}} bin/deploy
+      - bin/deploy
     deps:
       - check-credentials
-    vars:
+    env:
       AWS_PROFILE: '{{default "staging" .AWS_PROFILE}}'
       DRY_RUN: '{{default "true" .DRY_RUN}}'
 

--- a/website/docs/integrations/cicd/circleci.mdx
+++ b/website/docs/integrations/cicd/circleci.mdx
@@ -1,6 +1,7 @@
 ---
-title: "Running Optic in your CircleCI CI/CD environment"
-description: ""
+title: Running Optic in your CircleCI CI/CD environment
+sidebar_label: circleCI
+slug: /circleci
 ---
 
 Running Optic in your CircleCI environment assures that differences from documented behavior or undocumented routes in your tests can be caught before a pull request is merged. Optic lets your CI pipeline know that the intended behavior of your API is documented, and alerts you to unintended behavior before it gets to deployment. If you don't use CircleCI, [let us know your CI tool](https://github.com/opticdev/optic/issues/new?title=FR:%20Support%20for%20CI%20tool) and we'll be happy to help.
@@ -19,7 +20,9 @@ There's a few tasks required to integrate your tests with Optic into CircleCI:
   - If they pass, assure the shell exits with exit code 0.
   - If any tests fail, assure the shell exits with exit code 1.
 
-The following CircleCI config file accomplishes this for your example project. Note, that this is only a configuration file. It defines the actions CircleCI will take. CircleCI must be integrated with your central repository, such as GitHub, before it will take any actions. The exit statements determine the status of the check: a 0 passes, anything else (such as a 1) fails the check. When this is committed to the `.circleci/config.yml` directory and pushed to your central repository that's integrated with CircleCI, the `optic-ci` job will run on the appropriate triggers. The configuration also includes the `node/test` job, as this is a node project. It's not necessary, though it provides a nice extra check that your project can build and basic tests pass on their own (if present).
+The following CircleCI config file accomplishes this for your example project. Note, that this is only a configuration file. It defines the actions CircleCI will take. CircleCI must be integrated with your central repository, such as GitHub, before it will take any actions. The --exit-on-diff flag will result in an exit code of 0 (normal) when no diffs are detected between the test traffic and the specification. On any difference in behavior, the program will exit with exit code 1, signaling a failure to CircleCI. 
+
+When this is committed to the `.circleci/config.yml` directory and pushed to your central repository that's integrated with CircleCI, the `optic-ci` job will run on the appropriate triggers. The configuration also includes the `node/test` job, as this is a node project. It's not necessary, though it provides a nice extra check that your project can build and basic tests pass on their own (if present).
 
 ``` yaml
 version: 2.1
@@ -42,18 +45,10 @@ commands:
     steps:
     - checkout
     - run:
+        name: Run Optic CI
         command: |-
           npm install @useoptic/cli
-          node_modules/.bin/api run test-cci --collect-coverage | tee out.txt
-          if grep -q "No API Diff Observed" out.txt; then
-            echo "No Unexpected API behavior detected."
-            exit 0
-          else
-            echo "Unexpected API behavior or error in CI: please run Optic locally and check the dashboard, then review CI logs."
-            exit 1
-          fi
-        name: Run Optic CI
-
+          npx api run test-cci --collect-coverage --exit-on-diff
 ```
 
 ## Catching Undocumented Behavior

--- a/website/docs/integrations/cicd/github-actions.mdx
+++ b/website/docs/integrations/cicd/github-actions.mdx
@@ -1,6 +1,7 @@
 ---
-title: "Running CI/CD Tests through Optic with GitHub Actions"
-description: ""
+title: Running CI/CD Tests through Optic with GitHub Action
+sidebar_label: GitHub Actions
+slug: /github-actions
 ---
 
 Running Optic in your Continuous Integration (CI) pipeline assures that differences from documented behavior or undocumented routes in your tests can be caught before a pull request is merged. Optic lets your CI pipeline know that the intended behavior of your API is documented, and alerts you to unintended behavior before it gets to deployment. Optic runs can integrate with your pipeline, such as through GitHub Actions, to pass or fail checks and provide context in the pull request.
@@ -15,38 +16,31 @@ As an example, let's look at using GitHub Actions as a CI tool. There are a few 
 
 - Check out your project
 - Install Optic and any dependencies
-- Run your tests
+- Run your tests and signal success to GitHub:
   - If they pass, assure the shell exits with exit code 0.
   - If any tests fail, assure the shell exits with exit code 1.
 
-The following GitHub Action would accomplish this for your example project. It triggers when you open or push to a pull request in GitHub (not on every push), and will report the check status on the pull request. It will not prevent the pull request from being merged, it just reports the status of the check. When this is committed to the `.github/workflows` directory and pushed to GitHub, it will start running on the appropriate triggers. Since this is the only GitHub Action in this example, it can be added as `.github/workflows/main.yml` in the project repository and pushed to GitHub:
+The following GitHub Action would accomplish this for your example project. It triggers when you open or push to a pull request in GitHub (not on every push), and will report the check status on the pull request. It will not prevent the pull request from being merged, it just reports the status of the check. When this is committed to the `.github/workflows` directory and pushed to GitHub, it will start running on the appropriate triggers. The `--exit-on-diff` flag assures that if the tests behave according to the specification, the program will exit with exit code 0. If there are any differences in behavior from the specification, it will exit with exit code 1. Since this is the only GitHub Action in this example, it can be added as `.github/workflows/main.yml` in the project repository and pushed to GitHub:
 
 ``` yaml
 name: Optic CI
 
 on:
   pull_request:
+  workflow_dispatch:
 
 jobs:
-  build:
+  check-spec:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4 (or choose the latest version)
 
-      - name: Install Optic, json-server
-        run: npm install @useoptic/cli json-server
+      - name: Install Optic # Or add to your development/build dependencies in your package management
+        run: npm install @useoptic/cli
 
       - name: Run tests
-        run: |
-          node_modules/.bin/api run use-task --collect-coverage | tee out.txt
-          if grep -q "No API Diff Observed" out.txt; then
-            echo "No Unexpected API behavior detected."
-            exit 0
-          else
-            echo "Unexpected API behavior or error in CI: please run Optic locally and check the dashboard, then review CI logs."
-            exit 1
-          fi
+        run: npx api run run-tests --collect-coverage --exit-on-diff
 ```
 
 ## Catching Undocumented Behavior

--- a/website/docs/integrations/ides/intellij.md
+++ b/website/docs/integrations/ides/intellij.md
@@ -1,0 +1,54 @@
+---
+title: Using IntelliJ with Optic
+sidebar_label: IntelliJ
+slug: /intellij
+---
+
+## Set up a shell script
+
+To start, you'll need to set up a shell script to run Optic with IntelliJ. There are options to avoid doing this manually, such as the [BashSupport Pro plugin](https://www.bashsupport.com/pro/), if you've already purchased or subscribed to them. They come with added features you may find useful, though for today we'll focus on what's built in to IntelliJ. We're also assuming Optic is already installed on your system. You *do* have Optic already, don't you? If not, no worries: [installation is quick](https://www.useoptic.com/docs/) through several package managers such as Yarn, NPM, and Brew.
+
+For a simple demonstration, we'll create a trivial file `optic.sh` that will just call the Optic `api start` command to run a project through Optic. It won't do anything yet: we'll set that up next. For now, create the following `optic.sh` file in the root of your API project:
+
+``` bash
+#!/bin/sh
+
+api run start 
+```
+
+## Integrate Optic with a project
+
+Just like Git, Cargo, or many other coding tools, the first step for integrating any project with Optic is initializing Optic. In the root directory of the project, run `api init`. This starts the Optic daemon and opens a setup window in your browser. The setup process walks you through integrating with your project so Optic can observe traffic to your API.
+
+![Running api init](/img/blog-content/intellij-api-init.png)
+
+Here we've selected the Proxy integration. This allows us to set the port on which our application runs with the IntelliJ run configurations, and gives us a place to pass traffic through Optic. Our API project runs on port 8080, so the targetUrl is `http://localhost:8080`. Optic will observe and forward traffic sent to `http://locaalhost:4000`, which is how we'll test our work as we develop. 
+
+Optic guides us to check our configuration. Go ahead and start your project with the Green Play button next to the Run Configurations in IntelliJ, and wait for it to start up. Then, run `api check` from the terminal. Optic will run some tests and make sure the configuration is right. If there are any issues, it will enumerate them and provide some suggested remedies. When all is set up properly, you'll get a check passed message.
+
+![API Check passed](/img/blog-content/intellij-api-start.png)
+
+The Optic installer tells you to run `api start`, which will work. However, we can integrate this command with the IntelliJ Run Configurations so Optic will run with your existing configurations and even with your existing debugger.
+
+## Setting up Compound Run Configurations
+
+IntelliJ has the capability to manage multiple run configurations together. Here, we'll bundle the API project's existing run configuration with the `api start` command. On the Run/Debug Configurations drop-down, select **Edit Configurations...** Click the **+** icon to add a new configuration, and choose the **Shell Script** template. We'll invoke the shell script we wrote earlier, by setting the script path to our `optic.sh` script. Set your working directory as well. It's not needed for our simple script, though if you add on to it later it will save you some time.
+
+![Setting up an Optic run configuration](/img/blog-content/intellij-run-optic-configuration.png)
+
+The Shell Script Run Configuration will run the Optic proxy on its own, but we want to couple this with our API project. Back under **Edit Configurations...** click the **+** button again and this time select the **Compound** template. Set the **Name** to `Run w/Optic` and add both your current API Project run configuration and our new Shell Script. 
+
+![A compound run configuration with Optic](/img/blog-content/intellij-run-optic-compound.png)
+
+From now on, you can use the **Run w/Optic** configuration in IntelliiJ. It will run your API project exactly as it always has run before, and bring up Optic alongside it. Notice we haven't yet mentioned what language we're using in our project. Through this example I used a sample Spring project built with Gradle, but this setup would work with any language, framework, and build tool. By using Compound configurations, Optic runs alongside the project you have already set up. 
+
+That means it also works with all of the run commands, including Debugging. You may get some odd logs when debugging as stepping through the code may lead to timeouts in the Optic proxy, much like any client application or browser would time out when debugging. This is normal and expected, and shouldn't cause any additional complications.
+
+## Following Through
+
+Optic integrates well with IntelliJ, sitting in the Run Configurations behind "the green start button" used to start projects today. You can [get started with Optic](https://www.useoptic.com/docs/) and tailor your integration to your needs. Please [reach out to us](https://github.com/opticdev/optic/issues/new) if you have any issues, or set up time to [chat with the Optic team](https://calendly.com/optic-onboarding/setup-help) to go over your use case.
+
+## Resources
+
+- [IntelliJ Community edition 2020.2](https://www.jetbrains.com/idea/download/)
+- [Spring Guides: gs-rest-service](https://github.com/spring-guides/gs-rest-service) (using the "complete" folder as the project root)

--- a/website/docs/integrations/integrations.mdx
+++ b/website/docs/integrations/integrations.mdx
@@ -12,6 +12,14 @@ import {TOC} from '../../src/components/TOC';
 
 <TOC kind="integrations/frameworks" />
 
+## IDEs 📔 with Optic
+
+<TOC kind="integrations/ides" />
+
+## CI/CD environments 🛠️ with Optic
+
+<TOC kind="integrations/cicd" />
+
 <!--
 ## Code Hosts 🌐
 #### [GitHub](docs/express)

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -44,11 +44,18 @@ module.exports = {
           'integrations/frameworks/spring',
         ],
       },
-      // {
-      //   type: 'category',
-      //   label: 'CI/CD Pipelines',
-      //   items: ['integrations/cicd/github-actions', 'integrations/cicd/circleci'],
-      // },
+      {
+        type: 'category',
+        label: 'IDEs',
+        items: [
+          'integrations/ides/intellij',
+        ],
+      },
+      {
+        type: 'category',
+        label: 'CI/CD Pipelines',
+        items: [ 'integrations/cicd/circleci', 'integrations/cicd/github-actions' ],
+      },
     ],
   },
 };


### PR DESCRIPTION
## Why

Added IDEs, CI/CD tool sections to integrations to start collecting basic suggestions

## What

- [All Integrations](https://o3c.info/docs/integrations/integrations) has new sections.
- [IntelliJ integration](https://o3c.info/docs/intellij/)
- [CircleCI test runners](https://o3c.info/docs/circleci/)
- [GitHub Actions test runners](https://o3c.info/docs/github-actions/)
- A new taskfile just for the website, so I don't forget to run my tasks in order

## Validation

* [ ] CI passes
* [ ] A second set of eyes in staging

