### PR TITLE
enable `pass-exit-code` flag for tasks + test tasks

### DIFF
--- a/website/docs/using/cli-commands.mdx
+++ b/website/docs/using/cli-commands.mdx
@@ -49,6 +49,7 @@ Run has a few flags that can modify the default behavior:
 
 - `--collect-coverage` will report the [coverage](/docs/get-started/testing#api-coverage) of observed traffic over the API specification when the process is stopped.
 - `--exit-on-diff` returns an exit code of `1` if unexpected API behavior is returned, such as an undocumented route or a change in behavior on a documented route. Normally, Optic returns `0` on successful termination regardless of the behavior observed. This is primarily used in CI/CD scenarios, such as in [GitHub Actions](/docs/github-actions), to fail builds when undocumented behavior is detected.
+- `--pass-exit-code` returns the exit code of your task. If you are using a [dependent task](/docs/get-started/testing), the exit code of the dependent command (not the base command) will be passed through. This flag is overridden by `--exit-on-diff` which will always exit a capture session with exit code 1 when a diff was detected. 
 - `--transparent-proxy` configures Optic to [transparently forward](/docs/using/advanced-configuration#transparent-proxy-mode) all traffic, which may be necessary for certain application configurations.
 
 ### `spec`

--- a/workspaces/cli-shared/src/command-and-proxy-session-manager.ts
+++ b/workspaces/cli-shared/src/command-and-proxy-session-manager.ts
@@ -18,8 +18,17 @@ class CommandAndProxySessionManager {
     private onStarted?: () => void
   ) {}
 
+  private commandSession: CommandSession | undefined
+
+  public getExitCodeOfProcess(): number | undefined {
+    if (this.commandSession) {
+      return this.commandSession?.exitCode || undefined
+    }
+  }
+
   async run(persistenceManager: ICaptureSaver) {
-    const commandSession = new CommandSession();
+    this.commandSession = new CommandSession();
+    const commandSession = this.commandSession!
     const inboundProxy = new HttpToolkitCapturingProxy();
     const servicePort = this.config.serviceConfig.port;
     const serviceHost = this.config.serviceConfig.host;

--- a/workspaces/cli-shared/src/command-session.ts
+++ b/workspaces/cli-shared/src/command-session.ts
@@ -9,6 +9,7 @@ export interface ICommandSessionConfig {
 }
 
 class CommandSession {
+  public exitCode: number | null = null
   private child?: ChildProcess;
   private isRunning: boolean = false;
   public events: EventEmitter = new EventEmitter();
@@ -32,6 +33,7 @@ class CommandSession {
       this.isRunning = false;
     });
     this.child.on('exit', (code, signal) => {
+      this.exitCode = code
       developerDebugLogger(
         `command process exited with code ${code} and signal ${signal}`
       );

--- a/workspaces/local-cli/src/shared/local-cli-task-runner.ts
+++ b/workspaces/local-cli/src/shared/local-cli-task-runner.ts
@@ -61,6 +61,7 @@ export const runCommandFlags = {
   'exit-on-diff': flags.boolean({
     default: false,
     required: false,
+    description: "When a capture session ends, if a diff is detected Optic will exit with exit code 1. This takes priority over pass-exit-code."
   }),
   'transparent-proxy': flags.boolean({
     default: false,
@@ -69,6 +70,7 @@ export const runCommandFlags = {
   'pass-exit-code': flags.boolean({
     default: false,
     required: false,
+    description: "Passes through the exit code from your task (or dependent task). exit-on-diff overrides this when a diff is detected."
   }),
 };
 interface LocalCliTaskFlags {

--- a/workspaces/local-cli/src/shared/local-cli-task-runner.ts
+++ b/workspaces/local-cli/src/shared/local-cli-task-runner.ts
@@ -42,7 +42,7 @@ import { CaptureSaverWithDiffs } from '@useoptic/cli-shared/build/captures/avro/
 import { EventEmitter } from 'events';
 import { Config } from '../config';
 import { printCoverage } from './coverage';
-import { spawnProcess } from './spawn-process';
+import {spawnProcess, spawnProcessReturnExitCode} from './spawn-process';
 import { command } from '@oclif/test';
 import { getCaptureId } from './git/git-context-capture';
 import {getSpecEventsFrom} from "@useoptic/cli-config/build/helpers/read-specification-json";
@@ -66,12 +66,17 @@ export const runCommandFlags = {
     default: false,
     required: false,
   }),
+  'pass-exit-code': flags.boolean({
+    default: false,
+    required: false,
+  }),
 };
 interface LocalCliTaskFlags {
   'collect-coverage'?: boolean;
   'collect-diffs'?: boolean;
   'exit-on-diff'?: boolean;
   'transparent-proxy'?: boolean;
+  'pass-exit-code'?: boolean
 }
 
 export async function LocalTaskSessionWrapper(
@@ -106,9 +111,9 @@ export async function LocalTaskSessionWrapper(
     shouldCollectDiffs: flags['collect-diffs'] !== false,
     shouldExitOnDiff: flags['exit-on-diff'] !== false,
     shouldTransparentProxy: flags['transparent-proxy'] !== false,
+    shouldPassThroughExitCode: flags['pass-exit-code'] !== false,
   });
   const session = new CliTaskSession(runner);
-
   const task = config.tasks[taskName];
 
   if (!task) {
@@ -146,11 +151,12 @@ export async function LocalTaskSessionWrapper(
     return await cleanupAndExit(1);
   }
 
-  return await cleanupAndExit();
+  return await cleanupAndExit( flags['pass-exit-code'] !== false ? runner.exitWithCode : 0);
 }
 
 export class LocalCliTaskRunner implements IOpticTaskRunner {
   public foundDiff: boolean = false;
+  public exitWithCode: number | undefined;
 
   constructor(
     private captureId: string,
@@ -161,6 +167,7 @@ export class LocalCliTaskRunner implements IOpticTaskRunner {
       shouldCollectDiffs: boolean;
       shouldExitOnDiff: boolean;
       shouldTransparentProxy: boolean;
+      shouldPassThroughExitCode: boolean;
     }
   ) {}
 
@@ -255,6 +262,7 @@ ${blockers.map((x) => `[pid ${x.pid}]: ${x.cmd}`).join('\n')}
       ? 'yes'
       : process.env.OPTIC_ENABLE_TRANSPARENT_PROXY;
 
+
     const testCommand = commandToRunWhenStarted
       ? async () => {
           console.log(
@@ -264,12 +272,15 @@ ${blockers.map((x) => `[pid ${x.pid}]: ${x.cmd}`).join('\n')}
             )
           );
 
-          await spawnProcess(commandToRunWhenStarted!, {
+        const exitCodeOfTestProcess = await spawnProcessReturnExitCode(commandToRunWhenStarted!, {
             OPTIC_PROXY_PORT: taskConfig.proxyConfig.port.toString(),
             OPTIC_PROXY_HOST: taskConfig.proxyConfig.host.toString(),
             OPTIC_PROXY: `http://${taskConfig.proxyConfig.host.toString()}:${taskConfig.proxyConfig.port.toString()}`,
           });
-          // return new Promise((resolve) => setTimeout(resolve, 500)); // needs time to finish saving
+
+        if (this.options.shouldPassThroughExitCode) {
+          this.exitWithCode = exitCodeOfTestProcess
+        }
         }
       : undefined;
 
@@ -279,6 +290,10 @@ ${blockers.map((x) => `[pid ${x.pid}]: ${x.cmd}`).join('\n')}
     );
 
     await sessionManager.run(persistenceManager);
+
+    if (!commandToRunWhenStarted && this.options.shouldPassThroughExitCode) {
+      this.exitWithCode = sessionManager.getExitCodeOfProcess()
+    }
 
     ////////////////////////////////////////////////////////////////////////////////
     await cliClient.markCaptureAsCompleted(cliSession.session.id, captureId);

--- a/workspaces/local-cli/src/shared/spawn-process.ts
+++ b/workspaces/local-cli/src/shared/spawn-process.ts
@@ -22,3 +22,26 @@ export async function spawnProcess(
     });
   });
 }
+
+export async function spawnProcessReturnExitCode(
+  command: string,
+  env: any = {}
+): Promise<number> {
+  const taskOptions: SpawnOptions = {
+    env: {
+      ...process.env,
+      ...env,
+    },
+    shell: true,
+    cwd: process.cwd(),
+    stdio: 'inherit',
+  };
+
+  const child = spawn(command, taskOptions);
+
+  return await new Promise((resolve) => {
+    child.on('exit', (code) => {
+      resolve(code || 0);
+    });
+  });
+}


### PR DESCRIPTION
## Why [Responding to User Issue]
Users trying to run their tests in CI with Optic, have asked if it's possible to pass through the exit code from their task. When Optic does not find diffs, but the tests fail for other reasons, Optic will swallow that failure and produce false positives in CI (yikes!).  

## What
We added a `--pass-exit-code` flag that will make `api` exit with the status code from a test task or a regular task the user ran when provided. 

## Validation
* [x] CI passes
* [x] Verified locally with example projects
* [ ] Works on Windows? different shells? 
