### PR TITLE
Add cqrs_event macro to reduce Event trait implementation boilerplate

### DIFF
--- a/workspaces/diff-engine/src/events/endpoint.rs
+++ b/workspaces/diff-engine/src/events/endpoint.rs
@@ -105,12 +105,6 @@ pub struct PathComponentAdded {
   pub name: String,
   pub event_context: Option<EventContext>,
 }
-cqrs_event!(PathComponentAdded => "PathComponentAdded");
-cqrs_event!(EndpointEvent { PathComponentAdded });
-// cqrs_event!(EndpointEvent {
-//   PathComponentAdded => "PathComponentAdded",
-//   PathComponentRenamed => "PathComponentRenamed"
-// });
 
 #[derive(Deserialize, Debug, PartialEq, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -288,285 +282,36 @@ pub struct ResponseRemoved {
   pub event_context: Option<EventContext>,
 }
 
-// impl Event for EndpointEvent {
-//   fn event_type(&self) -> &'static str {
-//     match self {
-//       EndpointEvent::PathComponentAdded(evt) => evt.event_type(),
-//       EndpointEvent::PathComponentRenamed(evt) => evt.event_type(),
-//       EndpointEvent::PathComponentRemoved(evt) => evt.event_type(),
+cqrs_event!(EndpointEvent {
+  PathComponentAdded => "PathComponentAdded",
+  PathComponentRenamed => "PathComponentRenamed",
+  PathComponentRemoved => "PathComponentRemoved",
 
-//       // path parameters
-//       EndpointEvent::PathParameterAdded(evt) => evt.event_type(),
-//       EndpointEvent::PathParameterShapeSet(evt) => evt.event_type(),
-//       EndpointEvent::PathParameterRenamed(evt) => evt.event_type(),
-//       EndpointEvent::PathParameterRemoved(evt) => evt.event_type(),
+  PathParameterAdded => "PathParameterAdded",
+  PathParameterRenamed => "PathParameterRenamed",
+  PathParameterRemoved => "PathParameterRemoved",
+  PathParameterShapeSet => "PathParameterShapeSet",
 
-//       // request parameters
-//       EndpointEvent::RequestParameterAddedByPathAndMethod(evt) => evt.event_type(),
-//       EndpointEvent::RequestParameterRenamed(evt) => evt.event_type(),
-//       EndpointEvent::RequestParameterShapeSet(evt) => evt.event_type(),
-//       EndpointEvent::RequestParameterShapeUnset(evt) => evt.event_type(),
-//       EndpointEvent::RequestParameterRemoved(evt) => evt.event_type(),
+  RequestParameterAddedByPathAndMethod => "RequestParameterAddedByPathAndMethod",
+  RequestParameterRenamed => "RequestParameterRenamed",
+  RequestParameterShapeSet => "RequestParameterShapeSet",
+  RequestParameterShapeUnset => "RequestParameterShapeUnset",
+  RequestParameterRemoved => "RequestParameterRemoved",
 
-//       // Request events
-//       EndpointEvent::RequestAdded(evt) => evt.event_type(),
-//       EndpointEvent::RequestContentTypeSet(evt) => evt.event_type(),
-//       EndpointEvent::RequestBodySet(evt) => evt.event_type(),
-//       EndpointEvent::RequestBodyUnset(evt) => evt.event_type(),
+  // Request events
+  RequestAdded => "RequestAdded",
+  RequestContentTypeSet => "RequestContentTypeSet",
+  RequestBodySet => "RequestBodySet",
+  RequestBodyUnset => "RequestBodyUnset",
 
-//       // Response events
-//       EndpointEvent::ResponseAddedByPathAndMethod(evt) => evt.event_type(),
-//       EndpointEvent::ResponseStatusCodeSet(evt) => evt.event_type(),
-//       EndpointEvent::ResponseContentTypeSet(evt) => evt.event_type(),
-//       EndpointEvent::ResponseBodySet(evt) => evt.event_type(),
-//       EndpointEvent::ResponseBodyUnset(evt) => evt.event_type(),
-//       EndpointEvent::ResponseRemoved(evt) => evt.event_type(),
-//     }
-//   }
-// }
-
-// impl WithEventContext for EndpointEvent {
-//   fn with_event_context(&mut self, event_context: EventContext) {
-//     match self {
-//       EndpointEvent::PathComponentAdded(evt) => evt.event_context.replace(event_context),
-//       EndpointEvent::PathComponentRenamed(evt) => evt.event_context.replace(event_context),
-//       EndpointEvent::PathComponentRemoved(evt) => evt.event_context.replace(event_context),
-
-//       // path parameters
-//       EndpointEvent::PathParameterAdded(evt) => evt.event_context.replace(event_context),
-//       EndpointEvent::PathParameterShapeSet(evt) => evt.event_context.replace(event_context),
-//       EndpointEvent::PathParameterRenamed(evt) => evt.event_context.replace(event_context),
-//       EndpointEvent::PathParameterRemoved(evt) => evt.event_context.replace(event_context),
-
-//       // request parameters
-//       EndpointEvent::RequestParameterAddedByPathAndMethod(evt) => {
-//         evt.event_context.replace(event_context)
-//       }
-//       EndpointEvent::RequestParameterRenamed(evt) => evt.event_context.replace(event_context),
-//       EndpointEvent::RequestParameterShapeSet(evt) => evt.event_context.replace(event_context),
-//       EndpointEvent::RequestParameterShapeUnset(evt) => evt.event_context.replace(event_context),
-//       EndpointEvent::RequestParameterRemoved(evt) => evt.event_context.replace(event_context),
-
-//       // Request events
-//       EndpointEvent::RequestAdded(evt) => evt.event_context.replace(event_context),
-//       EndpointEvent::RequestContentTypeSet(evt) => evt.event_context.replace(event_context),
-//       EndpointEvent::RequestBodySet(evt) => evt.event_context.replace(event_context),
-//       EndpointEvent::RequestBodyUnset(evt) => evt.event_context.replace(event_context),
-
-//       // Response events
-//       EndpointEvent::ResponseAddedByPathAndMethod(evt) => evt.event_context.replace(event_context),
-//       EndpointEvent::ResponseStatusCodeSet(evt) => evt.event_context.replace(event_context),
-//       EndpointEvent::ResponseContentTypeSet(evt) => evt.event_context.replace(event_context),
-//       EndpointEvent::ResponseBodySet(evt) => evt.event_context.replace(event_context),
-//       EndpointEvent::ResponseBodyUnset(evt) => evt.event_context.replace(event_context),
-//       EndpointEvent::ResponseRemoved(evt) => evt.event_context.replace(event_context),
-//     };
-//   }
-// }
-
-// impl Event for PathComponentAdded {
-//   fn event_type(&self) -> &'static str {
-//     "PathComponentAdded"
-//   }
-// }
-
-impl Event for PathParameterShapeSet {
-  fn event_type(&self) -> &'static str {
-    "PathParameterShapeSet"
-  }
-}
-
-// impl Event for PathComponentRenamed {
-//   fn event_type(&self) -> &'static str {
-//     "PathComponentRenamed"
-//   }
-// }
-
-impl Event for PathComponentRemoved {
-  fn event_type(&self) -> &'static str {
-    "PathComponentRemoved"
-  }
-}
-
-impl Event for PathParameterAdded {
-  fn event_type(&self) -> &'static str {
-    "PathParameterAdded"
-  }
-}
-
-impl Event for PathParameterRenamed {
-  fn event_type(&self) -> &'static str {
-    "PathParameterRenamed"
-  }
-}
-
-impl Event for PathParameterRemoved {
-  fn event_type(&self) -> &'static str {
-    "PathParameterRemoved"
-  }
-}
-
-impl Event for RequestParameterAddedByPathAndMethod {
-  fn event_type(&self) -> &'static str {
-    "RequestParameterAddedByPathAndMethod"
-  }
-}
-
-impl Event for RequestParameterRenamed {
-  fn event_type(&self) -> &'static str {
-    "RequestParameterRenamed"
-  }
-}
-
-impl Event for RequestParameterShapeSet {
-  fn event_type(&self) -> &'static str {
-    "RequestParameterShapeSet"
-  }
-}
-
-impl Event for RequestParameterShapeUnset {
-  fn event_type(&self) -> &'static str {
-    "RequestParameterShapeUnset"
-  }
-}
-
-impl Event for RequestParameterRemoved {
-  fn event_type(&self) -> &'static str {
-    "RequestParameterRemoved"
-  }
-}
-
-impl Event for RequestAdded {
-  fn event_type(&self) -> &'static str {
-    "RequestAdded"
-  }
-}
-
-impl Event for RequestContentTypeSet {
-  fn event_type(&self) -> &'static str {
-    "RequestContentTypeSet"
-  }
-}
-
-impl Event for RequestBodySet {
-  fn event_type(&self) -> &'static str {
-    "RequestBodySet"
-  }
-}
-
-impl Event for RequestBodyUnset {
-  fn event_type(&self) -> &'static str {
-    "RequestBodyUnset"
-  }
-}
-
-impl Event for RequestRemoved {
-  fn event_type(&self) -> &'static str {
-    "RequestRemoved"
-  }
-}
-
-impl Event for ResponseAddedByPathAndMethod {
-  fn event_type(&self) -> &'static str {
-    "ResponseAddedByPathAndMethod"
-  }
-}
-
-impl Event for ResponseStatusCodeSet {
-  fn event_type(&self) -> &'static str {
-    "ResponseStatusCodeSet"
-  }
-}
-
-impl Event for ResponseContentTypeSet {
-  fn event_type(&self) -> &'static str {
-    "ResponseContentTypeSet"
-  }
-}
-
-impl Event for ResponseBodySet {
-  fn event_type(&self) -> &'static str {
-    "ResponseBodySet"
-  }
-}
-
-impl Event for ResponseBodyUnset {
-  fn event_type(&self) -> &'static str {
-    "ResponseBodyUnset"
-  }
-}
-
-impl Event for ResponseRemoved {
-  fn event_type(&self) -> &'static str {
-    "ResponseRemoved"
-  }
-}
-
-// impl From<PathComponentAdded> for EndpointEvent {
-//   fn from(event: PathComponentAdded) -> Self {
-//     Self::PathComponentAdded(event)
-//   }
-// }
-
-// impl From<PathComponentRenamed> for EndpointEvent {
-//   fn from(event: PathComponentRenamed) -> Self {
-//     Self::PathComponentRenamed(event)
-//   }
-// }
-
-impl From<PathComponentRemoved> for EndpointEvent {
-  fn from(event: PathComponentRemoved) -> Self {
-    Self::PathComponentRemoved(event)
-  }
-}
-
-impl From<PathParameterAdded> for EndpointEvent {
-  fn from(event: PathParameterAdded) -> Self {
-    Self::PathParameterAdded(event)
-  }
-}
-
-impl From<PathParameterShapeSet> for EndpointEvent {
-  fn from(event: PathParameterShapeSet) -> Self {
-    Self::PathParameterShapeSet(event)
-  }
-}
-
-impl From<PathParameterRenamed> for EndpointEvent {
-  fn from(event: PathParameterRenamed) -> Self {
-    Self::PathParameterRenamed(event)
-  }
-}
-
-impl From<PathParameterRemoved> for EndpointEvent {
-  fn from(event: PathParameterRemoved) -> Self {
-    Self::PathParameterRemoved(event)
-  }
-}
-
-impl From<RequestAdded> for EndpointEvent {
-  fn from(event: RequestAdded) -> Self {
-    Self::RequestAdded(event)
-  }
-}
-
-impl From<RequestBodySet> for EndpointEvent {
-  fn from(event: RequestBodySet) -> Self {
-    Self::RequestBodySet(event)
-  }
-}
-
-impl From<ResponseAddedByPathAndMethod> for EndpointEvent {
-  fn from(event: ResponseAddedByPathAndMethod) -> Self {
-    Self::ResponseAddedByPathAndMethod(event)
-  }
-}
-
-impl From<ResponseBodySet> for EndpointEvent {
-  fn from(event: ResponseBodySet) -> Self {
-    Self::ResponseBodySet(event)
-  }
-}
+  // Response events
+  ResponseAddedByPathAndMethod => "ResponseAddedByPathAndMethod",
+  ResponseStatusCodeSet => "ResponseStatusCodeSet",
+  ResponseContentTypeSet => "ResponseContentTypeSet",
+  ResponseBodySet => "ResponseBodySet",
+  ResponseBodyUnset => "ResponseBodyUnset",
+  ResponseRemoved => "ResponseRemoved"
+});
 
 // Conversion from commands
 // ------------------------

