### PR TITLE
fix: update regerssion suites workflow to cross-compile diff-engine

### DIFF
--- a/.github/workflows/regression-suites.yml
+++ b/.github/workflows/regression-suites.yml
@@ -44,10 +44,8 @@ jobs:
           echo "RUSTUP_HOME=$HOME/.rustup" >> $GITHUB_ENV
           echo "CARGO_HOME=$HOME/.cargo" >> $GITHUB_ENV
       - name: Install test dependencies
-        shell: bash
         run: task workspaces:build:ci
       - name: Display yarn error log
-        shell: bash
         run: cat yarn-error.log
         if: failure()
       - name: Restore cached cargo registry
@@ -77,7 +75,6 @@ jobs:
           BUILD_ARGS: --all-features --workspace --release
         run: task diff-engine:add-targets ${{ matrix.platform.task }} diff-engine:test
       - name: Run scenario
-        shell: bash
         timeout-minutes: 2
         env:
           NUM_INTERACTIONS: ${{ matrix.interaction-count }}
@@ -87,14 +84,11 @@ jobs:
         if: failure()
       - run: |
           echo "MESSAGE=${{ matrix.platform.os }}: Regression suites passed." >> $GITHUB_ENV
-        shell: bash
         if: success()
       - run: |
           echo "MESSAGE=${{ matrix.platform.os }}: Regression suites failed. https://github.com/opticdev/optic/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_ENV
-        shell: bash
         if: failure()
       - name: Report status
         run: |
           curl -X POST -H 'Content-type: application/json' --data '{"text":"${{ env.MESSAGE }}"}' ${{ secrets.SLACK_WEBHOOK_URL }}
-        shell: bash
         if: always()

--- a/.github/workflows/regression-suites.yml
+++ b/.github/workflows/regression-suites.yml
@@ -74,6 +74,7 @@ jobs:
             echo "SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path)" >> $GITHUB_ENV
             echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version)" >> $GITHUB_ENV
           fi
+        shell: bash
       - name: Prepare diff-engine
         env:
           BUILD_ARGS: --all-features --workspace --release

--- a/.github/workflows/regression-suites.yml
+++ b/.github/workflows/regression-suites.yml
@@ -1,8 +1,9 @@
+---
 name: Test Regression Scenarios
 
 on:
   schedule:
-    - cron: 11 11 * * * # 12:11AM CET, 3:11PM PT, 6:11PM ET
+    - cron: 11 11 * * *  # 12:11AM CET, 3:11PM PT, 6:11PM ET
   pull_request:
     branches:
       - release
@@ -23,18 +24,18 @@ jobs:
     runs-on: ${{ matrix.platform.os }}
     steps:
       - name: Checkout source
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
       - name: Install Task
-        uses: Arduino/actions/setup-taskfile@9d04a51fc17daddb0eb127933aaa950af1e3ff97 # they dont give us any tags :\
+        uses: Arduino/actions/setup-taskfile@9d04a51fc17daddb0eb127933aaa950af1e3ff97  # they dont give us any tags :\
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/setup-node@c46424eee26de4078d34105d3de3cc4992202b1e # v2.1.4
+      - uses: actions/setup-node@c46424eee26de4078d34105d3de3cc4992202b1e  # v2.1.4
         with:
           node-version: 12
       - name: Restore cached node_modules
         id: workspace-node-modules
-        uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v2.1.4
+        uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6  # v2.1.4
         with:
           path: node_modules
           key: workspace-node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}-v1
@@ -50,7 +51,7 @@ jobs:
         run: cat yarn-error.log
         if: failure()
       - name: Restore cached cargo registry
-        uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v2.1.4
+        uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6  # v2.1.4
         with:
           path: |
             ${{ env.CARGO_HOME }}/registry
@@ -58,7 +59,7 @@ jobs:
             target
           key: "${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}-v4"
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af  # v1.0.7
         with:
           toolchain: stable
           profile: minimal

