### PR TITLE
Allow for user enter press on input fields

### DIFF
--- a/workspaces/spectacle/src/in-memory/index.ts
+++ b/workspaces/spectacle/src/in-memory/index.ts
@@ -252,7 +252,6 @@ export class InMemoryDiffService implements IOpticDiffService {
           return x.pathId === pathId && x.method === method;
         }
       );
-      debugger;
       if (!learnedBodiesForPathIdAndMethod) {
         return {
           pathId,

--- a/workspaces/ui-v2/src/optic-components/common/CommitMessageModal.tsx
+++ b/workspaces/ui-v2/src/optic-components/common/CommitMessageModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogTitle,
   makeStyles,
 } from '@material-ui/core';
+import { useRunOnKeypress } from '<src>/optic-components/hooks/util';
 
 type CommitMessageModalProps = {
   open: boolean;
@@ -25,6 +26,19 @@ export const CommitMessageModal: FC<CommitMessageModalProps> = ({
 }) => {
   const [commitMessage, setCommitMessage] = useState('');
   const classes = useStyles();
+  const canSubmit = commitMessage.length > 0;
+  const onKeyPress = useRunOnKeypress(
+    () => {
+      if (canSubmit) {
+        onSave(commitMessage);
+        onClose();
+      }
+    },
+    {
+      keys: new Set(['Enter']),
+      inputTagNames: new Set(['input']),
+    }
+  );
 
   return (
     <Dialog
@@ -34,6 +48,7 @@ export const CommitMessageModal: FC<CommitMessageModalProps> = ({
       PaperProps={{
         className: classes.dialogContainer,
       }}
+      onKeyPress={onKeyPress}
     >
       <DialogTitle id="form-dialog-title">
         Save Changes to Specification
@@ -57,7 +72,7 @@ export const CommitMessageModal: FC<CommitMessageModalProps> = ({
           Cancel
         </Button>
         <Button
-          disabled={commitMessage.length === 0}
+          disabled={!canSubmit}
           onClick={() => {
             onSave(commitMessage);
             onClose();

--- a/workspaces/ui-v2/src/optic-components/diffs/DiffAccessoryNavigation.tsx
+++ b/workspaces/ui-v2/src/optic-components/diffs/DiffAccessoryNavigation.tsx
@@ -14,17 +14,11 @@ import AskForCommitMessage from './render/AskForCommitMessage';
 export function DiffAccessoryNavigation() {
   const classes = useStyles();
 
-  const { context, handledCount } = useSharedDiffContext();
+  const { context, handledCount, hasDiffChanges } = useSharedDiffContext();
   const diffReviewCapturePage = useDiffReviewCapturePageLink();
   const undocumentedUrlsPageLink = useDiffUndocumentedUrlsPageLink();
   const history = useHistory();
   const [handled, total] = handledCount;
-
-  const hasChanges =
-    handled > 0 ||
-    context.pendingEndpoints.filter((i) => i.staged).length > 0 ||
-    Object.keys(context.choices.existingEndpointNameContributions).length > 0 ||
-    Object.keys(context.choices.existingEndpointPathContributions).length > 0;
 
   const numberOfUndocumented = context.results?.displayedUndocumentedUrls.filter(
     (i) => !i.hide
@@ -75,7 +69,7 @@ export function DiffAccessoryNavigation() {
       </div>
       <div className={classes.content}>
         <div className={classes.counter} style={{ marginRight: 10 }}>
-          <AskForCommitMessage hasChanges={hasChanges} />
+          <AskForCommitMessage hasChanges={hasDiffChanges()} />
         </div>
       </div>
     </div>

--- a/workspaces/ui-v2/src/optic-components/diffs/render/AskForCommitMessage.tsx
+++ b/workspaces/ui-v2/src/optic-components/diffs/render/AskForCommitMessage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useHistory } from 'react-router-dom';
 import Button from '@material-ui/core/Button';
 import { CommitMessageModal } from '../../common';
@@ -42,13 +42,17 @@ const useStagedChangesCount = () => {
 export default function AskForCommitMessageDiffPage(props: {
   hasChanges: boolean;
 }) {
-  const [open, setOpen] = useState(false);
   const spectacleMutator = useSpectacleCommand();
   const history = useHistory();
   const lastBatchCommitId = useLastBatchCommitId();
   const changelogPageRoute = useChangelogPages();
 
-  const { context, startedFinalizing } = useSharedDiffContext();
+  const {
+    context,
+    startedFinalizing,
+    commitModalOpen,
+    setCommitModalOpen,
+  } = useSharedDiffContext();
 
   const {
     pendingEndpointsCount,
@@ -90,7 +94,7 @@ export default function AskForCommitMessageDiffPage(props: {
       <Button
         disabled={!props.hasChanges}
         onClick={() => {
-          setOpen(true);
+          setCommitModalOpen(true);
           startedFinalizing();
         }}
         size="small"
@@ -100,8 +104,8 @@ export default function AskForCommitMessageDiffPage(props: {
         Save Changes
       </Button>
       <CommitMessageModal
-        open={open}
-        onClose={() => setOpen(false)}
+        open={commitModalOpen}
+        onClose={() => setCommitModalOpen(false)}
         onSave={handleSave}
         dialogText={`You have added ${pendingEndpointsCount} new ${
           pendingEndpointsCount === 1 ? 'endpoint' : 'endpoints'

--- a/workspaces/ui-v2/src/optic-components/hooks/diffs/SharedDiffContext.tsx
+++ b/workspaces/ui-v2/src/optic-components/hooks/diffs/SharedDiffContext.tsx
@@ -51,6 +51,9 @@ type ISharedDiffContext = {
   getContributedEndpointName: (endpointId: string) => string | undefined;
   getContributedPathDescription: (pathId: string) => string | undefined;
   captureId: string;
+  commitModalOpen: boolean;
+  setCommitModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  hasDiffChanges: () => boolean;
 };
 
 type SharedDiffStoreProps = {
@@ -116,6 +119,8 @@ export const SharedDiffStore: FC<SharedDiffStoreProps> = (props) => {
   const [wipPatterns, setWIPPatterns] = useState<{
     [key: string]: PathComponentAuthoring[];
   }>({});
+
+  const [commitModalOpen, setCommitModalOpen] = useState(false);
 
   const value: ISharedDiffContext = {
     context,
@@ -192,6 +197,14 @@ export const SharedDiffStore: FC<SharedDiffStoreProps> = (props) => {
       return context.choices.existingEndpointPathContributions[pathId]?.command
         .AddContribution.value;
     },
+    commitModalOpen,
+    setCommitModalOpen,
+    hasDiffChanges: () =>
+      handled > 0 ||
+      context.pendingEndpoints.filter((i) => i.staged).length > 0 ||
+      Object.keys(context.choices.existingEndpointNameContributions).length >
+        0 ||
+      Object.keys(context.choices.existingEndpointPathContributions).length > 0,
   };
 
   return (

--- a/workspaces/ui-v2/src/optic-components/hooks/util/index.ts
+++ b/workspaces/ui-v2/src/optic-components/hooks/util/index.ts
@@ -1,2 +1,3 @@
 export * from './useDebouncedFn';
 export * from './useStateWithSideEffect';
+export * from './useRunOnKeypress';

--- a/workspaces/ui-v2/src/optic-components/hooks/util/useRunOnKeypress.ts
+++ b/workspaces/ui-v2/src/optic-components/hooks/util/useRunOnKeypress.ts
@@ -14,8 +14,12 @@ export const useRunOnKeypress = <T extends (...args: any) => any>(
       const upperCaseTags =
         inputTagNames &&
         new Set([...inputTagNames].map((tag) => tag.toUpperCase()));
+      const upperCaseKeys =
+        keys && new Set([...keys].map((key) => key.toUpperCase()));
 
-      const keyPressValid = keys ? keys.has(e.key) : true;
+      const keyPressValid = upperCaseKeys
+        ? upperCaseKeys.has(e.key.toUpperCase())
+        : true;
       const elementTagValid = upperCaseTags
         ? e.target instanceof Element
           ? upperCaseTags.has(e.target.tagName.toUpperCase())

--- a/workspaces/ui-v2/src/optic-components/hooks/util/useRunOnKeypress.ts
+++ b/workspaces/ui-v2/src/optic-components/hooks/util/useRunOnKeypress.ts
@@ -1,0 +1,31 @@
+import { KeyboardEvent, useCallback } from 'react';
+
+export const useRunOnKeypress = <T extends (...args: any) => any>(
+  fn: T,
+  options: {
+    keys?: Set<string>;
+    inputTagNames?: Set<string>;
+  } = {}
+) => {
+  return useCallback(
+    (e: KeyboardEvent) => {
+      const { keys, inputTagNames } = options;
+      // use upper case to handle case insensitivities
+      const upperCaseTags =
+        inputTagNames &&
+        new Set([...inputTagNames].map((tag) => tag.toUpperCase()));
+
+      const keyPressValid = keys ? keys.has(e.key) : true;
+      const elementTagValid = upperCaseTags
+        ? e.target instanceof Element
+          ? upperCaseTags.has(e.target.tagName.toUpperCase())
+          : false
+        : true;
+
+      if (keyPressValid && elementTagValid) {
+        fn(e);
+      }
+    },
+    [fn, options]
+  );
+};

--- a/workspaces/ui-v2/src/optic-components/layouts/FullWidth.tsx
+++ b/workspaces/ui-v2/src/optic-components/layouts/FullWidth.tsx
@@ -6,7 +6,7 @@ export function FullWidth(props: any) {
   const classes = useStyles();
 
   return (
-    <Container maxWidth="lg" className={classes.wrapper} style={props.style}>
+    <Container maxWidth="lg" className={classes.wrapper} {...props}>
       {props.children}
     </Container>
   );

--- a/workspaces/ui-v2/src/optic-components/pages/diffs/AddEndpointsPage/AddEndpointsPage.tsx
+++ b/workspaces/ui-v2/src/optic-components/pages/diffs/AddEndpointsPage/AddEndpointsPage.tsx
@@ -30,6 +30,7 @@ import { CenteredColumn } from '../../../layouts/CenteredColumn';
 import { EndpointName } from '../../../common';
 import { IPendingEndpoint } from '../../../hooks/diffs/SharedDiffState';
 import { useChangelogStyles } from '../../../changelog/ChangelogBackground';
+import { useRunOnKeypress } from '<src>/optic-components/hooks/util';
 
 import {
   ExistingEndpointNameField,
@@ -140,7 +141,11 @@ export function DiffUrlsPage(props: any) {
 export function DocumentationRootPageWithPendingEndpoints(props: any) {
   const { endpoints, loading } = useEndpoints();
 
-  const { pendingEndpoints } = useSharedDiffContext();
+  const {
+    pendingEndpoints,
+    setCommitModalOpen,
+    hasDiffChanges,
+  } = useSharedDiffContext();
   const pendingEndpointsToRender = pendingEndpoints.filter((i) => i.staged);
 
   const diffReviewPagePendingEndpoint = useDiffReviewPagePendingEndpoint();
@@ -150,6 +155,17 @@ export function DocumentationRootPageWithPendingEndpoints(props: any) {
 
   const history = useHistory();
   const endpointPageLink = useEndpointPageLink();
+  const onKeyPress = useRunOnKeypress(
+    () => {
+      if (hasDiffChanges()) {
+        setCommitModalOpen(true);
+      }
+    },
+    {
+      keys: new Set(['Enter']),
+      inputTagNames: new Set(['input']),
+    }
+  );
 
   if (loading) {
     return <Loading />;
@@ -157,7 +173,7 @@ export function DocumentationRootPageWithPendingEndpoints(props: any) {
 
   return (
     <CenteredColumn maxWidth="md" style={{ marginTop: 35 }}>
-      <List dense>
+      <List dense onKeyPress={onKeyPress}>
         {pendingEndpointsToRender.length > 0 && (
           <div style={{ paddingBottom: 25 }}>
             <Typography

--- a/workspaces/ui-v2/src/optic-components/pages/diffs/CapturePage.tsx
+++ b/workspaces/ui-v2/src/optic-components/pages/diffs/CapturePage.tsx
@@ -266,63 +266,6 @@ function DiffCaptureResults() {
   );
 }
 
-/*
-<Typography variant="h6" style={{ fontSize: 18 }}>
-        Real Environments [Beta]
-      </Typography>
-
-      <Typography variant="body2">
-        Optic can securely monitor your API in real environments. Once deployed,
-        Optic verifies your API meets its contract, alert you when it behaves
-        unexpectedly, and help you understand what parts of your API each
-        consumer relies upon.
-      </Typography>
-
-      <Grid container spacing={3} style={{ marginTop: 5 }}>
-        <Grid xs={4} item style={{ opacity: 0.4 }}>
-          <RealEnvColumn
-            name={'development'}
-            examples={[
-              { buildN: 19, diffs: '1 diff', requests: '1.1k' },
-              { buildN: 18, diffs: '4 diffs', requests: '6.1k' },
-            ]}
-          />
-        </Grid>
-        <Grid xs={4} item style={{ opacity: 0.4 }}>
-          <RealEnvColumn
-            name={'staging'}
-            examples={[
-              { buildN: 13, diffs: '3 diffs', requests: '12.2k' },
-              { buildN: 12, diffs: '12 diffs', requests: '7.2k' },
-            ]}
-          />
-        </Grid>
-        <Grid
-          xs={4}
-          item
-          alignContent="center"
-          justifyContent="center"
-          display="flex"
-          flexDirection="column"
-          component={Box}
-        >
-          <Typography
-            variant="body2"
-            style={{
-              fontFamily: 'Ubuntu Mono',
-              marginBottom: 5,
-              marginTop: -15,
-            }}
-          >
-            Ready to put Optic into a real environment?
-          </Typography>
-          <Button color="secondary" variant="contained">
-            Join Beta
-          </Button>
-        </Grid>
-      </Grid>
- */
-
 export function RealEnvColumn({
   name,
   examples,

--- a/workspaces/ui-v2/src/optic-components/pages/diffs/EndpointDocumentationPane.tsx
+++ b/workspaces/ui-v2/src/optic-components/pages/diffs/EndpointDocumentationPane.tsx
@@ -25,13 +25,16 @@ type EndpointDocumentationPaneProps = {
   renderHeader: () => ReactNode;
 };
 
-export const EndpointDocumentationPane: FC<EndpointDocumentationPaneProps> = ({
+export const EndpointDocumentationPane: FC<
+  EndpointDocumentationPaneProps & React.HtmlHTMLAttributes<HTMLDivElement>
+> = ({
   method,
   pathId,
   lastBatchCommit,
   highlightedLocation,
   highlightBodyChanges,
   renderHeader,
+  ...props
 }) => {
   const { endpoints, loading } = useEndpoints();
   // const previewCommands = useSimulatedCommands();
@@ -56,7 +59,10 @@ export const EndpointDocumentationPane: FC<EndpointDocumentationPaneProps> = ({
   });
 
   return (
-    <FullWidth style={{ padding: 30, paddingTop: 15, paddingBottom: 400 }}>
+    <FullWidth
+      style={{ padding: 30, paddingTop: 15, paddingBottom: 400 }}
+      {...props}
+    >
       {renderHeader()}
       <div style={{ height: 20 }} />
       <CodeBlock

--- a/workspaces/ui-v2/src/optic-components/pages/diffs/PendingEndpointPage.tsx
+++ b/workspaces/ui-v2/src/optic-components/pages/diffs/PendingEndpointPage.tsx
@@ -23,6 +23,7 @@ import { EndpointDocumentationPane } from './EndpointDocumentationPane';
 import { SpectacleContext } from '../../../spectacle-implementations/spectacle-provider';
 import { IIgnoreBody } from '../../hooks/diffs/LearnInitialBodiesMachine';
 import { useDebouncedFn, useStateWithSideEffect } from '../../hooks/util';
+import { useRunOnKeypress } from '<src>/optic-components/hooks/util';
 
 export function PendingEndpointPageSession(props: any) {
   const { match } = props;
@@ -83,7 +84,6 @@ export function PendingEndpointPage(props: any) {
 
   const classes = useStyles();
   const spectacle = useContext(SpectacleContext)!;
-  // const lastBatchId = useLastBatchCommitId();
   const debouncedSetName = useDebouncedFn(changeEndpointName, 200);
   const { value: name, setValue: setName } = useStateWithSideEffect({
     initialValue: endpointName,
@@ -92,6 +92,15 @@ export function PendingEndpointPage(props: any) {
 
   const requestCheckboxes = (learnedBodies?.requests || []).filter((i) =>
     Boolean(i.contentType)
+  );
+  const onKeyPress = useRunOnKeypress(
+    () => {
+      stageEndpoint();
+    },
+    {
+      keys: new Set(['Enter']),
+      inputTagNames: new Set(['input']),
+    }
   );
 
   return (
@@ -128,6 +137,7 @@ export function PendingEndpointPage(props: any) {
                 onChange={(e: any) => {
                   setName(e.target.value);
                 }}
+                onKeyPress={onKeyPress}
               />
 
               <Typography
@@ -138,7 +148,7 @@ export function PendingEndpointPage(props: any) {
                 Document the bodies for this endpoint:
               </Typography>
 
-              <FormControl component="fieldset">
+              <FormControl component="fieldset" onKeyPress={onKeyPress}>
                 {requestCheckboxes.map((i, index) => {
                   if (!i.contentType) {
                     return null;
@@ -163,7 +173,7 @@ export function PendingEndpointPage(props: any) {
 
               {requestCheckboxes.length > 0 && <Divider />}
 
-              <FormControl component="fieldset">
+              <FormControl component="fieldset" onKeyPress={onKeyPress}>
                 {learnedBodies!.responses.map((i, index) => {
                   const body: IIgnoreBody = {
                     isResponse: true,
@@ -204,11 +214,6 @@ export function PendingEndpointPage(props: any) {
       }
       right={
         <>
-          <pre style={{ paddingTop: 60 }}>
-            {JSON.stringify(newEndpointCommands)}
-            <br />
-            {JSON.stringify(stagedCommandsIds)}
-          </pre>
           <SimulatedCommandStore
             key={JSON.stringify(newEndpointCommands)}
             spectacle={spectacle as IForkableSpectacle}

--- a/workspaces/ui-v2/src/optic-components/pages/diffs/ReviewEndpointDiffPage/ReviewEndpointDiffPage.tsx
+++ b/workspaces/ui-v2/src/optic-components/pages/diffs/ReviewEndpointDiffPage/ReviewEndpointDiffPage.tsx
@@ -19,6 +19,7 @@ import {
 import { useDiffReviewCapturePageLink } from '<src>/optic-components/navigation/Routes';
 import { IInterpretation } from '<src>/lib/Interfaces';
 import { getEndpointId } from '<src>/optic-components/utilities/endpoint-utilities';
+import { useRunOnKeypress } from '<src>/optic-components/hooks/util';
 
 import {
   RenderedDiffHeaderProps,
@@ -62,6 +63,8 @@ export const ReviewEndpointDiffPage: FC<ReviewEndpointDiffPageProps> = ({
     isDiffHandled,
     setEndpointName: setGlobalDiffEndpointName,
     addDiffHashIgnore,
+    setCommitModalOpen,
+    hasDiffChanges,
   } = useSharedDiffContext();
 
   const debouncedSetName = useDebouncedFn(setGlobalDiffEndpointName, 200);
@@ -97,6 +100,17 @@ export const ReviewEndpointDiffPage: FC<ReviewEndpointDiffPageProps> = ({
   const [currentIndex, setCurrentIndex] = useState(getNextIncompleteDiff());
   const [previewCommands, setPreviewCommands] = useState<any[]>([]);
   const renderedDiff = shapeDiffs[currentIndex];
+  const onKeyPress = useRunOnKeypress(
+    () => {
+      if (hasDiffChanges()) {
+        setCommitModalOpen(true);
+      }
+    },
+    {
+      keys: new Set(['Enter']),
+      inputTagNames: new Set(['input']),
+    }
+  );
 
   return (
     <TwoColumnFullWidth
@@ -162,6 +176,7 @@ export const ReviewEndpointDiffPage: FC<ReviewEndpointDiffPageProps> = ({
                 />
               </>
             )}
+            onKeyPress={onKeyPress}
           />
         </SimulatedCommandStore>
       }

--- a/workspaces/ui-v2/src/optic-components/pages/docs/DocumentationPage.tsx
+++ b/workspaces/ui-v2/src/optic-components/pages/docs/DocumentationPage.tsx
@@ -34,6 +34,7 @@ import { useBaseUrl } from '../../hooks/useBaseUrl';
 import { useAppConfig } from '../../hooks/config/AppConfiguration';
 import { useChangelogStyles } from '../../changelog/ChangelogBackground';
 import { IShapeRenderer, JsonLike } from '../../shapes/ShapeRenderInterfaces';
+import { useRunOnKeypress } from '<src>/optic-components/hooks/util';
 
 export function DocumentationPages(props: any) {
   const documentationPageLink = useDocumentationPageLink();
@@ -101,10 +102,27 @@ export function DocumentationRootPage(props: {
   //@nic TODO fork changelog from documentation page
   const isChangelogPage = props.changelogBatchId !== undefined;
 
+  const {
+    isEditing,
+    pendingCount,
+    setCommitModalOpen,
+  } = useContributionEditing();
+
   const grouped = useMemo(() => groupBy(endpoints, 'group'), [endpoints]);
   const tocKeys = Object.keys(grouped).sort();
   const changelogStyles = useChangelogStyles();
   const styles = useStyles();
+  const onKeyPress = useRunOnKeypress(
+    () => {
+      if (isEditing && pendingCount > 0) {
+        setCommitModalOpen(true);
+      }
+    },
+    {
+      keys: new Set(['Enter']),
+      inputTagNames: new Set(['input']),
+    }
+  );
 
   if (loading) {
     return <Loading />;
@@ -112,7 +130,7 @@ export function DocumentationRootPage(props: {
 
   return (
     <CenteredColumn maxWidth="md" style={{ marginTop: 35 }}>
-      <List dense>
+      <List dense onKeyPress={onKeyPress}>
         {tocKeys.map((tocKey) => {
           return (
             <div key={tocKey}>
@@ -193,6 +211,23 @@ export const EndpointRootPage: FC<
     () => endpoints.find((i) => i.pathId === pathId && i.method === method),
     [pathId, method, endpoints]
   );
+  const {
+    isEditing,
+    pendingCount,
+    setCommitModalOpen,
+  } = useContributionEditing();
+
+  const onKeyPress = useRunOnKeypress(
+    () => {
+      if (isEditing && pendingCount > 0) {
+        setCommitModalOpen(true);
+      }
+    },
+    {
+      keys: new Set(['Enter']),
+      inputTagNames: new Set(['input']),
+    }
+  );
 
   if (loading) {
     return <Loading />;
@@ -207,7 +242,10 @@ export const EndpointRootPage: FC<
   );
 
   return (
-    <FullWidth style={{ paddingTop: 30, paddingBottom: 400 }}>
+    <FullWidth
+      style={{ paddingTop: 30, paddingBottom: 400 }}
+      onKeyPress={onKeyPress}
+    >
       {/* @nic TODO fork documentation page from changelog page */}
       {isChangelogPage ? (
         <Typography className={styles.regularField}>

--- a/workspaces/ui-v2/src/optic-components/pages/docs/EditContributionsButton.tsx
+++ b/workspaces/ui-v2/src/optic-components/pages/docs/EditContributionsButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { ToggleButton } from '@material-ui/lab';
 import { Typography, makeStyles } from '@material-ui/core';
 import SaveAltIcon from '@material-ui/icons/SaveAlt';
@@ -8,13 +8,14 @@ import { CommitMessageModal } from '../../common';
 
 export function EditContributionsButton() {
   const classes = useStyles();
-  const [open, setOpen] = useState(false);
 
   const {
     isEditing,
     save,
     pendingCount,
     setEditing,
+    commitModalOpen,
+    setCommitModalOpen,
   } = useContributionEditing();
 
   const contents = !isEditing ? (
@@ -40,7 +41,7 @@ export function EditContributionsButton() {
         onClick={() => {
           isEditing
             ? pendingCount > 0
-              ? setOpen(true)
+              ? setCommitModalOpen(true)
               : setEditing(false)
             : setEditing(true);
         }}
@@ -50,8 +51,8 @@ export function EditContributionsButton() {
         {contents}
       </ToggleButton>
       <CommitMessageModal
-        open={open}
-        onClose={() => setOpen(false)}
+        open={commitModalOpen}
+        onClose={() => setCommitModalOpen(false)}
         onSave={save}
         dialogText={`You have ${pendingCount} ${
           pendingCount === 1 ? 'change' : 'changes'


### PR DESCRIPTION
## Why
Describe the motivation for the changes.
Allow users to press enter on input fields to go to the next stage (this is usually opening the commit modal)

## What
What's changing? Anything of note to call out?

### Documentation page
pressing enter in one of these pages will open the commit modal
<img width="1111" alt="Screen Shot 2021-05-04 at 4 26 38 PM" src="https://user-images.githubusercontent.com/18374483/117081846-a16a5f00-acf5-11eb-96ff-8abc66d63277.png">
<img width="1115" alt="Screen Shot 2021-05-04 at 4 26 57 PM" src="https://user-images.githubusercontent.com/18374483/117081855-a7f8d680-acf5-11eb-804b-2ebbb3187f4f.png">

Commit modal will submit the message
<img width="677" alt="Screen Shot 2021-05-04 at 4 26 46 PM" src="https://user-images.githubusercontent.com/18374483/117081848-a3ccb900-acf5-11eb-8f58-e97b158a2fff.png">

### Diff page
Review diffs page - will open the commit modal
*NOTE - I don't actually think this is the right place for contributions (for request / response fields), or even that we should commit here - it may be potentially confusing to have two different workflows for adding contributions? Perhaps having a streamlined diff review process (simplified) where it walks you through what to do? This way a user isn't going to "leave" the diff process half way through, which it feels like currently they can quite easily do so

<img width="1110" alt="Screen Shot 2021-05-04 at 4 28 48 PM" src="https://user-images.githubusercontent.com/18374483/117081951-d8d90b80-acf5-11eb-8039-42b69f7e3eb1.png">

Unrecognized url - will stage the endpoint
<img width="814" alt="Screen Shot 2021-05-04 at 4 29 29 PM" src="https://user-images.githubusercontent.com/18374483/117081977-e8585480-acf5-11eb-8519-9aff437d6242.png">

Pending + existing endpoints - will open commit modal
<img width="543" alt="Screen Shot 2021-05-04 at 4 29 51 PM" src="https://user-images.githubusercontent.com/18374483/117082012-f60dda00-acf5-11eb-9dc1-bef602ef9315.png">


## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
