### PR TITLE
Implement Rust learners for InMemorySpectacle

### DIFF
--- a/workspaces/diff-engine-wasm/engine/Cargo.lock
+++ b/workspaces/diff-engine-wasm/engine/Cargo.lock
@@ -42,7 +42,7 @@ dependencies = [
  "digest",
  "libflate",
  "num-bigint",
- "rand",
+ "rand 0.4.6",
  "serde",
  "serde_json",
  "strum",
@@ -284,6 +284,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nanoid"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
+dependencies = [
+ "rand 0.8.3",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,6 +359,7 @@ dependencies = [
  "chrono",
  "console_error_panic_hook",
  "log",
+ "nanoid",
  "optic_diff_engine",
  "serde",
  "serde_json",
@@ -367,6 +377,12 @@ dependencies = [
  "fixedbitset",
  "indexmap",
 ]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro2"
@@ -425,6 +441,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core 0.6.2",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.2",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,6 +476,24 @@ name = "rand_core"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rand_core"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core 0.6.2",
+]
 
 [[package]]
 name = "rdrand"

--- a/workspaces/diff-engine-wasm/engine/Cargo.toml
+++ b/workspaces/diff-engine-wasm/engine/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["cdylib"]
 chrono = { version = "0.4.19", features = ["serde", "wasmbind"] }
 console_error_panic_hook = "0.1.6"
 log = "0.4.6"
+nanoid = "0.4.0"
 serde = { version = "1.0.106", features = ["derive"] }
 serde_json = "1.0.57"
 wasm-bindgen = "0.2.68"

--- a/workspaces/diff-engine/cli/src/learn.rs
+++ b/workspaces/diff-engine/cli/src/learn.rs
@@ -12,15 +12,14 @@ use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 
 use optic_diff_engine::streams;
-use optic_diff_engine::streams::{TaggedInput, Tags};
 use optic_diff_engine::Aggregate;
 use optic_diff_engine::{
   analyze_documented_bodies, analyze_undocumented_bodies, EndpointCommand, InteractionDiffResult,
-  LearnedUndocumentedBodiesProjection, SpecCommand,
+  LearnedShapeDiffAffordancesProjection, LearnedUndocumentedBodiesProjection, SpecCommand,
 };
 use optic_diff_engine::{
   BodyAnalysisLocation, HttpInteraction, JsonTrail, SpecChunkEvent, SpecEvent, SpecIdGenerator,
-  SpecProjection, TrailObservationsResult, TrailValues,
+  SpecProjection, TaggedInput, Tags, TrailObservationsResult, TrailValues,
 };
 
 pub const SUBCOMMAND_NAME: &'static str = "learn";
@@ -77,10 +76,13 @@ pub async fn main<'a>(
     let interaction_lines = streams::http_interaction::json_lines(stdin);
     let diffs = streams::diff::tagged_from_json_line_file(diffs_path)
       .await
-      .expect("could not read diffs");
+      .expect("could not read diffs")
+      .into_iter()
+      .map(TaggedInput::into_input);
+
     let sink = stdout();
 
-    learn_diff_trail_affordances(
+    learn_shape_diff_affordances(
       spec_events,
       diffs,
       input_queue_size,
@@ -166,45 +168,19 @@ async fn learn_undocumented_bodies<S: 'static + AsyncWrite + Unpin + Send>(
   try_join!(analyzing_bodies, aggregating_results).expect("essential worker task panicked");
 }
 
-async fn learn_diff_trail_affordances<S: 'static + AsyncWrite + Unpin + Send>(
+async fn learn_shape_diff_affordances<S: 'static + AsyncWrite + Unpin + Send>(
   spec_events: Vec<SpecEvent>,
-  tagged_diffs: Vec<TaggedInput<InteractionDiffResult>>,
+  diffs: impl Iterator<Item = InteractionDiffResult>,
   input_queue_size: usize,
   interaction_lines: impl Stream<Item = Result<String, std::io::Error>>,
   sink: S,
 ) {
   let spec_projection = Arc::new(SpecProjection::from(spec_events));
-  let diffs_by_spec_id = Arc::new({
-    let mut diffs_by_spec_id = HashMap::new();
-    for tagged_diff in tagged_diffs {
-      let (diff, _diff_tags) = tagged_diff.into_parts();
-      let spec_id = match &diff {
-        InteractionDiffResult::UnmatchedRequestBodyShape(diff) => diff
-          .requests_trail
-          .get_request_id()
-          .expect("UnmatchedRequestBodyShape should have a request id in the requests trail"),
-        InteractionDiffResult::UnmatchedResponseBodyShape(diff) => diff
-          .requests_trail
-          .get_response_id()
-          .expect("UnmatchedResponseBodyShape should have a response id in the requests trail"),
-        _ => continue, // filter out diffs we don't care about
-      }
-      .clone();
-
-      diffs_by_spec_id
-        .entry(spec_id)
-        .or_insert_with(|| vec![])
-        .push(diff);
-    }
-    diffs_by_spec_id
-  });
-
-  // dbg!(&diffs_by_spec_id);
+  let mut learned_shape_diff_affordances: LearnedShapeDiffAffordancesProjection = diffs.collect();
 
   let (analysis_sender, analysis_receiver) = mpsc::channel(32);
 
   let analyzing_bodies = {
-    let diffs_by_spec_id = diffs_by_spec_id.clone();
     let spec_projection = spec_projection.clone();
 
     async move {
@@ -212,7 +188,6 @@ async fn learn_diff_trail_affordances<S: 'static + AsyncWrite + Unpin + Send>(
         .map(Ok)
         .try_for_each_concurrent(input_queue_size, |interaction_json_result| {
           let analysis_sender = analysis_sender.clone();
-          let diffs_by_spec_id = diffs_by_spec_id.clone();
           let spec_projection = spec_projection.clone();
 
           let analyze_task = tokio::spawn(async move {
@@ -223,44 +198,18 @@ async fn learn_diff_trail_affordances<S: 'static + AsyncWrite + Unpin + Send>(
               let TaggedInput(interaction, interaction_tags): TaggedInput<HttpInteraction> =
                 serde_json::from_str(&interaction_json).expect("could not parse interaction json");
 
-              let analysis_results = analyze_documented_bodies(&spec_projection, interaction);
-
-              analysis_results
-                .filter_map(|analysis_result| {
-                  let spec_id = match analysis_result.body_location {
-                    BodyAnalysisLocation::MatchedRequest { request_id, .. } => Some(request_id),
-                    BodyAnalysisLocation::MatchedResponse { response_id, .. } => Some(response_id),
-                    _ => None,
-                  }?;
-
-                  // dbg!(&spec_id);
-
-                  let interaction_diffs = diffs_by_spec_id.get(&spec_id)?;
-
-                  let mut results = vec![]; // imperative loops as nested filter maps cause ownership issues
-                  for diff in interaction_diffs {
-                    let json_trail = diff.json_trail().unwrap();
-
-                    let trail_result = analysis_result
-                      .trail_observations
-                      .get(json_trail)
-                      .cloned()
-                      .unwrap_or_else(|| TrailValues::new(json_trail));
-
-                    results.push((diff.fingerprint(), trail_result, interaction_tags.clone()))
-                  }
-
-                  Some(results)
-                })
-                .flatten()
-                .collect::<Vec<_>>()
+              (
+                analyze_documented_bodies(&spec_projection, interaction),
+                interaction_tags,
+              )
             });
 
             match analyze_comp.await {
-              Ok(results) => {
+              Ok((results, interaction_tags)) => {
                 for result in results {
+                  let tagged = TaggedInput(result, interaction_tags.clone());
                   analysis_sender
-                    .send(result)
+                    .send(tagged)
                     .await
                     .expect("could not send analysis result to aggregation channel")
                 }
@@ -284,22 +233,13 @@ async fn learn_diff_trail_affordances<S: 'static + AsyncWrite + Unpin + Send>(
     let mut analysiss = ReceiverStream::new(analysis_receiver);
 
     tokio::spawn(async move {
-      let mut affordances_by_diff_fingerprint = HashMap::new();
-      while let Some(analysis) = analysiss.next().await {
-        // dbg!(&analysis.0, &analysis.1, &analysis.2);
-        let (diff_fingerprint, trail_values, tags) = analysis;
-
-        let affordances = affordances_by_diff_fingerprint
-          .entry(diff_fingerprint)
-          .or_insert_with(|| InteractionDiffTrailAffordances::default());
-
-        affordances.push((trail_values, tags));
+      while let Some(tagged_analysis) = analysiss.next().await {
+        learned_shape_diff_affordances.apply(tagged_analysis);
       }
 
-      let mut json_lines_sink =
-        streams::into_json_lines::<_, (String, InteractionDiffTrailAffordances)>(sink);
+      let mut json_lines_sink = streams::shape_diff_affordances::into_json_lines(sink);
 
-      for (fingerprint, affordances) in affordances_by_diff_fingerprint {
+      for (fingerprint, affordances) in learned_shape_diff_affordances {
         if let Err(err) = json_lines_sink.send((affordances, fingerprint)).await {
           panic!("Could not write result to stdout: {}", err);
         }
@@ -320,89 +260,6 @@ impl SpecIdGenerator for IdGenerator {
     // - 17 years for a 1% chance of at least one global collision assuming
     //   writing 1000 ids per hour (https://zelark.github.io/nano-id-cc/)
     format!("{}{}", prefix, nanoid!(10))
-  }
-}
-
-// Output types: shape diff affordances
-// ------------------------------------
-
-#[derive(Default, Debug, Serialize)]
-struct InteractionDiffTrailAffordances {
-  affordances: Vec<TrailValues>,
-  interactions: InteractionsAffordances,
-}
-type InteractionPointers = Tags;
-
-#[derive(Debug, Default, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct InteractionsAffordances {
-  was_string: InteractionPointers,
-  was_number: InteractionPointers,
-  was_boolean: InteractionPointers,
-  was_null: InteractionPointers,
-  was_array: InteractionPointers,
-  was_object: InteractionPointers,
-  was_missing: InteractionPointers,
-  was_string_trails: HashMap<String, Vec<JsonTrail>>,
-  was_number_trails: HashMap<String, Vec<JsonTrail>>,
-  was_boolean_trails: HashMap<String, Vec<JsonTrail>>,
-  was_null_trails: HashMap<String, Vec<JsonTrail>>,
-  was_array_trails: HashMap<String, Vec<JsonTrail>>,
-  was_object_trails: HashMap<String, Vec<JsonTrail>>,
-  was_missing_trails: HashMap<String, Vec<JsonTrail>>,
-}
-
-impl InteractionDiffTrailAffordances {
-  pub fn push(&mut self, (trail_values, pointers): (TrailValues, InteractionPointers)) {
-    self.interactions.push((&trail_values, pointers));
-
-    // TODO: find alternative way of serializing to an array of affordances, even though
-    // logic tells us there will only ever be one (supposed to be per JsonTrail, but
-    // both TrailValues en InteractionDiffResult use normalized trails, so would always
-    // just be one).
-    if self.affordances.len() > 0 {
-      let current_affordances = &mut self.affordances[0];
-      current_affordances.union(trail_values);
-    } else {
-      self.affordances.push(trail_values);
-    }
-  }
-}
-
-impl InteractionsAffordances {
-  pub fn push(&mut self, (trail_values, pointers): (&TrailValues, InteractionPointers)) {
-    let json_trail = trail_values.trail.clone();
-    let json_trails_by_pointer_iter = || {
-      pointers
-        .iter()
-        .map(|pointer| (pointer.clone(), vec![json_trail.clone()]))
-    };
-    if trail_values.was_string {
-      self.was_string.extend(pointers.clone());
-      self.was_string_trails.extend(json_trails_by_pointer_iter());
-    }
-    if trail_values.was_number {
-      self.was_number.extend(pointers.clone());
-      self.was_number_trails.extend(json_trails_by_pointer_iter());
-    }
-    if trail_values.was_null {
-      self.was_null.extend(pointers.clone());
-      self.was_null_trails.extend(json_trails_by_pointer_iter());
-    }
-    if trail_values.was_array {
-      self.was_array.extend(pointers.clone());
-      self.was_array_trails.extend(json_trails_by_pointer_iter());
-    }
-    if trail_values.was_object {
-      self.was_object.extend(pointers.clone());
-      self.was_object_trails.extend(json_trails_by_pointer_iter());
-    }
-    if trail_values.was_unknown() {
-      self.was_missing.extend(pointers.clone());
-      self
-        .was_missing_trails
-        .extend(json_trails_by_pointer_iter());
-    }
   }
 }
 
@@ -444,7 +301,9 @@ mod test {
 
     let _diffs = streams::diff::tagged_from_json_line_file(diffs_path)
       .await
-      .expect("should be able to read test diffs fixture");
+      .expect("should be able to read test diffs fixture")
+      .into_iter()
+      .map(TaggedInput::into_input);
 
     let _interaction_lines =
       streams::http_interaction::json_lines(fs::File::open(interactions_path).await.unwrap());

--- a/workspaces/diff-engine/cli/src/learn.rs
+++ b/workspaces/diff-engine/cli/src/learn.rs
@@ -289,6 +289,10 @@ mod test {
   #[tokio::main]
   #[test]
   async fn can_learn_shape_diffs_affordances_from_interactions() {
+    let spec_events_path = Path::new("../tests/fixtures/ergast-example-spec.json")
+      .absolutize()
+      .unwrap()
+      .to_path_buf();
     let diffs_path = Path::new("../tests/fixtures/ergast-captures/diff-results.jsonl")
       .absolutize()
       .unwrap()
@@ -299,15 +303,19 @@ mod test {
         .unwrap()
         .to_path_buf();
 
-    let _diffs = streams::diff::tagged_from_json_line_file(diffs_path)
+    let spec_events = streams::spec_events::from_file(spec_events_path)
+      .await
+      .expect("should be able to read test spec fixture");
+
+    let diffs = streams::diff::tagged_from_json_line_file(diffs_path)
       .await
       .expect("should be able to read test diffs fixture")
       .into_iter()
       .map(TaggedInput::into_input);
 
-    let _interaction_lines =
+    let interaction_lines =
       streams::http_interaction::json_lines(fs::File::open(interactions_path).await.unwrap());
 
-    // learn_diff_trail_affordances(diffs, 1, interaction_lines, tokio::io::sink()).await;
+    learn_shape_diff_affordances(spec_events, diffs, 1, interaction_lines, tokio::io::sink()).await;
   }
 }

--- a/workspaces/diff-engine/cli/src/learn.rs
+++ b/workspaces/diff-engine/cli/src/learn.rs
@@ -11,10 +11,12 @@ use tokio::io::{stdin, stdout, AsyncWrite};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 
+use optic_diff_engine::streams;
 use optic_diff_engine::streams::{TaggedInput, Tags};
+use optic_diff_engine::Aggregate;
 use optic_diff_engine::{
-  analyze_documented_bodies, analyze_undocumented_bodies, streams, EndpointCommand,
-  InteractionDiffResult, SpecCommand,
+  analyze_documented_bodies, analyze_undocumented_bodies, EndpointCommand, InteractionDiffResult,
+  LearnedUndocumentedBodiesProjection, SpecCommand,
 };
 use optic_diff_engine::{
   BodyAnalysisLocation, HttpInteraction, JsonTrail, SpecChunkEvent, SpecEvent, SpecIdGenerator,
@@ -146,40 +148,17 @@ async fn learn_undocumented_bodies<S: 'static + AsyncWrite + Unpin + Send>(
     let mut analysiss = ReceiverStream::new(analysis_receiver);
     let mut id_generator = IdGenerator::default();
 
-    let mut observations_by_body_location = HashMap::new();
+    let mut learned_undocumented_bodies = LearnedUndocumentedBodiesProjection::default();
+
     while let Some(analysis) = analysiss.next().await {
-      let existing_observations = observations_by_body_location
-        .entry(analysis.body_location)
-        .or_insert_with(|| TrailObservationsResult::default());
-
-      existing_observations.union(analysis.trail_observations);
+      learned_undocumented_bodies.apply(analysis);
     }
 
-    let mut endpoints_by_endpoint = HashMap::new();
-    for (body_location, observations) in observations_by_body_location {
-      let (root_shape_id, body_commands) = observations.into_commands(&mut id_generator);
-      let endpoint_body = EndpointBody::new(&body_location, root_shape_id, body_commands);
+    let endpoint_bodies = learned_undocumented_bodies
+      .into_endpoint_bodies(&mut id_generator)
+      .collect::<Vec<_>>();
 
-      let (path_id, method) = match body_location {
-        BodyAnalysisLocation::UnmatchedRequest {
-          path_id, method, ..
-        } => (path_id, method),
-        BodyAnalysisLocation::UnmatchedResponse {
-          path_id, method, ..
-        } => (path_id, method),
-        _ => unreachable!("analyzing undocumented bodies should only yield unmatched results"),
-      };
-
-      let endpoint_bodies = endpoints_by_endpoint
-        .entry((path_id, method))
-        .or_insert_with_key(|(path_id, method)| {
-          EndpointBodies::new(path_id.clone(), method.clone())
-        });
-
-      endpoint_bodies.push(endpoint_body);
-    }
-
-    streams::write_to_json_lines(sink, endpoints_by_endpoint.values())
+    streams::write_to_json_lines(sink, endpoint_bodies.iter())
       .await
       .expect("could not write endpoint bodies to stdout");
   });
@@ -341,179 +320,6 @@ impl SpecIdGenerator for IdGenerator {
     // - 17 years for a 1% chance of at least one global collision assuming
     //   writing 1000 ids per hour (https://zelark.github.io/nano-id-cc/)
     format!("{}{}", prefix, nanoid!(10))
-  }
-}
-
-// Output types: undocumented bodies
-// ---------------------------------
-
-#[derive(Default, Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct EndpointBodies {
-  path_id: String,
-  method: String,
-  requests: Vec<EndpointRequestBody>,
-  responses: Vec<EndpointResponseBody>,
-}
-
-impl EndpointBodies {
-  pub fn new(path_id: String, method: String) -> Self {
-    Self {
-      path_id,
-      method,
-      requests: vec![],
-      responses: vec![],
-    }
-  }
-
-  pub fn push(&mut self, endpoint: EndpointBody) {
-    match endpoint {
-      EndpointBody::Request(endpoint_request) => {
-        self.requests.push(endpoint_request);
-      }
-      EndpointBody::Response(endpoint_response) => {
-        self.responses.push(endpoint_response);
-      }
-    }
-  }
-}
-
-#[derive(Debug)]
-enum EndpointBody {
-  Request(EndpointRequestBody),
-  Response(EndpointResponseBody),
-}
-
-#[derive(Default, Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct EndpointRequestBody {
-  commands: Vec<SpecCommand>,
-
-  #[serde(skip)]
-  path_id: String,
-  #[serde(skip)]
-  method: String,
-
-  #[serde(flatten)]
-  body_descriptor: Option<EndpointBodyDescriptor>,
-}
-
-#[derive(Default, Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct EndpointResponseBody {
-  commands: Vec<SpecCommand>,
-  status_code: u16,
-
-  #[serde(skip)]
-  path_id: String,
-  #[serde(skip)]
-  method: String,
-
-  #[serde(flatten)]
-  body_descriptor: Option<EndpointBodyDescriptor>,
-}
-
-#[derive(Default, Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct EndpointBodyDescriptor {
-  content_type: String,
-  root_shape_id: String,
-}
-
-impl EndpointBody {
-  fn new(
-    body_location: &BodyAnalysisLocation,
-    root_shape_id: Option<String>,
-    body_commands: impl IntoIterator<Item = SpecCommand>,
-  ) -> Self {
-    let body_descriptor = match root_shape_id {
-      Some(root_shape_id) => Some(EndpointBodyDescriptor {
-        content_type: body_location
-          .content_type()
-          .expect("root shape id implies a content type to be present")
-          .clone(),
-        root_shape_id,
-      }),
-      None => None,
-    };
-
-    let mut body = match body_location {
-      BodyAnalysisLocation::UnmatchedRequest {
-        path_id, method, ..
-      } => EndpointBody::Request(EndpointRequestBody {
-        body_descriptor,
-        path_id: path_id.clone(),
-        method: method.clone(),
-        commands: body_commands.into_iter().collect(),
-      }),
-      BodyAnalysisLocation::UnmatchedResponse {
-        status_code,
-        path_id,
-        method,
-        ..
-      } => EndpointBody::Response(EndpointResponseBody {
-        body_descriptor,
-        path_id: path_id.clone(),
-        method: method.clone(),
-        commands: body_commands.into_iter().collect(),
-        status_code: *status_code,
-      }),
-      _ => panic!("EndpointBody should only be created for unmatched responses and requests"),
-    };
-
-    body.append_endpoint_commands();
-
-    body
-  }
-
-  fn append_endpoint_commands(&mut self) {
-    let mut ids = IdGenerator::default();
-
-    match self {
-      EndpointBody::Request(request_body) => {
-        let request_id = ids.request();
-        request_body
-          .commands
-          .push(SpecCommand::from(EndpointCommand::add_request(
-            request_id.clone(),
-            request_body.path_id.clone(),
-            request_body.method.clone(),
-          )));
-
-        if let Some(body_descriptor) = &request_body.body_descriptor {
-          request_body
-            .commands
-            .push(SpecCommand::from(EndpointCommand::set_request_body_shape(
-              request_id,
-              body_descriptor.root_shape_id.clone(),
-              body_descriptor.content_type.clone(),
-              false,
-            )));
-        }
-      }
-      EndpointBody::Response(response_body) => {
-        let response_id = ids.response();
-        response_body.commands.push(SpecCommand::from(
-          EndpointCommand::add_response_by_path_and_method(
-            response_id.clone(),
-            response_body.path_id.clone(),
-            response_body.method.clone(),
-            response_body.status_code.clone(),
-          ),
-        ));
-
-        if let Some(body_descriptor) = &response_body.body_descriptor {
-          response_body
-            .commands
-            .push(SpecCommand::from(EndpointCommand::set_response_body_shape(
-              response_id,
-              body_descriptor.root_shape_id.clone(),
-              body_descriptor.content_type.clone(),
-              false,
-            )));
-        }
-      }
-    };
   }
 }
 

--- a/workspaces/diff-engine/cli/src/learn.rs
+++ b/workspaces/diff-engine/cli/src/learn.rs
@@ -3,9 +3,7 @@ use super::events_from_chunks;
 use clap::{App, Arg, ArgGroup, ArgMatches, SubCommand};
 use futures::{try_join, SinkExt, Stream, StreamExt, TryStreamExt};
 use nanoid::nanoid;
-use serde::Serialize;
 use serde_json;
-use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::io::{stdin, stdout, AsyncWrite};
 use tokio::sync::mpsc;
@@ -14,12 +12,11 @@ use tokio_stream::wrappers::ReceiverStream;
 use optic_diff_engine::streams;
 use optic_diff_engine::Aggregate;
 use optic_diff_engine::{
-  analyze_documented_bodies, analyze_undocumented_bodies, EndpointCommand, InteractionDiffResult,
-  LearnedShapeDiffAffordancesProjection, LearnedUndocumentedBodiesProjection, SpecCommand,
+  analyze_documented_bodies, analyze_undocumented_bodies, InteractionDiffResult,
+  LearnedShapeDiffAffordancesProjection, LearnedUndocumentedBodiesProjection,
 };
 use optic_diff_engine::{
-  BodyAnalysisLocation, HttpInteraction, JsonTrail, SpecChunkEvent, SpecEvent, SpecIdGenerator,
-  SpecProjection, TaggedInput, Tags, TrailObservationsResult, TrailValues,
+  HttpInteraction, SpecChunkEvent, SpecEvent, SpecIdGenerator, SpecProjection, TaggedInput,
 };
 
 pub const SUBCOMMAND_NAME: &'static str = "learn";

--- a/workspaces/diff-engine/src/lib.rs
+++ b/workspaces/diff-engine/src/lib.rs
@@ -25,14 +25,14 @@ pub use interactions::result::{BodyAnalysisLocation, BodyAnalysisResult, Interac
 pub use interactions::{analyze_documented_bodies, analyze_undocumented_bodies};
 pub use learn_shape::{TrailObservationsResult, TrailValues};
 pub use projections::{
-  EndpointProjection, LearnedUndocumentedBodiesProjection, ShapeProjection,
-  SpecAssemblerProjection, SpecProjection,
+  EndpointProjection, LearnedShapeDiffAffordancesProjection, LearnedUndocumentedBodiesProjection,
+  ShapeProjection, SpecAssemblerProjection, SpecProjection,
 };
 pub use protos::shapehash;
 pub use queries::endpoint::EndpointQueries;
 pub use shapes::{diff as diff_shape, JsonTrail};
 pub use spec::append_batch as append_batch_to_spec;
-pub use state::{body::BodyDescriptor, SpecIdGenerator};
+pub use state::{body::BodyDescriptor, SpecIdGenerator, TaggedInput, Tags};
 
 pub mod errors {
   pub use super::events::EventLoadingError;

--- a/workspaces/diff-engine/src/lib.rs
+++ b/workspaces/diff-engine/src/lib.rs
@@ -25,7 +25,8 @@ pub use interactions::result::{BodyAnalysisLocation, BodyAnalysisResult, Interac
 pub use interactions::{analyze_documented_bodies, analyze_undocumented_bodies};
 pub use learn_shape::{TrailObservationsResult, TrailValues};
 pub use projections::{
-  EndpointProjection, ShapeProjection, SpecAssemblerProjection, SpecProjection,
+  EndpointProjection, LearnedUndocumentedBodiesProjection, ShapeProjection,
+  SpecAssemblerProjection, SpecProjection,
 };
 pub use protos::shapehash;
 pub use queries::endpoint::EndpointQueries;

--- a/workspaces/diff-engine/src/projections/learners/mod.rs
+++ b/workspaces/diff-engine/src/projections/learners/mod.rs
@@ -1,1 +1,2 @@
+pub mod shape_diff_affordances;
 pub mod undocumented_bodies;

--- a/workspaces/diff-engine/src/projections/learners/mod.rs
+++ b/workspaces/diff-engine/src/projections/learners/mod.rs
@@ -1,0 +1,1 @@
+pub mod undocumented_bodies;

--- a/workspaces/diff-engine/src/projections/learners/shape_diff_affordances.rs
+++ b/workspaces/diff-engine/src/projections/learners/shape_diff_affordances.rs
@@ -11,7 +11,7 @@ use crate::state::{TaggedInput, Tags};
 #[derive(Default, Debug)]
 pub struct LearnedShapeDiffAffordancesProjection {
   diffs_by_spec_id: HashMap<String, Vec<InteractionDiffResult>>,
-  affordances_by_diff_fingerprint: HashMap<String, InteractionDiffTrailAffordances>,
+  affordances_by_diff_fingerprint: HashMap<String, ShapeDiffAffordances>,
 }
 
 impl LearnedShapeDiffAffordancesProjection {
@@ -44,7 +44,7 @@ impl LearnedShapeDiffAffordancesProjection {
 
       let affordances = affordances_by_diff_fingerprint
         .entry(fingerprint)
-        .or_insert_with(|| InteractionDiffTrailAffordances::default());
+        .or_insert_with(|| ShapeDiffAffordances::default());
 
       affordances.push((trail_result, interaction_pointers.clone()));
     }
@@ -84,8 +84,8 @@ impl FromIterator<InteractionDiffResult> for LearnedShapeDiffAffordancesProjecti
 
 // easy consuming of the results in a for loop
 impl IntoIterator for LearnedShapeDiffAffordancesProjection {
-  type Item = (String, InteractionDiffTrailAffordances);
-  type IntoIter = std::collections::hash_map::IntoIter<String, InteractionDiffTrailAffordances>;
+  type Item = (String, ShapeDiffAffordances);
+  type IntoIter = std::collections::hash_map::IntoIter<String, ShapeDiffAffordances>;
 
   fn into_iter(self) -> Self::IntoIter {
     self.affordances_by_diff_fingerprint.into_iter()
@@ -115,7 +115,7 @@ impl AggregateEvent<LearnedShapeDiffAffordancesProjection> for TaggedInput<BodyA
 // ------------
 
 #[derive(Default, Debug, Serialize)]
-pub struct InteractionDiffTrailAffordances {
+pub struct ShapeDiffAffordances {
   affordances: Vec<TrailValues>,
   interactions: InteractionsAffordances,
 }
@@ -140,7 +140,7 @@ pub struct InteractionsAffordances {
   was_missing_trails: HashMap<String, Vec<JsonTrail>>,
 }
 
-impl InteractionDiffTrailAffordances {
+impl ShapeDiffAffordances {
   pub fn push(&mut self, (trail_values, pointers): (TrailValues, InteractionPointers)) {
     self.interactions.push((&trail_values, pointers));
 

--- a/workspaces/diff-engine/src/projections/learners/shape_diff_affordances.rs
+++ b/workspaces/diff-engine/src/projections/learners/shape_diff_affordances.rs
@@ -82,6 +82,12 @@ impl FromIterator<InteractionDiffResult> for LearnedShapeDiffAffordancesProjecti
   }
 }
 
+impl From<Vec<InteractionDiffResult>> for LearnedShapeDiffAffordancesProjection {
+  fn from(diff_results: Vec<InteractionDiffResult>) -> Self {
+    diff_results.into_iter().collect()
+  }
+}
+
 // easy consuming of the results in a for loop
 impl IntoIterator for LearnedShapeDiffAffordancesProjection {
   type Item = (String, ShapeDiffAffordances);

--- a/workspaces/diff-engine/src/projections/learners/shape_diff_affordances.rs
+++ b/workspaces/diff-engine/src/projections/learners/shape_diff_affordances.rs
@@ -1,0 +1,195 @@
+use cqrs_core::{Aggregate, AggregateEvent, Event};
+use serde::Serialize;
+use std::collections::HashMap;
+use std::iter::FromIterator;
+
+use crate::interactions::{BodyAnalysisLocation, BodyAnalysisResult, InteractionDiffResult};
+use crate::learn_shape::{TrailObservationsResult, TrailValues};
+use crate::shapes::JsonTrail;
+use crate::state::{TaggedInput, Tags};
+
+#[derive(Default, Debug)]
+pub struct LearnedShapeDiffAffordancesProjection {
+  diffs_by_spec_id: HashMap<String, Vec<InteractionDiffResult>>,
+  affordances_by_diff_fingerprint: HashMap<String, InteractionDiffTrailAffordances>,
+}
+
+impl LearnedShapeDiffAffordancesProjection {
+  fn with_body_analysis_result(
+    &mut self,
+    (analysis, interaction_pointers): (BodyAnalysisResult, InteractionPointers),
+  ) {
+    let diffs_by_spec_id = &self.diffs_by_spec_id;
+    let affordances_by_diff_fingerprint = &mut self.affordances_by_diff_fingerprint;
+
+    let spec_id = match analysis.body_location {
+      BodyAnalysisLocation::MatchedRequest { request_id, .. } => Some(request_id),
+      BodyAnalysisLocation::MatchedResponse { response_id, .. } => Some(response_id),
+      _ => None,
+    };
+
+    let diffs = spec_id
+      .into_iter()
+      .flat_map(|spec_id| diffs_by_spec_id.get(&spec_id).into_iter().flatten());
+
+    for diff in diffs {
+      let json_trail = diff.json_trail().unwrap();
+      let trail_result = analysis
+        .trail_observations
+        .get(json_trail)
+        .cloned()
+        .unwrap_or_else(|| TrailValues::new(json_trail));
+
+      let fingerprint = diff.fingerprint();
+
+      let affordances = affordances_by_diff_fingerprint
+        .entry(fingerprint)
+        .or_insert_with(|| InteractionDiffTrailAffordances::default());
+
+      affordances.push((trail_result, interaction_pointers.clone()));
+    }
+  }
+}
+
+// allows iterator.collect() right into this projection
+impl FromIterator<InteractionDiffResult> for LearnedShapeDiffAffordancesProjection {
+  fn from_iter<I: IntoIterator<Item = InteractionDiffResult>>(diff_results: I) -> Self {
+    let mut diffs_by_spec_id = HashMap::new();
+    for diff_result in diff_results {
+      let spec_id = match &diff_result {
+        InteractionDiffResult::UnmatchedRequestBodyShape(diff) => diff
+          .requests_trail
+          .get_request_id()
+          .expect("UnmatchedRequestBodyShape should have a request id in the requests trail"),
+        InteractionDiffResult::UnmatchedResponseBodyShape(diff) => diff
+          .requests_trail
+          .get_response_id()
+          .expect("UnmatchedResponseBodyShape should have a response id in the requests trail"),
+        _ => continue, // filter out diffs we don't care about
+      }
+      .clone();
+
+      diffs_by_spec_id
+        .entry(spec_id)
+        .or_insert_with(|| vec![])
+        .push(diff_result);
+    }
+
+    Self {
+      diffs_by_spec_id,
+      affordances_by_diff_fingerprint: HashMap::new(),
+    }
+  }
+}
+
+// easy consuming of the results in a for loop
+impl IntoIterator for LearnedShapeDiffAffordancesProjection {
+  type Item = (String, InteractionDiffTrailAffordances);
+  type IntoIter = std::collections::hash_map::IntoIter<String, InteractionDiffTrailAffordances>;
+
+  fn into_iter(self) -> Self::IntoIter {
+    self.affordances_by_diff_fingerprint.into_iter()
+  }
+}
+
+impl Aggregate for LearnedShapeDiffAffordancesProjection {
+  fn aggregate_type() -> &'static str {
+    "learned_shaped_diff_affordances_projection"
+  }
+}
+
+impl Event for TaggedInput<BodyAnalysisResult> {
+  fn event_type(&self) -> &'static str {
+    "body_analysis_result_with_interaction_pointers"
+  }
+}
+
+impl AggregateEvent<LearnedShapeDiffAffordancesProjection> for TaggedInput<BodyAnalysisResult> {
+  fn apply_to(self, aggregate: &mut LearnedShapeDiffAffordancesProjection) {
+    let (analysis, interaction_pointers) = self.into_parts();
+    aggregate.with_body_analysis_result((analysis, interaction_pointers));
+  }
+}
+
+// Output structs
+// ------------
+
+#[derive(Default, Debug, Serialize)]
+pub struct InteractionDiffTrailAffordances {
+  affordances: Vec<TrailValues>,
+  interactions: InteractionsAffordances,
+}
+pub type InteractionPointers = Tags;
+
+#[derive(Debug, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InteractionsAffordances {
+  was_string: InteractionPointers,
+  was_number: InteractionPointers,
+  was_boolean: InteractionPointers,
+  was_null: InteractionPointers,
+  was_array: InteractionPointers,
+  was_object: InteractionPointers,
+  was_missing: InteractionPointers,
+  was_string_trails: HashMap<String, Vec<JsonTrail>>,
+  was_number_trails: HashMap<String, Vec<JsonTrail>>,
+  was_boolean_trails: HashMap<String, Vec<JsonTrail>>,
+  was_null_trails: HashMap<String, Vec<JsonTrail>>,
+  was_array_trails: HashMap<String, Vec<JsonTrail>>,
+  was_object_trails: HashMap<String, Vec<JsonTrail>>,
+  was_missing_trails: HashMap<String, Vec<JsonTrail>>,
+}
+
+impl InteractionDiffTrailAffordances {
+  pub fn push(&mut self, (trail_values, pointers): (TrailValues, InteractionPointers)) {
+    self.interactions.push((&trail_values, pointers));
+
+    // TODO: find alternative way of serializing to an array of affordances, even though
+    // logic tells us there will only ever be one (supposed to be per JsonTrail, but
+    // both TrailValues en InteractionDiffResult use normalized trails, so would always
+    // just be one).
+    if self.affordances.len() > 0 {
+      let current_affordances = &mut self.affordances[0];
+      current_affordances.union(trail_values);
+    } else {
+      self.affordances.push(trail_values);
+    }
+  }
+}
+
+impl InteractionsAffordances {
+  pub fn push(&mut self, (trail_values, pointers): (&TrailValues, InteractionPointers)) {
+    let json_trail = trail_values.trail.clone();
+    let json_trails_by_pointer_iter = || {
+      pointers
+        .iter()
+        .map(|pointer| (pointer.clone(), vec![json_trail.clone()]))
+    };
+    if trail_values.was_string {
+      self.was_string.extend(pointers.clone());
+      self.was_string_trails.extend(json_trails_by_pointer_iter());
+    }
+    if trail_values.was_number {
+      self.was_number.extend(pointers.clone());
+      self.was_number_trails.extend(json_trails_by_pointer_iter());
+    }
+    if trail_values.was_null {
+      self.was_null.extend(pointers.clone());
+      self.was_null_trails.extend(json_trails_by_pointer_iter());
+    }
+    if trail_values.was_array {
+      self.was_array.extend(pointers.clone());
+      self.was_array_trails.extend(json_trails_by_pointer_iter());
+    }
+    if trail_values.was_object {
+      self.was_object.extend(pointers.clone());
+      self.was_object_trails.extend(json_trails_by_pointer_iter());
+    }
+    if trail_values.was_unknown() {
+      self.was_missing.extend(pointers.clone());
+      self
+        .was_missing_trails
+        .extend(json_trails_by_pointer_iter());
+    }
+  }
+}

--- a/workspaces/diff-engine/src/projections/learners/undocumented_bodies.rs
+++ b/workspaces/diff-engine/src/projections/learners/undocumented_bodies.rs
@@ -1,0 +1,246 @@
+use cqrs_core::{Aggregate, AggregateEvent, Event};
+use serde::Serialize;
+use std::collections::HashMap;
+
+use crate::commands::{EndpointCommand, SpecCommand};
+use crate::interactions::{BodyAnalysisLocation, BodyAnalysisResult};
+use crate::learn_shape::TrailObservationsResult;
+use crate::state::SpecIdGenerator;
+
+#[derive(Default, Debug)]
+pub struct LearnedUndocumentedBodiesProjection {
+  observations_by_body_location: HashMap<BodyAnalysisLocation, TrailObservationsResult>,
+}
+
+impl LearnedUndocumentedBodiesProjection {
+  fn with_body_analysis_result(&mut self, analysis: BodyAnalysisResult) {
+    let existing_observations = self
+      .observations_by_body_location
+      .entry(analysis.body_location)
+      .or_insert_with(|| TrailObservationsResult::default());
+
+    existing_observations.union(analysis.trail_observations);
+  }
+
+  pub fn into_endpoint_bodies(
+    self,
+    id_generator: &mut impl SpecIdGenerator,
+  ) -> impl Iterator<Item = EndpointBodies> {
+    let mut endpoints_by_endpoint = HashMap::new();
+    for (body_location, observations) in self.observations_by_body_location {
+      let (root_shape_id, body_commands) = observations.into_commands(id_generator);
+      let endpoint_body =
+        EndpointBody::new(&body_location, root_shape_id, body_commands, id_generator);
+
+      let (path_id, method) = match body_location {
+        BodyAnalysisLocation::UnmatchedRequest {
+          path_id, method, ..
+        } => (path_id, method),
+        BodyAnalysisLocation::UnmatchedResponse {
+          path_id, method, ..
+        } => (path_id, method),
+        _ => unreachable!("analyzing undocumented bodies should only yield unmatched results"),
+      };
+
+      let endpoint_bodies = endpoints_by_endpoint
+        .entry((path_id, method))
+        .or_insert_with_key(|(path_id, method)| {
+          EndpointBodies::new(path_id.clone(), method.clone())
+        });
+
+      endpoint_bodies.push(endpoint_body);
+    }
+
+    endpoints_by_endpoint.into_iter().map(|(k, v)| v)
+  }
+}
+
+impl Aggregate for LearnedUndocumentedBodiesProjection {
+  fn aggregate_type() -> &'static str {
+    "learned_undocument_bodies"
+  }
+}
+
+impl Event for BodyAnalysisResult {
+  fn event_type(&self) -> &'static str {
+    "body_analysis_result"
+  }
+}
+
+impl AggregateEvent<LearnedUndocumentedBodiesProjection> for BodyAnalysisResult {
+  fn apply_to(self, aggregate: &mut LearnedUndocumentedBodiesProjection) {
+    aggregate.with_body_analysis_result(self)
+  }
+}
+
+// Output structs
+// --------------
+
+#[derive(Default, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EndpointBodies {
+  path_id: String,
+  method: String,
+  requests: Vec<EndpointRequestBody>,
+  responses: Vec<EndpointResponseBody>,
+}
+
+impl EndpointBodies {
+  pub fn new(path_id: String, method: String) -> Self {
+    Self {
+      path_id,
+      method,
+      requests: vec![],
+      responses: vec![],
+    }
+  }
+
+  pub fn push(&mut self, endpoint: EndpointBody) {
+    match endpoint {
+      EndpointBody::Request(endpoint_request) => {
+        self.requests.push(endpoint_request);
+      }
+      EndpointBody::Response(endpoint_response) => {
+        self.responses.push(endpoint_response);
+      }
+    }
+  }
+}
+
+#[derive(Debug)]
+pub enum EndpointBody {
+  Request(EndpointRequestBody),
+  Response(EndpointResponseBody),
+}
+
+#[derive(Default, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EndpointRequestBody {
+  commands: Vec<SpecCommand>,
+
+  #[serde(skip)]
+  path_id: String,
+  #[serde(skip)]
+  method: String,
+
+  #[serde(flatten)]
+  body_descriptor: Option<EndpointBodyDescriptor>,
+}
+
+#[derive(Default, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EndpointResponseBody {
+  commands: Vec<SpecCommand>,
+  status_code: u16,
+
+  #[serde(skip)]
+  path_id: String,
+  #[serde(skip)]
+  method: String,
+
+  #[serde(flatten)]
+  body_descriptor: Option<EndpointBodyDescriptor>,
+}
+
+#[derive(Default, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EndpointBodyDescriptor {
+  content_type: String,
+  root_shape_id: String,
+}
+
+impl EndpointBody {
+  fn new(
+    body_location: &BodyAnalysisLocation,
+    root_shape_id: Option<String>,
+    body_commands: impl IntoIterator<Item = SpecCommand>,
+    id_generator: &mut impl SpecIdGenerator,
+  ) -> Self {
+    let body_descriptor = match root_shape_id {
+      Some(root_shape_id) => Some(EndpointBodyDescriptor {
+        content_type: body_location
+          .content_type()
+          .expect("root shape id implies a content type to be present")
+          .clone(),
+        root_shape_id,
+      }),
+      None => None,
+    };
+
+    let mut body = match body_location {
+      BodyAnalysisLocation::UnmatchedRequest {
+        path_id, method, ..
+      } => EndpointBody::Request(EndpointRequestBody {
+        body_descriptor,
+        path_id: path_id.clone(),
+        method: method.clone(),
+        commands: body_commands.into_iter().collect(),
+      }),
+      BodyAnalysisLocation::UnmatchedResponse {
+        status_code,
+        path_id,
+        method,
+        ..
+      } => EndpointBody::Response(EndpointResponseBody {
+        body_descriptor,
+        path_id: path_id.clone(),
+        method: method.clone(),
+        commands: body_commands.into_iter().collect(),
+        status_code: *status_code,
+      }),
+      _ => panic!("EndpointBody should only be created for unmatched responses and requests"),
+    };
+
+    body.append_endpoint_commands(id_generator);
+
+    body
+  }
+
+  fn append_endpoint_commands(&mut self, ids: &mut impl SpecIdGenerator) {
+    match self {
+      EndpointBody::Request(request_body) => {
+        let request_id = ids.request();
+        request_body
+          .commands
+          .push(SpecCommand::from(EndpointCommand::add_request(
+            request_id.clone(),
+            request_body.path_id.clone(),
+            request_body.method.clone(),
+          )));
+
+        if let Some(body_descriptor) = &request_body.body_descriptor {
+          request_body
+            .commands
+            .push(SpecCommand::from(EndpointCommand::set_request_body_shape(
+              request_id,
+              body_descriptor.root_shape_id.clone(),
+              body_descriptor.content_type.clone(),
+              false,
+            )));
+        }
+      }
+      EndpointBody::Response(response_body) => {
+        let response_id = ids.response();
+        response_body.commands.push(SpecCommand::from(
+          EndpointCommand::add_response_by_path_and_method(
+            response_id.clone(),
+            response_body.path_id.clone(),
+            response_body.method.clone(),
+            response_body.status_code.clone(),
+          ),
+        ));
+
+        if let Some(body_descriptor) = &response_body.body_descriptor {
+          response_body
+            .commands
+            .push(SpecCommand::from(EndpointCommand::set_response_body_shape(
+              response_id,
+              body_descriptor.root_shape_id.clone(),
+              body_descriptor.content_type.clone(),
+              false,
+            )));
+        }
+      }
+    };
+  }
+}

--- a/workspaces/diff-engine/src/projections/mod.rs
+++ b/workspaces/diff-engine/src/projections/mod.rs
@@ -1,6 +1,7 @@
 pub mod conflicts;
 pub mod endpoint;
 pub mod history;
+pub mod learners;
 pub mod shape;
 pub mod spec_events;
 pub mod spectacle;
@@ -8,6 +9,7 @@ pub mod spectacle;
 pub use conflicts::ConflictsProjection;
 pub use endpoint::EndpointProjection;
 pub use history::{CommitId, HistoryProjection};
+pub use learners::undocumented_bodies::LearnedUndocumentedBodiesProjection;
 pub use shape::ShapeProjection;
 pub use spec_events::{SpecAssemblerError, SpecAssemblerProjection};
 pub use spectacle::endpoints::EndpointsProjection;

--- a/workspaces/diff-engine/src/projections/mod.rs
+++ b/workspaces/diff-engine/src/projections/mod.rs
@@ -9,7 +9,10 @@ pub mod spectacle;
 pub use conflicts::ConflictsProjection;
 pub use endpoint::EndpointProjection;
 pub use history::{CommitId, HistoryProjection};
-pub use learners::undocumented_bodies::LearnedUndocumentedBodiesProjection;
+pub use learners::{
+  shape_diff_affordances::LearnedShapeDiffAffordancesProjection,
+  undocumented_bodies::LearnedUndocumentedBodiesProjection,
+};
 pub use shape::ShapeProjection;
 pub use spec_events::{SpecAssemblerError, SpecAssemblerProjection};
 pub use spectacle::endpoints::EndpointsProjection;

--- a/workspaces/diff-engine/src/state/mod.rs
+++ b/workspaces/diff-engine/src/state/mod.rs
@@ -1,3 +1,7 @@
+use serde::de::{self, Deserializer, IgnoredAny, SeqAccess, Visitor};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
 pub mod body;
 pub mod endpoint;
 pub mod shape;
@@ -25,3 +29,98 @@ pub trait SpecIdGenerator {
     self.generate_id("shape_param_")
   }
 }
+
+#[derive(Debug, Serialize)]
+pub struct TaggedInput<T>(pub T, pub Tags);
+pub type Tags = HashSet<String>;
+
+impl<T> TaggedInput<T> {
+  pub fn into_parts(self) -> (T, Tags) {
+    (self.0, self.1)
+  }
+
+  pub fn parts(&self) -> (&T, &Tags) {
+    (&self.0, &self.1)
+  }
+
+  pub fn into_input(self) -> T {
+    self.0
+  }
+}
+
+// Custom implementation of Deserialize, to allow ignoring additional items in the tuple,
+// making it significantly easier to pipe results back in as inputs.
+impl<'de, T> Deserialize<'de> for TaggedInput<T>
+where
+  T: Deserialize<'de>,
+{
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+  where
+    D: Deserializer<'de>,
+  {
+    struct TaggedInputVisitor<T> {
+      marker: std::marker::PhantomData<T>,
+    }
+
+    impl<'de, T> Visitor<'de> for TaggedInputVisitor<T>
+    where
+      T: Deserialize<'de>,
+    {
+      type Value = TaggedInput<T>;
+
+      fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("struct TaggedInput")
+      }
+
+      fn visit_seq<V>(self, mut seq: V) -> Result<Self::Value, V::Error>
+      where
+        V: SeqAccess<'de>,
+      {
+        let s = seq
+          .next_element()?
+          .ok_or_else(|| de::Error::invalid_length(0, &self))?;
+        let n = seq
+          .next_element()?
+          .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+
+        // we must visit the rest of the elements in the sequence to prevent panics
+        while let Some(IgnoredAny) = seq.next_element()? {
+          // but we can just ignore them
+        }
+
+        Ok(TaggedInput(s, n))
+      }
+    }
+
+    deserializer.deserialize_seq(TaggedInputVisitor {
+      marker: std::marker::PhantomData,
+    })
+  }
+}
+
+// pub struct TaggedInputIterator<T> {
+//   inner: Option<TaggedInput<T>>,
+// }
+
+// impl<T> Iterator for TaggedInputIterator<T> {
+//   type Item = (Tags, T);
+
+//   #[inline]
+//   fn next(&mut self) -> Option<Self::Item> {
+//     self.inner.take();
+
+//     tagged_input.map(|tagged_input| {
+//       let TaggedInput(input, tags) = tagged_input;
+//       (tags, input)
+//     })
+//   }
+// }
+
+// impl<T> IntoIterator for TaggedInput<T> {
+//   type Item = (Tags, T);
+//   type IntoIter = TaggedInputIterator<T>;
+
+//   fn into_iter(self) -> Self::IntoIter {
+//     TaggedInputIterator { inner: Some(self) }
+//   }
+// }

--- a/workspaces/diff-engine/src/streams/diff.rs
+++ b/workspaces/diff-engine/src/streams/diff.rs
@@ -1,4 +1,4 @@
-use super::{JsonLineEncoder, JsonLineReaderError, TaggedInput};
+use super::{JsonLineEncoder, JsonLineReaderError};
 use futures::{sink::Sink, Stream, StreamExt, TryStreamExt};
 use serde::Serialize;
 use serde_json;
@@ -8,6 +8,7 @@ use tokio::io::{AsyncWrite, BufWriter};
 use tokio_util::codec::FramedWrite;
 
 use crate::interactions::InteractionDiffResult;
+use crate::state::TaggedInput;
 
 // TODO: return a Stream instead of a Vec, so consumer can decide on allocation
 pub async fn tagged_from_json_line_file(

--- a/workspaces/diff-engine/src/streams/mod.rs
+++ b/workspaces/diff-engine/src/streams/mod.rs
@@ -1,6 +1,5 @@
 use bytes::{BufMut, Bytes, BytesMut};
 use futures::{sink::Sink, SinkExt, Stream};
-use serde::de::{self, Deserializer, IgnoredAny, SeqAccess, Visitor};
 use serde::{Deserialize, Serialize};
 use serde_json;
 use std::{collections::HashSet, io};
@@ -92,97 +91,6 @@ pub enum JsonLineReaderError {
     source: io::Error,
   },
 }
-
-#[derive(Debug, Serialize)]
-pub struct TaggedInput<T>(pub T, pub Tags);
-pub type Tags = HashSet<String>;
-
-impl<T> TaggedInput<T> {
-  pub fn into_parts(self) -> (T, Tags) {
-    (self.0, self.1)
-  }
-
-  pub fn parts(&self) -> (&T, &Tags) {
-    (&self.0, &self.1)
-  }
-}
-
-// Custom implementation of Deserialize, to allow ignoring additional items in the tuple,
-// making it significantly easier to pipe results back in as inputs.
-impl<'de, T> Deserialize<'de> for TaggedInput<T>
-where
-  T: Deserialize<'de>,
-{
-  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-  where
-    D: Deserializer<'de>,
-  {
-    struct TaggedInputVisitor<T> {
-      marker: std::marker::PhantomData<T>,
-    }
-
-    impl<'de, T> Visitor<'de> for TaggedInputVisitor<T>
-    where
-      T: Deserialize<'de>,
-    {
-      type Value = TaggedInput<T>;
-
-      fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("struct TaggedInput")
-      }
-
-      fn visit_seq<V>(self, mut seq: V) -> Result<Self::Value, V::Error>
-      where
-        V: SeqAccess<'de>,
-      {
-        let s = seq
-          .next_element()?
-          .ok_or_else(|| de::Error::invalid_length(0, &self))?;
-        let n = seq
-          .next_element()?
-          .ok_or_else(|| de::Error::invalid_length(1, &self))?;
-
-        // we must visit the rest of the elements in the sequence to prevent panics
-        while let Some(IgnoredAny) = seq.next_element()? {
-          // but we can just ignore them
-        }
-
-        Ok(TaggedInput(s, n))
-      }
-    }
-
-    deserializer.deserialize_seq(TaggedInputVisitor {
-      marker: std::marker::PhantomData,
-    })
-  }
-}
-
-// pub struct TaggedInputIterator<T> {
-//   inner: Option<TaggedInput<T>>,
-// }
-
-// impl<T> Iterator for TaggedInputIterator<T> {
-//   type Item = (Tags, T);
-
-//   #[inline]
-//   fn next(&mut self) -> Option<Self::Item> {
-//     self.inner.take();
-
-//     tagged_input.map(|tagged_input| {
-//       let TaggedInput(input, tags) = tagged_input;
-//       (tags, input)
-//     })
-//   }
-// }
-
-// impl<T> IntoIterator for TaggedInput<T> {
-//   type Item = (Tags, T);
-//   type IntoIter = TaggedInputIterator<T>;
-
-//   fn into_iter(self) -> Self::IntoIter {
-//     TaggedInputIterator { inner: Some(self) }
-//   }
-// }
 
 pub fn json_lines<R>(
   source: R,

--- a/workspaces/diff-engine/src/streams/mod.rs
+++ b/workspaces/diff-engine/src/streams/mod.rs
@@ -12,6 +12,7 @@ use tokio_util::codec::{Encoder, FramedWrite};
 
 pub mod diff;
 pub mod http_interaction;
+pub mod shape_diff_affordances;
 pub mod spec_chunks;
 pub mod spec_events;
 

--- a/workspaces/diff-engine/src/streams/shape_diff_affordances.rs
+++ b/workspaces/diff-engine/src/streams/shape_diff_affordances.rs
@@ -1,0 +1,13 @@
+use super::JsonLineEncoderError;
+use crate::projections::learners::shape_diff_affordances::ShapeDiffAffordances;
+use futures::Sink;
+use tokio::io::AsyncWrite;
+
+pub fn into_json_lines<S>(
+  sink: S,
+) -> impl Sink<(ShapeDiffAffordances, String), Error = JsonLineEncoderError>
+where
+  S: AsyncWrite,
+{
+  super::into_json_lines::<S, (ShapeDiffAffordances, String)>(sink)
+}


### PR DESCRIPTION
## Why
We're moving to Spectacle, and we've got new Rust learners, separately. We'll want Spectacle to start using the Rust learners, with the first step being the in memory implementation doing so.


## What
Exposes function to the diff-engine-wasm interface to perform the learning and yield back the results. Extracts aggregation logic for both learners into projections so they can be re-used between interfaces.

## Validation
* [ ] CI passes
* [ ] Add more of these validation checks before going out of draft
