### PR TITLE
added a jsontrail to the into_commands signature

### DIFF
--- a/workspaces/diff-engine-wasm/engine/src/lib.rs
+++ b/workspaces/diff-engine-wasm/engine/src/lib.rs
@@ -106,9 +106,9 @@ pub fn affordances_to_commands(
     values_by_trail: values_by_trail_map,
   };
   let mut id_generator = IdGenerator::default();
-  let (root_shape_id_option, commands_iter, new_shape_id) =
-    trail_observation_results.into_commands(&mut id_generator);
-  let result: (Vec<SpecCommand>, String) = (commands_iter.collect(), new_shape_id.unwrap());
+  let (root_shape_id_option, commands_iter) =
+    trail_observation_results.into_commands(&mut id_generator, &json_trail);
+  let result: (Vec<SpecCommand>, String) = (commands_iter.collect(), root_shape_id_option.unwrap());
   serde_json::to_string(&result)
     .map_err(|err| JsValue::from(format!("new commands could not be serialized: {:?}", err)))
 }

--- a/workspaces/diff-engine/src/learn_shape/result.rs
+++ b/workspaces/diff-engine/src/learn_shape/result.rs
@@ -757,7 +757,6 @@ mod test {
       nullable_primitive_observations.into_commands(&mut test_id_generator, &JsonTrail::empty()),
     );
     assert!(nullable_primitive_results.0.is_some());
