### PR TITLE
feature: Implement s3 ingest capture saver

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "[javascript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}

--- a/workspaces/analytics/src/events/tasks.ts
+++ b/workspaces/analytics/src/events/tasks.ts
@@ -36,3 +36,18 @@ export const ExitedTaskWithLocalCli = DescribeEvent<
   ExitedTaskWithLocalCliSchema,
   (props) => `User ran task`
 );
+
+const LiveTrafficIngestedCliSchema = Joi.object({
+  captureId: Joi.string().required(),
+  interactionCount: Joi.number().required()
+});
+type LiveTrafficIngestedCliProperties = Joi.extractType<
+  typeof LiveTrafficIngestedCliSchema
+>;
+export const LiveTrafficIngestedWithLocalCli = DescribeEvent<
+  LiveTrafficIngestedCliProperties
+>(
+  Events.LiveTrafficIngestedWithLocalCli,
+  LiveTrafficIngestedCliSchema,
+  (props) => `User ingested live traffic`
+);

--- a/workspaces/cli-shared/package.json
+++ b/workspaces/cli-shared/package.json
@@ -25,6 +25,7 @@
     "@useoptic/domain-types": "10.0.64",
     "@useoptic/domain-utilities": "10.0.64",
     "avsc": "^5.4.21",
+    "aws-sdk": "^2.870.0",
     "bottleneck": "^2.19.5",
     "colors": "^1.4.0",
     "execa": "^4.0.3",