--- a/workspaces/diff-engine/src/events/endpoint.rs
+++ b/workspaces/diff-engine/src/events/endpoint.rs
@@ -45,58 +45,6 @@ pub enum EndpointEvent {
   ResponseRemoved(ResponseRemoved),
 }
 
-macro_rules! cqrs_event {
-  // Single Event => event_name. Impls for a single event
-  ($event_type: ty => $name: expr) => {
-    impl ::cqrs_core::Event for $event_type {
-      fn event_type(&self) -> &'static str {
-        $name
-      }
-    }
-
-    impl WithEventContext for $event_type {
-      fn with_event_context(&mut self, event_context: EventContext) {
-        self.event_context.replace(event_context);
-      }
-    }
-  };
-
-  // Group (enum) { Event }. Impls for a group of events
-  ($group_type: ident { $($event_type: ident),+ }) => {
-    impl ::cqrs_core::Event for $group_type {
-      fn event_type(&self) -> &'static str {
-        match self {
-          $( $group_type::$event_type(evt) => evt.event_type() ),+
-        }
-      }
-    }
-
-    impl WithEventContext for $group_type {
-      fn with_event_context(&mut self, event_context: EventContext) {
-        match self {
-          $( $group_type::$event_type(evt) => evt.with_event_context(event_context)),+,
-        }
-      }
-    }
-
-    $(
-      impl From<$event_type> for $group_type {
-        fn from(event: $event_type) -> Self {
-          Self::$event_type(event)
-        }
-      }
-    )+
-  };
-
-  // Group (enum) { Event => event_name }, combining impls for group and it's single events
-  ($group_type: ident { $($event_type: ident => $name: expr),+ }) => {
-    $( cqrs_event!($event_type => $name); )+
-
-    cqrs_event!($group_type { $($event_type),+});
-  }
-
-}
-
 #[derive(Deserialize, Debug, PartialEq, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct PathComponentAdded {

