### PR TITLE
switch macos aarch64 build to stable rustup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
           - os: macos-11.0
             target: aarch64-apple-darwin
             platform_name: macos-aarch64
-            rustup_channel: beta
+            rustup_channel: stable
             suffix: ''
           - os: windows-latest
             target: x86_64-pc-windows-msvc


### PR DESCRIPTION
closes https://github.com/opticdev/issues/issues/39

![](https://media.giphy.com/media/Qvpxb0bju1rEp9Nipy/giphy.gif)