### PR TITLE
Write EventContext for each event with new Rust command handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "js-sys",
+ "libc",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "time",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
 name = "clap"
 version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,6 +535,7 @@ checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 name = "optic_diff"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "clap",
  "futures",
  "num_cpus",
@@ -537,6 +554,7 @@ dependencies = [
  "avro-rs",
  "base64",
  "bytes",
+ "chrono",
  "clap",
  "cqrs-core",
  "futures",
@@ -899,6 +917,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi",
+ "winapi",
+]
+
+[[package]]
 name = "tokio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1013,9 +1042,9 @@ checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,6 +527,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-util",
+ "uuid",
 ]
 
 [[package]]

--- a/workspaces/cli-server/src/routers/spec-router.ts
+++ b/workspaces/cli-server/src/routers/spec-router.ts
@@ -23,6 +23,7 @@ import { makeRouter as makeCaptureRouter } from './capture-router';
 import { LocalCaptureInteractionPointerConverter } from '@useoptic/cli-shared/build/captures/avro/file-system/interaction-iterator';
 import { IgnoreFileHelper } from '@useoptic/cli-config/build/helpers/ignore-file-interface';
 import { SessionsManager } from '../sessions';
+import { getOrCreateAnonId } from '@useoptic/cli-config/build/opticrc/optic-rc';
 import { patchInitialTaskOpticYaml } from '@useoptic/cli-config/build/helpers/patch-optic-config';
 import * as DiffEngine from '@useoptic/diff-engine';
 import { AsyncTools as AT } from '@useoptic/diff-engine-wasm';
@@ -239,6 +240,8 @@ ${events.map((x: any) => JSON.stringify(x)).join('\n,')}
         const events = DiffEngine.commit(commands, {
           specDirPath: req.optic.paths.specDirPath,
           commitMessage: payload.commitMessage,
+          clientSessionId: payload.clientSessionId || 'unknown-session',
+          clientId: await getOrCreateAnonId(),
           appendToRoot: !isEnvTrue(process.env.OPTIC_SPLIT_SPEC_EVENTS),
         });
 

--- a/workspaces/diff-engine-wasm/engine/Cargo.lock
+++ b/workspaces/diff-engine-wasm/engine/Cargo.lock
@@ -96,6 +96,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "js-sys",
+ "libc",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "time",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
 name = "clap"
 version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,6 +330,7 @@ dependencies = [
  "avro-rs",
  "base64",
  "bytes",
+ "chrono",
  "clap",
  "cqrs-core",
  "num_cpus",
@@ -548,6 +565,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi",
+ "winapi",
+]
+
+[[package]]
 name = "typed-builder"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,9 +634,9 @@ checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"

--- a/workspaces/diff-engine/Cargo.toml
+++ b/workspaces/diff-engine/Cargo.toml
@@ -16,6 +16,7 @@ streams = ["futures", "tokio", "tokio-util", "tokio-stream"]
 avro-rs = "~0.11.0"
 base64 = "0.12.3"
 bytes = "1.0.1"
+chrono = { version = "0.4.19", features = ["serde", "wasmbind"] }
 clap = "~2.33.3"
 cqrs-core = "0.2.2"
 futures = { version = "0.3.12", optional = true }

--- a/workspaces/diff-engine/cli/Cargo.toml
+++ b/workspaces/diff-engine/cli/Cargo.toml
@@ -16,3 +16,4 @@ serde_json = "1.0.57"
 # all of tokio for now, until we figure out what we need exactly
 tokio = { version = "~1.1.1", features = ["full"] } 
 tokio-util = { version = "0.6.3", features = ["codec"] }
+uuid = { version = "0.8.2", features = ["v4"] }

--- a/workspaces/diff-engine/cli/Cargo.toml
+++ b/workspaces/diff-engine/cli/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+chrono = "0.4.19" 
 clap = "~2.33.3"
 futures = "0.3.12"
 num_cpus = "1.13.0"