-    assert!(nullable_primitive_results.0.is_some());
     assert_valid_commands(nullable_primitive_results.1.clone());
     assert_debug_snapshot!(
       "trail_observations_can_generate_commands_for_nullable_bodies__nullable_primitive_results",
@@ -767,7 +766,6 @@ mod test {
     let nullable_object_field_results = collect_commands(
       nullable_object_field_observations.into_commands(&mut test_id_generator, &JsonTrail::empty()),
     );
-    assert!(nullable_object_field_results.0.is_some());
     assert!(nullable_object_field_results.0.is_some());
     assert_valid_commands(nullable_object_field_results.1.clone());
     assert_debug_snapshot!(
@@ -779,7 +777,6 @@ mod test {
       nullable_array_item_observations.into_commands(&mut test_id_generator, &JsonTrail::empty()),
     );
     assert!(nullable_array_item_results.0.is_some());
-    assert!(nullable_array_item_results.0.is_some());
     assert_valid_commands(nullable_array_item_results.1.clone());
     assert_debug_snapshot!(
       "trail_observations_can_generate_commands_for_nullable_bodies__nullable_array_item_results",
@@ -789,7 +786,6 @@ mod test {
     let nullable_one_off_results = collect_commands(
       nullable_one_off_observations.into_commands(&mut test_id_generator, &JsonTrail::empty()),
     );
-    assert!(nullable_one_off_results.0.is_some());
     assert!(nullable_one_off_results.0.is_some());
     assert_valid_commands(nullable_one_off_results.1.clone());
     assert_debug_snapshot!(
@@ -802,7 +798,6 @@ mod test {
     );
     assert!(only_null_results.0.is_some());
     assert_valid_commands(only_null_results.1.clone());
-    assert!(only_null_results.0.is_some());
     assert_debug_snapshot!(
       "trail_observations_can_generate_commands_for_nullable_bodies__only_null_results",
       &only_null_results

--- a/workspaces/diff-engine/src/learn_shape/result.rs
+++ b/workspaces/diff-engine/src/learn_shape/result.rs
@@ -43,11 +43,8 @@ impl TrailObservationsResult {
   pub fn into_commands(
     mut self,
     id_generator: &mut impl SpecIdGenerator,
-  ) -> (
-    Option<String>,
-    impl Iterator<Item = SpecCommand>,
-    Option<String>,
-  ) {
+    root_trail: &JsonTrail,
+  ) -> (Option<String>, impl Iterator<Item = SpecCommand>) {
     let sorted_trails = {
       let mut trails = self
         .values_by_trail
@@ -60,7 +57,6 @@ impl TrailObservationsResult {
 
     let mut shape_prototypes_by_trail = HashMap::new();
     let mut shape_prototypes = Vec::with_capacity(sorted_trails.len());
-    let mut new_shape_id: Option<String> = None;
 
     for json_trail in sorted_trails.into_iter().rev() {
       let trail_values = self.values_by_trail.remove(&json_trail).unwrap();
@@ -68,23 +64,18 @@ impl TrailObservationsResult {
       let shape_prototype =
         trail_values.into_shape_prototype(id_generator, &shape_prototypes_by_trail);
 
-      // collect the id of the first shape prototype we create
-      if new_shape_id.is_none() {
-        new_shape_id = Some(shape_prototype.id.clone());
-      }
-
       shape_prototypes_by_trail.insert(json_trail, shape_prototype.clone());
       shape_prototypes.push(shape_prototype);
     }
 
     let root_shape_id = shape_prototypes_by_trail
-      .get(&JsonTrail::empty())
+      .get(root_trail)
       .map(|root_shape_prototype| root_shape_prototype.id.clone());
 
     let commands =
       shape_prototypes_to_commands(shape_prototypes).map(|command| SpecCommand::from(command));
 
-    (root_shape_id, commands, new_shape_id)
+    (root_shape_id, commands)
   }
 }
 
@@ -528,11 +519,11 @@ mod test {
     let mut test_id_generator = TestIdGenerator::default();
     let spec_projection = SpecProjection::default();
 
-    let string_results =
-      collect_commands(string_observations.into_commands(&mut test_id_generator));
+    let string_results = collect_commands(
+      string_observations.into_commands(&mut test_id_generator, &JsonTrail::empty()),
+    );
     assert!(string_results.0.is_some());
     assert_eq!(string_results.1.len(), 1);
-    assert!(string_results.2.is_some());
     spec_projection
       .execute((&string_results.1[0]).clone())
       .expect("generated command should be valid");
@@ -541,11 +532,11 @@ mod test {
       &string_results
     );
 
-    let number_results =
-      collect_commands(number_observations.into_commands(&mut test_id_generator));
+    let number_results = collect_commands(
+      number_observations.into_commands(&mut test_id_generator, &JsonTrail::empty()),
+    );
     assert!(number_results.0.is_some());
     assert_eq!(number_results.1.len(), 1);
-    assert!(number_results.2.is_some());
     spec_projection
       .execute((&number_results.1[0]).clone())
       .expect("generated command should be valid");
@@ -554,11 +545,11 @@ mod test {
       number_results
     );
 
-    let boolean_results =
-      collect_commands(boolean_observations.into_commands(&mut test_id_generator));
+    let boolean_results = collect_commands(
+      boolean_observations.into_commands(&mut test_id_generator, &JsonTrail::empty()),
+    );
     assert!(boolean_results.0.is_some());
     assert_eq!(boolean_results.1.len(), 1);
-    assert!(boolean_results.2.is_some());
     spec_projection
       .execute((&boolean_results.1[0]).clone())
       .expect("generated command should be valid");
@@ -580,28 +571,29 @@ mod test {
 
     let mut test_id_generator = TestIdGenerator::default();
 
-    let primitive_array_results =
-      collect_commands(primitive_array_observations.into_commands(&mut test_id_generator));
+    let primitive_array_results = collect_commands(
+      primitive_array_observations.into_commands(&mut test_id_generator, &JsonTrail::empty()),
+    );
     assert!(primitive_array_results.0.is_some());
-    assert!(primitive_array_results.2.is_some());
     assert_valid_commands(primitive_array_results.1.clone());
     assert_debug_snapshot!(
       "trail_observations_can_generate_commands_for_array_bodies__primitive_array_results",
       &primitive_array_results
     );
 
-    let empty_array_results =
-      collect_commands(empty_array_observations.into_commands(&mut test_id_generator));
+    let empty_array_results = collect_commands(
+      empty_array_observations.into_commands(&mut test_id_generator, &JsonTrail::empty()),
+    );
     assert!(empty_array_results.0.is_some());
-    assert!(empty_array_results.2.is_some());
     assert_valid_commands(empty_array_results.1.clone());
     assert_debug_snapshot!(
       "trail_observations_can_generate_commands_for_array_bodies__empty_array_results",
       &empty_array_results
     );
 
-    let polymorphic_array_results =
-      collect_commands(polymorphic_array_observations.into_commands(&mut test_id_generator));
+    let polymorphic_array_results = collect_commands(
+      polymorphic_array_observations.into_commands(&mut test_id_generator, &JsonTrail::empty()),
+    );
     assert!(polymorphic_array_results.0.is_some());
     assert_valid_commands(polymorphic_array_results.1.clone());
     assert_debug_snapshot!(
@@ -609,7 +601,6 @@ mod test {
       &polymorphic_array_results
     );
   }
-
   #[test]
   fn trail_observations_can_generate_commands_for_object_bodies() {
     let primitive_object_body = BodyDescriptor::from(json!({
@@ -631,30 +622,30 @@ mod test {
 
     let mut test_id_generator = TestIdGenerator::default();
 
-    let primitive_object_results =
-      collect_commands(primitive_object_observations.into_commands(&mut test_id_generator));
+    let primitive_object_results = collect_commands(
+      primitive_object_observations.into_commands(&mut test_id_generator, &JsonTrail::empty()),
+    );
     assert!(primitive_object_results.0.is_some());
-    assert!(primitive_object_results.2.is_some());
     assert_valid_commands(primitive_object_results.1.clone());
     assert_debug_snapshot!(
       "trail_observations_can_generate_commands_for_object_bodies__primitive_object_results",
       &primitive_object_results
     );
 
-    let empty_object_results =
-      collect_commands(empty_object_observations.into_commands(&mut test_id_generator));
+    let empty_object_results = collect_commands(
+      empty_object_observations.into_commands(&mut test_id_generator, &JsonTrail::empty()),
+    );
     assert!(empty_object_results.0.is_some());
-    assert!(empty_object_results.2.is_some());
     assert_valid_commands(empty_object_results.1.clone());
     assert_debug_snapshot!(
       "trail_observations_can_generate_commands_for_object_bodies__empty_object_results",
       &empty_object_results
     );
 
-    let nested_object_results =
-      collect_commands(nested_object_observations.into_commands(&mut test_id_generator));
+    let nested_object_results = collect_commands(
+      nested_object_observations.into_commands(&mut test_id_generator, &JsonTrail::empty()),
+    );
     assert!(nested_object_results.0.is_some());
-    assert!(nested_object_results.2.is_some());
     assert_valid_commands(nested_object_results.1.clone());
     assert_debug_snapshot!(
       "trail_observations_can_generate_commands_for_object_bodies__nested_object_results",
@@ -698,20 +689,20 @@ mod test {
 
     let mut test_id_generator = TestIdGenerator::default();
 
-    let primitive_object_results =
-      collect_commands(primitive_object_observations.into_commands(&mut test_id_generator));
+    let primitive_object_results = collect_commands(
+      primitive_object_observations.into_commands(&mut test_id_generator, &JsonTrail::empty()),
+    );
     assert!(primitive_object_results.0.is_some());
-    assert!(primitive_object_results.2.is_some());
     assert_valid_commands(primitive_object_results.1.clone());
     assert_debug_snapshot!(
       "trail_observations_can_generate_commands_for_object_with_optional_fields__primitive_object_results",
       &primitive_object_results
     );
 
-    let nested_optional_results =
-      collect_commands(nested_optional_observations.into_commands(&mut test_id_generator));
+    let nested_optional_results = collect_commands(
+      nested_optional_observations.into_commands(&mut test_id_generator, &JsonTrail::empty()),
+    );
     assert!(nested_optional_results.0.is_some());
-    assert!(nested_optional_results.2.is_some());
     assert_valid_commands(nested_optional_results.1.clone());
     assert_debug_snapshot!(
       "trail_observations_can_generate_commands_for_object_with_optional_fields__nested_optional_results",
@@ -762,8 +753,9 @@ mod test {
 
     let mut test_id_generator = TestIdGenerator::default();
 
-    let nullable_primitive_results =
-      collect_commands(nullable_primitive_observations.into_commands(&mut test_id_generator));
+    let nullable_primitive_results = collect_commands(
+      nullable_primitive_observations.into_commands(&mut test_id_generator, &JsonTrail::empty()),
+    );
     assert!(nullable_primitive_results.0.is_some());
     assert!(nullable_primitive_results.0.is_some());
     assert_valid_commands(nullable_primitive_results.1.clone());
@@ -772,8 +764,9 @@ mod test {
       &nullable_primitive_results
     );
 
-    let nullable_object_field_results =
-      collect_commands(nullable_object_field_observations.into_commands(&mut test_id_generator));
+    let nullable_object_field_results = collect_commands(
+      nullable_object_field_observations.into_commands(&mut test_id_generator, &JsonTrail::empty()),
+    );
     assert!(nullable_object_field_results.0.is_some());
     assert!(nullable_object_field_results.0.is_some());
     assert_valid_commands(nullable_object_field_results.1.clone());
@@ -782,8 +775,9 @@ mod test {
       &nullable_object_field_results
     );
 
-    let nullable_array_item_results =
-      collect_commands(nullable_array_item_observations.into_commands(&mut test_id_generator));
+    let nullable_array_item_results = collect_commands(
+      nullable_array_item_observations.into_commands(&mut test_id_generator, &JsonTrail::empty()),
+    );
     assert!(nullable_array_item_results.0.is_some());
     assert!(nullable_array_item_results.0.is_some());
     assert_valid_commands(nullable_array_item_results.1.clone());
@@ -792,8 +786,9 @@ mod test {
       &nullable_array_item_results
     );
 
-    let nullable_one_off_results =
-      collect_commands(nullable_one_off_observations.into_commands(&mut test_id_generator));
+    let nullable_one_off_results = collect_commands(
+      nullable_one_off_observations.into_commands(&mut test_id_generator, &JsonTrail::empty()),
+    );
     assert!(nullable_one_off_results.0.is_some());
     assert!(nullable_one_off_results.0.is_some());
     assert_valid_commands(nullable_one_off_results.1.clone());
@@ -802,8 +797,9 @@ mod test {
       &nullable_one_off_results
     );
 
-    let only_null_results =
-      collect_commands(only_null_observations.into_commands(&mut test_id_generator));
+    let only_null_results = collect_commands(
+      only_null_observations.into_commands(&mut test_id_generator, &JsonTrail::empty()),
+    );
     assert!(only_null_results.0.is_some());
     assert_valid_commands(only_null_results.1.clone());
     assert!(only_null_results.0.is_some());
@@ -841,9 +837,9 @@ mod test {
 
     let mut test_id_generator = TestIdGenerator::default();
 
-    let primitive_results =
-      collect_commands(primitive_observations.into_commands(&mut test_id_generator));
-    assert!(primitive_results.0.is_some());
+    let primitive_results = collect_commands(
+      primitive_observations.into_commands(&mut test_id_generator, &JsonTrail::empty()),
+    );
     assert!(primitive_results.0.is_some());
     assert_valid_commands(primitive_results.1.clone());
     assert_debug_snapshot!(
@@ -851,9 +847,9 @@ mod test {
       &primitive_results
     );
 
-    let collections_results =
-      collect_commands(collections_observations.into_commands(&mut test_id_generator));
-    assert!(collections_results.0.is_some());
+    let collections_results = collect_commands(
+      collections_observations.into_commands(&mut test_id_generator, &JsonTrail::empty()),
+    );
     assert!(collections_results.0.is_some());
     assert_valid_commands(collections_results.1.clone());
     assert_debug_snapshot!(
@@ -862,14 +858,45 @@ mod test {
     );
   }
 
+  #[test]
+  fn trail_observations_can_generate_for_non_root_json_trails() {
+    let complete_nested_object_body = BodyDescriptor::from(json!({
+      "nested": {
+        "nested-object": {
+          "key1": true,
+          "key2": 123,
+          "key3": [1,2,3]
+        }
+      },
+      "other-field": true
+    }));
+
+    let json_trail = JsonTrail::empty()
+      .with_object_key(String::from("nested"))
+      .with_object_key(String::from("nested-object"));
+
+    let collections_observations = {
+      let mut observations = TrailObservationsResult::default();
+      observations.union(observe_body_trails(complete_nested_object_body));
+      observations
+    };
+
+    let mut test_id_generator = TestIdGenerator::default();
+
+    let collections_results =
+      collect_commands(collections_observations.into_commands(&mut test_id_generator, &json_trail));
+    assert!(collections_results.0.is_some());
+    assert_valid_commands(collections_results.1.clone());
+    assert_debug_snapshot!(
+      "trail_observations_can_generate_for_non_root_json_trails__collection_results",
+      &collections_results
+    );
+  }
+
   fn collect_commands(
-    (root_shape_id, commands, new_shape_id): (
-      Option<String>,
-      impl Iterator<Item = SpecCommand>,
-      Option<String>,
-    ),
-  ) -> (Option<String>, Vec<SpecCommand>, Option<String>) {
-    (root_shape_id, commands.collect::<Vec<_>>(), new_shape_id)
+    (root_shape_id, commands): (Option<String>, impl Iterator<Item = SpecCommand>),
+  ) -> (Option<String>, Vec<SpecCommand>) {
+    (root_shape_id, commands.collect::<Vec<_>>())
   }
 
   fn assert_valid_commands(commands: impl IntoIterator<Item = SpecCommand>) {

--- a/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_can_generate_commands_for_array_bodies__empty_array_results.snap
+++ b/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_can_generate_commands_for_array_bodies__empty_array_results.snap
@@ -43,7 +43,4 @@ expression: "&empty_array_results"
             ),
         ),
     ],
-    Some(
-        "test-id-3",
-    ),
 )

--- a/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_can_generate_commands_for_array_bodies__primitive_array_results.snap
+++ b/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_can_generate_commands_for_array_bodies__primitive_array_results.snap
@@ -43,7 +43,4 @@ expression: "&primitive_array_results"
             ),
         ),
     ],
-    Some(
-        "test-id-0",
-    ),
 )

--- a/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_can_generate_commands_for_nullable_bodies__nullable_object_field_results.snap
+++ b/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_can_generate_commands_for_nullable_bodies__nullable_object_field_results.snap
@@ -67,7 +67,4 @@ expression: "&nullable_object_field_results"
             ),
         ),
     ],
-    Some(
-        "test-id-3",
-    ),
 )

--- a/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_can_generate_commands_for_nullable_bodies__nullable_primitive_results.snap
+++ b/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_can_generate_commands_for_nullable_bodies__nullable_primitive_results.snap
@@ -43,7 +43,4 @@ expression: "&nullable_primitive_results"
             ),
         ),
     ],
-    Some(
-        "test-id-1",
-    ),
 )

--- a/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_can_generate_commands_for_object_bodies__empty_object_results.snap
+++ b/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_can_generate_commands_for_object_bodies__empty_object_results.snap
@@ -17,7 +17,4 @@ expression: "&empty_object_results"
             ),
         ),
     ],
-    Some(
-        "test-id-7",
-    ),
 )

--- a/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_can_generate_commands_for_object_bodies__primitive_object_results.snap
+++ b/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_can_generate_commands_for_object_bodies__primitive_object_results.snap
@@ -89,7 +89,4 @@ expression: "&primitive_object_results"
             ),
         ),
     ],
-    Some(
-        "test-id-0",
-    ),
 )

