### PR TITLE
Fix next diff interactions when reviewing diffs

### DIFF
--- a/workspaces/ui-v2/src/optic-components/diffs/render/BuildSpecPatch.tsx
+++ b/workspaces/ui-v2/src/optic-components/diffs/render/BuildSpecPatch.tsx
@@ -16,13 +16,13 @@ import {
 import { OpticBlueReadable, SubtleBlueBackground } from '../../theme';
 import { namerForOptions } from '../../../lib/quick-namer';
 import { ArrowRight } from '@material-ui/icons';
-import { useSharedDiffContext } from '../../hooks/diffs/SharedDiffContext';
 
 type IBuildSpecPatch = {
   patchChoices?: IPatchChoices;
   diffHash: string;
   onPathChoicesUpdated: (pathChoices?: IPatchChoices) => void;
   approved: () => void;
+  ignore: () => void;
 };
 
 export function BuildSpecPatch({
@@ -30,10 +30,9 @@ export function BuildSpecPatch({
   onPathChoicesUpdated,
   diffHash,
   approved,
+  ignore,
 }: IBuildSpecPatch) {
   const classes = useStyles();
-  const { addDiffHashIgnore } = useSharedDiffContext();
-
   const [selectedChoices, setSelectedChoices] = useState(
     deepCopy(patchChoices)
   );
@@ -119,9 +118,7 @@ export function BuildSpecPatch({
               <Button
                 size="small"
                 style={{ color: OpticBlueReadable }}
-                onClick={() => {
-                  addDiffHashIgnore(diffHash);
-                }}
+                onClick={ignore}
               >
                 Ignore Diff
               </Button>

--- a/workspaces/ui-v2/src/optic-components/diffs/render/DiffCard.tsx
+++ b/workspaces/ui-v2/src/optic-components/diffs/render/DiffCard.tsx
@@ -40,6 +40,8 @@ export function DiffCard({
   diffDescription,
   approve,
   ignore,
+  // @nic todo add in handled
+  handled,
   specChoices,
   updatedSpecChoices,
 }: IDiffCardProps) {

--- a/workspaces/ui-v2/src/optic-components/diffs/render/DiffCard.tsx
+++ b/workspaces/ui-v2/src/optic-components/diffs/render/DiffCard.tsx
@@ -29,6 +29,7 @@ type IDiffCardProps = {
   previewTabs: IInteractionPreviewTab[];
   diffDescription: IDiffDescription;
   approve: () => void;
+  ignore: () => void;
   handled: boolean;
   specChoices?: IPatchChoices;
   updatedSpecChoices: (choices?: IPatchChoices) => void;
@@ -38,6 +39,7 @@ export function DiffCard({
   previewTabs,
   diffDescription,
   approve,
+  ignore,
   specChoices,
   updatedSpecChoices,
 }: IDiffCardProps) {
@@ -137,6 +139,7 @@ export function DiffCard({
           diffHash={diffDescription.diffHash}
           patchChoices={specChoices}
           onPathChoicesUpdated={updatedSpecChoices}
+          ignore={ignore}
         />
       </div>
     </>

--- a/workspaces/ui-v2/src/optic-components/diffs/render/DiffCard.tsx
+++ b/workspaces/ui-v2/src/optic-components/diffs/render/DiffCard.tsx
@@ -40,8 +40,6 @@ export function DiffCard({
   diffDescription,
   approve,
   ignore,
-  // @nic todo add in handled
-  handled,
   specChoices,
   updatedSpecChoices,
 }: IDiffCardProps) {

--- a/workspaces/ui-v2/src/optic-components/hooks/diffs/SharedDiffContext.tsx
+++ b/workspaces/ui-v2/src/optic-components/hooks/diffs/SharedDiffContext.tsx
@@ -104,8 +104,12 @@ export const SharedDiffStore: FC<SharedDiffStoreProps> = (props) => {
       },
       [0, 0]
     );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(Object.keys(state.context.choices.approvedSuggestions))]);
+    /* eslint-disable react-hooks/exhaustive-deps */
+  }, [
+    JSON.stringify(Object.keys(state.context.choices.approvedSuggestions)),
+    JSON.stringify(state.context.browserDiffHashIgnoreRules),
+  ]);
+  /* eslint-enable react-hooks/exhaustive-deps */
 
   const [wipPatterns, setWIPPatterns] = useState<{
     [key: string]: PathComponentAuthoring[];

--- a/workspaces/ui-v2/src/optic-components/pages/diffs/CapturePage.tsx
+++ b/workspaces/ui-v2/src/optic-components/pages/diffs/CapturePage.tsx
@@ -191,7 +191,12 @@ function DiffCaptureResults() {
                 disableRipple
                 button
                 key={index}
-                onClick={handleChangeToEndpointPage(i.pathId, i.method)}
+                onClick={() =>
+                  !done && handleChangeToEndpointPage(i.pathId, i.method)
+                }
+                style={{
+                  cursor: done ? 'default' : 'pointer',
+                }}
               >
                 <EndpointName
                   leftPad={3}

--- a/workspaces/ui-v2/src/optic-components/pages/diffs/CapturePage.tsx
+++ b/workspaces/ui-v2/src/optic-components/pages/diffs/CapturePage.tsx
@@ -145,9 +145,8 @@ function DiffCaptureResults() {
 
   const [handled, total] = handledCount;
 
-  // const history = useHistory();
-
-  const handleChangeToEndpointPage = (pathId: string, method: string) => () => {
+  const handleChangeToEndpointPage = (pathId: string, method: string) => {
+    console.log(diffForEndpointLink.linkTo(pathId, method));
     history.push(diffForEndpointLink.linkTo(pathId, method));
   };
   const handleChangeToUndocumentedUrlPage = () => {

--- a/workspaces/ui-v2/src/optic-components/pages/diffs/CapturePage.tsx
+++ b/workspaces/ui-v2/src/optic-components/pages/diffs/CapturePage.tsx
@@ -146,7 +146,6 @@ function DiffCaptureResults() {
   const [handled, total] = handledCount;
 
   const handleChangeToEndpointPage = (pathId: string, method: string) => {
-    console.log(diffForEndpointLink.linkTo(pathId, method));
     history.push(diffForEndpointLink.linkTo(pathId, method));
   };
   const handleChangeToUndocumentedUrlPage = () => {

--- a/workspaces/ui-v2/src/optic-components/pages/diffs/ReviewEndpointDiffPage/RenderedDiffHeader.tsx
+++ b/workspaces/ui-v2/src/optic-components/pages/diffs/ReviewEndpointDiffPage/RenderedDiffHeader.tsx
@@ -1,0 +1,81 @@
+import React, { FC, useState } from 'react';
+
+import { Collapse, IconButton, Typography } from '@material-ui/core';
+import { ArrowLeft, ArrowRight, Menu as MenuIcon } from '@material-ui/icons';
+
+import { EndpointName } from '<src>/optic-components/common';
+import { DiffHeader } from '<src>/optic-components/diffs/DiffHeader';
+import { IEndpoint } from '<src>/optic-components/hooks/useEndpointsHook';
+import { IInterpretation } from '<src>/lib/Interfaces';
+
+import { DiffLinks } from './DiffLinks';
+
+export type RenderedDiffHeaderProps = {
+  endpoint: IEndpoint;
+  shapeDiffs: IInterpretation[];
+  currentIndex: number;
+  setCurrentIndex: React.Dispatch<React.SetStateAction<number>>;
+};
+
+export const RenderedDiffHeader: FC<RenderedDiffHeaderProps> = ({
+  endpoint,
+  shapeDiffs,
+  currentIndex,
+  setCurrentIndex,
+}) => {
+  const [showToc, setShowToc] = useState(false);
+
+  return (
+    <DiffHeader
+      name={
+        <EndpointName
+          method={endpoint.method}
+          fullPath={endpoint.fullPath}
+          leftPad={0}
+        />
+      }
+      secondary={
+        <Collapse in={showToc}>
+          <DiffLinks
+            shapeDiffs={shapeDiffs}
+            setSelectedDiffHash={(hash: string) => {
+              const hashIndex = shapeDiffs.findIndex(
+                (i) => i.diffDescription?.diffHash === hash
+              );
+              // findIndex possibly returns -1
+              setCurrentIndex(Math.max(hashIndex, 0));
+              setShowToc(false);
+            }}
+          />
+        </Collapse>
+      }
+    >
+      <IconButton
+        size="small"
+        color="primary"
+        onClick={() => setCurrentIndex((prevIndex) => prevIndex - 1)}
+        disabled={currentIndex === 0}
+      >
+        <ArrowLeft />
+      </IconButton>
+      <Typography variant="caption" color="textPrimary">
+        ({currentIndex + 1}/{shapeDiffs.length})
+      </Typography>
+      <IconButton
+        size="small"
+        color="primary"
+        onClick={() => setCurrentIndex((prevIndex) => prevIndex + 1)}
+        disabled={shapeDiffs.length - 1 === currentIndex}
+      >
+        <ArrowRight />
+      </IconButton>
+      <IconButton
+        size="small"
+        color="primary"
+        onClick={() => setShowToc(!showToc)}
+      >
+        <MenuIcon style={{ width: 20, height: 20 }} />
+      </IconButton>
+    </DiffHeader>
+  );
+};


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Fixing interactions when reviewing diffs

## What
What's changing? Anything of note to call out?
- On an approve or an ignore, the next unhandled diff should be selected
- On a navigate back to review diffs page with a partially reviewed endpoint, a user should land on the newest available diff

These are both handled by `getNextIncompleteDiff` - this will return the first diff that has _not_ been completed (a user could jump around, the simpleist logic is to just find the first one in shapeDiffs)

See demo here:
https://www.loom.com/share/161bc3dd3391415392d191d4fdfac8c8

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
