### PR TITLE
fixed critical diff bugs

### DIFF
--- a/workspaces/cli-shared/package.json
+++ b/workspaces/cli-shared/package.json
@@ -40,7 +40,7 @@
     "ora": "^4.0.4",
     "proper-lockfile": "^4.1.1",
     "semver": "^7.3.4",
-    "shape-hash": "^1.0.6",
+    "shape-hash": "1.0.25",
     "stream-chain": "^2.2.3",
     "stream-fork": "^1.0.3",
     "stream-json": "^1.7.1",

--- a/workspaces/cli-shared/src/diffs/shape-trail.ts
+++ b/workspaces/cli-shared/src/diffs/shape-trail.ts
@@ -5,6 +5,7 @@ export type IShapeTrailComponent =
   | IListTrail
   | IListItemTrail
   | INullableTrail
+  | IOptionalTrail
   | IOptionalItemTrail
   | INullableItemTrail
   | IUnknownTrail;
@@ -76,13 +77,13 @@ export interface IUnknownTrail {
 }
 
 export interface IOneOfTrail {
-  IOneOfTrail: {
+  OneOfTrail: {
     shapeId: string;
   };
 }
 
 export interface IOptionalTrail {
-  IOptionalTrail: {
+  OptionalTrail: {
     shapeId: string;
   };
 }

--- a/workspaces/ui-v2/src/lib/diff-description-interpreter.ts
+++ b/workspaces/ui-v2/src/lib/diff-description-interpreter.ts
@@ -54,7 +54,7 @@ const { toJsonExample } = require('shape-hash');
 export async function descriptionForShapeDiff(
   asShapeDiff: BodyShapeDiff,
   query: any,
-  currentSpecContext: CurrentSpecContext,
+  currentSpecContext: CurrentSpecContext
 ): Promise<IDiffDescription> {
   const location = asShapeDiff.location;
 
@@ -96,7 +96,7 @@ export async function descriptionForShapeDiff(
   const expected = await getExpectationsForShapeTrail(
     asShapeDiff.shapeTrail,
     query,
-    currentSpecContext,
+    currentSpecContext
   );
 
   //root handler

--- a/workspaces/ui-v2/src/lib/shape-diffs/field.ts
+++ b/workspaces/ui-v2/src/lib/shape-diffs/field.ts
@@ -109,7 +109,7 @@ export function fieldShapeDiffInterpreter(
       if (isUnmatched) {
         const { commands, rootShapeId } = builderInnerShapeFromChoices(
           choices,
-          expected,
+          expected.allowedCoreShapeKindsByShapeId(),
           actual,
           currentSpecContext
         );
@@ -120,9 +120,10 @@ export function fieldShapeDiffInterpreter(
         ];
       } else if (isUnspecified) {
         const fieldId = currentSpecContext.domainIds.newFieldId();
+
         const { commands, rootShapeId } = builderInnerShapeFromChoices(
           choices,
-          expected,
+          {}, //always empty, unspecified
           actual,
           currentSpecContext
         );

--- a/workspaces/ui-v2/src/lib/shape-diffs/list.ts
+++ b/workspaces/ui-v2/src/lib/shape-diffs/list.ts
@@ -73,7 +73,7 @@ export function listItemShapeDiffInterpreter(
       if (isUnmatched) {
         const { commands, rootShapeId } = builderInnerShapeFromChoices(
           choices,
-          expected,
+          expected.allowedCoreShapeKindsByShapeId(),
           actual,
           currentSpecContext
         );

--- a/workspaces/ui-v2/src/lib/shape-diffs/root.ts
+++ b/workspaces/ui-v2/src/lib/shape-diffs/root.ts
@@ -80,7 +80,7 @@ export function rootShapeDiffInterpreter(
       }
       const { commands, rootShapeId } = builderInnerShapeFromChoices(
         choices,
-        expected,
+        expected.allowedCoreShapeKindsByShapeId(),
         actual,
         currentSpecContext
       );

--- a/workspaces/ui-v2/src/lib/shape-diffs/shape-diffs.ts
+++ b/workspaces/ui-v2/src/lib/shape-diffs/shape-diffs.ts
@@ -11,7 +11,7 @@ export async function interpretShapeDiffs(
   diff: BodyShapeDiff,
   learnedTrails: IValueAffordanceSerializationWithCounter,
   spectacle: any,
-  currentSpecContext: CurrentSpecContext,
+  currentSpecContext: CurrentSpecContext
 ): Promise<IInterpretation> {
   const { normalizedShapeTrail, jsonTrail } = diff;
 
@@ -21,14 +21,14 @@ export async function interpretShapeDiffs(
   const diffDescription = await descriptionForShapeDiff(
     diff,
     spectacle,
-    currentSpecContext,
+    currentSpecContext
   );
 
   const actual = new Actual(learnedTrails, normalizedShapeTrail, jsonTrail);
   const expected = await getExpectationsForShapeTrail(
     diff.shapeTrail,
     spectacle,
-    currentSpecContext,
+    currentSpecContext
   );
 
   // Route to field interpreter
@@ -40,7 +40,7 @@ export async function interpretShapeDiffs(
       actual,
       expected,
       diffDescription,
-      currentSpecContext,
+      currentSpecContext
     );
   }
 
@@ -52,7 +52,7 @@ export async function interpretShapeDiffs(
       actual,
       expected,
       diffDescription,
-      currentSpecContext,
+      currentSpecContext
     );
   }
 
@@ -64,7 +64,7 @@ export async function interpretShapeDiffs(
       diffDescription,
       actual,
       expected,
-      currentSpecContext,
+      currentSpecContext
     );
   }
 

--- a/workspaces/ui-v2/src/lib/shape-trail-parser.ts
+++ b/workspaces/ui-v2/src/lib/shape-trail-parser.ts
@@ -5,6 +5,7 @@ import {
   IObjectFieldTrail,
   IObjectTrail,
   IOneOfItemTrail,
+  IOptionalTrail,
   IShapeTrail,
   IShapeTrailComponent,
 } from '@useoptic/cli-shared/build/diffs/shape-trail';
@@ -115,38 +116,26 @@ export async function shapeTrailParserLastId(
         ...choices,
       };
     }
-    //
-    // if (lastTrail.hasOwnProperty('OptionalItemTrail')) {
-    //   const shapeId = (lastTrail as IOptionalItemTrail).OptionalItemTrail
-    //     .shapeId;
-    //   const choices = await getChoices(shapeId, query);
-    //   return {
-    //     ...choices,
-    //   };
-    // }
-    //
-    // if (lastTrail.hasOwnProperty('NullableItemTrail')) {
-    //   const shapeId = (lastTrail as INullableItemTrail).NullableItemTrail
-    //     .innerShapeId;
-    //   const choices = await getChoices(shapeId, query);
-    // }
+    if (lastTrail.hasOwnProperty('OptionalTrail')) {
+      const shapeId = (lastTrail as IOptionalTrail).OptionalTrail.shapeId;
+      const choices = await getChoices(shapeId, spectacle);
+      const lastItems = await shapeTrailParserLastId(
+        {
+          ...shapeTrail,
+          path: [...shapeTrail.path.slice(0, shapeTrail.path.length - 1)],
+        },
+        spectacle
+      );
+      return {
+        lastObject: lastItems.lastObject,
+        lastField: lastItems.lastField,
+        lastFieldKey: lastItems.lastFieldKey,
+        lastFieldShapeId: lastItems.lastFieldShapeId,
+        ...choices,
+      };
+    }
 
-    //
-    // if (lastTrail['UnknownTrail']) {
-    //   const shapeId = (lastTrail as IUnknownTrail).UnknownTrail || 'unknown';
-    //   getChoices(shapeId, query);
-    // }
-    //
-    // if (lastTrail['OneOfTrail']) {
-    //   const shapeId = (lastTrail as IOneOfTrail).OneOfTrail.shapeId;
-    //   getChoices(shapeId, query);
-    // }
-    //
-    // if (lastTrail['OptionalTrail']) {
-    //   const shapeId = (lastTrail as IOptionalTrail).OptionalTrail.shapeId;
-    //   getChoices(shapeId, query);
-    // }
-    invariant(true, 'shape trail could not be parsed');
+    invariant(false, 'shape trail could not be parsed');
   } else {
     const choices = await getChoices(shapeTrail.rootShapeId, spectacle);
     const lastObject = Object.entries(


### PR DESCRIPTION
## Why
Our diff use cases example session was failing, I spent time this afternoon debugging it and getting it ready for prime time. There's still one bug, documented on twist, for @JaapRood to take on in the AM. 

## What
- Handled the case where an undocumented field was at the root object
- Handled optional fields with diffs 
- Updated to a correct version of shape hash

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
