### PR TITLE
Allow persistence to a single or multiple spec change files through Rust

### DIFF
--- a/workspaces/diff-engine/src/events/rfc.rs
+++ b/workspaces/diff-engine/src/events/rfc.rs
@@ -45,8 +45,10 @@ pub struct GitStateSet {
 pub struct BatchCommitStarted {
   pub batch_id: String,
   pub commit_message: String,
-  pub parent_id: Option<String>,
   event_context: Option<EventContext>,
+
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub parent_id: Option<String>,
 }
 
 #[derive(Deserialize, Debug, PartialEq, Serialize, Clone)]

--- a/workspaces/diff-engine/src/events/spec_chunk.rs
+++ b/workspaces/diff-engine/src/events/spec_chunk.rs
@@ -10,17 +10,6 @@ pub enum SpecChunkEvent {
   Unknown(UnknownChunkEvent),
 }
 
-impl SpecChunkEvent {
-  pub fn batch_from_events(
-    batch_id: String,
-    events: Vec<SpecEvent>,
-  ) -> Result<SpecChunkEvent, &'static str> {
-    let batch = BatchChunkEvent::try_from((batch_id, events)).map_err(|(msg, _, _)| msg)?;
-
-    Ok(SpecChunkEvent::Batch(batch))
-  }
-}
-
 #[derive(Debug)]
 pub struct RootChunkEvent {
   pub id: String,
@@ -43,6 +32,19 @@ pub struct UnknownChunkEvent {
 }
 
 impl SpecChunkEvent {
+  pub fn batch_from_events(
+    batch_id: String,
+    events: Vec<SpecEvent>,
+  ) -> Result<SpecChunkEvent, &'static str> {
+    let batch = BatchChunkEvent::try_from((batch_id, events)).map_err(|(msg, _, _)| msg)?;
+
+    Ok(SpecChunkEvent::Batch(batch))
+  }
+
+  pub fn root_from_events(events: Vec<SpecEvent>) -> SpecChunkEvent {
+    SpecChunkEvent::from((String::from("root"), true, events))
+  }
+
   pub fn events(&self) -> &Vec<SpecEvent> {
     let events = match self {
       SpecChunkEvent::Root(chunk) => &chunk.events,

--- a/workspaces/diff-engine/src/events/spec_chunk.rs
+++ b/workspaces/diff-engine/src/events/spec_chunk.rs
@@ -3,21 +3,21 @@ use cqrs_core::Event;
 use serde_json;
 use std::convert::TryFrom;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum SpecChunkEvent {
   Root(RootChunkEvent),
   Batch(BatchChunkEvent),
   Unknown(UnknownChunkEvent),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RootChunkEvent {
   pub id: String,
   pub name: String,
   pub events: Vec<SpecEvent>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BatchChunkEvent {
   pub id: String,
   pub name: String,
@@ -25,7 +25,7 @@ pub struct BatchChunkEvent {
   pub events: Vec<SpecEvent>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct UnknownChunkEvent {
   pub name: String,
   pub events: Vec<SpecEvent>,

--- a/workspaces/diff-engine/src/lib.rs
+++ b/workspaces/diff-engine/src/lib.rs
@@ -26,4 +26,7 @@ pub use state::body::BodyDescriptor;
 
 pub mod errors {
   pub use super::events::EventLoadingError;
+
+  #[cfg(feature = "streams")]
+  pub use super::streams::spec_chunks::{SpecChunkLoaderError, SpecChunkWriterError};
 }

--- a/workspaces/diff-engine/src/streams/spec_chunks.rs
+++ b/workspaces/diff-engine/src/streams/spec_chunks.rs
@@ -74,7 +74,6 @@ pub async fn to_api_dir(
       ))?,
     };
 
-    // let name = batch_chunk.name.clone();
     let events = chunk_event.events();
 
     let file_path = path.as_ref().join(format!("{}.json", name));
@@ -85,7 +84,7 @@ pub async fn to_api_dir(
 
     sink
       .get_mut()
-      .write_u8(b'[')
+      .write_all(b"[\n")
       .await
       .expect("could not write array start to file");
 
@@ -95,7 +94,7 @@ pub async fn to_api_dir(
 
     sink
       .get_mut()
-      .write_u8(b']')
+      .write_all(b"\n]")
       .await
       .expect("could not write array end to file");
 

--- a/workspaces/diff-engine/src/streams/spec_chunks.rs
+++ b/workspaces/diff-engine/src/streams/spec_chunks.rs
@@ -82,6 +82,7 @@ pub async fn to_api_dir(
     let file_path = path.as_ref().join(format!("{}.json", name));
     let file = fs::File::create(file_path).await?;
 
+    // TODO: use spec_events::write_to_json_array instead of doing this manually
     let mut sink = spec_events::into_json_array_items(file);
 
     sink

--- a/workspaces/diff-engine/src/streams/spec_chunks.rs
+++ b/workspaces/diff-engine/src/streams/spec_chunks.rs
@@ -66,18 +66,16 @@ pub async fn to_api_dir(
 ) -> Result<usize, SpecChunkWriterError> {
   let mut count = 0;
   for chunk_event in chunk_events {
-    let batch_chunk = match chunk_event {
-      SpecChunkEvent::Batch(batch_chunk) => batch_chunk,
-      SpecChunkEvent::Root(_) => Err(SpecChunkWriterError::UnsupportedKind(
-        "writing of root chunk events not supported",
-      ))?,
+    let name = match chunk_event {
+      SpecChunkEvent::Batch(batch_chunk) => batch_chunk.name.clone(),
+      SpecChunkEvent::Root(_) => String::from("specification"),
       SpecChunkEvent::Unknown(_) => Err(SpecChunkWriterError::UnsupportedKind(
         "writing of unknown chunk events not supported",
       ))?,
     };
 
-    let name = batch_chunk.name.clone();
-    let events = &batch_chunk.events;
+    // let name = batch_chunk.name.clone();
+    let events = chunk_event.events();
 
     let file_path = path.as_ref().join(format!("{}.json", name));
     let file = fs::File::create(file_path).await?;

--- a/workspaces/diff-engine/src/streams/spec_events.rs
+++ b/workspaces/diff-engine/src/streams/spec_events.rs
@@ -52,7 +52,7 @@ where
   S: AsyncWrite,
 {
   let writer = BufWriter::new(sink);
-  let codec = JsonLineEncoder::new(b",\n");
+  let codec = JsonLineEncoder::new(b"\n,");
   FramedWrite::new(writer, codec)
 }
 

--- a/workspaces/diff-engine/src/streams/spec_events.rs
+++ b/workspaces/diff-engine/src/streams/spec_events.rs
@@ -1,10 +1,13 @@
 use super::JsonLineEncoder;
 use crate::events::{EventLoadingError, SpecChunkEvent, SpecEvent};
 use crate::projections::{SpecAssemblerError, SpecAssemblerProjection};
-use futures::sink::Sink;
+use futures::sink::{Sink, SinkExt};
+use futures::stream::{Stream, StreamExt};
 use serde::Serialize;
 use std::path::Path;
-use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, BufReader, BufWriter, Lines};
+use tokio::io::{
+  AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader, BufWriter, Lines,
+};
 use tokio::{fs::read_to_string, io::AsyncReadExt};
 use tokio_stream::wrappers::LinesStream;
 use tokio_util::codec::FramedWrite;
@@ -51,4 +54,44 @@ where
   let writer = BufWriter::new(sink);
   let codec = JsonLineEncoder::new(b",\n");
   FramedWrite::new(writer, codec)
+}
+
+// TODO: return a proper error, so downstream can distinguish between IO, serde, etc
+// TODO: make this work with impl Stream instead
+pub async fn write_to_json_array<S>(
+  sink: S,
+  spec_events: impl IntoIterator<Item = &SpecEvent>,
+) -> Result<(), &'static str>
+where
+  S: AsyncWrite,
+  S: Unpin,
+  // E: Stream<Item = SpecEvent>,
+  // E: Unpin,
+{
+  let mut framed_write = into_json_array_items(sink);
+
+  framed_write
+    .get_mut()
+    .write_u8(b'[')
+    .await
+    .map_err(|_| "could not write array start")?;
+
+  for spec_event in spec_events {
+    if let Err(_) = framed_write.send(spec_event).await {
+      panic!("could not stream event result to stdout"); // TODO: Find way to actually write error info
+    }
+  }
+  framed_write
+    .get_mut()
+    .write_u8(b']')
+    .await
+    .map_err(|_| "could not write array start to stdout")?;
+
+  framed_write
+    .get_mut()
+    .flush()
+    .await
+    .map_err(|_| "could not flush stdout")?;
+
+  Ok(())
 }


### PR DESCRIPTION
## Why
We've identified the need to be able to ship Rust being in charge reading, mutating and persisting specs _without_ also shipping the splitting up of spec changes. The latter has further reaching implications on other parts of the system the roll-out of which needing to be tested, vetted and controlled carefully.

## What
This PR adds the ability for Rust to save new batch commits as part of the original `specification.json` when there aren't any additional spec change files yet (once there are, `specification.json` is assumed to be immutable). The `cli-server` uses this ability to toggle this ability, controlled through a feature flag.

## Validation
* [ ] CI passes
* [ ] New batches are appended to the specification file when splitting file feature is disabled.
* [ ] New batches can't be appended to the specification file once other spec change files exist.
