### PR TITLE
Implement processing of spec commands for ExampleSpecService

### DIFF
--- a/workspaces/cli-client/src/spec-service-client.ts
+++ b/workspaces/cli-client/src/spec-service-client.ts
@@ -142,7 +142,7 @@ export class Client implements ISpecService {
       })
     );
 
-    this.eventEmitter.emit('events-appended', newEvents);
+    this.eventEmitter.emit('events-updated');
     return newEvents;
   }
 }

--- a/workspaces/diff-engine-wasm/engine/Cargo.lock
+++ b/workspaces/diff-engine-wasm/engine/Cargo.lock
@@ -351,6 +351,7 @@ dependencies = [
  "optic_diff_engine",
  "serde",
  "serde_json",
+ "uuid",
  "wasm-bindgen",
  "wasm-logger",
 ]

--- a/workspaces/diff-engine-wasm/engine/Cargo.lock
+++ b/workspaces/diff-engine-wasm/engine/Cargo.lock
@@ -346,6 +346,7 @@ dependencies = [
 name = "optic_diff_wasm"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "console_error_panic_hook",
  "log",
  "optic_diff_engine",

--- a/workspaces/diff-engine-wasm/engine/Cargo.toml
+++ b/workspaces/diff-engine-wasm/engine/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["cdylib"]
 [workspace] # Creating a new workspace prevents this from being built as part of the pre-built binaries
 
 [dependencies]
+chrono = { version = "0.4.19", features = ["serde", "wasmbind"] }
 console_error_panic_hook = "0.1.6"
 log = "0.4.6"
 serde = { version = "1.0.106", features = ["derive"] }

--- a/workspaces/diff-engine-wasm/engine/Cargo.toml
+++ b/workspaces/diff-engine-wasm/engine/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1.0.106", features = ["derive"] }
 serde_json = "1.0.57"
 wasm-bindgen = "0.2.68"
 wasm-logger = "0.2.0"
+uuid = { version = "0.8.2", features = ["v4", "wasm-bindgen"] }
 
 [dependencies.optic_diff_engine]
 path = "../../diff-engine" 

--- a/workspaces/diff-engine-wasm/engine/src/lib.rs
+++ b/workspaces/diff-engine-wasm/engine/src/lib.rs
@@ -1,8 +1,11 @@
 #![allow(dead_code, unused_imports, unused_variables)]
 
+use uuid::Uuid;
 use wasm_bindgen::prelude::*;
 
-use optic_diff_engine::{HttpInteraction, InteractionDiffResult, SpecEvent, SpecProjection};
+use optic_diff_engine::{
+  HttpInteraction, InteractionDiffResult, SpecCommand, SpecEvent, SpecProjection,
+};
 
 #[wasm_bindgen(start)]
 pub fn init() {
@@ -59,4 +62,19 @@ impl From<InteractionDiffResult> for ResultContainer<InteractionDiffResult> {
     let fingerprint = result.fingerprint();
     Self(result, fingerprint)
   }
+}
+
+// Commit batch
+// ------------
+
+#[wasm_bindgen]
+pub fn append_batch(
+  spec: &mut WasmSpecProjection,
+  commands: String,
+  command_message: String,
+) -> Result<String, JsValue> {
+  let commands: Vec<SpecCommand> = serde_json::from_str(&commands).unwrap();
+  let batch_id = Uuid::new_v4().to_hyphenated().to_string();
+
+  Ok(String::from("Okay!"))
 }

--- a/workspaces/diff-engine/src/lib.rs
+++ b/workspaces/diff-engine/src/lib.rs
@@ -23,6 +23,7 @@ pub use projections::{
 };
 pub use protos::shapehash;
 pub use shapes::diff as diff_shape;
+pub use spec::append_batch as append_batch_to_spec;
 pub use state::body::BodyDescriptor;
 
 pub mod errors {

--- a/workspaces/diff-engine/src/lib.rs
+++ b/workspaces/diff-engine/src/lib.rs
@@ -7,6 +7,7 @@ mod projections;
 mod protos;
 mod queries;
 mod shapes;
+mod spec;
 mod state;
 
 #[cfg(feature = "streams")]

--- a/workspaces/diff-engine/src/spec/mod.rs
+++ b/workspaces/diff-engine/src/spec/mod.rs
@@ -1,0 +1,76 @@
+pub use super::{diff_interaction, diff_shape};
+use crate::commands::{
+  CommandContext, RfcCommand, SpecCommand, SpecCommandError, SpecCommandHandler,
+};
+use crate::events::SpecEvent;
+use crate::projections::SpecProjection;
+use cqrs_core::Aggregate;
+
+pub struct BatchAppend {
+  batch_id: String,
+  command_handler: SpecCommandHandler,
+  new_events: Vec<SpecEvent>,
+}
+
+impl BatchAppend {
+  pub fn new(
+    spec_projection: SpecProjection,
+    commit_message: String,
+    batch_command_context: CommandContext,
+  ) -> Self {
+    let batch_id = batch_command_context.client_command_batch_id.clone();
+    let mut command_handler = SpecCommandHandler::new(batch_command_context, spec_projection);
+
+    let append_batch = SpecCommand::from(RfcCommand::append_batch_commit(
+      batch_id.clone(),
+      String::from(commit_message),
+    ));
+    let mut new_events = Vec::new();
+
+    // Start event
+    let start_event = command_handler
+      .execute(append_batch)
+      .expect("should be able to append new batch commit to spec")
+      .remove(0);
+
+    command_handler.apply(start_event.clone());
+
+    new_events.push(start_event);
+
+    Self {
+      batch_id,
+      command_handler,
+      new_events,
+    }
+  }
+
+  pub fn with_command(&mut self, command: SpecCommand) -> Result<(), SpecCommandError> {
+    let command_handler = &mut self.command_handler;
+    let new_events = &mut self.new_events;
+
+    let mut events = command_handler.execute(command)?;
+
+    for event in &events {
+      self.command_handler.apply(event.clone());
+    }
+
+    new_events.append(&mut events);
+
+    Ok(())
+  }
+
+  pub fn into_new_events(self) -> Vec<SpecEvent> {
+    let mut new_events = self.new_events;
+    let end_event = self
+      .command_handler
+      .execute(SpecCommand::from(RfcCommand::end_batch_commit(
+        self.batch_id.clone(),
+      )))
+      .expect("should be able to append new batch commit to spec")
+      .remove(0);
+
+    new_events.push(end_event);
+
+    new_events
+  }
+}

--- a/workspaces/diff-engine/src/spec/mod.rs
+++ b/workspaces/diff-engine/src/spec/mod.rs
@@ -6,13 +6,21 @@ use crate::events::SpecEvent;
 use crate::projections::SpecProjection;
 use cqrs_core::Aggregate;
 
-pub struct BatchAppend {
+pub fn append_batch(
+  spec_projection: SpecProjection,
+  commit_message: String,
+  batch_command_context: CommandContext,
+) -> AppendedBatch {
+  AppendedBatch::new(spec_projection, commit_message, batch_command_context)
+}
+
+pub struct AppendedBatch {
   batch_id: String,
   command_handler: SpecCommandHandler,
   new_events: Vec<SpecEvent>,
 }
 
-impl BatchAppend {
+impl AppendedBatch {
   pub fn new(
     spec_projection: SpecProjection,
     commit_message: String,
@@ -59,7 +67,7 @@ impl BatchAppend {
     Ok(())
   }
 
-  pub fn into_new_events(self) -> Vec<SpecEvent> {
+  pub fn commit(self) -> Vec<SpecEvent> {
     let mut new_events = self.new_events;
     let end_event = self
       .command_handler

--- a/workspaces/ui/src/components/loaders/ApiLoader.js
+++ b/workspaces/ui/src/components/loaders/ApiLoader.js
@@ -303,8 +303,18 @@ export async function createExampleSpecServiceFactory(data) {
     },
     processCommands(commands, commitMessage) {
       let spec = DiffEngine.spec_from_events(events);
-      DiffEngine.append_batch(spec, JSON.stringify(commands), commitMessage);
-      return Promise.resolve();
+      let newEventsJson = DiffEngine.append_batch_to_spec(
+        spec,
+        JSON.stringify(commands),
+        commitMessage
+      );
+      let newEvents = JSON.parse(newEventsJson);
+
+      events = JSON.stringify([...JSON.parse(events), ...newEvents]);
+      eventEmitter.emit('events-updated');
+
+      // eventEmitter.emit('events-appended', newEvents);
+      return Promise.resolve(newEvents);
     },
   };
 

--- a/workspaces/ui/src/components/loaders/ApiLoader.js
+++ b/workspaces/ui/src/components/loaders/ApiLoader.js
@@ -228,6 +228,7 @@ function useDiffServiceFactory(loadingExampleDiff) {
 export const captureId = 'example-session';
 export async function createExampleSpecServiceFactory(data) {
   let events = JSON.stringify(data.events);
+  let DiffEngine = await import('@useoptic/diff-engine-wasm/engine/browser');
 
   const examples = data.examples || {};
   const eventEmitter = new EventEmitter();
@@ -301,7 +302,8 @@ export async function createExampleSpecServiceFactory(data) {
       };
     },
     processCommands(commands, commitMessage) {
-      console.log('make wasm to me');
+      let spec = DiffEngine.spec_from_events(events);
+      DiffEngine.append_batch(spec, JSON.stringify(commands), commitMessage);
       return Promise.resolve();
     },
   };

--- a/workspaces/ui/src/components/loaders/ApiLoader.js
+++ b/workspaces/ui/src/components/loaders/ApiLoader.js
@@ -29,23 +29,6 @@ export function ApiSpecServiceLoader(props) {
     }
   }, [specService]);
 
-  useEffect(() => {
-    if (specService) {
-      function onEventAppended(newEvents) {
-        setEvents([...events, ...newEvents]);
-      }
-
-      specService.eventEmitter.on('events-appended', onEventAppended);
-
-      return function cleanup() {
-        specService.eventEmitter.removeListener(
-          'events-appended',
-          onEventAppended
-        );
-      };
-    }
-  }, [specService]);
-
   const captureServiceFactory = useCaptureServiceFactory(loadingExampleDiff);
   const diffServiceFactory = useDiffServiceFactory(loadingExampleDiff);
 


### PR DESCRIPTION
## Why
We've introduced a new `processCommands` method for the `SpecServiceClient`, which is the new interface to persist spec changes through the new Rust command handlers. However, we skipped implementing it for the `ExampleSpecService` implementation, disallowing this new way of saving spec changes to be used for debug / example / private sessions.

## What
This PR adds an `append_batch_to_spec` method to the WASM DiffEngine implementation, accepting commands describing the spec change and a commit message, returning the newly generated events, or throwing if there were any command handling errors.

In order to implement this, it extracts the logic for starting a batch, handling commands and committing it from the CLI interface, to a `AppendedBatch` struct and a convenient function to set this up. This way the CLI and WASM interfaces only detail the interface specifics, like how the I/O works.

## Validation
* [x] CI passes
* [x] Finalized changes from the Diff Review UI causes an updated spec in Documentation.