--- a/workspaces/diff-engine/src/events/endpoint.rs
+++ b/workspaces/diff-engine/src/events/endpoint.rs
@@ -46,6 +46,8 @@ pub enum EndpointEvent {
 }
 
 macro_rules! cqrs_event {
+
+  // Single Event => event_name
   ($event_type: ty => $name: expr) => {
     impl ::cqrs_core::Event for $event_type {
       fn event_type(&self) -> &'static str {
@@ -59,7 +61,9 @@ macro_rules! cqrs_event {
       }
     }
   };
-  ($group_type:ident { $($event_type: ident => $name: expr),+ }) => {
+
+  // Group (enum) { Event => event_name }
+  ($group_type: ident { $($event_type: ident => $name: expr),+ }) => {
 
     $( cqrs_event!($event_type => $name); )+
 
@@ -80,6 +84,14 @@ macro_rules! cqrs_event {
         }
       }
     }
+
+    $(
+      impl From<$event_type> for $group_type {
+        fn from(event: $event_type) -> Self {
+          Self::$event_type(event)
+        }
+      }
+    )+
   };
 
 }
@@ -92,11 +104,12 @@ pub struct PathComponentAdded {
   pub name: String,
   pub event_context: Option<EventContext>,
 }
-// cqrs_event!(PathComponentAdded => "PathComponentAdded");
-cqrs_event!(EndpointEvent {
-  PathComponentAdded => "PathComponentAdded",
-  PathComponentRenamed => "PathComponentRenamed"
-});
+cqrs_event!(PathComponentAdded => "PathComponentAdded");
+cqrs_event!(EndpointEvent { PathComponentAdded });
+// cqrs_event!(EndpointEvent {
+//   PathComponentAdded => "PathComponentAdded",
+//   PathComponentRenamed => "PathComponentRenamed"
+// });
 
 #[derive(Deserialize, Debug, PartialEq, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -488,17 +501,17 @@ impl Event for ResponseRemoved {
   }
 }
 