--- a/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_can_generate_commands_for_object_with_optional_fields__nested_optional_results.snap
+++ b/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_can_generate_commands_for_object_with_optional_fields__nested_optional_results.snap
@@ -115,7 +115,4 @@ expression: "&nested_optional_results"
             ),
         ),
     ],
-    Some(
-        "test-id-8",
-    ),
 )

--- a/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_can_generate_commands_for_object_with_optional_fields__primitive_object_results.snap
+++ b/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_can_generate_commands_for_object_with_optional_fields__primitive_object_results.snap
@@ -115,7 +115,4 @@ expression: "&primitive_object_results"
             ),
         ),
     ],
-    Some(
-        "test-id-0",
-    ),
 )

--- a/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_can_generate_commands_for_one_off_polymorphic_bodies__collections_results.snap
+++ b/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_can_generate_commands_for_one_off_polymorphic_bodies__collections_results.snap
@@ -137,7 +137,4 @@ expression: "&collections_results"
             ),
         ),
     ],
-    Some(
-        "test-id-7",
-    ),
 )

--- a/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_can_generate_commands_for_one_off_polymorphic_bodies__primitive_results.snap
+++ b/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_can_generate_commands_for_one_off_polymorphic_bodies__primitive_results.snap
@@ -122,7 +122,4 @@ expression: "&primitive_results"
             ),
         ),
     ],
