### PR TITLE
Fix some react warnings

### DIFF
--- a/workspaces/ui-v2/src/optic-components/changelog/ChangelogDropdown.tsx
+++ b/workspaces/ui-v2/src/optic-components/changelog/ChangelogDropdown.tsx
@@ -58,9 +58,6 @@ export function ChangesSinceDropdown(props: any) {
       <ToggleButton
         value="check"
         selected={false}
-        // onClick={() => {
-        //   isEditing ? save() : setEditing(true);
-        // }}
         size="small"
         className={classes.button}
         onClick={handleClick}
@@ -79,9 +76,8 @@ export function ChangesSinceDropdown(props: any) {
         style={{ marginTop: 20 }}
       >
         {allBatchCommits.map((i, index) => (
-          <BatchCommitMenuItem
-            batch={index === 0 ? { ...i, commitMessage: 'Latest' } : i}
-            key={index}
+          <MenuItem
+            key={i.batchId}
             onClick={() => {
               if (index === 0) {
                 history.push(documentationPageLink.linkTo());
@@ -89,52 +85,48 @@ export function ChangesSinceDropdown(props: any) {
                 history.push(changelogPageRoute.linkTo(i.batchId));
               }
             }}
-          />
+          >
+            <BatchCommitMenuItem
+              batch={index === 0 ? { ...i, commitMessage: 'Latest' } : i}
+            />
+          </MenuItem>
         ))}
       </Menu>
     </>
   );
 }
 
-function BatchCommitMenuItem({
-  batch,
-  onClick,
-}: {
-  batch: BatchCommit;
-  onClick: () => void;
-}) {
+function BatchCommitMenuItem({ batch }: { batch: BatchCommit }) {
   const name =
     batch.commitMessage &&
     (batch.commitMessage.split('\n')[0] ||
       `API  ${batch.commitMessage.split('\n').length}  changes`);
   return (
-    <MenuItem onClick={onClick}>
-      <Box display="flex" flexDirection="column">
-        <Typography
-          component="span"
-          variant="subtitle1"
-          style={{
-            fontFamily: 'Ubuntu Mono',
-            fontSize: 16,
-            color: OpticBlue,
-          }}
-        >
-          {name || 'Changes from'}
-        </Typography>
-        <Typography
-          component="span"
-          variant="subtitle1"
-          style={{
-            fontFamily: 'Ubuntu Mono',
-            fontSize: 12,
-            marginTop: -7,
-            color: OpticBlueReadable,
-          }}
-        >
-          {batch.createdAt && timeAgo.format(new Date(batch.createdAt))}
-        </Typography>
-      </Box>
-    </MenuItem>
+    <Box display="flex" flexDirection="column">
+      <Typography
+        component="span"
+        variant="subtitle1"
+        style={{
+          fontFamily: 'Ubuntu Mono',
+          fontSize: 16,
+          color: OpticBlue,
+        }}
+      >
+        {name || 'Changes from'}
+      </Typography>
+      <Typography
+        component="span"
+        variant="subtitle1"
+        style={{
+          fontFamily: 'Ubuntu Mono',
+          fontSize: 12,
+          marginTop: -7,
+          color: OpticBlueReadable,
+        }}
+      >
+        {batch.createdAt && timeAgo.format(new Date(batch.createdAt))}
+      </Typography>
+    </Box>
   );
 }
 

--- a/workspaces/ui-v2/src/optic-components/diffs/CircularDiffProgress.tsx
+++ b/workspaces/ui-v2/src/optic-components/diffs/CircularDiffProgress.tsx
@@ -23,7 +23,7 @@ export function CircularDiffProgress(props: any) {
     <Box position="relative" display="inline-flex">
       <Grow in={!allHandled}>
         <CircularProgress
-          variant="static"
+          variant="determinate"
           value={value}
           size={total < 50 ? 40 : 55}
           style={{ color: UpdatedBlueBackground }}
@@ -74,7 +74,7 @@ export function CircularDiffLoaderProgress(props: any) {
   return (
     <Box position="relative" display="inline-flex">
       <CircularProgress
-        variant={handled === 0 ? 'indeterminate' : 'static'}
+        variant={handled === 0 ? 'indeterminate' : 'determinate'}
         value={handled === 0 ? undefined : value}
         size={90}
         style={{ color: UpdatedBlueBackground }}

--- a/workspaces/ui-v2/src/optic-components/diffs/contexts/CaptureSelectDropdown.tsx
+++ b/workspaces/ui-v2/src/optic-components/diffs/contexts/CaptureSelectDropdown.tsx
@@ -57,9 +57,6 @@ export function CaptureSelectDropdown(props: any) {
       <ToggleButton
         value="check"
         selected={false}
-        // onClick={() => {
-        //   isEditing ? save() : setEditing(true);
-        // }}
         size="small"
         className={classes.button}
         onClick={handleClick}
@@ -76,47 +73,41 @@ export function CaptureSelectDropdown(props: any) {
         onClose={handleClose}
         style={{ marginTop: 20 }}
       >
-        {captures.captures.map((i, index) => (
-          <CaptureMenuItem
-            capture={i}
-            key={index}
+        {captures.captures.map((capture) => (
+          <MenuItem
+            key={capture.captureId}
             onClick={() => {
               history.push(
-                diffEnvironmentsRoot.linkTo('local', i.captureId) + '/review'
+                diffEnvironmentsRoot.linkTo('local', capture.captureId) +
+                  '/review'
               );
             }}
-          />
+          >
+            <CaptureMenuItem capture={capture} />
+          </MenuItem>
         ))}
       </Menu>
     </>
   );
 }
 
-function CaptureMenuItem({
-  capture,
-  onClick,
-}: {
-  capture: ICapture;
-  onClick: () => void;
-}) {
+function CaptureMenuItem({ capture }: { capture: ICapture }) {
   return (
-    <MenuItem onClick={onClick}>
-      <Box display="flex" flexDirection="column">
-        <Typography
-          component="span"
-          variant="subtitle1"
-          style={{
-            fontFamily: 'Ubuntu Mono',
-            fontSize: 12,
-            marginTop: -7,
-            color: OpticBlueReadable,
-          }}
-        >
-          Local Capture:{' '}
-          {capture.startedAt && timeAgo.format(new Date(capture.startedAt))}
-        </Typography>
-      </Box>
-    </MenuItem>
+    <Box display="flex" flexDirection="column">
+      <Typography
+        component="span"
+        variant="subtitle1"
+        style={{
+          fontFamily: 'Ubuntu Mono',
+          fontSize: 12,
+          marginTop: -7,
+          color: OpticBlueReadable,
+        }}
+      >
+        Local Capture:{' '}
+        {capture.startedAt && timeAgo.format(new Date(capture.startedAt))}
+      </Typography>
+    </Box>
   );
 }
 

--- a/workspaces/ui-v2/src/optic-components/hooks/useCapturesHook.tsx
+++ b/workspaces/ui-v2/src/optic-components/hooks/useCapturesHook.tsx
@@ -8,30 +8,38 @@ export function useCaptures(): {
   error?: any;
 } {
   const capturesService = useContext(CapturesServiceContext)!;
-  const [captures, setCaptures] = useState<ICapture[] | null>(null)
+  const [captures, setCaptures] = useState<ICapture[] | null>(null);
   useEffect(() => {
+    let shouldCancel = false;
     async function task() {
-      const captures = await capturesService.listCaptures()
-      setCaptures(captures)
+      const captures = await capturesService.listCaptures();
+      if (!shouldCancel) {
+        setCaptures(captures);
+      }
     }
 
-    task()
-  }, [capturesService])
+    task();
+    return () => {
+      shouldCancel = true;
+    };
+  }, [capturesService]);
   if (captures === null) {
     return { captures: [], loading: true };
   }
   return {
     captures,
-    loading: false
-  }
+    loading: false,
+  };
 }
 
 interface CapturesServiceStoreProps {
-  capturesService: IOpticCapturesService,
-  children: any
+  capturesService: IOpticCapturesService;
+  children: any;
 }
 
-export const CapturesServiceContext = React.createContext<IOpticCapturesService | null>(null);
+export const CapturesServiceContext = React.createContext<IOpticCapturesService | null>(
+  null
+);
 
 export function CapturesServiceStore(props: CapturesServiceStoreProps) {
   return (


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

The react warnings were annoying me, so I wanted to fix them.

## What
What's changing? Anything of note to call out?

Fixed two types of warnings (well 3 depending on your definition of fix)
- `Function components cannot be given refs` - this is because of how material ui expects Menu and MenuItem to be rendered (it passes in refs) - so the direct children are cloned and injected refs. The easy fix here is to just change the component structure slightly
- `Failed prop-type` - change to use determinate instead of static
- `Can't perform a React state update on an unmounted component` - this is because we are setting state after the component unmounts due to a remount (?) - (not entirely sure about the interactions here) - we can "fix" this by throwing in a shouldCancel block. But the better solution here is to load up all data in a provider and pass it down using a hook - this somewhat fits into the idea of a global state - I think this is somewhat worth tackling to simplify and not have to handle loading / error states when any `useSpectacleQuery` hook is used so I'll lean towards using that as a fix.

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
