### PR TITLE
command-session: change logging level

### DIFF
--- a/workspaces/cli-shared/src/command-session.ts
+++ b/workspaces/cli-shared/src/command-session.ts
@@ -49,8 +49,7 @@ class CommandSession {
       return new Promise((resolve) => {
         treeKill(pid, (e) => {
           if (e) {
-            console.error(e);
-            return resolve();
+            developerDebugLogger(`Issue killing child process: ${e}`);
           }
           this.events.emit('stopped', { state: 'terminated' });
           resolve();


### PR DESCRIPTION
## Why

Per pairing session, resolve logging level discrepancy when stopping child processes.

## What


## Validation
* [ ] CI passes
* [ ] Verified in staging

