### PR TITLE
Fix for optional field interpreters 

### DIFF
--- a/workspaces/ui/src/engine/interpreter/interpreter-types/field.ts
+++ b/workspaces/ui/src/engine/interpreter/interpreter-types/field.ts
@@ -57,13 +57,10 @@ export function fieldShapeDiffInterpretor(
     if (actual.wasMissing() && expected.aRequiredField()) {
       present.askMakeOptional();
       present.askRemoveField();
-    }
-
-    if (observedShapeDidNotMatch) {
+    } else if (observedShapeDidNotMatch) {
       present.addAdditionalCoreShapeKinds(unexpectedShapesObserved);
     }
   }
-
   // we've already check if isField() is true, so this is always add field
   if (isUnspecified) {
     present.askAddField(actual.fieldKey()!);
@@ -105,10 +102,7 @@ class FieldShapeInterpretationHelper {
     }
     ///////////////////////////////////////////////////////////////
 
-    if (
-      this.additionalCoreShapeKinds.length > 0 &&
-      !this.actual.wasMissing() /* when missing, change shape commands are gets included in the optional/required commands  */
-    ) {
+    if (this.additionalCoreShapeKinds.length > 0) {
       if (this.expected.isOptionalField()) {
         const {
           shapeChange,


### PR DESCRIPTION
## Why
Users reported an issue where optional fields, presented with an unmatched shape, would yield a diff, but never provide suggestions. 

The expected behavior is a suggestion when field: [A] is presented with B are to:

a) change the type to [B]
b) make the type of the field the union [A, B]

## What
There was a branch in the control flow that prevented optional fields to return suggestions, this has been mediated by creating a better separation of concerns in the interpreters 

## Validation
* [x] CI passes
* [x] Unit tests pass
* etc...