--- a/workspaces/diff-engine/cli/src/commit.rs
+++ b/workspaces/diff-engine/cli/src/commit.rs
@@ -1,0 +1,185 @@
+use super::events_from_chunks;
+use chrono::Utc;
+use clap::{App, Arg, ArgMatches, SubCommand};
+use futures::StreamExt;
+use optic_diff_engine::streams;
+use optic_diff_engine::Aggregate;
+use optic_diff_engine::CommandContext;
+use optic_diff_engine::{RfcCommand, SpecCommand, SpecCommandHandler};
+use optic_diff_engine::{SpecChunkEvent, SpecEvent};
+use std::path::Path;
+use std::process;
+use tokio::io::{stdin, stdout};
+use uuid::Uuid;
+
+pub const SUBCOMMAND_NAME: &'static str = "commit";
+
+pub fn create_subcommand<'a, 'b>() -> App<'a, 'b> {
+  SubCommand::with_name(SUBCOMMAND_NAME)
+    .about("Commits results of commands received over stdin as a new batch commit")
+    .arg(
+      Arg::with_name("commit-message")
+        .short("m")
+        .required(true)
+        .value_name("COMMIT_MESSAGE")
+        .takes_value(true)
+        .help("The commit message describing the commands as a whole"),
+    )
+    .arg(
+      Arg::with_name("append-to-root")
+        .long("append-to-root")
+        .required(false)
+        .takes_value(false)
+        .help("Append new batch commit to the root spec file, instead of a new spec change file"),
+    )
+    .arg(
+      Arg::with_name("client-session-id")
+        .long("client-session-id")
+        .required(false)
+        .value_name("CLIENT_SESSION_ID")
+        .takes_value(true)
+        .default_value("unknown-session")
+        .help("The session id of the client requesting the commands to be committed"),
+    )
+    .arg(
+      Arg::with_name("client-id")
+        .long("client-id")
+        .required(false)
+        .value_name("CLIENT_ID")
+        .takes_value(true)
+        .default_value("anonymous")
+        .help("Unique id of the client the commands to be committed"),
+    )
+}
+
+pub async fn main<'a>(
+  command_matches: &'a ArgMatches<'a>,
+  spec_chunks: Vec<SpecChunkEvent>,
+  spec_path: impl AsRef<Path>,
+) {
+  let commit_message = command_matches
+    .value_of("commit-message")
+    .expect("commit-message is required");
+
+  let append_to_root = command_matches.is_present("append-to-root");
+
+  if append_to_root
+    && !spec_chunks
+      .iter()
+      .all(|chunk| matches!(chunk, SpecChunkEvent::Root(_)))
+  {
+    eprintln!("Commits cannot be appended to the root when non-root chunks exist");
+    process::exit(1);
+  }
+
+  let client_session_id = command_matches
+    .value_of("client-session-id")
+    .expect("client-session-id is required");
+
+  let client_id = command_matches
+    .value_of("client-id")
+    .expect("client-id is required");
+
+  commit(
+    events_from_chunks(spec_chunks).await,
+    &spec_path,
+    commit_message,
+    append_to_root,
+    client_id,
+    client_session_id,
+  )
+  .await;
+}
+
+async fn commit(
+  spec_events: Vec<SpecEvent>,
+  spec_dir_path: impl AsRef<Path>,
+  commit_message: &str,
+  append_to_root: bool,
+  client_id: &str,
+  client_session_id: &str,
+) {
+  let mut spec_command_handler = SpecCommandHandler::from(spec_events.clone());
+
+  let stdin = stdin(); // TODO: deal with std in never having been attached
+
+  let input_commands = streams::spec_events::from_json_lines(stdin);
+
+  let batch_id = Uuid::new_v4().to_hyphenated().to_string();
+  let batch_command_context = CommandContext::new(
+    batch_id.clone(),
+    String::from(client_id),
+    String::from(client_session_id),
+    Utc::now(),
+  );
+  spec_command_handler.with_command_context(batch_command_context);
+
+  let append_batch = SpecCommand::from(RfcCommand::append_batch_commit(
+    batch_id.clone(),
+    String::from(commit_message),
+  ));
+
+  // Start event
+  let start_event = spec_command_handler
+    .execute(append_batch)
+    .expect("should be able to append new batch commit to spec")
+    .remove(0);
+
+  spec_command_handler.apply(start_event.clone());
+
+  // input events
+  let mut input_events: Vec<SpecEvent> = input_commands
+    .map(|command_json_result| -> Vec<SpecEvent> {
+      // TODO: provide more useful error messages, like forwarding command validation errors
+      let command_json = command_json_result.expect("can read input commands as jsonl from stdin");
+      let command: SpecCommand =
+        serde_json::from_str(&command_json).expect("could not parse command");
+      let events = spec_command_handler
+        .execute(command)
+        .expect("could not execute command");
+
+      for event in &events {
+        spec_command_handler.apply(event.clone());
+      }
+
+      events
+    })
+    .collect::<Vec<_>>()
+    .await
+    .into_iter()
+    .flatten()
+    .collect();
+
+  // end events
+  let end_event = spec_command_handler
+    .execute(SpecCommand::from(RfcCommand::end_batch_commit(
+      batch_id.clone(),
+    )))
+    .expect("should be able to append new batch commit to spec")
+    .remove(0);
+  spec_command_handler.apply(end_event.clone());
+
+  let mut new_events = Vec::with_capacity(input_events.len() + 2);
+  new_events.push(start_event);
+  new_events.append(&mut input_events);
+  new_events.push(end_event);
+
+  let spec_chunk_event = if append_to_root {
+    let mut all_events = spec_events;
+    all_events.append(&mut new_events);
+    SpecChunkEvent::root_from_events(all_events)
+  } else {
+    SpecChunkEvent::batch_from_events(batch_id, new_events)
+      .expect("valid batch chunk should have been created")
+  };
+
+  streams::spec_chunks::to_api_dir(std::iter::once(&spec_chunk_event), spec_dir_path)
+    .await
+    .unwrap_or_else(|err| {
+      panic!("could not write new spec batch chunk to api dir: {:?}", err);
+    });
+
+  streams::spec_events::write_to_json_array(stdout(), spec_chunk_event.events())
+    .await
+    .unwrap_or_else(|err| panic!("could not write new events to stdout: {}", err))
+}

--- a/workspaces/diff-engine/cli/src/main.rs
+++ b/workspaces/diff-engine/cli/src/main.rs
@@ -82,6 +82,22 @@ fn main() {
             .help(
               "Append new batch commit to the root spec file, instead of a new spec change file",
             ),
+        )
+        .arg(
+          Arg::with_name("client-session-id")
+            .long("client-session-id")
+            .required(true)
+            .value_name("CLIENT_SESSION_ID")
+            .takes_value(true)
+            .help("The session id of the client requesting the commands to be committed"),
+        )
+        .arg(
+          Arg::with_name("client-id")
+            .long("client-id")
+            .required(true)
+            .value_name("CLIENT_ID")
+            .takes_value(true)
+            .help("Unique id of the client the commands to be committed"),
         ),
     )
     .subcommand(
@@ -167,11 +183,21 @@ fn main() {
           process::exit(1);
         }
 
+        let client_session_id = subcommand_matches
+          .value_of("client-session-id")
+          .expect("client-session-id is required");
+
+        let client_id = subcommand_matches
+          .value_of("client-id")
+          .expect("client-id is required");
+
         commit(
           events_from_chunks(spec_chunks).await,
           &spec_path,
           commit_message,
           append_to_root,
+          client_id,
+          client_session_id,
         )
         .await;
       }
