### PR TITLE
chore: remain root user in devel container

### DIFF
--- a/docker/devel/Dockerfile
+++ b/docker/devel/Dockerfile
@@ -9,11 +9,9 @@ RUN apk --no-cache add \
 
 RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
 
-USER appuser
-
 # rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-ENV PATH=/home/appuser/.cargo/bin:$PATH
+ENV PATH=/root/.cargo/bin:$PATH
 
 # .profile isn't sourced if you exec a shell, so we copy to .bashrc
 RUN cp $HOME/.profile $HOME/.bashrc


### PR DESCRIPTION
## Why
while testing https://github.com/opticdev/optic/pull/639 dev ran into some file ownership issues on the volume mount. this was the file ownership not matching in and out of the container. impacts local linux users only, not macos, and not linux CI builds.

## What
we can remain the root user and sidestep permissions issue. this is fine imo as this image will never be run in/staging.prod.

## Validation
* [x] CI passes, https://github.com/opticdev/optic/actions/runs/658349713
