### PR TITLE
(diff-engine): Allow events module to be accessed outside the crate

### DIFF
--- a/workspaces/diff-engine/src/events/http_interaction.rs
+++ b/workspaces/diff-engine/src/events/http_interaction.rs
@@ -5,14 +5,14 @@ use avro_rs;
 use base64;
 use cqrs_core::Event;
 use protobuf;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json;
 use std::io;
 use std::iter::FromIterator;
 
 // TODO: consider whether these aren't actually Events and the Traverser not an Aggregator
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 pub struct HttpInteraction {
   pub uuid: String,
   pub request: Request,
@@ -20,13 +20,13 @@ pub struct HttpInteraction {
   pub tags: Vec<HttpInteractionTag>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 pub struct HttpInteractionTag {
   name: String,
   value: String,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 pub struct Request {
   pub host: String,
   pub method: String,
@@ -36,7 +36,7 @@ pub struct Request {
   pub body: Body,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Response {
   pub status_code: u16,
@@ -45,7 +45,7 @@ pub struct Response {
   pub body: Body,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Body {
   pub content_type: Option<String>,
@@ -53,7 +53,7 @@ pub struct Body {
   pub value: ArbitraryData,
 }
 
-#[derive(Deserialize, Debug, Default)]
+#[derive(Deserialize, Serialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ArbitraryData {
   pub shape_hash_v1_base64: Option<String>,

--- a/workspaces/diff-engine/src/events/http_interaction.rs
+++ b/workspaces/diff-engine/src/events/http_interaction.rs
@@ -31,6 +31,7 @@ pub struct Request {
   pub host: String,
   pub method: String,
   pub path: String,
+  pub headers: ArbitraryData,
   // #[serde(skip)]
   pub query: ArbitraryData,
   pub body: Body,

--- a/workspaces/diff-engine/src/events/http_interaction.rs
+++ b/workspaces/diff-engine/src/events/http_interaction.rs
@@ -53,12 +53,12 @@ pub struct Body {
   pub value: ArbitraryData,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ArbitraryData {
-  shape_hash_v1_base64: Option<String>,
-  as_json_string: Option<String>,
-  as_text: Option<String>,
+  pub shape_hash_v1_base64: Option<String>,
+  pub as_json_string: Option<String>,
+  pub as_text: Option<String>,
 }
 
 impl From<&ArbitraryData> for Option<serde_json::value::Value> {

--- a/workspaces/diff-engine/src/lib.rs
+++ b/workspaces/diff-engine/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, unused_imports, unused_variables)]
 
 mod commands;
-mod events;
+pub mod events;
 mod interactions;
 mod projections;
 mod protos;

--- a/workspaces/diff-engine/src/lib.rs
+++ b/workspaces/diff-engine/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code, unused_imports, unused_variables)]
 
 mod commands;
-pub mod events;
+mod events;
 mod interactions;
 mod projections;
 mod protos;
@@ -15,7 +15,10 @@ pub mod streams;
 
 pub use commands::{CommandContext, RfcCommand, SpecCommand, SpecCommandHandler};
 pub use cqrs_core::Aggregate;
-pub use events::{HttpInteraction, RfcEvent, SpecChunkEvent, SpecEvent};
+pub use events::{
+  http_interaction::{HttpInteraction, ArbitraryData, Request, Response, Body},
+  RfcEvent, SpecChunkEvent, SpecEvent,
+};
 pub use interactions::diff as diff_interaction;
 pub use interactions::result::InteractionDiffResult;
 pub use projections::{


### PR DESCRIPTION
## Why
For my work on the proxy, I need to create and serialize `HttpInteraction` objects. @JaapRood didn't expose them originally to make sure the surface area didn't explode, but in this case it seems pragmatic to expose them.

## What
I made `HttpInteraction` public, along with all of its dependent types. I also added a `Serialize` derive to teach serde how to write these out as json

## Validation
Not sure about this one. There are some tests, and they appear to pass.