### PR TITLE
Fix typing after merge

### DIFF
--- a/workspaces/ui-v2/src/spectacle-implementations/local-cli.tsx
+++ b/workspaces/ui-v2/src/spectacle-implementations/local-cli.tsx
@@ -196,7 +196,7 @@ class LocalCliDiffService implements IOpticDiffService {
   }
 
   async listDiffs(): Promise<IListDiffsResponse> {
-    const result = await this.dependencies.spectacle.query({
+    const result = await this.dependencies.spectacle.query<any, any>({
       query: `query X($diffId: ID) {
         diff(diffId: $diffId) {
           diffs
@@ -211,7 +211,7 @@ class LocalCliDiffService implements IOpticDiffService {
   }
 
   async listUnrecognizedUrls(): Promise<IListUnrecognizedUrlsResponse> {
-    const result = await this.dependencies.spectacle.query({
+    const result = await this.dependencies.spectacle.query<any, any>({
       query: `query X($diffId: ID) {
         diff(diffId: $diffId) {
           unrecognizedUrls


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Fixes the ui-v2 build

## What
What's changing? Anything of note to call out?

I missed this because of:
- the latest run of the ci on the latest commit passes - this PR https://github.com/opticdev/optic/pull/704
- something on develop gets merged
- the merge is still valid (i.e. i can still press merge without having the latest develop changes merged into my branch)

Any thoughts on blocking PRs on:
- failing builds
- requiring PRs to be up to date before merging?

We should also run the ui-v2 build on PRs

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
