### PR TITLE
command handlers should emit events for added contributions

### DIFF
--- a/workspaces/diff-engine/src/commands/snapshots/optic_diff_engine__commands__rfc__test__can_handle_add_contribution_command__new_events.snap
+++ b/workspaces/diff-engine/src/commands/snapshots/optic_diff_engine__commands__rfc__test__can_handle_add_contribution_command__new_events.snap
@@ -1,0 +1,14 @@
+---
+source: workspaces/diff-engine/src/commands/rfc.rs
+expression: new_events
+---
+[
+    ContributionAdded(
+        ContributionAdded {
+            id: "path123.method",
+            key: "purpose",
+            value: "Name of Endpoint",
+            event_context: None,
+        },
+    ),
+]

--- a/workspaces/diff-engine/src/events/rfc.rs
+++ b/workspaces/diff-engine/src/events/rfc.rs
@@ -124,6 +124,12 @@ impl From<BatchCommitEnded> for RfcEvent {
   }
 }
 
+impl From<ContributionAdded> for RfcEvent {
+  fn from(event: ContributionAdded) -> Self {
+    Self::ContributionAdded(event)
+  }
+}
+
 // Conversion from commands
 // ------------------------
 
@@ -132,6 +138,7 @@ impl From<RfcCommand> for RfcEvent {
     match rfc_command {
       RfcCommand::StartBatchCommit(command) => RfcEvent::from(BatchCommitStarted::from(command)),
       RfcCommand::EndBatchCommit(command) => RfcEvent::from(BatchCommitEnded::from(command)),
+      RfcCommand::AddContribution(command) => RfcEvent::from(ContributionAdded::from(command)),
       _ => unimplemented!(
         "conversion from rfc command to rfc event not implemented for variant: {:?}",
         rfc_command
@@ -156,6 +163,17 @@ impl From<rfc_commands::EndBatchCommit> for BatchCommitEnded {
     Self {
       batch_id: command.batch_id,
       event_context: None,
+    }
+  }
+}
+
+impl From<rfc_commands::AddContribution> for ContributionAdded {
+  fn from(command: rfc_commands::AddContribution) -> Self {
+    Self {
+      id: command.id,
+      key: command.key,
+      value: command.value,
+      event_context: None
     }
   }
 }


### PR DESCRIPTION
## Why
The new Rust command handlers need to implement the AddContributions command and emit the ContributionAdded event as users add descriptions throughout their specifications. 

## What
Simple command handler and snapshot tests have been written. As the contribution projection will be a simple lookup, there's no need to add validation rules this stage. You can add contributions even if some of the IDs they reference don't exist in the specification.  

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
