### PR TITLE
feat: support for building workspaces and diff-engine inside docker

### DIFF
--- a/.github/workflows/release-side-channel.yml
+++ b/.github/workflows/release-side-channel.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Build NPM packages for S3
         env:
           FLAGS_FILE: ${{ github.event.inputs.flags_file }}
-        run: task release:side-channel:npm_packages
+        run: task verdaccio:up release:side-channel:npm_packages
       - uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571 # v2.2.2
         with:
           name: side-channel-announce

--- a/.github/workflows/release-side-channel.yml
+++ b/.github/workflows/release-side-channel.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Build NPM packages for S3
         env:
           FLAGS_FILE: ${{ github.event.inputs.flags_file }}
-        run: task verdaccio:up release:side-channel:npm_packages
+        run: task utility:create-docker-network verdaccio:up release:side-channel:npm_packages
       - uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571 # v2.2.2
         with:
           name: side-channel-announce

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,19 +5,22 @@ dotenv:
 
 env:
   DOCKER_REGISTRY: 513974440343.dkr.ecr.us-east-1.amazonaws.com
+  NODE_ENV: '{{default "development" .NODE_ENV}}'
 
 includes:
   diff-engine:
     taskfile: workspaces/diff-engine/Taskfile.yml
-  ui:
-    taskfile: workspaces/ui/Taskfile.yml
-    dir: workspaces/ui
   regression:
     taskfile: taskfiles/regression-tests/Taskfile.yml
   release:
     taskfile: taskfiles/release/Taskfile.yml
   release:side-channel:
     taskfile: taskfiles/release/side-channel/Taskfile.yml
+  ui:
+    taskfile: workspaces/ui/Taskfile.yml
+    dir: workspaces/ui
+  utility:
+    taskfile: taskfiles/utility/Taskfile.yml
   verdaccio:
     taskfile: docker/private-npm-registry/Taskfile.yml
     dir: docker/private-npm-registry
@@ -33,7 +36,8 @@ tasks:
     desc: Build Yarn workspaces
     vars:
       FLAGS_FILE: '{{.FLAGS_FILE}}'
-    deps: ["workspaces:setup"]
+    deps:
+      - workspaces:setup
     cmds:
       - |
         if [[ -n "$FLAGS_FILE" ]]; then
@@ -48,9 +52,6 @@ tasks:
           cp $FLAGS_FILE workspaces/ui/.env.production.local
         fi
         yarn wsrun --stages --report --fast-exit --exclude-missing ws:build
-
-    sources:
-      - !workspaces/*/build/**/*
     generates:
       - workspaces/diff-engine-wasm/lib/**/*
       - workspaces/diff-engine-wasm/engine/browser/**/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3"
+
+services:
+  devel:
+    image: optic/devel
+    build:
+      context: docker/devel
+      dockerfile: Dockerfile
+    volumes:
+      - ./:/app
+      # hack for https://github.com/EverlastingBugstopper/binary-install/issues/3
+      # once wasm-pack updates to a more recent binary-install package we
+      # should be able to drop this.
+      - wasm-pack-nodejs:/home/appuser/.config/wasm-pack-nodejs/bin
+    environment:
+      NPM_REGISTRY: http://verdaccio-local-registry:4873
+      NODE_ENV: development
+    networks: [optic]
+
+networks:
+  optic:
+    name: optic
+    external: true
+
+volumes:
+  wasm-pack-nodejs:

--- a/docker/devel/Dockerfile
+++ b/docker/devel/Dockerfile
@@ -1,0 +1,25 @@
+FROM 513974440343.dkr.ecr.us-east-1.amazonaws.com/nodejs-base:latest
+
+RUN apk --no-cache add \
+    bash curl wget jq git openssh-client \
+    # linux build deps
+    musl-dev gcc \
+    # windows build deps
+    mingw-w64-gcc
+
+RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
+
+USER appuser
+
+# rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH=/home/appuser/.cargo/bin:$PATH
+
+# .profile isn't sourced if you exec a shell, so we copy to .bashrc
+RUN cp $HOME/.profile $HOME/.bashrc
+
+# hack for,
+# https://github.com/EverlastingBugstopper/binary-install/issues/3
+# once wasm-pack updates to a more recent binary-install package we
+# should be able to drop this.
+RUN mkdir -p $HOME/.config/wasm-pack-nodejs/bin