-    Some(
-        "test-id-0",
-    ),
 )

--- a/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_can_generate_commands_for_primitive_bodies__number_results.snap
+++ b/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_can_generate_commands_for_primitive_bodies__number_results.snap
@@ -17,7 +17,4 @@ expression: number_results
             ),
         ),
     ],
-    Some(
-        "test-id-1",
-    ),
 )

--- a/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_can_generate_commands_for_primitive_bodies__string_results.snap
+++ b/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_can_generate_commands_for_primitive_bodies__string_results.snap
@@ -17,7 +17,4 @@ expression: "&string_results"
             ),
         ),
     ],
-    Some(
-        "test-id-0",
-    ),
 )

--- a/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_can_generate_for_non_root_json_trails__collection_results.snap
+++ b/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_can_generate_for_non_root_json_trails__collection_results.snap
@@ -1,0 +1,190 @@
+---
+source: workspaces/diff-engine/src/learn_shape/result.rs
+expression: "&collections_results"
+---
+(
+    Some(
+        "test-id-8",
+    ),
+    [
+        ShapeCommand(
+            AddShape(
+                AddShape {
+                    shape_id: "test-id-0",
+                    base_shape_id: "$boolean",
+                    name: "",
+                },
+            ),
+        ),
+        ShapeCommand(
+            AddShape(
+                AddShape {
+                    shape_id: "test-id-1",
+                    base_shape_id: "$number",
+                    name: "",
+                },
+            ),
+        ),
+        ShapeCommand(
+            AddShape(
+                AddShape {
+                    shape_id: "test-id-2",
+                    base_shape_id: "$list",
+                    name: "",
+                },
+            ),
+        ),
+        ShapeCommand(
+            SetParameterShape(
+                SetParameterShape {
+                    shape_descriptor: ProviderInShape(
+                        ProviderInShape {
+                            shape_id: "test-id-2",
+                            provider_descriptor: ShapeProvider(
+                                ShapeProvider {
+                                    shape_id: "test-id-1",
+                                },
+                            ),
+                            consuming_parameter_id: "$listItem",
+                        },
+                    ),
+                },
+            ),
+        ),
+        ShapeCommand(
+            AddShape(
+                AddShape {
+                    shape_id: "test-id-3",
+                    base_shape_id: "$number",
+                    name: "",
+                },
+            ),
+        ),
+        ShapeCommand(
+            AddShape(
+                AddShape {
+                    shape_id: "test-id-4",
+                    base_shape_id: "$boolean",
+                    name: "",
+                },
+            ),
+        ),
+        ShapeCommand(
+            AddShape(
+                AddShape {
+                    shape_id: "test-id-8",
+                    base_shape_id: "$object",
+                    name: "",
+                },
+            ),
+        ),
+        ShapeCommand(
+            AddField(
+                AddField {
+                    field_id: "test-id-5",
+                    shape_id: "test-id-8",
+                    name: "key1",
+                    shape_descriptor: FieldShapeFromShape(
+                        FieldShapeFromShape {
+                            field_id: "test-id-5",
+                            shape_id: "test-id-4",
+                        },
+                    ),
+                },
+            ),
+        ),
+        ShapeCommand(
+            AddField(
+                AddField {
+                    field_id: "test-id-6",
+                    shape_id: "test-id-8",
+                    name: "key2",
+                    shape_descriptor: FieldShapeFromShape(
+                        FieldShapeFromShape {
+                            field_id: "test-id-6",
+                            shape_id: "test-id-3",
+                        },
+                    ),
+                },
+            ),
+        ),
+        ShapeCommand(
+            AddField(
+                AddField {
+                    field_id: "test-id-7",
+                    shape_id: "test-id-8",
+                    name: "key3",
+                    shape_descriptor: FieldShapeFromShape(
+                        FieldShapeFromShape {
+                            field_id: "test-id-7",
+                            shape_id: "test-id-2",
+                        },
+                    ),
+                },
+            ),
+        ),
+        ShapeCommand(
+            AddShape(
+                AddShape {
+                    shape_id: "test-id-10",
+                    base_shape_id: "$object",
+                    name: "",
+                },
+            ),
+        ),
+        ShapeCommand(
+            AddField(
+                AddField {
+                    field_id: "test-id-9",
+                    shape_id: "test-id-10",
+                    name: "nested-object",
+                    shape_descriptor: FieldShapeFromShape(
+                        FieldShapeFromShape {
+                            field_id: "test-id-9",
+                            shape_id: "test-id-8",
+                        },
+                    ),
+                },
+            ),
+        ),
+        ShapeCommand(
+            AddShape(
+                AddShape {
+                    shape_id: "test-id-13",
+                    base_shape_id: "$object",
+                    name: "",
+                },
+            ),
+        ),
+        ShapeCommand(
+            AddField(
+                AddField {
+                    field_id: "test-id-11",
+                    shape_id: "test-id-13",
+                    name: "nested",
+                    shape_descriptor: FieldShapeFromShape(
+                        FieldShapeFromShape {
+                            field_id: "test-id-11",
+                            shape_id: "test-id-10",
+                        },
+                    ),
+                },
+            ),
+        ),
+        ShapeCommand(
+            AddField(
+                AddField {
+                    field_id: "test-id-12",
+                    shape_id: "test-id-13",
+                    name: "other-field",
+                    shape_descriptor: FieldShapeFromShape(
+                        FieldShapeFromShape {
+                            field_id: "test-id-12",
+                            shape_id: "test-id-0",
+                        },
+                    ),
+                },
+            ),
+        ),
+    ],
+)

