### PR TITLE
Fix bug where commit messages of batches would contain escape characters

### DIFF
--- a/workspaces/diff-engine/lib/index.js
+++ b/workspaces/diff-engine/lib/index.js
@@ -87,10 +87,8 @@ function commit(
 
   const binPath = getBinPath();
 
-  // Execa requires escaping of spaces for arguments, but nothing else
-  let messageArgument = commitMessage.replaceAll(/(\s)/g, '\\$1');
-
-  const optionalArgs = Object.entries({
+  const args = Object.entries({
+    '-m': commitMessage,
     '--append-to-root': appendToRoot,
     '--client-id': clientId,
     '--client-session-id': clientSessionId,
@@ -100,13 +98,9 @@ function commit(
       typeof value === 'string' ? [key, value] : [key]
     );
 
-  const commitProcess = Execa(
-    binPath,
-    [specDirPath, 'commit', '-m', messageArgument, ...optionalArgs],
-    {
-      stdio: ['pipe', 'pipe', 'inherit'],
-    }
-  );
+  const commitProcess = Execa(binPath, [specDirPath, 'commit', ...args], {
+    stdio: ['pipe', 'pipe', 'inherit'],
+  });
 
   input.pipe(commitProcess.stdin);
   commitProcess.stdout.pipe(output);


### PR DESCRIPTION
## Why
Commit messages for batch events generated by the Rust command handler would include unnecessary escape characters, which should have been cleaned up.

## What
We no longer manually escape the commit message when passing it from Node.js to the diff engine CLI. This is safe, as the requirement for having to do so was [misinterpreted from Execa's documentation](https://github.com/sindresorhus/execa#execacommandcommand-options), as validated by reading it's source code and experimenting. Turns out the escaping requirement exists when using execa like `execa('command arg1 arg2 arg3')`, rather than passing the arguments as an array separately.

## Validation
* [ ] CI passes
* [x] Commit message is persisted without unnecessarily escape chars.
* [x] It's safe not to escape them.
