### PR TITLE
refactor: Include `pathId` in response from `generateEndpointChanges`

### DIFF
--- a/workspaces/changelog/src/index.ts
+++ b/workspaces/changelog/src/index.ts
@@ -39,6 +39,7 @@ export async function generateEndpointChanges(
           change {
             category
           }
+          pathId
           path
           method
         }
@@ -51,6 +52,7 @@ export async function generateEndpointChanges(
           change {
             category
           }
+          pathId
           path
           method
         }


### PR DESCRIPTION
## Why
The gitbot needs `pathId` in order to generate the deep links correctly

## What
This exposes the new `pathId` field on `EndpointChange` to the consumers of `generateEndpointChanges`
