### PR TITLE
Update response resolver for requests query

### DIFF
--- a/workspaces/graph-lib/src/endpoints-graph/index.ts
+++ b/workspaces/graph-lib/src/endpoints-graph/index.ts
@@ -171,6 +171,12 @@ export class RequestNodeWrapper implements NodeWrapper {
     return neighbors.results[0] as PathNodeWrapper;
   }
 
+  responses(): ResponseNodeWrapper[] {
+    return (this.path().responses() as any).results.filter(
+      (response: any) => response.value.httpMethod === this.value.httpMethod
+    );
+  }
+
   bodies(): NodeListWrapper {
     return this.queries.listIncomingNeighborsByType(
       this.result.id,

--- a/workspaces/spectacle/src/index.ts
+++ b/workspaces/spectacle/src/index.ts
@@ -304,7 +304,7 @@ export async function makeSpectacle(opticContext: IOpticContext) {
         return Promise.resolve(parent.bodies().results);
       },
       responses: (parent: endpoints.RequestNodeWrapper) => {
-        return Promise.resolve(parent.path().responses().results);
+        return Promise.resolve(parent.responses());
       },
       pathContributions: (parent: any, args: any, context: any) => {
         const pathId = parent.path().value.pathId;


### PR DESCRIPTION
This updates the HttpRequest.responses resolver to return only responses related to the parent request.