### PR TITLE
invalid regexes should not crash daemon

### DIFF
--- a/workspaces/cli-config/src/helpers/ignore-parser.ts
+++ b/workspaces/cli-config/src/helpers/ignore-parser.ts
@@ -61,14 +61,19 @@ export function parseRule(
       .map((i) => i.toUpperCase())
       .filter((i) => allowedMethods.includes(i));
   }
-  const regex = pathToRegexp(pathInput);
-  const shouldIgnore = (method: string, url: string) =>
-    methods.includes(method) && regex.exec(url) !== null;
+  try {
+    const regex = pathToRegexp(pathInput);
+    const shouldIgnore = (method: string, url: string) =>
+      methods.includes(method) && regex.exec(url) !== null;
 
-  return {
-    methods,
-    path: pathInput,
-    regex,
-    shouldIgnore,
-  };
+    return {
+      methods,
+      path: pathInput,
+      regex,
+      shouldIgnore,
+    };
+  } catch (e) {
+    console.warn('Invalid regex in ignore rule, skipping:' + userInput);
+    return undefined;
+  }
 }


### PR DESCRIPTION
## Why
In a user session, it was revealed that invalid Regex ex: `(*.)` vs `(.*)` will crash the daemon

## What
Any rule containing an invalid regex will be skipped. There's not any user feedback right now, but this seems ok for now. Anyone writing a regex will notice the rule is not having the intended effect and take the time to go back and revise it, hopefully, stumbling upon the issue as they go. 

In the future, feedback about valid/invalid config should run on every CLI command

## Validation
* [ ] CI passes
* [ ] Verified in staging