@@ -47,6 +48,7 @@
   },
   "devDependencies": {
     "@types/lodash.throttle": "^4.1.6",
+    "@types/node": "^14.14.35",
     "@types/semver": "^7.3.4",
     "@types/stream-chain": "^2.0.0",
     "@types/stream-fork": "^1.0.0",

--- a/workspaces/cli-shared/src/captures/avro/file-system/ingest-s3-capture-saver.ts
+++ b/workspaces/cli-shared/src/captures/avro/file-system/ingest-s3-capture-saver.ts
@@ -9,54 +9,46 @@ import oboe from 'oboe';
 import AWS, { Endpoint } from "aws-sdk";
 import { CaptureSaver } from './capture-saver';
 import { Token as ContinuationToken, Object as S3Object } from 'aws-sdk/clients/s3';
-import {Command} from "commander";
+import { Command } from "commander";
 import { IIgnoreRunnablePredicate } from '@useoptic/cli-config/build/helpers/ignore-parser';
 
-async function main(
-  // bucketName: string,
-  // region: string,
-  // captureId: string,
-  // outputBaseDirectory: string,
-  // pathPrefix: string = "",
-  // endpointOverride: string | null = null
-) {
-  const program = new Command();
-  program
-    .requiredOption("-b, --bucket-name <name>", "Bucket name")
-    .requiredOption("-r, --region <region>", "S3 region")
-    .requiredOption("-c, --capture-id <capture id>", "Capture ID")
-    .option("--path-prefix <path>", "S3 path prefix")
-    .option("--endpoint-override <endpoint>", "S3 endpoint override");
-  program.parse(process.argv);
-
-  let {
-    bucketName, region, captureId, pathPrefix, endpointOverride
-  } = program.opts();
-
-  let {capturesPath: captureBaseDirectory, opticIgnorePath, configPath} = await getPathsRelativeToConfig();
+export async function ingestS3({ 
+  bucketName, 
+  region, 
+  captureId, 
+  pathPrefix, 
+  endpointOverride
+}: {
+  bucketName: string,
+  region?: string,
+  captureId: string,
+  pathPrefix?: string,
+  endpointOverride?: string
+}) {
+  let { capturesPath: captureBaseDirectory, opticIgnorePath, configPath } = await getPathsRelativeToConfig();
 
   let ignoreRules = await new IgnoreFileHelper(opticIgnorePath, configPath).getCurrentIgnoreRules();
   let parsedRules = ignoreRules
     .allRules
-    .map(r=>parseRule(r))
+    .map(r => parseRule(r))
     .filter((r): r is IIgnoreRunnablePredicate => r !== undefined);
 
-  AWS.config.update({region});
+  AWS.config.update({ region });
 
   // Apparently we need to include the bucket here...
   // Doesn't work if we leave it off and just pass to `listObjectsV2` :s
-  const s3 = new AWS.S3(endpointOverride ? {endpoint: `${endpointOverride}/${bucketName}`, s3BucketEndpoint: true} : undefined);
-    
+  const s3 = new AWS.S3(endpointOverride ? { endpoint: `${endpointOverride}/${bucketName}`, s3BucketEndpoint: true } : undefined);
+
   const captureSaver = new CaptureSaver({
     captureBaseDirectory,
     captureId,
   });
   await captureSaver.init();
-  
-  const prefix = `${path.join(pathPrefix??"", captureId??"")}`;
+
+  const prefix = `${path.join(pathPrefix ?? "", captureId ?? "")}`;
 
   console.log(`Looking in s3://${bucketName}${prefix} in region ${region}, ${endpointOverride ?? ''}`);
-  
+
   const listAll = async (token?: ContinuationToken): Promise<S3Object[]> => {
     const objects = await s3.listObjectsV2({
       Bucket: bucketName,
@@ -64,9 +56,9 @@ async function main(
       Prefix: prefix,
       ContinuationToken: token
     }).promise();
-    if(objects.Contents){
-      console.log(`Found ${objects.Contents.length} files`);
-      if(objects.IsTruncated) {
+    if (objects.Contents) {
+      console.log(`Found ${objects.Contents.length} capture files to ingest.`);
+      if (objects.IsTruncated) {
         let rest = await listAll(objects.NextContinuationToken);
         return objects.Contents.concat(rest);
       } else {
@@ -84,7 +76,7 @@ async function main(
 
   let fetchPump = async () => {
     for (const obj of allObjects) {
-      if(obj.Key) {
+      if (obj.Key) {
         let objReadStream = s3.getObject({
           Bucket: bucketName,
           Key: obj.Key
@@ -99,7 +91,7 @@ async function main(
   const oboePromose = new Promise<void>((resolve, reject) => {
     oboe(passThrough)
       .node('!', (row: IHttpInteraction) => {
-        if(!parsedRules.some(r=>r.shouldIgnore(row.request.method, `${row.request.host}${row.request.path}?${row.request.query}`))) {
+        if (!parsedRules.some(r => r.shouldIgnore(row.request.method, `${row.request.host}${row.request.path}?${row.request.query}`))) {
           captureSaver.save(row);
         }
       })
@@ -113,8 +105,6 @@ async function main(
   });
 
   await Promise.all([fetchPump(), oboePromose]);
-
-  console.log("Done!");
 }
 
 async function pipeAsync(tap: Readable, sink: Writable) {
@@ -124,5 +114,3 @@ async function pipeAsync(tap: Readable, sink: Writable) {
     tap.on("error", reject)
   })
 }
-
-main();

--- a/workspaces/cli-shared/src/captures/avro/file-system/ingest-s3-capture-saver.ts
+++ b/workspaces/cli-shared/src/captures/avro/file-system/ingest-s3-capture-saver.ts
@@ -1,0 +1,128 @@
+import fs from 'fs-extra';
+import stream, { Readable, Writable } from "stream";
+import { getPathsRelativeToConfig, parseRule } from '@useoptic/cli-config';
+import { IgnoreFileHelper } from '@useoptic/cli-config/build/helpers/ignore-file-interface';
+import path from 'path';
+import { IHttpInteraction } from '@useoptic/domain-types';
+//@ts-ignore
+import oboe from 'oboe';
+import AWS, { Endpoint } from "aws-sdk";
+import { CaptureSaver } from './capture-saver';
+import { Token as ContinuationToken, Object as S3Object } from 'aws-sdk/clients/s3';
+import {Command} from "commander";
+import { IIgnoreRunnablePredicate } from '@useoptic/cli-config/build/helpers/ignore-parser';
+
+async function main(
+  // bucketName: string,
+  // region: string,
+  // captureId: string,
+  // outputBaseDirectory: string,
+  // pathPrefix: string = "",
+  // endpointOverride: string | null = null
+) {
+  const program = new Command();
+  program
+    .requiredOption("-b, --bucket-name <name>", "Bucket name")
+    .requiredOption("-r, --region <region>", "S3 region")
+    .requiredOption("-c, --capture-id <capture id>", "Capture ID")
+    .option("--path-prefix <path>", "S3 path prefix")
+    .option("--endpoint-override <endpoint>", "S3 endpoint override");
+  program.parse(process.argv);
+
+  let {
+    bucketName, region, captureId, pathPrefix, endpointOverride
+  } = program.opts();
+
+  let {capturesPath: captureBaseDirectory, opticIgnorePath, configPath} = await getPathsRelativeToConfig();
+
+  let ignoreRules = await new IgnoreFileHelper(opticIgnorePath, configPath).getCurrentIgnoreRules();
+  let parsedRules = ignoreRules
+    .allRules
+    .map(r=>parseRule(r))
+    .filter((r): r is IIgnoreRunnablePredicate => r !== undefined);
+
+  AWS.config.update({region});
+
+  // Apparently we need to include the bucket here...
+  // Doesn't work if we leave it off and just pass to `listObjectsV2` :s
+  const s3 = new AWS.S3(endpointOverride ? {endpoint: `${endpointOverride}/${bucketName}`, s3BucketEndpoint: true} : undefined);
+    
+  const captureSaver = new CaptureSaver({
+    captureBaseDirectory,
+    captureId,
+  });
+  await captureSaver.init();
+  
+  const prefix = `${path.join(pathPrefix??"", captureId??"")}`;
+
+  console.log(`Looking in s3://${bucketName}${prefix} in region ${region}, ${endpointOverride ?? ''}`);
+  
+  const listAll = async (token?: ContinuationToken): Promise<S3Object[]> => {
+    const objects = await s3.listObjectsV2({
+      Bucket: bucketName,
+      MaxKeys: 100,
+      Prefix: prefix,
+      ContinuationToken: token
+    }).promise();
+    if(objects.Contents){
+      console.log(`Found ${objects.Contents.length} files`);
+      if(objects.IsTruncated) {
+        let rest = await listAll(objects.NextContinuationToken);
+        return objects.Contents.concat(rest);
+      } else {
+        return objects.Contents;
+      }
+    } else {
+      console.log("No object contents?");
+      return [];
+    }
+  }
+
+  let allObjects = await listAll();
+  let objectsHandled = 0;
+  let passThrough = new stream.PassThrough();
+
+  let fetchPump = async () => {
+    for (const obj of allObjects) {
+      if(obj.Key) {
+        let objReadStream = s3.getObject({
+          Bucket: bucketName,
+          Key: obj.Key
+        }).createReadStream();
+        await pipeAsync(objReadStream, passThrough);
+        objectsHandled++;
+        console.log(`Handled ${objectsHandled}/${allObjects.length} files`);
+      }
+    }
+  }
+
+  const oboePromose = new Promise<void>((resolve, reject) => {
+    oboe(passThrough)
+      .node('!', (row: IHttpInteraction) => {
+        if(!parsedRules.some(r=>r.shouldIgnore(row.request.method, `${row.request.host}${row.request.path}?${row.request.query}`))) {
+          captureSaver.save(row);
+        }
+      })
+      .on('done', function () {
+        resolve();
+      })
+      .on('fail', function (e: any) {
+        console.error(e);
+        reject(e);
+      });
+  });
+
+  await Promise.all([fetchPump(), oboePromose]);
+
+  console.log("Done!");
+}
+
+async function pipeAsync(tap: Readable, sink: Writable) {
+  return new Promise((resolve, reject) => {
+    tap.pipe(sink, { end: false })
+    tap.on("end", resolve)
+    tap.on("error", reject)
+  })
+}
+
+main();

--- a/workspaces/cli-shared/src/captures/avro/file-system/ingest-s3-capture-saver.ts
+++ b/workspaces/cli-shared/src/captures/avro/file-system/ingest-s3-capture-saver.ts
@@ -1,41 +1,55 @@
 import fs from 'fs-extra';
-import {cli} from "cli-ux";
-import { Readable } from "stream";
+import { cli } from 'cli-ux';
+import { Readable } from 'stream';
 import { getPathsRelativeToConfig } from '@useoptic/cli-config';
 import { IgnoreFileHelper } from '@useoptic/cli-config/build/helpers/ignore-file-interface';
 import path from 'path';
 import { parser as jsonlParser } from 'stream-json/jsonl/Parser';
-import {map as streamMap, flatMap} from "axax";
+import { map as streamMap, flatMap } from 'axax';
 import { IHttpInteraction } from '@useoptic/domain-types';
 //@ts-ignore
-import AWS from "aws-sdk";
+import AWS from 'aws-sdk';
 import { CaptureSaver } from './capture-saver';
 import { Token as ContinuationToken } from 'aws-sdk/clients/s3';
 import { parseIgnore } from '@useoptic/cli-config/build/helpers/ignore-parser';
 
-export async function ingestS3({ 
-  bucketName, 
-  region, 
-  captureId, 
-  pathPrefix, 
-  endpointOverride
+export async function ingestS3({
+  bucketName,
+  region,
+  captureId,
+  pathPrefix,
+  endpointOverride,
 }: {
-  bucketName: string,
-  region?: string,
-  captureId: string,
-  pathPrefix?: string,
-  endpointOverride?: string
+  bucketName: string;
+  region?: string;
+  captureId: string;
+  pathPrefix?: string;
+  endpointOverride?: string;
 }) {
-  let { capturesPath: capturesBaseDirectory, opticIgnorePath, configPath } = await getPathsRelativeToConfig();
+  let {
+    capturesPath: capturesBaseDirectory,
+    opticIgnorePath,
+    configPath,
+  } = await getPathsRelativeToConfig();
 
-  let {allRules} = await new IgnoreFileHelper(opticIgnorePath, configPath).getCurrentIgnoreRules();
+  let { allRules } = await new IgnoreFileHelper(
+    opticIgnorePath,
+    configPath
+  ).getCurrentIgnoreRules();
   let { shouldIgnore } = parseIgnore(allRules);
 
   AWS.config.update({ region });
 
   // Apparently we need to include the bucket here...
   // Doesn't work if we leave it off and just pass to `listObjectsV2` :s
-  const s3 = new AWS.S3(endpointOverride ? { endpoint: `${endpointOverride}/${bucketName}`, s3BucketEndpoint: true } : undefined);
+  const s3 = new AWS.S3(
+    endpointOverride
+      ? {
+          endpoint: `${endpointOverride}/${bucketName}`,
+          s3BucketEndpoint: true,
+        }
+      : undefined
+  );
 
   const captureSaver = new CaptureSaver({
     captureBaseDirectory: capturesBaseDirectory,
@@ -43,68 +57,87 @@ export async function ingestS3({
   });
   await captureSaver.init();
 
-  const prefix = `${path.join(pathPrefix ?? "", captureId ?? "")}`;
+  const prefix = `${path.join(pathPrefix ?? '', captureId ?? '')}`;
 
-  console.log(`Looking in s3://${bucketName}${prefix} in region ${region}, ${endpointOverride ?? ''}`);
+  console.log(
+    `Looking in s3://${bucketName}${prefix} in region ${region}, ${
+      endpointOverride ?? ''
+    }`
+  );
 
   const customBar = cli.progress({
-    format: 'Ingesting | {bar} | {value}/{total} batches, {interactions} interactions',
+    format:
+      'Ingesting | {bar} | {value}/{total} batches, {interactions} interactions',
     barCompleteChar: '\u2588',
     barIncompleteChar: '\u2591',
-  })
+  });
 
   let interactionCount = 0;
   let batchCount = 0;
   let totalBatches = 0;
 
-  async function* bucket_keys(cursor?: ContinuationToken): AsyncIterable<string> {
-    const objects = await s3.listObjectsV2({
-      Bucket: bucketName,
-      MaxKeys: 1000,
-      Prefix: prefix,
-      ContinuationToken: cursor
-    }).promise();
+  async function* bucket_keys(
+    cursor?: ContinuationToken
+  ): AsyncIterable<string> {
+    const objects = await s3
+      .listObjectsV2({
+        Bucket: bucketName,
+        MaxKeys: 1000,
+        Prefix: prefix,
+        ContinuationToken: cursor,
+      })
+      .promise();
 
-    let batch_files = objects.Contents?.map(c=>c?.Key).filter((o): o is string => !!o) ?? [];
+    let batch_files =
+      objects.Contents?.map((c) => c?.Key).filter((o): o is string => !!o) ??
+      [];
     totalBatches += batch_files.length;
 
     customBar.setTotal(totalBatches);
-    
-    for(const batch of batch_files){
+
+    for (const batch of batch_files) {
       yield batch;
       batchCount++;
       customBar.update(batchCount);
     }
-    
-    if(objects.IsTruncated){
+
+    if (objects.IsTruncated) {
       yield* bucket_keys(objects.NextContinuationToken);
     }
   }
-  
+
   function key_to_readstream(key: string): Readable {
-    return s3.getObject({
-      Bucket: bucketName,
-      Key: key
-    }).createReadStream();
+    return s3
+      .getObject({
+        Bucket: bucketName,
+        Key: key,
+      })
+      .createReadStream();
   }
 
-  let continuous_readable: Readable = Readable.from(flatMap(key_to_readstream)(bucket_keys()));
+  let continuous_readable: Readable = Readable.from(
+    flatMap(key_to_readstream)(bucket_keys())
+  );
   let parser = continuous_readable.pipe(jsonlParser());
-  let obj_stream = streamMap((obj: {value: IHttpInteraction}) => obj.value)(parser);
+  let obj_stream = streamMap((obj: { value: IHttpInteraction }) => obj.value)(
+    parser
+  );
 
-  customBar.start(0,0,{interactions: 0});
+  customBar.start(0, 0, { interactions: 0 });
 
-  for await (const interaction of obj_stream){
+  for await (const interaction of obj_stream) {
     if (!shouldIgnore(interaction.request.method, interaction.request.path)) {
       captureSaver.save(interaction);
       interactionCount++;
-      customBar.update({interactions: interactionCount});
+      customBar.update({ interactions: interactionCount });
     }
   }
 
   customBar.stop();
 
-  console.log(`Successfully loaded ${interactionCount} interaction events from your bucket!`);
+  console.log(
+    `Successfully loaded ${interactionCount} interaction events from your bucket!`
+  );
 
   const files = [
     {
@@ -131,7 +164,7 @@ export async function ingestS3({
       await fs.ensureDir(path.dirname(location));
       return fs.writeFile(location, contents);
     })
-  );  
+  );
 
   return interactionCount;
 }

--- a/workspaces/local-cli/src/commands/ingest/s3.ts
+++ b/workspaces/local-cli/src/commands/ingest/s3.ts
@@ -46,7 +46,7 @@ export default class IngestS3 extends Command {
       cliClient.setIdentity(await getUser());
       const cliSession = await cliClient.findSession(paths.cwd, null, null);
       const uiBaseUrl = makeUiBaseUrl(daemonState);
-      const uiUrl = `${uiBaseUrl}/apis/${cliSession.session.id}/dashboard`;
+      const uiUrl = `${uiBaseUrl}/apis/${cliSession.session.id}/diffs/${captureId}`;
       openBrowser(uiUrl);
       cleanupAndExit();
     } catch (e) {

--- a/workspaces/local-cli/src/commands/ingest/s3.ts
+++ b/workspaces/local-cli/src/commands/ingest/s3.ts
@@ -1,9 +1,7 @@
 import { Command, flags } from '@oclif/command';
 import { ensureDaemonStarted } from '@useoptic/cli-server';
-import { ingestS3 } from "@useoptic/cli-shared/build/captures/avro/file-system/ingest-s3-capture-saver";
-import {
-  LiveTrafficIngestedWithLocalCli,
-} from '@useoptic/analytics/lib/events/tasks';
+import { ingestS3 } from '@useoptic/cli-shared/build/captures/avro/file-system/ingest-s3-capture-saver';
+import { LiveTrafficIngestedWithLocalCli } from '@useoptic/analytics/lib/events/tasks';
 import { lockFilePath } from '../../shared/paths';
 import { Config } from '../../config';
 import { cleanupAndExit, makeUiBaseUrl } from '@useoptic/cli-shared';
@@ -16,32 +14,31 @@ export default class IngestS3 extends Command {
   static hidden: boolean = true;
 
   static flags = {
-    bucketName: flags.string({ required: true, char: "b" }),
-    region: flags.string({ char: "r" }),
-    captureId: flags.string({ char: "c", required: true }),
+    bucketName: flags.string({ required: true, char: 'b' }),
+    region: flags.string({ char: 'r' }),
+    captureId: flags.string({ char: 'c', required: true }),
     pathPrefix: flags.string({ required: false }),
-    endpointOverride: flags.string({ required: false })
-  }
+    endpointOverride: flags.string({ required: false }),
+  };
 
   async run() {
     try {
-      const { flags: {
-        bucketName,
-        region,
-        captureId,
-        pathPrefix,
-        endpointOverride
-      } } = this.parse(IngestS3);
+      const {
+        flags: { bucketName, region, captureId, pathPrefix, endpointOverride },
+      } = this.parse(IngestS3);
 
       let interactionCount = await ingestS3({
         bucketName,
         region,
         captureId,
         pathPrefix,
-        endpointOverride
+        endpointOverride,
       });
 
-      const daemonState = await ensureDaemonStarted(lockFilePath, Config.apiBaseUrl);
+      const daemonState = await ensureDaemonStarted(
+        lockFilePath,
+        Config.apiBaseUrl
+      );
 
       const apiBaseUrl = `http://localhost:${daemonState.port}/api`;
       const paths = await getPathsRelativeToConfig();
@@ -62,7 +59,7 @@ export default class IngestS3 extends Command {
         apiCfg.name,
         LiveTrafficIngestedWithLocalCli.withProps({
           captureId,
-          interactionCount
+          interactionCount,
         })
       );
 

--- a/workspaces/local-cli/src/commands/ingest/s3.ts
+++ b/workspaces/local-cli/src/commands/ingest/s3.ts
@@ -1,0 +1,56 @@
+import { Command, flags } from '@oclif/command';
+import { ensureDaemonStarted } from '@useoptic/cli-server';
+import { ingestS3 } from "@useoptic/cli-shared/build/captures/avro/file-system/ingest-s3-capture-saver";
+import { lockFilePath } from '../../shared/paths';
+import { Config } from '../../config';
+import { cleanupAndExit, makeUiBaseUrl } from '@useoptic/cli-shared';
+import { getPathsRelativeToConfig } from '@useoptic/cli-config';
+import { Client } from '@useoptic/cli-client';
+import { getUser } from '../../shared/analytics';
+import openBrowser from 'react-dev-utils/openBrowser';
+export default class IngestS3 extends Command {
+  static description = 'Ingest from S3';
+  static hidden: boolean = true;
+
+  static flags = {
+    bucketName: flags.string({ required: true, char: "b" }),
+    region: flags.string({ char: "r" }),
+    captureId: flags.string({ char: "c", required: true }),
+    pathPrefix: flags.string({ required: false }),
+    endpointOverride: flags.string({ required: false })
+  }
+
+  async run() {
+    try {
+      const { flags: {
+        bucketName,
+        region,
+        captureId,
+        pathPrefix,
+        endpointOverride
+      } } = this.parse(IngestS3);
+
+      await ingestS3({
+        bucketName,
+        region,
+        captureId,
+        pathPrefix,
+        endpointOverride
+      });
+
+      const daemonState = await ensureDaemonStarted(lockFilePath, Config.apiBaseUrl);
+
+      const apiBaseUrl = `http://localhost:${daemonState.port}/api`;
+      const paths = await getPathsRelativeToConfig();
+      const cliClient = new Client(apiBaseUrl);
+      cliClient.setIdentity(await getUser());
+      const cliSession = await cliClient.findSession(paths.cwd, null, null);
+      const uiBaseUrl = makeUiBaseUrl(daemonState);
+      const uiUrl = `${uiBaseUrl}/apis/${cliSession.session.id}/dashboard`;
+      openBrowser(uiUrl);
+      cleanupAndExit();
+    } catch (e) {
+      this.error(e);
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3326,6 +3326,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.27.tgz#a151873af5a5e851b51b3b065c9e63390a9e0eb1"
   integrity sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==
 
+"@types/node@^14.14.35":
+  version "14.14.35"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.35.tgz#42c953a4e2b18ab931f72477e7012172f4ffa313"
+  integrity sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
@@ -4546,6 +4551,21 @@ avsc@^5.4.18, avsc@^5.4.21:
   resolved "https://registry.yarnpkg.com/avsc/-/avsc-5.4.21.tgz#eafaf5cbfd72bbc3d1bd82fc6bdeb7dda3ba8b2c"
   integrity sha512-Vr733yyksCfwwXVZ6WjgttDF1TLlUeYWBJDHpO61qeOo6GnaIaVRiJ64ZgpwXfFtbPv1fCuLFV0qz++QUFCZPw==
 
+aws-sdk@^2.870.0:
+  version "2.870.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.870.0.tgz#fc5c0ff65d4564a58cc183059727c77ebbce46a9"
+  integrity sha512-pbNO+RuEx45aaEZind0Tl9NADxncLJf0mRAwof0szyYMB+FZm165yz7FCxFLumU4R9qw8vOG5YFACBaNoQkJdg==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
@@ -5448,7 +5468,7 @@ buffer-xor@^1.0.3:
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
   integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
 
-buffer@^4.3.0:
+buffer@4.9.2, buffer@^4.3.0:
   version "4.9.2"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
   integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
@@ -8019,6 +8039,11 @@ events-to-array@^1.0.1:
   resolved "https://registry.yarnpkg.com/events-to-array/-/events-to-array-1.1.2.tgz#2d41f563e1fe400ed4962fe1a4d5c6a7539df7f6"
   integrity sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y=
 
+events@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
+
 events@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.1.0.tgz#84279af1b34cb75aa88bf5ff291f6d0bd9b31a59"
@@ -9693,7 +9718,7 @@ icss-utils@^4.0.0, icss-utils@^4.1.0, icss-utils@^4.1.1:
   dependencies:
     postcss "^7.0.14"
 
-ieee754@^1.1.4:
+ieee754@1.1.13, ieee754@^1.1.4:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
   integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
@@ -11434,6 +11459,11 @@ jest@^26.4.0:
     "@jest/core" "^26.4.0"
     import-local "^3.0.2"
     jest-cli "^26.4.0"
+
+jmespath@0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
+  integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
 
 joi-extract-type@^15.0.8:
   version "15.0.8"
@@ -16150,7 +16180,12 @@ sass-loader@^8.0.2:
     schema-utils "^2.6.1"
     semver "^6.3.0"
 
-sax@^1.2.4, sax@~1.2.4:
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
+
+sax@>=0.6.0, sax@^1.2.4, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -18183,6 +18218,14 @@ url-parse@^1.4.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
+url@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
+  integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
+
 url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
@@ -18279,6 +18322,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
+
+uuid@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
 uuid@^3.0.1, uuid@^3.1.0, uuid@^3.2.1, uuid@^3.3.2:
   version "3.4.0"
@@ -19074,6 +19122,19 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xml2js@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~9.0.1"
+
+xmlbuilder@~9.0.1:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
 
 xmlchars@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
## Why
Slurp saves `IHttpInteraction`s in batches to an S3 bucket. We want to load that data into your local Optic instance. This PR implements the S3 ingest capture saver that does that

So far so good!


Opens the UI and contains the right knowledge from the captures! 
<img width="790" alt="Screen Shot 2021-03-24 at 4 03 41 PM" src="https://user-images.githubusercontent.com/4368270/112376323-b3022500-8cba-11eb-8636-6ff8c9f7c7f3.png">

And we have a progress bar
 

https://user-images.githubusercontent.com/4368270/112524972-ca9ee380-8d76-11eb-99ec-81bec6e5d571.mov




## TODO:
- [x] Better progress bar
- [x] Integrate with the existing CLI 
- [x] Launch daemon and open browser upon completion
- [ ] Add option to limit total size of files ingested. E.g to 1gb or something.