### PR TITLE
Add default text to new endpoints page

### DIFF
--- a/workspaces/ui-v2/src/optic-components/pages/diffs/AddEndpointsPage/EndpointNameEditFields.tsx
+++ b/workspaces/ui-v2/src/optic-components/pages/diffs/AddEndpointsPage/EndpointNameEditFields.tsx
@@ -30,6 +30,7 @@ export const PendingEndpointNameField: FC<{
       value={value}
       setValue={setValue}
       variant={TextFieldVariant.SMALL}
+      defaultText="name for this endpoint"
     />
   );
 };
@@ -57,6 +58,7 @@ export const ExistingEndpointNameField: FC<{
       value={value}
       setValue={setValue}
       variant={TextFieldVariant.SMALL}
+      defaultText="name for this endpoint"
     />
   );
 };


### PR DESCRIPTION
## Why
Describe the motivation for the changes.
Without the default text here, it looks bare - updating the textfields in this to have default helper text


## What
What's changing? Anything of note to call out?
<img width="919" alt="Screen Shot 2021-05-03 at 12 42 49 PM" src="https://user-images.githubusercontent.com/18374483/116924921-5aa13a00-ac0d-11eb-808f-a1b9fc3f7b37.png">

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