-impl From<PathComponentAdded> for EndpointEvent {
-  fn from(event: PathComponentAdded) -> Self {
-    Self::PathComponentAdded(event)
-  }
-}
+// impl From<PathComponentAdded> for EndpointEvent {
+//   fn from(event: PathComponentAdded) -> Self {
+//     Self::PathComponentAdded(event)
+//   }
+// }
 
-impl From<PathComponentRenamed> for EndpointEvent {
-  fn from(event: PathComponentRenamed) -> Self {
-    Self::PathComponentRenamed(event)
-  }
-}
+// impl From<PathComponentRenamed> for EndpointEvent {
+//   fn from(event: PathComponentRenamed) -> Self {
+//     Self::PathComponentRenamed(event)
+//   }
+// }
 
 impl From<PathComponentRemoved> for EndpointEvent {
   fn from(event: PathComponentRemoved) -> Self {

--- a/workspaces/diff-engine/src/events/endpoint.rs
+++ b/workspaces/diff-engine/src/events/endpoint.rs
@@ -66,8 +66,7 @@ macro_rules! cqrs_event {
     impl ::cqrs_core::Event for $group_type {
       fn event_type(&self) -> &'static str {
         match self {
-          $( $group_type::$event_type(evt) => evt.event_type() ),+,
-          _ => "unknown"
+          $( $group_type::$event_type(evt) => evt.event_type() ),+
         }
       }
     }
@@ -76,7 +75,6 @@ macro_rules! cqrs_event {
       fn with_event_context(&mut self, event_context: EventContext) {
         match self {
           $( $group_type::$event_type(evt) => evt.with_event_context(event_context)),+,
-          _ => {},
         }
       }
     }

--- a/workspaces/diff-engine/src/events/endpoint.rs
+++ b/workspaces/diff-engine/src/events/endpoint.rs
@@ -46,8 +46,7 @@ pub enum EndpointEvent {
 }
 
 macro_rules! cqrs_event {
-
-  // Single Event => event_name
+  // Single Event => event_name. Impls for a single event
   ($event_type: ty => $name: expr) => {
     impl ::cqrs_core::Event for $event_type {
       fn event_type(&self) -> &'static str {
@@ -62,11 +61,8 @@ macro_rules! cqrs_event {
     }
   };
 
-  // Group (enum) { Event => event_name }
-  ($group_type: ident { $($event_type: ident => $name: expr),+ }) => {
-
-    $( cqrs_event!($event_type => $name); )+
-
+  // Group (enum) { Event }. Impls for a group of events
+  ($group_type: ident { $($event_type: ident),+ }) => {
     impl ::cqrs_core::Event for $group_type {
       fn event_type(&self) -> &'static str {
         match self {
@@ -93,6 +89,13 @@ macro_rules! cqrs_event {
       }
     )+
   };
+
+  // Group (enum) { Event => event_name }, combining impls for group and it's single events
+  ($group_type: ident { $($event_type: ident => $name: expr),+ }) => {
+    $( cqrs_event!($event_type => $name); )+
+
+    cqrs_event!($group_type { $($event_type),+});
+  }
 
 }
 

--- a/workspaces/diff-engine/src/events/macros.rs
+++ b/workspaces/diff-engine/src/events/macros.rs
@@ -1,3 +1,4 @@
+/// Implements cqrs_core::Event and WithEventContext for struct or enum of structs
 #[macro_export]
 macro_rules! cqrs_event {
   // Single Event => event_name. Impls for a single event

--- a/workspaces/diff-engine/src/events/macros.rs
+++ b/workspaces/diff-engine/src/events/macros.rs
@@ -10,7 +10,7 @@ macro_rules! cqrs_event {
     }
 
     impl $crate::events::WithEventContext for $event_type {
-      fn with_event_context(&mut self, event_context: EventContext) {
+      fn with_event_context(&mut self, event_context: $crate::events::EventContext) {
         self.event_context.replace(event_context);
       }
     }
@@ -27,7 +27,7 @@ macro_rules! cqrs_event {
     }
 
     impl $crate::events::WithEventContext for $group_type {
-      fn with_event_context(&mut self, event_context: EventContext) {
+      fn with_event_context(&mut self, event_context: $crate::events::EventContext) {
         match self {
           $( $group_type::$event_type(evt) => evt.with_event_context(event_context)),+,
         }

--- a/workspaces/diff-engine/src/events/macros.rs
+++ b/workspaces/diff-engine/src/events/macros.rs
@@ -1,0 +1,52 @@
+#[macro_export]
+macro_rules! cqrs_event {
+  // Single Event => event_name. Impls for a single event
+  ($event_type: ty => $name: expr) => {
+    impl ::cqrs_core::Event for $event_type {
+      fn event_type(&self) -> &'static str {
+        $name
+      }
+    }
+
+    impl $crate::events::WithEventContext for $event_type {
+      fn with_event_context(&mut self, event_context: EventContext) {
+        self.event_context.replace(event_context);
+      }
+    }
+  };
+
+  // Group (enum) { Event }. Impls for a group of events
+  ($group_type: ident { $($event_type: ident),+ }) => {
+    impl ::cqrs_core::Event for $group_type {
+      fn event_type(&self) -> &'static str {
+        match self {
+          $( $group_type::$event_type(evt) => evt.event_type() ),+
+        }
+      }
+    }
+
+    impl $crate::events::WithEventContext for $group_type {
+      fn with_event_context(&mut self, event_context: EventContext) {
+        match self {
+          $( $group_type::$event_type(evt) => evt.with_event_context(event_context)),+,
+        }
+      }
+    }
+
+    $(
+      impl From<$event_type> for $group_type {
+        fn from(event: $event_type) -> Self {
+          Self::$event_type(event)
+        }
+      }
+    )+
+  };
+
+  // Group (enum) { Event => event_name }, combining impls for group and it's single events
+  ($group_type: ident { $($event_type: ident => $name: expr),+ }) => {
+    $( cqrs_event!($event_type => $name); )+
+
+    cqrs_event!($group_type { $($event_type),+});
+  }
+
+}

--- a/workspaces/diff-engine/src/events/macros.rs
+++ b/workspaces/diff-engine/src/events/macros.rs
@@ -1,4 +1,75 @@
-/// Implements cqrs_core::Event and WithEventContext for struct or enum of structs
+/// Compactly implement Events or groups of Events. Implements `Event` and `WithEventContext` traits and links between groups.
+///
+/// # Examples
+///
+/// The most basic use is a single event struct, where one provides the struct and it's &'static str event name
+/// ```
+/// # use optic_diff_engine::EventContext;
+/// # use optic_diff_engine::cqrs_event;
+/// #
+/// struct ExampleEvent {
+///   some_property: String,
+///   // struct is required to have an optional event_context
+///   event_context: Option<EventContext>,
+/// }
+///
+/// cqrs_event!(ExampleEvent => "example_event_name");
+/// ```
+///
+/// A enum of nested events can also be expressed, as long as the variants and struct names match. In addition to
+/// `Event` and `WithEventContext` traits, it also implements `From<Variant> for Group` for each variant.
+/// ```
+/// # use optic_diff_engine::EventContext;
+/// # use optic_diff_engine::cqrs_event;
+/// #
+/// struct ExampleEvent {
+///   some_property: String,
+///   // struct is required to have an optional event_context
+///   event_context: Option<EventContext>,
+/// }
+///
+/// struct AnotherExampleEvent {
+///   other_property: u16,
+///   // struct is required to have an optional event_context
+///   event_context: Option<EventContext>,
+/// }
+///
+/// enum EventGroup {
+///   ExampleEvent(ExampleEvent),
+///   AnotherExampleEvent(AnotherExampleEvent)
+/// }
+///
+/// cqrs_event!(ExampleEvent => "example_event_name");
+/// cqrs_event!(AnotherExampleEvent => "another_example_event");
+/// cqrs_event!(EventGroup {
+///   ExampleEvent,
+///   AnotherExampleEvent
+/// });
+/// ```
+///
+/// The two forms can also be combined, generating trait implementations for both the single events, as well as the group.
+/// ```
+/// # use optic_diff_engine::EventContext;
+/// # use optic_diff_engine::cqrs_event;
+/// #
+/// # struct ExampleEvent {
+/// #  event_context: Option<EventContext>,
+/// # }
+/// #
+/// # struct AnotherExampleEvent {
+/// #  event_context: Option<EventContext>,
+/// # }
+/// #
+/// # enum EventGroup {
+/// #  ExampleEvent(ExampleEvent),
+/// #  AnotherExampleEvent(AnotherExampleEvent)
+/// # }
+/// #
+/// cqrs_event!(EventGroup {
+///   ExampleEvent => "example_event_name",
+///   AnotherExampleEvent => "another_example_event_name"
+/// });
+/// ```
 #[macro_export]
 macro_rules! cqrs_event {
   // Single Event => event_name. Impls for a single event
@@ -9,8 +80,8 @@ macro_rules! cqrs_event {
       }
     }
 
-    impl $crate::events::WithEventContext for $event_type {
-      fn with_event_context(&mut self, event_context: $crate::events::EventContext) {
+    impl $crate::WithEventContext for $event_type {
+      fn with_event_context(&mut self, event_context: $crate::EventContext) {
         self.event_context.replace(event_context);
       }
     }
@@ -26,8 +97,8 @@ macro_rules! cqrs_event {
       }
     }
 
-    impl $crate::events::WithEventContext for $group_type {
-      fn with_event_context(&mut self, event_context: $crate::events::EventContext) {
+    impl $crate::WithEventContext for $group_type {
+      fn with_event_context(&mut self, event_context: $crate::EventContext) {
         match self {
           $( $group_type::$event_type(evt) => evt.with_event_context(event_context)),+,
         }

--- a/workspaces/diff-engine/src/events/mod.rs
+++ b/workspaces/diff-engine/src/events/mod.rs
@@ -33,25 +33,11 @@ pub enum SpecEvent {
   ShapeEvent(shape::ShapeEvent),
 }
 
-impl Event for SpecEvent {
-  fn event_type(&self) -> &'static str {
-    match self {
-      SpecEvent::EndpointEvent(evt) => evt.event_type(),
-      SpecEvent::RfcEvent(evt) => evt.event_type(),
-      SpecEvent::ShapeEvent(evt) => evt.event_type(),
-    }
-  }
-}
-
-impl WithEventContext for SpecEvent {
-  fn with_event_context(&mut self, event_context: EventContext) {
-    match self {
-      SpecEvent::EndpointEvent(evt) => evt.with_event_context(event_context),
-      SpecEvent::RfcEvent(evt) => evt.with_event_context(event_context),
-      SpecEvent::ShapeEvent(evt) => evt.with_event_context(event_context),
-    };
-  }
-}
+cqrs_event!(SpecEvent {
+  EndpointEvent,
+  RfcEvent,
+  ShapeEvent
+});
 
 impl SpecEvent {
   pub fn from_file(filename: impl AsRef<Path>) -> Result<Vec<SpecEvent>, EventLoadingError> {
@@ -60,24 +46,6 @@ impl SpecEvent {
     let events: Vec<SpecEvent> = serde_json::from_str(&file_contents)?;
 
     Ok(events)
-  }
-}
-
-impl From<EndpointEvent> for SpecEvent {
-  fn from(endpoint_event: EndpointEvent) -> Self {
-    Self::EndpointEvent(endpoint_event)
-  }
-}
-
-impl From<RfcEvent> for SpecEvent {
-  fn from(rfc_event: RfcEvent) -> Self {
-    Self::RfcEvent(rfc_event)
-  }
-}
-
-impl From<ShapeEvent> for SpecEvent {
-  fn from(shape_event: ShapeEvent) -> Self {
-    Self::ShapeEvent(shape_event)
   }
 }
 

--- a/workspaces/diff-engine/src/events/mod.rs
+++ b/workspaces/diff-engine/src/events/mod.rs
@@ -8,6 +8,9 @@ use std::fs;
 use std::io;
 use std::path::Path;
 
+#[macro_use]
+mod macros;
+
 pub mod endpoint;
 pub mod http_interaction;
 pub mod rfc;

--- a/workspaces/diff-engine/src/events/rfc.rs
+++ b/workspaces/diff-engine/src/events/rfc.rs
@@ -58,71 +58,13 @@ pub struct BatchCommitEnded {
   event_context: Option<EventContext>,
 }
 
-impl Event for RfcEvent {
-  fn event_type(&self) -> &'static str {
-    match self {
-      RfcEvent::ContributionAdded(evt) => evt.event_type(),
-      RfcEvent::APINamed(evt) => evt.event_type(),
-      RfcEvent::GitStateSet(evt) => evt.event_type(),
-      RfcEvent::BatchCommitStarted(evt) => evt.event_type(),
-      RfcEvent::BatchCommitEnded(evt) => evt.event_type(),
-    }
-  }
-}
-
-impl WithEventContext for RfcEvent {
-  fn with_event_context(&mut self, event_context: EventContext) {
-    match self {
-      RfcEvent::ContributionAdded(evt) => evt.event_context.replace(event_context),
-      RfcEvent::APINamed(evt) => evt.event_context.replace(event_context),
-      RfcEvent::GitStateSet(evt) => evt.event_context.replace(event_context),
-      RfcEvent::BatchCommitStarted(evt) => evt.event_context.replace(event_context),
-      RfcEvent::BatchCommitEnded(evt) => evt.event_context.replace(event_context),
-    };
-  }
-}
-
-impl Event for ContributionAdded {
-  fn event_type(&self) -> &'static str {
-    "ContributionAdded"
-  }
-}
-
-impl Event for APINamed {
-  fn event_type(&self) -> &'static str {
-    "APINamed"
-  }
-}
-
-impl Event for GitStateSet {
-  fn event_type(&self) -> &'static str {
-    "GitStateSet"
-  }
-}
-
-impl Event for BatchCommitStarted {
-  fn event_type(&self) -> &'static str {
-    "BatchCommitStarted"
-  }
-}
-
-impl Event for BatchCommitEnded {
-  fn event_type(&self) -> &'static str {
-    "BatchCommitEnded"
-  }
-}
-
-impl From<BatchCommitStarted> for RfcEvent {
-  fn from(event: BatchCommitStarted) -> Self {
-    Self::BatchCommitStarted(event)
-  }
-}
-
-impl From<BatchCommitEnded> for RfcEvent {
-  fn from(event: BatchCommitEnded) -> Self {
-    Self::BatchCommitEnded(event)
-  }
-}
+cqrs_event!(RfcEvent {
+  ContributionAdded => "ContributionAdded",
+  APINamed => "APINamed",
+  GitStateSet => "GitStateSet",
+  BatchCommitStarted => "BatchCommitStarted",
+  BatchCommitEnded => "BatchCommitEnded"
+});
 
 // Conversion from commands
 // ------------------------

--- a/workspaces/diff-engine/src/events/shape.rs
+++ b/workspaces/diff-engine/src/events/shape.rs
@@ -128,153 +128,21 @@ pub struct FieldRemoved {
   pub event_context: Option<EventContext>,
 }
 
-impl Event for ShapeEvent {
-  fn event_type(&self) -> &'static str {
-    match self {
-      ShapeEvent::ShapeAdded(evt) => evt.event_type(),
-      ShapeEvent::BaseShapeSet(evt) => evt.event_type(),
-      ShapeEvent::ShapeRenamed(evt) => evt.event_type(),
-      ShapeEvent::ShapeRemoved(evt) => evt.event_type(),
-      ShapeEvent::ShapeParameterAdded(evt) => evt.event_type(),
-      ShapeEvent::ShapeParameterShapeSet(evt) => evt.event_type(),
-      ShapeEvent::ShapeParameterRenamed(evt) => evt.event_type(),
-      ShapeEvent::ShapeParameterRemoved(evt) => evt.event_type(),
+cqrs_event!(ShapeEvent {
+  ShapeAdded => "ShapeAdded",
+  BaseShapeSet => "BaseShapeSet",
+  ShapeRenamed => "ShapeRenamed",
+  ShapeRemoved => "ShapeRemoved",
+  ShapeParameterAdded => "ShapeParameterAdded",
+  ShapeParameterShapeSet => "ShapeParameterShapeSet",
+  ShapeParameterRenamed => "ShapeParameterRenamed",
+  ShapeParameterRemoved => "ShapeParameterRemoved",
 
-      ShapeEvent::FieldAdded(evt) => evt.event_type(),
-      ShapeEvent::FieldShapeSet(evt) => evt.event_type(),
-      ShapeEvent::FieldRenamed(evt) => evt.event_type(),
-      ShapeEvent::FieldRemoved(evt) => evt.event_type(),
-    }
-  }
-}
-
-impl WithEventContext for ShapeEvent {
-  fn with_event_context(&mut self, event_context: EventContext) {
-    match self {
-      ShapeEvent::ShapeAdded(evt) => evt.event_context.replace(event_context),
-      ShapeEvent::BaseShapeSet(evt) => evt.event_context.replace(event_context),
-      ShapeEvent::ShapeRenamed(evt) => evt.event_context.replace(event_context),
-      ShapeEvent::ShapeRemoved(evt) => evt.event_context.replace(event_context),
-      ShapeEvent::ShapeParameterAdded(evt) => evt.event_context.replace(event_context),
-      ShapeEvent::ShapeParameterShapeSet(evt) => evt.event_context.replace(event_context),
-      ShapeEvent::ShapeParameterRenamed(evt) => evt.event_context.replace(event_context),
-      ShapeEvent::ShapeParameterRemoved(evt) => evt.event_context.replace(event_context),
-
-      ShapeEvent::FieldAdded(evt) => evt.event_context.replace(event_context),
-      ShapeEvent::FieldShapeSet(evt) => evt.event_context.replace(event_context),
-      ShapeEvent::FieldRenamed(evt) => evt.event_context.replace(event_context),
-      ShapeEvent::FieldRemoved(evt) => evt.event_context.replace(event_context),
-    };
-  }
-}
-
-impl Event for ShapeAdded {
-  fn event_type(&self) -> &'static str {
-    "ShapeAdded"
-  }
-}
-
-impl Event for BaseShapeSet {
-  fn event_type(&self) -> &'static str {
-    "BaseShapeSet"
-  }
-}
-
-impl Event for ShapeRenamed {
-  fn event_type(&self) -> &'static str {
-    "ShapeRenamed"
-  }
-}
-
-impl Event for ShapeRemoved {
-  fn event_type(&self) -> &'static str {
-    "ShapeRemoved"
-  }
-}
-
-impl Event for ShapeParameterAdded {
-  fn event_type(&self) -> &'static str {
-    "ShapeParameterAdded"
-  }
-}
-
-impl Event for ShapeParameterShapeSet {
-  fn event_type(&self) -> &'static str {
-    "ShapeParameterShapeSet"
-  }
-}
-
-impl Event for ShapeParameterRenamed {
-  fn event_type(&self) -> &'static str {
-    "ShapeParameterRenamed"
-  }
-}
-
-impl Event for ShapeParameterRemoved {
-  fn event_type(&self) -> &'static str {
-    "ShapeParameterRemoved"
-  }
-}
-
-impl Event for FieldAdded {
-  fn event_type(&self) -> &'static str {
-    "FieldAdded"
-  }
-}
-
-impl Event for FieldShapeSet {
-  fn event_type(&self) -> &'static str {
-    "FieldShapeSet"
-  }
-}
-
-impl Event for FieldRenamed {
-  fn event_type(&self) -> &'static str {
-    "FieldRenamed"
-  }
-}
-
-impl Event for FieldRemoved {
-  fn event_type(&self) -> &'static str {
-    "FieldRemoved"
-  }
-}
-
-impl From<ShapeAdded> for ShapeEvent {
-  fn from(event: ShapeAdded) -> Self {
-    Self::ShapeAdded(event)
-  }
-}
-
-impl From<BaseShapeSet> for ShapeEvent {
-  fn from(event: BaseShapeSet) -> Self {
-    Self::BaseShapeSet(event)
-  }
-}
-
-impl From<FieldAdded> for ShapeEvent {
-  fn from(event: FieldAdded) -> Self {
-    Self::FieldAdded(event)
-  }
-}
-
-impl From<FieldShapeSet> for ShapeEvent {
-  fn from(event: FieldShapeSet) -> Self {
-    Self::FieldShapeSet(event)
-  }
-}
-
-impl From<ShapeParameterAdded> for ShapeEvent {
-  fn from(event: ShapeParameterAdded) -> Self {
-    Self::ShapeParameterAdded(event)
-  }
-}
-
-impl From<ShapeParameterShapeSet> for ShapeEvent {
-  fn from(event: ShapeParameterShapeSet) -> Self {
-    Self::ShapeParameterShapeSet(event)
-  }
-}
+  FieldAdded => "FieldAdded",
+  FieldShapeSet => "FieldShapeSet",
+  FieldRenamed => "FieldRenamed",
+  FieldRemoved => "FieldRemoved"
+});
 
 // Conversions from commands
 // -------------------------

