### PR TITLE
Set pending contributions if component is remounted

### DIFF
--- a/workspaces/ui-v2/src/optic-components/hooks/diffs/SharedDiffContext.tsx
+++ b/workspaces/ui-v2/src/optic-components/hooks/diffs/SharedDiffContext.tsx
@@ -48,6 +48,8 @@ type ISharedDiffContext = {
     endpointId: string
   ) => void;
   setPendingEndpointName: (id: string, name: string) => void;
+  getContributedEndpointName: (endpointId: string) => string | undefined;
+  getContributedPathDescription: (pathId: string) => string | undefined;
   captureId: string;
 };
 
@@ -178,6 +180,14 @@ export const SharedDiffStore: FC<SharedDiffStoreProps> = (props) => {
       });
     },
     captureId: props.captureId,
+    getContributedEndpointName: (endpointId: string): string | undefined => {
+      return context.choices.existingEndpointNameContributions[endpointId]
+        ?.AddContribution.value;
+    },
+    getContributedPathDescription: (pathId: string): string | undefined => {
+      return context.choices.existingEndpointPathContributions[pathId]?.command
+        .AddContribution.value;
+    },
   };
 
   return (

--- a/workspaces/ui-v2/src/optic-components/hooks/diffs/SharedDiffState.ts
+++ b/workspaces/ui-v2/src/optic-components/hooks/diffs/SharedDiffState.ts
@@ -249,7 +249,7 @@ export const newSharedDiffMachine = (
                   ...ctx.choices,
                   existingEndpointPathContributions: {
                     ...ctx.choices.existingEndpointPathContributions,
-                    [event.id]: {
+                    [event.pathId]: {
                       command: event.command,
                       endpointId: event.endpointId,
                     },
@@ -416,7 +416,7 @@ export type SharedDiffStateEvent =
     }
   | {
       type: 'SET_PATH_DESCRIPTION';
-      id: string;
+      pathId: string;
       command: any;
       endpointId: string;
     };

--- a/workspaces/ui-v2/src/optic-components/pages/diffs/AddEndpointsPage/EndpointNameEditFields.tsx
+++ b/workspaces/ui-v2/src/optic-components/pages/diffs/AddEndpointsPage/EndpointNameEditFields.tsx
@@ -41,12 +41,13 @@ export const ExistingEndpointNameField: FC<{
     method: endpoint.method,
     pathId: endpoint.pathId,
   });
-  const { setEndpointName: setGlobalDiffEndpointName } = useSharedDiffContext();
-
+  const {
+    setEndpointName: setGlobalDiffEndpointName,
+    getContributedEndpointName,
+  } = useSharedDiffContext();
   const debouncedSet = useDebouncedFn(setGlobalDiffEndpointName, 200);
-
   const { value, setValue } = useStateWithSideEffect({
-    initialValue: endpoint.purpose,
+    initialValue: getContributedEndpointName(endpointId) || endpoint.purpose,
     sideEffect: (newName: string) => debouncedSet(endpointId, newName),
   });
 

--- a/workspaces/ui-v2/src/optic-components/pages/diffs/EndpointDocumentationPane.tsx
+++ b/workspaces/ui-v2/src/optic-components/pages/diffs/EndpointDocumentationPane.tsx
@@ -150,11 +150,16 @@ const DiffPathParamField: FC<{
     value: undefined,
   };
 
-  const { setPathDescription } = useSharedDiffContext();
+  const {
+    setPathDescription,
+    getContributedPathDescription,
+  } = useSharedDiffContext();
 
   const debouncedAddContribution = useDebouncedFn(setPathDescription, 200);
   const { value, setValue } = useStateWithSideEffect({
-    initialValue: pathParameter.description,
+    initialValue:
+      getContributedPathDescription(pathParameter.id) ||
+      pathParameter.description,
     sideEffect: (description: string) =>
       debouncedAddContribution(pathParameter.id, description, endpointId),
   });


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

On a remount of a component, we need to set initial values to also take into account staged (or user input) contributions. This needs to be done in two places:
- Path contributions on the new endpoint diff page
- Review existing endpoint diff page
- New pending endpoint diff page 

The other store (IPendingEndpointDiff) store the data in a way that this is already included. There's two sources of truth here so we need to take this into account differently

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
