### PR TITLE
add a latest tag for cloud-spec-viewer

### DIFF
--- a/.github/workflows/build-ui-v2.yml
+++ b/.github/workflows/build-ui-v2.yml
@@ -49,7 +49,13 @@ jobs:
           echo "DOCKER_REGISTRY=${{ steps.login-ecr.outputs.registry }}" >> $GITHUB_ENV
           echo "TAG=${BRANCH}-b${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
           echo "USER=${GITHUB_ACTOR}" >> $GITHUB_ENV
-      - run: task ui-v2:ci
+      - run: |
+          task ui-v2:ci
+          if [ "$BRANCH" = "develop" ] || [ "$BRANCH" = "master" ]
+          then
+            docker tag "513974440343.dkr.ecr.us-east-1.amazonaws.com/cloud-spec-viewer:${TAG}" 513974440343.dkr.ecr.us-east-1.amazonaws.com/cloud-spec-viewer:latest
+            TAG=latest task ui-v2:cloud-spec-viewer:docker:push
+          fi
         env:
           SLACK_WEBHOOK: ${{ secrets.BUILD_BOT_SLACK_WEBHOOK_URL }}
           REACT_APP_PROD_API_BASE: https://api.useoptic.com

--- a/.github/workflows/build-ui-v2.yml
+++ b/.github/workflows/build-ui-v2.yml
@@ -53,7 +53,9 @@ jobs:
           task ui-v2:ci
           if [ "$BRANCH" = "develop" ] || [ "$BRANCH" = "master" ]
           then
-            docker tag "513974440343.dkr.ecr.us-east-1.amazonaws.com/cloud-spec-viewer:${TAG}" 513974440343.dkr.ecr.us-east-1.amazonaws.com/cloud-spec-viewer:latest
+            docker tag \
+              "513974440343.dkr.ecr.us-east-1.amazonaws.com/cloud-spec-viewer:${TAG}" \
+              513974440343.dkr.ecr.us-east-1.amazonaws.com/cloud-spec-viewer:latest
             TAG=latest task ui-v2:cloud-spec-viewer:docker:push
           fi
         env:


### PR DESCRIPTION
## Why
Having a `latest` tag floating on the most recent default branch build is nice.

## What
Tag's default branch (or master) builds as `latest` in addition to the usual naming scheme. We wouldn't want to deploy `latest` to prod, but it can be useful for local use, or baselining staging without having to look up specific tags. 

## Validation
Won't know until if hits develop, but this is a well-worn pattern we use. For example, https://github.com/opticdev/monorail/blob/master/.github/workflows/optic-hub.yml#L73-L81
