### PR TITLE
using target as hostnameFilter

### DIFF
--- a/workspaces/cli-config/src/index.ts
+++ b/workspaces/cli-config/src/index.ts
@@ -130,6 +130,7 @@ export interface IOpticApiInterceptConfig {
 
 export interface IOpticTaskRunnerConfig {
   command?: string;
+  hostnameFilter?: string;
   // the target service, implementing the API we're observing
   serviceConfig: {
     port: number;
@@ -210,8 +211,13 @@ export async function TaskToStartConfig(
     basePath: serviceConfig.basePath,
   };
 
+  const hostnameFilter = targetUrl
+    ? (targetUrl as url.UrlWithStringQuery).hostname!
+    : undefined;
+
   return {
     command: task.command,
+    hostnameFilter,
     serviceConfig,
     proxyConfig,
   };

--- a/workspaces/cli-shared/src/command-and-proxy-session-manager.ts
+++ b/workspaces/cli-shared/src/command-and-proxy-session-manager.ts
@@ -53,6 +53,10 @@ class CommandAndProxySessionManager {
         includeQueryString: true,
       },
       host: this.config.proxyConfig.host,
+      hostnameFilter:
+        process.env.OPTIC_ENABLE_TRANSPARENT_PROXY === 'yes'
+          ? this.config.hostnameFilter
+          : undefined,
       proxyTarget:
         process.env.OPTIC_ENABLE_TRANSPARENT_PROXY === 'yes'
           ? undefined


### PR DESCRIPTION
## Why
In transparent proxy mode, users want to filter down to a specific hostname. 

## What
Now, whatever `targetUrl` is set will be used as a hostname filter. 

## Validation
* [ ] CI passes
* [x] Verified in staging