--- a/.github/workflows/regression-suites.yml
+++ b/.github/workflows/regression-suites.yml
@@ -64,7 +64,7 @@ jobs:
           profile: minimal
           override: true
       - name: Set MacOS cross-compilation env
-        run:
+        run: |
           if uname -a | grep -q Darwin
           then
             sudo xcode-select -s /Applications/Xcode_12.4.app

--- a/.github/workflows/regression-suites.yml
+++ b/.github/workflows/regression-suites.yml
@@ -15,10 +15,12 @@ jobs:
       fail-fast: false
       matrix:
         platform:
+          - os: windows-latest
+            task: diff-engine:build-windows
           - os: macos-latest
             task: diff-engine:build-macos
           - os: ubuntu-latest
-            task: diff-engine:build-linux diff-engine:build-windows
+            task: diff-engine:build-linux
         interaction-count: [10000]
         rust-diff-engine: [true]
     runs-on: ${{ matrix.platform.os }}

--- a/.github/workflows/regression-suites.yml
+++ b/.github/workflows/regression-suites.yml
@@ -46,8 +46,10 @@ jobs:
           echo "RUSTUP_HOME=$HOME/.rustup" >> $GITHUB_ENV
           echo "CARGO_HOME=$HOME/.cargo" >> $GITHUB_ENV
       - name: Install test dependencies
+        shell: bash
         run: task workspaces:build:ci
       - name: Display yarn error log
+        shell: bash
         run: cat yarn-error.log
         if: failure()
       - name: Restore cached cargo registry
@@ -77,6 +79,7 @@ jobs:
           BUILD_ARGS: --all-features --workspace --release
         run: task diff-engine:add-targets ${{ matrix.platform.task }} diff-engine:test
       - name: Run scenario
+        shell: bash
         timeout-minutes: 2
         env:
           NUM_INTERACTIONS: ${{ matrix.interaction-count }}
@@ -86,11 +89,14 @@ jobs:
         if: failure()
       - run: |
           echo "MESSAGE=${{ matrix.platform.os }}: Regression suites passed." >> $GITHUB_ENV
+        shell: bash
         if: success()
       - run: |
           echo "MESSAGE=${{ matrix.platform.os }}: Regression suites failed. https://github.com/opticdev/optic/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_ENV
+        shell: bash
         if: failure()
       - name: Report status
         run: |
           curl -X POST -H 'Content-type: application/json' --data '{"text":"${{ env.MESSAGE }}"}' ${{ secrets.SLACK_WEBHOOK_URL }}
+        shell: bash
         if: always()

--- a/.github/workflows/regression-suites.yml
+++ b/.github/workflows/regression-suites.yml
@@ -14,12 +14,10 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - os: windows-latest
-            task: diff-engine:build-windows
           - os: macos-latest
             task: diff-engine:build-macos
           - os: ubuntu-latest
-            task: diff-engine:build-linux
+            task: diff-engine:build-linux diff-engine:build-windows
         interaction-count: [10000]
         rust-diff-engine: [true]
     runs-on: ${{ matrix.platform.os }}
@@ -65,6 +63,14 @@ jobs:
           toolchain: stable
           profile: minimal
           override: true
+      - name: Set MacOS cross-compilation env
+        run:
+          if uname -a | grep -q Darwin
+          then
+            sudo xcode-select -s /Applications/Xcode_12.4.app
+            echo "SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path)" >> $GITHUB_ENV
+            echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version)" >> $GITHUB_ENV
+          fi
       - name: Prepare diff-engine
         env:
           BUILD_ARGS: --all-features --workspace --release


### PR DESCRIPTION
## Why
in https://github.com/opticdev/optic/pull/613 i changes to the `diff-engine:build-macos` to enable cross-compiling aarch64 from macos 10.15 hosts. those changes broke the regression suite due to a couple missing env vars. https://opticteamworkspace.slack.com/archives/C017H0H8M9A/p1614599060000100

## Validation
* [x] https://github.com/opticdev/optic/actions/runs/611573338