--- a/workspaces/diff-engine/src/projections/learners/undocumented_bodies.rs
+++ b/workspaces/diff-engine/src/projections/learners/undocumented_bodies.rs
@@ -6,6 +6,7 @@ use crate::commands::{EndpointCommand, SpecCommand};
 use crate::interactions::{BodyAnalysisLocation, BodyAnalysisResult};
 use crate::learn_shape::TrailObservationsResult;
 use crate::state::SpecIdGenerator;
+use crate::JsonTrail;
 
 #[derive(Default, Debug)]
 pub struct LearnedUndocumentedBodiesProjection {
@@ -28,7 +29,8 @@ impl LearnedUndocumentedBodiesProjection {
   ) -> impl Iterator<Item = EndpointBodies> {
     let mut endpoints_by_endpoint = HashMap::new();
     for (body_location, observations) in self.observations_by_body_location {
-      let (root_shape_id, body_commands, new_shape_id) = observations.into_commands(id_generator);
+      let (root_shape_id, body_commands) =
+        observations.into_commands(id_generator, &JsonTrail::empty());
       let endpoint_body =
         EndpointBody::new(&body_location, root_shape_id, body_commands, id_generator);
 


### PR DESCRIPTION
## Why
An assumption was baked into the into_commands function: we always want root_shape_id to be the id of the shape created at json trail [] -- in reality, sometimes we want a subtrail to the ID that gets returned. 

## What
Jaap and I paired and updated the into_commands signature to allow you to specify which trail you cared about and wanted to get the generated shape ID for. 

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