--- a/workspaces/diff-engine/src/lib.rs
+++ b/workspaces/diff-engine/src/lib.rs
@@ -15,7 +15,9 @@ pub mod streams;
 
 pub use commands::{CommandContext, RfcCommand, SpecCommand, SpecCommandHandler};
 pub use cqrs_core::Aggregate;
-pub use events::{HttpInteraction, RfcEvent, SpecChunkEvent, SpecEvent};
+pub use events::{
+  EventContext, HttpInteraction, RfcEvent, SpecChunkEvent, SpecEvent, WithEventContext,
+};
 pub use interactions::diff as diff_interaction;
 pub use interactions::result::InteractionDiffResult;
 pub use projections::{


### PR DESCRIPTION
## Why
The project uses a large amount of events, a number which is only set to grow. To allow us work within a CQRS methodology efficiently and correctly, this involves a lot of boilerplate for implementing `Event` and `WithEventContext` traits for both individual events as well as groups. On top of that, there's a bunch of `From<T>` trait implementations to make working with groups of events vs. individual events simpler.

Also, I've been studying declarative macros in Rust and needed something to apply the theory too 😅.

## What
This PR implements a `cqrs_event!` macro that handles these trait implementations for each event, as well as groups of events and applies it for all the `SpecEvent` variants.

The most basic use is a single event struct, where one provides the struct and it's &'static str event name
```rust
struct ExampleEvent {
  some_property: String,
  // struct is required to have an optional event_context
  event_context: Option<EventContext>,
}

cqrs_event!(ExampleEvent => "example_event_name");
```

A enum of nested events can also be expressed, as long as the variants and struct names match. In addition to
`Event` and `WithEventContext` traits, it also implements `From<Variant> for Group` for each variant.
```rust
struct ExampleEvent {
  some_property: String,
  // struct is required to have an optional event_context
  event_context: Option<EventContext>,
}

struct AnotherExampleEvent {
  other_property: u16,
  // struct is required to have an optional event_context
  event_context: Option<EventContext>,
}

enum EventGroup {
  ExampleEvent(ExampleEvent),
  AnotherExampleEvent(AnotherExampleEvent)
}

cqrs_event!(ExampleEvent => "example_event_name");
cqrs_event!(AnotherExampleEvent => "another_example_event");
cqrs_event!(EventGroup {
  ExampleEvent,
  AnotherExampleEvent
});
```

The two forms can also be combined, generating trait implementations for both the single events, as well as the group.
```rust
cqrs_event!(EventGroup {
  ExampleEvent => "example_event_name",
  AnotherExampleEvent => "another_example_event_name"
});
```

### Why not also the enum and struct definitions?

From what I've learned about declarative macros, things get very complicated if you want to generate the structs and enums as well. While it can works for the basics, it falls down as soon as you try to use things like derive macros, variant / field level derives, etc. 

On top of that, it makes navigating to the event definition elsewhere in the code a lot harder to understand, as it'll jump to the macro's code (if it works at all). Being able to Find / replace the basic constructs of a program is something you want to work without friction.

## Validation
* [ ] CI passes
* [x] Traits only, definitions of structs and enum still traversable.
