### PR TITLE
Prevent editing from the changelog page

### DIFF
--- a/workspaces/ui-v2/src/optic-components/pages/changelog/ChangelogPages.tsx
+++ b/workspaces/ui-v2/src/optic-components/pages/changelog/ChangelogPages.tsx
@@ -21,6 +21,7 @@ export function ChangelogPages(props: any) {
   const allBatchCommits = useBatchCommits();
   const history = useHistory();
   return (
+    // TODO fork changelog from documentation page and remove contribution editing store
     <ContributionEditingStore initialIsEditingState={false}>
       <>
         <NavigationRoute
@@ -54,7 +55,9 @@ export function ChangelogPages(props: any) {
         />
         <NavigationRoute
           path={changelogPagesEndpointLink.path}
-          Component={EndpointRootPage}
+          Component={(props: any) => (
+            <EndpointRootPage {...props} isChangelogPage={true} />
+          )}
           AccessoryNavigation={ChangelogPageAccessoryNavigation}
         />
       </>

--- a/workspaces/ui-v2/src/optic-components/pages/changelog/ChangelogPages.tsx
+++ b/workspaces/ui-v2/src/optic-components/pages/changelog/ChangelogPages.tsx
@@ -21,7 +21,7 @@ export function ChangelogPages(props: any) {
   const allBatchCommits = useBatchCommits();
   const history = useHistory();
   return (
-    // TODO fork changelog from documentation page and remove contribution editing store
+    // @nic TODO fork changelog from documentation page and remove contribution editing store
     <ContributionEditingStore initialIsEditingState={false}>
       <>
         <NavigationRoute


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Users should not be able to make contributions on the changelog page (but they should be able to view their contributions). Right now contributions are not tied to versions but in the future we'd probably want to make contributions linked to versions (and above) - this would take some thought to figure out how to model this (contributions are valid for a minimum version and above, and the latest applies?)

## What
What's changing? Anything of note to call out?

Ideally we would fork the documentation page from the changelog page, the data requirements and UI rendering are different enough and splitting them makes it change them as we expand on this work (the changelog and documentation page are similar now, but they likely will diverge in functionality more and more)
- This is a task i'll follow up on (annotated with `@nic TODO`

Unnamed endpoint is the default name
<img width="1730" alt="Screen Shot 2021-05-04 at 9 57 40 AM" src="https://user-images.githubusercontent.com/18374483/117040910-3ef66c00-acbf-11eb-8314-367187180853.png">
<img width="1734" alt="Screen Shot 2021-05-04 at 9 57 44 AM" src="https://user-images.githubusercontent.com/18374483/117040918-40c02f80-acbf-11eb-8c3d-8912d151e47e.png">

Contributed names show up if defined
<img width="1731" alt="Screen Shot 2021-05-04 at 9 58 41 AM" src="https://user-images.githubusercontent.com/18374483/117041022-5c2b3a80-acbf-11eb-97b8-0b286d485d37.png">


## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