@@ -286,6 +312,8 @@ async fn commit(
   spec_dir_path: impl AsRef<Path>,
   commit_message: &str,
   append_to_root: bool,
+  client_id: &str,
+  client_session_id: &str,
 ) {
   let mut spec_projection = SpecProjection::from(spec_events.clone());
 

--- a/workspaces/diff-engine/cli/src/main.rs
+++ b/workspaces/diff-engine/cli/src/main.rs
@@ -1,4 +1,3 @@
-use chrono::Utc;
 use clap::{crate_version, App, Arg, ArgGroup, SubCommand};
 use futures::try_join;
 use futures::SinkExt;
@@ -7,20 +6,17 @@ use num_cpus;
 use optic_diff_engine::diff_interaction;
 use optic_diff_engine::errors;
 use optic_diff_engine::streams;
-use optic_diff_engine::Aggregate;
-use optic_diff_engine::CommandContext;
 use optic_diff_engine::HttpInteraction;
 use optic_diff_engine::InteractionDiffResult;
 use optic_diff_engine::SpecProjection;
-use optic_diff_engine::{RfcCommand, SpecCommand, SpecCommandHandler};
-use optic_diff_engine::{RfcEvent, SpecChunkEvent, SpecEvent};
+use optic_diff_engine::{SpecChunkEvent, SpecEvent};
 use std::cmp;
-use std::path::Path;
 use std::process;
 use std::sync::Arc;
 use tokio::io::{stdin, stdout};
 use tokio::sync::mpsc;
-use uuid::Uuid;
+
+mod commit;
 
 fn main() {
   let cli = App::new("Optic Engine CLI")
@@ -66,45 +62,7 @@ fn main() {
       SubCommand::with_name("assemble")
         .about("Assembles a directory of API spec files into a single events stream"),
     )
-    .subcommand(
-      SubCommand::with_name("commit")
-        .about("Commits results of commands received over stdin as a new batch commit")
-        .arg(
-          Arg::with_name("commit-message")
-            .short("m")
-            .required(true)
-            .value_name("COMMIT_MESSAGE")
-            .takes_value(true)
-            .help("The commit message describing the commands as a whole"),
-        )
-        .arg(
-          Arg::with_name("append-to-root")
-            .long("append-to-root")
-            .required(false)
-            .takes_value(false)
-            .help(
-              "Append new batch commit to the root spec file, instead of a new spec change file",
-            ),
-        )
-        .arg(
-          Arg::with_name("client-session-id")
-            .long("client-session-id")
-            .required(false)
-            .value_name("CLIENT_SESSION_ID")
-            .takes_value(true)
-            .default_value("unknown-session")
-            .help("The session id of the client requesting the commands to be committed"),
-        )
-        .arg(
-          Arg::with_name("client-id")
-            .long("client-id")
-            .required(false)
-            .value_name("CLIENT_ID")
-            .takes_value(true)
-            .default_value("anonymous")
-            .help("Unique id of the client the commands to be committed"),
-        ),
-    )
+    .subcommand(commit::create_subcommand())
     .subcommand(
       SubCommand::with_name("diff")
         .about("Detects differences between API spec and captured interactions (default)"),
@@ -172,39 +130,8 @@ fn main() {
         eprintln!("assembling spec folder into spec");
         assemble(spec_chunks).await;
       }
-      ("commit", Some(subcommand_matches)) => {
-        let commit_message = subcommand_matches
-          .value_of("commit-message")
-          .expect("commit-message is required");
-
-        let append_to_root = subcommand_matches.is_present("append-to-root");
-
-        if append_to_root
-          && !spec_chunks
-            .iter()
-            .all(|chunk| matches!(chunk, SpecChunkEvent::Root(_)))
-        {
-          eprintln!("Commits cannot be appended to the root when non-root chunks exist");
-          process::exit(1);
-        }
-
-        let client_session_id = subcommand_matches
-          .value_of("client-session-id")
-          .expect("client-session-id is required");
-
-        let client_id = subcommand_matches
-          .value_of("client-id")
-          .expect("client-id is required");
-
-        commit(
-          events_from_chunks(spec_chunks).await,
-          &spec_path,
-          commit_message,
-          append_to_root,
-          client_id,
-          client_session_id,
-        )
-        .await;
+      (commit::SUBCOMMAND_NAME, Some(subcommand_matches)) => {
+        commit::main(subcommand_matches, spec_chunks, spec_path).await
       }
       _ => {
         eprintln!("diffing interations against a spec");
@@ -310,99 +237,6 @@ async fn assemble(spec_chunks: Vec<SpecChunkEvent>) {
   streams::spec_events::write_to_json_array(stdout, &spec_events)
     .await
     .unwrap_or_else(|err| panic!("could not write new events to stdout: {}", err));
-}
-
-async fn commit(
-  spec_events: Vec<SpecEvent>,
-  spec_dir_path: impl AsRef<Path>,
-  commit_message: &str,
-  append_to_root: bool,
-  client_id: &str,
-  client_session_id: &str,
-) {
-  let mut spec_command_handler = SpecCommandHandler::from(spec_events.clone());
-
-  let stdin = stdin(); // TODO: deal with std in never having been attached
-
-  let input_commands = streams::spec_events::from_json_lines(stdin);
-
-  let batch_id = Uuid::new_v4().to_hyphenated().to_string();
-  let batch_command_context = CommandContext::new(
-    batch_id.clone(),
-    String::from(client_id),
-    String::from(client_session_id),
-    Utc::now(),
-  );
-  spec_command_handler.with_command_context(batch_command_context);
-
-  let append_batch = SpecCommand::from(RfcCommand::append_batch_commit(
-    batch_id.clone(),
-    String::from(commit_message),
-  ));
-
-  // Start event
-  let start_event = spec_command_handler
-    .execute(append_batch)
-    .expect("should be able to append new batch commit to spec")
-    .remove(0);
-
-  spec_command_handler.apply(start_event.clone());
-
-  // input events
-  let mut input_events: Vec<SpecEvent> = input_commands
-    .map(|command_json_result| -> Vec<SpecEvent> {
-      // TODO: provide more useful error messages, like forwarding command validation errors
-      let command_json = command_json_result.expect("can read input commands as jsonl from stdin");
-      let command: SpecCommand =
-        serde_json::from_str(&command_json).expect("could not parse command");
-      let events = spec_command_handler
-        .execute(command)
-        .expect("could not execute command");
-
-      for event in &events {
-        spec_command_handler.apply(event.clone());
-      }
-
-      events
-    })
-    .collect::<Vec<_>>()
-    .await
-    .into_iter()
-    .flatten()
-    .collect();
-
-  // end events
-  let end_event = spec_command_handler
-    .execute(SpecCommand::from(RfcCommand::end_batch_commit(
-      batch_id.clone(),
-    )))
-    .expect("should be able to append new batch commit to spec")
-    .remove(0);
-  spec_command_handler.apply(end_event.clone());
-
-  let mut new_events = Vec::with_capacity(input_events.len() + 2);
-  new_events.push(start_event);
-  new_events.append(&mut input_events);
-  new_events.push(end_event);
-
-  let spec_chunk_event = if append_to_root {
-    let mut all_events = spec_events;
-    all_events.append(&mut new_events);
-    SpecChunkEvent::root_from_events(all_events)
-  } else {
-    SpecChunkEvent::batch_from_events(batch_id, new_events)
-      .expect("valid batch chunk should have been created")
-  };
-
-  streams::spec_chunks::to_api_dir(std::iter::once(&spec_chunk_event), spec_dir_path)
-    .await
-    .unwrap_or_else(|err| {
-      panic!("could not write new spec batch chunk to api dir: {:?}", err);
-    });
-
-  streams::spec_events::write_to_json_array(stdout(), spec_chunk_event.events())
-    .await
-    .unwrap_or_else(|err| panic!("could not write new events to stdout: {}", err))
 }
 
 enum SpecPathType {

--- a/workspaces/diff-engine/cli/src/main.rs
+++ b/workspaces/diff-engine/cli/src/main.rs
@@ -87,17 +87,19 @@ fn main() {
         .arg(
           Arg::with_name("client-session-id")
             .long("client-session-id")
-            .required(true)
+            .required(false)
             .value_name("CLIENT_SESSION_ID")
             .takes_value(true)
+            .default_value("unknown-session")
             .help("The session id of the client requesting the commands to be committed"),
         )
         .arg(
           Arg::with_name("client-id")
             .long("client-id")
-            .required(true)
+            .required(false)
             .value_name("CLIENT_ID")
             .takes_value(true)
+            .default_value("anonymous")
             .help("Unique id of the client the commands to be committed"),
         ),
     )

--- a/workspaces/diff-engine/cli/src/main.rs
+++ b/workspaces/diff-engine/cli/src/main.rs
@@ -1,3 +1,4 @@
+use chrono::Utc;
 use clap::{crate_version, App, Arg, ArgGroup, SubCommand};
 use futures::try_join;
 use futures::SinkExt;
@@ -330,6 +331,7 @@ async fn commit(
     batch_id.clone(),
     String::from(client_id),
     String::from(client_session_id),
+    Utc::now(),
   );
   spec_command_handler.with_command_context(batch_command_context);
 

--- a/workspaces/diff-engine/lib/index.d.ts
+++ b/workspaces/diff-engine/lib/index.d.ts
@@ -17,6 +17,8 @@ export interface CommitOptions {
   specDirPath: String;
   commitMessage: String;
   appendToRoot?: boolean;
+  clientSessionId: String;
+  clientId: String;
 }
 
 export function commit<T>(commands: AsyncIterable<T>, CommitOptions): Readable;

--- a/workspaces/diff-engine/src/commands/mod.rs
+++ b/workspaces/diff-engine/src/commands/mod.rs
@@ -279,6 +279,7 @@ impl AggregateCommand<SpecProjection> for SpecCommand {
 #[cfg(test)]
 mod test {
   use super::*;
+  use chrono::Local;
   use insta::assert_debug_snapshot;
   use serde_json::json;
 
@@ -289,14 +290,14 @@ mod test {
     ]))
     .expect("initial events should be valid spec events");
 
-    let mut command_handler = SpecCommandHandler::from(initial_events);
+    let mut projection = SpecProjection::from(initial_events);
 
     let valid_command: SpecCommand = serde_json::from_value(json!(
       {"AddPathParameter": {"pathId": "path_2","parentPathId": "path_1","name": "todoId"}}
     ))
     .expect("example command should be a valid command");
 
-    let new_events = command_handler
+    let new_events = projection
       .execute(valid_command)
       .expect("valid command should yield new events");
     assert_eq!(new_events.len(), 3);
@@ -307,7 +308,7 @@ mod test {
       {"AddPathParameter": {"pathId": "path_2","parentPathId": "not-a-path","name": "todoId"}}
     ))
     .unwrap();
-    let unexisting_parent_result = command_handler.execute(unexisting_parent);
+    let unexisting_parent_result = projection.execute(unexisting_parent);
     assert!(unexisting_parent_result.is_err());
     assert_debug_snapshot!(
       "can_handle_add_path_parameter_command__unexisting_parent_result",
@@ -318,7 +319,7 @@ mod test {
       {"AddPathParameter": {"pathId": "path_1","parentPathId": "path_1","name": "todoId"}}
     ))
     .unwrap();
-    let unassignable_path_id_result = command_handler.execute(unassignable_path_id);
+    let unassignable_path_id_result = projection.execute(unassignable_path_id);
     assert!(unassignable_path_id_result.is_err());
     assert_debug_snapshot!(
       "can_handle_add_path_parameter_command__unassignable_path_id_result",
@@ -326,7 +327,7 @@ mod test {
     );
 
     for event in new_events {
-      command_handler.apply(event); // verify this doesn't panic goes a long way to verifying the events
+      projection.apply(event); // verify this doesn't panic goes a long way to verifying the events
     }
   }
 
@@ -339,14 +340,14 @@ mod test {
     ]))
     .expect("initial events should be valid spec events");
 
-    let mut command_handler = SpecCommandHandler::from(initial_events);
+    let mut projection = SpecProjection::from(initial_events);
 
     let valid_command: SpecCommand = serde_json::from_value(json!(
       {"SetPathParameterShape":{"pathId":"path_2","shapedRequestParameterShapeDescriptor":{"shapeId":"string_shape_1","isRemoved":false}}}
     ))
     .expect("example command should be a valid command");
 
-    let new_events = command_handler
+    let new_events = projection
       .execute(valid_command)
       .expect("valid command should yield new events");
     assert_eq!(new_events.len(), 1);
@@ -354,7 +355,7 @@ mod test {
     let setting_root_path: SpecCommand = serde_json::from_value(json!(
       {"SetPathParameterShape":{"pathId":"root","shapedRequestParameterShapeDescriptor":{"shapeId":"string_shape_1","isRemoved":false}}}
     )).unwrap();
-    let setting_root_path_result = command_handler.execute(setting_root_path);
+    let setting_root_path_result = projection.execute(setting_root_path);
     assert!(setting_root_path_result.is_err());
     assert_debug_snapshot!(
       "can_handle_set_path_parameter_shape_command__setting_root_path_result",
@@ -364,7 +365,7 @@ mod test {
     let unexisting_path: SpecCommand = serde_json::from_value(json!(
       {"SetPathParameterShape":{"pathId":"not-a-path","shapedRequestParameterShapeDescriptor":{"shapeId":"string_shape_1","isRemoved":false}}}
     )).unwrap();
-    let unexisting_path_result = command_handler.execute(unexisting_path);
+    let unexisting_path_result = projection.execute(unexisting_path);
     assert!(unexisting_path_result.is_err());
     assert_debug_snapshot!(
       "can_handle_set_path_parameter_shape_command__unexisting_path_result",
@@ -374,7 +375,7 @@ mod test {
     let unexisting_shape: SpecCommand = serde_json::from_value(json!(
       {"SetPathParameterShape":{"pathId":"path_2","shapedRequestParameterShapeDescriptor":{"shapeId":"not_a_shape_id","isRemoved":false}}}
     )).unwrap();
-    let unexisting_shape_result = command_handler.execute(unexisting_shape);
+    let unexisting_shape_result = projection.execute(unexisting_shape);
     assert!(unexisting_shape_result.is_err());
     assert_debug_snapshot!(
       "can_handle_set_path_parameter_shape_command__unexisting_shape_result",
@@ -382,7 +383,7 @@ mod test {
     );
 
     for event in new_events {
-      command_handler.apply(event); // verify this doesn't panic goes a long way to verifying the events
+      projection.apply(event); // verify this doesn't panic goes a long way to verifying the events
     }
   }
 
@@ -395,14 +396,14 @@ mod test {
     ]))
     .expect("initial events should be valid endpoint events");
 
-    let mut command_handler = SpecCommandHandler::from(initial_events);
+    let mut projection = SpecProjection::from(initial_events);
 
     let valid_command: SpecCommand = serde_json::from_value(json!(
       {"SetRequestBodyShape": {"requestId": "request_1", "bodyDescriptor": { "httpContentType": "application/json", "shapeId": "string_shape_1", "isRemoved": false }}}
     ))
     .expect("example command should be a valid command");
 
-    let new_events = command_handler
+    let new_events = projection
       .execute(valid_command)
       .expect("valid command should yield new events");
     assert_eq!(new_events.len(), 1);
@@ -415,7 +416,7 @@ mod test {
       {"SetRequestBodyShape": {"requestId": "request_1", "bodyDescriptor": { "httpContentType": "application/json", "shapeId": "not-a-shape-id", "isRemoved": false }}}
     ))
     .unwrap();
-    let unexisting_shape_result = command_handler.execute(unexisting_shape);
+    let unexisting_shape_result = projection.execute(unexisting_shape);
     assert!(unexisting_shape_result.is_err());
     assert_debug_snapshot!(
       "can_handle_set_request_body_shape_command__unexisting_shape_result",
@@ -423,7 +424,7 @@ mod test {
     );
 
     for event in new_events {
-      command_handler.apply(event); // verify this doesn't panic goes a long way to verifying the events
+      projection.apply(event); // verify this doesn't panic goes a long way to verifying the events
     }
   }
 
@@ -437,14 +438,14 @@ mod test {
     ]))
     .expect("initial events should be valid endpoint events");
 
-    let mut command_handler = SpecCommandHandler::from(initial_events);
+    let mut projection = SpecProjection::from(initial_events);
 
     let valid_command: SpecCommand = serde_json::from_value(json!(
       {"SetResponseBodyShape": {"responseId": "response_1", "bodyDescriptor": { "httpContentType": "application/json", "shapeId": "string_shape_1", "isRemoved": false }}}
     ))
     .expect("example command should be a valid command");
 
-    let new_events = command_handler
+    let new_events = projection
       .execute(valid_command)
       .expect("valid command should yield new events");
     assert_eq!(new_events.len(), 1);
@@ -457,7 +458,7 @@ mod test {
       {"SetResponseBodyShape": {"responseId": "response_1", "bodyDescriptor": { "httpContentType": "application/json", "shapeId": "not-a-shape-id", "isRemoved": false }}}
     ))
     .unwrap();
-    let unexisting_shape_result = command_handler.execute(unexisting_shape);
+    let unexisting_shape_result = projection.execute(unexisting_shape);
     assert!(unexisting_shape_result.is_err());
     assert_debug_snapshot!(
       "can_handle_set_response_body_shape_command__unexisting_shape_result",
@@ -465,7 +466,67 @@ mod test {
     );
 
     for event in new_events {
-      command_handler.apply(event); // verify this doesn't panic goes a long way to verifying the events
+      projection.apply(event); // verify this doesn't panic goes a long way to verifying the events
     }
+  }
+
+  #[test]
+  pub fn spec_handler_provides_event_context_from_capture_context() {
+    let initial_events: Vec<SpecEvent> = serde_json::from_value(json!([
+      {"PathComponentAdded": {"pathId": "path_1","parentPathId": "root","name": "todos"}},
+    ]))
+    .expect("initial events should be valid spec events");
+
+    let mut command_handler = SpecCommandHandler::from(initial_events);
+
+    let command_context = CommandContext::new(
+      String::from("test-batch-1"),
+      String::from("test-client-id"),
+      String::from("test-client-session-id"),
+      Utc.timestamp(0, 0),
+    );
+
+    command_handler.with_command_context(command_context.clone());
+
+    let valid_command: SpecCommand = serde_json::from_value(json!(
+      {"AddPathComponent": {"pathId": "path_2","parentPathId": "path_1","name": "completed"}}
+    ))
+    .expect("example command should be a valid command");
+
+    let new_events = command_handler
+      .execute(valid_command)
+      .expect("valid command should yield new events");
+
+    let new_event = match new_events.get(0) {
+      Some(SpecEvent::EndpointEvent(EndpointEvent::PathComponentAdded(event))) => event,
+      _ => unreachable!(
+        "PathComponentAdded event should have been generated from AddPathComponent command"
+      ),
+    };
+
+    assert!(new_event.event_context.is_some());
+    let event_context = new_event.event_context.clone().unwrap();
+
+    assert_eq!(event_context.client_id, command_context.client_id);
+    assert_eq!(
+      event_context.client_session_id,
+      command_context.client_session_id
+    );
+    assert_eq!(
+      event_context.client_command_batch_id,
+      command_context.client_command_batch_id
+    );
+    assert_eq!(
+      event_context.created_at,
+      command_context
+        .created_at
+        .with_timezone(&Local)
+        .to_rfc3339()
+    );
+
+    assert_debug_snapshot!(
+      "spec_handler_provides_event_context_from_capture_context",
+      &new_event
+    );
   }
 }

--- a/workspaces/diff-engine/src/commands/mod.rs
+++ b/workspaces/diff-engine/src/commands/mod.rs
@@ -71,8 +71,32 @@ pub struct CommandContext {
   pub client_command_batch_id: String,
 }
 
+impl CommandContext {
+  pub fn new(batch_id: String, client_id: String, client_session_id: String) -> Self {
+    Self {
+      client_id,
+      client_command_batch_id: batch_id,
+      client_session_id,
+    }
+  }
+}
+
 // Command handling
 // ----------------
+
+pub struct SpecCommandHandler {
+  command_context: CommandContext,
+  spec_projection: SpecProjection,
+}
+
+impl SpecCommandHandler {
+  pub fn new(command_context: CommandContext, spec_projection: SpecProjection) -> Self {
+    Self {
+      command_context,
+      spec_projection,
+    }
+  }
+}
 
 impl AggregateCommand<SpecProjection> for SpecCommand {
   type Error = SpecCommandError;

--- a/workspaces/diff-engine/src/commands/mod.rs
+++ b/workspaces/diff-engine/src/commands/mod.rs
@@ -518,10 +518,7 @@ mod test {
     );
     assert_eq!(
       event_context.created_at,
-      command_context
-        .created_at
-        .with_timezone(&Local)
-        .to_rfc3339()
+      command_context.created_at.to_rfc3339()
     );
 
     assert_debug_snapshot!(

--- a/workspaces/diff-engine/src/commands/mod.rs
+++ b/workspaces/diff-engine/src/commands/mod.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, TimeZone, Utc};
 use std::process::Command;
 
 use cqrs_core::{Aggregate, AggregateCommand, AggregateEvent};
@@ -71,14 +72,21 @@ pub struct CommandContext {
   pub client_id: String,
   pub client_session_id: String,
   pub client_command_batch_id: String,
+  pub created_at: DateTime<Utc>,
 }
 
 impl CommandContext {
-  pub fn new(batch_id: String, client_id: String, client_session_id: String) -> Self {
+  pub fn new(
+    batch_id: String,
+    client_id: String,
+    client_session_id: String,
+    created_at: DateTime<impl TimeZone>,
+  ) -> Self {
     Self {
       client_id,
       client_command_batch_id: batch_id,
       client_session_id,
+      created_at: created_at.with_timezone(&Utc),
     }
   }
 }
@@ -89,6 +97,7 @@ impl Default for CommandContext {
       client_id: String::from("anonymous"),
       client_session_id: String::from("unknown-session"),
       client_command_batch_id: String::from("unknown-batch"),
+      created_at: Utc.timestamp(0, 0),
     }
   }
 }

--- a/workspaces/diff-engine/src/commands/rfc.rs
+++ b/workspaces/diff-engine/src/commands/rfc.rs
@@ -5,7 +5,6 @@ use crate::projections::{CommitId, HistoryProjection};
 use crate::queries::history::HistoryQueries;
 use cqrs_core::AggregateCommand;
 use serde::Deserialize;
-use uuid::Uuid;
 
 #[derive(Deserialize, Debug, Clone)]
 pub enum RfcCommand {
@@ -23,13 +22,14 @@ pub enum RfcCommand {
 }
 
 impl RfcCommand {
-  pub fn append_batch_commit(commit_message: String) -> Self {
-    Self::AppendBatch(AppendBatch { commit_message })
+  pub fn append_batch_commit(batch_id: String, commit_message: String) -> Self {
+    Self::AppendBatch(AppendBatch {
+      batch_id,
+      commit_message,
+    })
   }
 
-  pub fn start_batch_commit(parent_id: String, commit_message: String) -> Self {
-    let batch_id = Uuid::new_v4().to_hyphenated().to_string();
-
+  pub fn start_batch_commit(batch_id: String, parent_id: String, commit_message: String) -> Self {
     Self::StartBatchCommit(StartBatchCommit {
       batch_id,
       parent_id,
@@ -85,6 +85,7 @@ pub struct EndBatchCommit {
 
 #[derive(Debug, Clone)]
 pub struct AppendBatch {
+  pub batch_id: String,
   pub commit_message: String,
 }
 
@@ -107,6 +108,7 @@ impl AggregateCommand<HistoryProjection> for RfcCommand {
         };
 
         vec![RfcEvent::from(RfcCommand::start_batch_commit(
+          command.batch_id.clone(),
           parent_batch_id,
           command.commit_message.clone(),
         ))]
@@ -195,7 +197,8 @@ mod test {
 
     let mut projection = HistoryProjection::from(initial_events);
 
-    let command: RfcCommand = RfcCommand::append_batch_commit(String::from("second commit"));
+    let command: RfcCommand =
+      RfcCommand::append_batch_commit(String::from("test-batch-1"), String::from("second commit"));
 
     let new_events = projection
       .execute(command)

--- a/workspaces/diff-engine/src/commands/snapshots/optic_diff_engine__commands__test__spec_handler_provides_event_context_from_capture_context.snap
+++ b/workspaces/diff-engine/src/commands/snapshots/optic_diff_engine__commands__test__spec_handler_provides_event_context_from_capture_context.snap
@@ -1,0 +1,17 @@
+---
+source: workspaces/diff-engine/src/commands/mod.rs
+expression: "&new_event"
+---
+PathComponentAdded {
+    path_id: "path_2",
+    parent_path_id: "path_1",
+    name: "completed",
+    event_context: Some(
+        EventContext {
+            client_id: "test-client-id",
+            client_session_id: "test-client-session-id",
+            client_command_batch_id: "test-batch-1",
+            created_at: "1970-01-01T01:00:00+01:00",
+        },
+    ),
+}

--- a/workspaces/diff-engine/src/commands/snapshots/optic_diff_engine__commands__test__spec_handler_provides_event_context_from_capture_context.snap
+++ b/workspaces/diff-engine/src/commands/snapshots/optic_diff_engine__commands__test__spec_handler_provides_event_context_from_capture_context.snap
@@ -11,7 +11,7 @@ PathComponentAdded {
             client_id: "test-client-id",
             client_session_id: "test-client-session-id",
             client_command_batch_id: "test-batch-1",
-            created_at: "1970-01-01T01:00:00+01:00",
+            created_at: "1970-01-01T00:00:00+00:00",
         },
     ),
 }

--- a/workspaces/diff-engine/src/events/endpoint.rs
+++ b/workspaces/diff-engine/src/events/endpoint.rs
@@ -1,4 +1,4 @@
-use super::EventContext;
+use super::{EventContext, WithEventContext};
 use cqrs_core::Event;
 use endpoint_commands::RemovePathParameter;
 use serde::{Deserialize, Serialize};
@@ -264,6 +264,45 @@ impl Event for EndpointEvent {
       EndpointEvent::ResponseBodyUnset(evt) => evt.event_type(),
       EndpointEvent::ResponseRemoved(evt) => evt.event_type(),
     }
+  }
+}
+
+impl WithEventContext for EndpointEvent {
+  fn with_event_context(&mut self, event_context: EventContext) {
+    match self {
+      EndpointEvent::PathComponentAdded(evt) => evt.event_context.replace(event_context),
+      EndpointEvent::PathComponentRenamed(evt) => evt.event_context.replace(event_context),
+      EndpointEvent::PathComponentRemoved(evt) => evt.event_context.replace(event_context),
+
+      // path parameters
+      EndpointEvent::PathParameterAdded(evt) => evt.event_context.replace(event_context),
+      EndpointEvent::PathParameterShapeSet(evt) => evt.event_context.replace(event_context),
+      EndpointEvent::PathParameterRenamed(evt) => evt.event_context.replace(event_context),
+      EndpointEvent::PathParameterRemoved(evt) => evt.event_context.replace(event_context),
+
+      // request parameters
+      EndpointEvent::RequestParameterAddedByPathAndMethod(evt) => {
+        evt.event_context.replace(event_context)
+      }
+      EndpointEvent::RequestParameterRenamed(evt) => evt.event_context.replace(event_context),
+      EndpointEvent::RequestParameterShapeSet(evt) => evt.event_context.replace(event_context),
+      EndpointEvent::RequestParameterShapeUnset(evt) => evt.event_context.replace(event_context),
+      EndpointEvent::RequestParameterRemoved(evt) => evt.event_context.replace(event_context),
+
+      // Request events
+      EndpointEvent::RequestAdded(evt) => evt.event_context.replace(event_context),
+      EndpointEvent::RequestContentTypeSet(evt) => evt.event_context.replace(event_context),
+      EndpointEvent::RequestBodySet(evt) => evt.event_context.replace(event_context),
+      EndpointEvent::RequestBodyUnset(evt) => evt.event_context.replace(event_context),
+
+      // Response events
+      EndpointEvent::ResponseAddedByPathAndMethod(evt) => evt.event_context.replace(event_context),
+      EndpointEvent::ResponseStatusCodeSet(evt) => evt.event_context.replace(event_context),
+      EndpointEvent::ResponseContentTypeSet(evt) => evt.event_context.replace(event_context),
+      EndpointEvent::ResponseBodySet(evt) => evt.event_context.replace(event_context),
+      EndpointEvent::ResponseBodyUnset(evt) => evt.event_context.replace(event_context),
+      EndpointEvent::ResponseRemoved(evt) => evt.event_context.replace(event_context),
+    };
   }
 }
 

--- a/workspaces/diff-engine/src/events/mod.rs
+++ b/workspaces/diff-engine/src/events/mod.rs
@@ -46,6 +46,16 @@ impl Event for SpecEvent {
   }
 }
 
+impl WithEventContext for SpecEvent {
+  fn with_event_context(&mut self, event_context: EventContext) {
+    match self {
+      SpecEvent::EndpointEvent(evt) => evt.with_event_context(event_context),
+      SpecEvent::RfcEvent(evt) => evt.with_event_context(event_context),
+      SpecEvent::ShapeEvent(evt) => evt.with_event_context(event_context),
+    };
+  }
+}
+
 impl SpecEvent {
   pub fn from_file(filename: impl AsRef<Path>) -> Result<Vec<SpecEvent>, EventLoadingError> {
     let file_contents = fs::read_to_string(filename)?;
@@ -101,4 +111,8 @@ impl From<avro_rs::Error> for EventLoadingError {
   fn from(err: avro_rs::Error) -> EventLoadingError {
     EventLoadingError::Avro(err)
   }
+}
+
+pub trait WithEventContext {
+  fn with_event_context(&mut self, event_context: EventContext);
 }

--- a/workspaces/diff-engine/src/events/mod.rs
+++ b/workspaces/diff-engine/src/events/mod.rs
@@ -113,10 +113,10 @@ impl From<avro_rs::Error> for EventLoadingError {
 #[derive(Deserialize, Debug, PartialEq, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct EventContext {
-  client_id: String,
-  client_session_id: String,
-  client_command_batch_id: String,
-  created_at: String,
+  pub client_id: String,
+  pub client_session_id: String,
+  pub client_command_batch_id: String,
+  pub created_at: String,
 }
 
 impl From<CommandContext> for EventContext {

--- a/workspaces/diff-engine/src/events/rfc.rs
+++ b/workspaces/diff-engine/src/events/rfc.rs
@@ -1,4 +1,4 @@
-use super::EventContext;
+use super::{EventContext, WithEventContext};
 use crate::commands::rfc as rfc_commands;
 use crate::commands::RfcCommand;
 use cqrs_core::Event;
@@ -67,6 +67,18 @@ impl Event for RfcEvent {
       RfcEvent::BatchCommitStarted(evt) => evt.event_type(),
       RfcEvent::BatchCommitEnded(evt) => evt.event_type(),
     }
+  }
+}
+
+impl WithEventContext for RfcEvent {
+  fn with_event_context(&mut self, event_context: EventContext) {
+    match self {
+      RfcEvent::ContributionAdded(evt) => evt.event_context.replace(event_context),
+      RfcEvent::APINamed(evt) => evt.event_context.replace(event_context),
+      RfcEvent::GitStateSet(evt) => evt.event_context.replace(event_context),
+      RfcEvent::BatchCommitStarted(evt) => evt.event_context.replace(event_context),
+      RfcEvent::BatchCommitEnded(evt) => evt.event_context.replace(event_context),
+    };
   }
 }
 

--- a/workspaces/diff-engine/src/events/shape.rs
+++ b/workspaces/diff-engine/src/events/shape.rs
@@ -1,4 +1,4 @@
-use super::EventContext;
+use super::{EventContext, WithEventContext};
 use crate::state::shape::{
   FieldShapeDescriptor, ParameterShapeDescriptor, ShapeParametersDescriptor,
 };
@@ -145,6 +145,26 @@ impl Event for ShapeEvent {
       ShapeEvent::FieldRenamed(evt) => evt.event_type(),
       ShapeEvent::FieldRemoved(evt) => evt.event_type(),
     }
+  }
+}
+
+impl WithEventContext for ShapeEvent {
+  fn with_event_context(&mut self, event_context: EventContext) {
+    match self {
+      ShapeEvent::ShapeAdded(evt) => evt.event_context.replace(event_context),
+      ShapeEvent::BaseShapeSet(evt) => evt.event_context.replace(event_context),
+      ShapeEvent::ShapeRenamed(evt) => evt.event_context.replace(event_context),
+      ShapeEvent::ShapeRemoved(evt) => evt.event_context.replace(event_context),
+      ShapeEvent::ShapeParameterAdded(evt) => evt.event_context.replace(event_context),
+      ShapeEvent::ShapeParameterShapeSet(evt) => evt.event_context.replace(event_context),
+      ShapeEvent::ShapeParameterRenamed(evt) => evt.event_context.replace(event_context),
+      ShapeEvent::ShapeParameterRemoved(evt) => evt.event_context.replace(event_context),
+
+      ShapeEvent::FieldAdded(evt) => evt.event_context.replace(event_context),
+      ShapeEvent::FieldShapeSet(evt) => evt.event_context.replace(event_context),
+      ShapeEvent::FieldRenamed(evt) => evt.event_context.replace(event_context),
+      ShapeEvent::FieldRemoved(evt) => evt.event_context.replace(event_context),
+    };
   }
 }
 

--- a/workspaces/diff-engine/src/lib.rs
+++ b/workspaces/diff-engine/src/lib.rs
@@ -12,7 +12,7 @@ mod state;
 #[cfg(feature = "streams")]
 pub mod streams;
 
-pub use commands::{RfcCommand, SpecCommand};
+pub use commands::{CommandContext, RfcCommand, SpecCommand, SpecCommandHandler};
 pub use cqrs_core::Aggregate;
 pub use events::{HttpInteraction, RfcEvent, SpecChunkEvent, SpecEvent};
 pub use interactions::diff as diff_interaction;


### PR DESCRIPTION
## Why
We ported the command handling to the Rust domain implementation, but had so far ignored the writing of the `eventContext` for each event. We'll definitely want to make sure this contextual information gets captured for specs and achieve parity with the Scala implementation.

## What
The `commit` CLI command now accepts two additional arguments: `--client-id` and `--client-session-id`, which the endpoint to commit batch commands provides. Using a new `SpecCommandHandler` aggregate on the Rust side, the batch id and time of creation get added as well.

## Validation
* [ ] CI passes
* [x] Client id and Client session Id from Node make it into each new event's eventContext.
* [x] Time and batch information is persisted as part of each event context.
* [x] Resulsting spec is readable by both domain implementations.