--- a/docker/private-npm-registry/docker-compose.yml
+++ b/docker/private-npm-registry/docker-compose.yml
@@ -1,12 +1,17 @@
-version: '2.1'
+version: "3"
+
 services:
   verdaccio:
     image: verdaccio/verdaccio:4.6
     container_name: verdaccio-local-registry
     ports:
-      - "4873:4873"
+      - 4873:4873
     volumes:
-      - "./conf:/verdaccio/conf"
-volumes:
-  verdaccio:
-    driver: local
+      - ./conf:/verdaccio/conf
+    networks:
+      - optic
+
+networks:
+  optic:
+    name: optic
+    external: true

--- a/taskfiles/release/side-channel/Taskfile.yml
+++ b/taskfiles/release/side-channel/Taskfile.yml
@@ -21,7 +21,6 @@ tasks:
       - task: :workspaces:build
         env:
           FLAGS_FILE: '{{.FLAGS_FILE}}'
-      - :verdaccio:up
     cmds:
       - rm -rf {{.TMP_DIR}} && mkdir -p {{.TMP_DIR}}
       - task: publish-local

--- a/taskfiles/utility/Taskfile.yml
+++ b/taskfiles/utility/Taskfile.yml
@@ -1,0 +1,14 @@
+version: 3
+
+tasks:
+  default:
+    desc: Runs all `util` tasks
+    cmds:
+      - task: create-docker-network
+
+  create-docker-network:
+    desc: Creates the Docker network applications may use locally to make communication simpler
+    cmds:
+      - docker network create optic
+    status:
+      - docker network inspect "optic"

--- a/workspaces/scripts/publish.js
+++ b/workspaces/scripts/publish.js
@@ -7,7 +7,7 @@ const { workspaces } = packageJson;
 console.log({ workspaces });
 const isPrivatePublish = process.env.OPTIC_PUBLISH_SCOPE !== 'public';
 const registry =
-  (process.env.OPTIC_PUBLISH_SCOPE === 'private' && 'http://localhost:4873') ||
+  (process.env.OPTIC_PUBLISH_SCOPE === 'private' && (process.env.NPM_REGISTRY || 'http://localhost:4873')) ||
   (process.env.OPTIC_PUBLISH_SCOPE === 'github' &&
     'https://npm.pkg.github.com/useoptic');
 const skipList = new Set((process.env.OPTIC_SKIP_CSV || '').split(','));
@@ -30,7 +30,7 @@ const promise = packages.reduce((acc, { name, version }) => {
         return resolve([...previousResults, true]);
       }
       const promise =
-        registry === 'http://localhost:4873'
+        registry === (process.env.NPM_REGISTRY || 'http://localhost:4873')
           ? new Promise((resolve1, reject1) => {
               console.log(`\nunpublish ${packageId}`);
               exec(


### PR DESCRIPTION
## What
Adds support for building npm packages and diff-engine (except macos) inside docker (and maintains support for building them directly on your workstation. I'd been working ton these changes in the context of some CI improvements in https://github.com/opticdev/optic/compare/build-in-container. I split these bits out because I think there's standalone benefit to this flexibility. 

 Build directly on your workstation,
```
➜ task workspaces:build diff-engine:add-targets diff-engine:build-linux diff-engine:build-windows
```

Build nside our devel container,
```
➜ docker-compose run devel \
  task workspaces:build diff-engine:add-targets diff-engine:build-linux diff-engine:build-windows
```

The devel container mounts the repo as a volume at /app inside. So filesystem changes within that path are persisted (think node_modules). Word of caution, running `yarn install`/`workspaces:setup` will cause  node_modules will be reinstalled each time  you switch running it in/out of docker. This is fixed in Yarn v2, so it's more something to be aware of than a real problem for now.

## Why
Flexibility in how and where this builds.

- A development image can make it easier to get up and running with our stuff without the need for brittle local configurations.
- Docker-based CI workflows give us additional options for caching and sharing data between workflows or runs.

## Validation
* [x] The tasks run. Both example commands above run for me and exit 0.
* [x] CI workflows that use the build tasks still work
    * [x] regression suite, https://github.com/opticdev/optic/runs/2116662288?check_suite_focus=true
    * [x] side-channel, https://github.com/opticdev/optic/actions/runs/655860156/workflow