### PR TITLE
Fix position sticky on TwoBodyColumn

### DIFF
--- a/workspaces/ui-v2/src/optic-components/documentation/TwoColumn.tsx
+++ b/workspaces/ui-v2/src/optic-components/documentation/TwoColumn.tsx
@@ -23,7 +23,6 @@ const useStyles = makeStyles((theme) => ({
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'flex-start',
-    overflow: 'auto',
     width: '100%',
   },
   left: {

--- a/workspaces/ui-v2/src/optic-components/navigation/NavigationRoute.tsx
+++ b/workspaces/ui-v2/src/optic-components/navigation/NavigationRoute.tsx
@@ -46,10 +46,8 @@ const useStyles = makeStyles((theme) => ({
   root: {
     display: 'flex',
     flexDirection: 'column',
-    overflow: 'hidden',
   },
   scroll: {
-    overflow: 'scroll',
     paddingTop: 40,
     flex: 1,
   },

--- a/workspaces/ui-v2/src/spectacle-implementations/cloud-viewer.tsx
+++ b/workspaces/ui-v2/src/spectacle-implementations/cloud-viewer.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { useRouteMatch, useParams, Switch } from 'react-router-dom';
 import { Provider as BaseUrlProvider } from '../optic-components/hooks/useBaseUrl';
 import { makeSpectacle } from '@useoptic/spectacle';
-import { useEffect, useState } from 'react';
 import { DocumentationPages } from '../optic-components/pages/docs/DocumentationPage';
 import { AsyncStatus, SpectacleStore } from './spectacle-provider';
 import { Loading } from '../optic-components/loaders/Loading';
@@ -114,6 +113,7 @@ export interface CloudInMemorySpectacleDependencies {
 
 export type CloudInMemorySpectacleDependenciesLoader = () => Promise<CloudInMemorySpectacleDependencies>;
 
+// eslint-disable-next-line
 class CloudInMemorySpectacle
   implements IForkableSpectacle, InMemoryBaseSpectacle {
   private spectaclePromise: Promise<any>;


### PR DESCRIPTION
## Why
Describe the motivation for the changes.
The twobody column now sticks!
<img width="1747" alt="Screen Shot 2021-05-03 at 10 41 38 AM" src="https://user-images.githubusercontent.com/18374483/116911947-646e7180-abfc-11eb-90ed-9c8bb0ba3575.png">

## What
What's changing? Anything of note to call out?

So this is caused by [ancestor elements having the overflow property set](https://www.designcise.com/web/tutorial/how-to-fix-issues-with-css-position-sticky-not-working#checking-if-an-ancestor-element-has-overflow-property-set). I also tried adding a specific height here to fix this problem, but it wouldn't work for me. I removed the overflow properties here - I'm not sure what the original intent for these properties were but I played around with this with those properties and it seems to work as intended without them? I think it should be fine without the NavigationRoute ones since those are on the top level - so overflows will be handled by the browser (?)

I also fixed the lint errors which was causing the `ui-v2` pipeline to fail (perhaps we should run this on PR build + block PR merges if the build fails)?

rust binary build is failing - potentially will be fixed in this PR https://github.com/opticdev/optic/pull/700#issuecomment-831376205 - happy to also fix the changes there

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
