### PR TITLE
revert some changes that were overwritten

### DIFF
--- a/workspaces/ui-v2/src/spectacle-implementations/cloud-viewer.tsx
+++ b/workspaces/ui-v2/src/spectacle-implementations/cloud-viewer.tsx
@@ -17,6 +17,7 @@ import {
   OpticAppConfig,
 } from '../optic-components/hooks/config/AppConfiguration';
 import { AsyncStatus } from '<src>/types';
+import { useInMemorySpectacle } from '<src>/spectacle-implementations/public-examples';
 
 const appConfig: OpticAppConfig = {
   featureFlags: {},
@@ -114,7 +115,6 @@ export interface CloudInMemorySpectacleDependencies {
 
 export type CloudInMemorySpectacleDependenciesLoader = () => Promise<CloudInMemorySpectacleDependencies>;
 
-// eslint-disable-next-line
 class CloudInMemorySpectacle
   implements IForkableSpectacle, InMemoryBaseSpectacle {
   private spectaclePromise: ReturnType<typeof makeSpectacle>;
@@ -153,6 +153,5 @@ export interface InMemoryBaseSpectacle extends IBaseSpectacle {
 export function useCloudInMemorySpectacle(
   loadDependencies: CloudInMemorySpectacleDependenciesLoader
 ): AsyncStatus<InMemoryBaseSpectacle> {
-  //@dev fill this in
-  throw new Error('copy me from public-examples.tsx when ready');
+  return useInMemorySpectacle(loadDependencies);
 }

--- a/workspaces/ui-v2/src/spectacle-implementations/cloud-viewer.tsx
+++ b/workspaces/ui-v2/src/spectacle-implementations/cloud-viewer.tsx
@@ -17,7 +17,8 @@ import {
   OpticAppConfig,
 } from '../optic-components/hooks/config/AppConfiguration';
 import { AsyncStatus } from '<src>/types';
-import { useInMemorySpectacle } from '<src>/spectacle-implementations/public-examples';
+import { useOpticEngine } from '<src>/optic-components/hooks/useOpticEngine';
+import { useEffect, useState } from 'react';
 
 const appConfig: OpticAppConfig = {
   featureFlags: {},
@@ -108,15 +109,8 @@ export default function CloudViewer() {
   );
 }
 
-export interface CloudInMemorySpectacleDependencies {
-  events: any[];
-  samples: any[];
-}
-
-export type CloudInMemorySpectacleDependenciesLoader = () => Promise<CloudInMemorySpectacleDependencies>;
-
 class CloudInMemorySpectacle
-  implements IForkableSpectacle, InMemoryBaseSpectacle {
+  implements IForkableSpectacle, CloudInMemoryBaseSpectacle {
   private spectaclePromise: ReturnType<typeof makeSpectacle>;
 
   constructor(
@@ -145,13 +139,78 @@ class CloudInMemorySpectacle
   }
 }
 
-export interface InMemoryBaseSpectacle extends IBaseSpectacle {
+export interface CloudInMemoryBaseSpectacle extends IBaseSpectacle {
   samples: any[];
   opticContext: IOpticContext;
 }
 
+export interface CloudInMemorySpectacleDependencies {
+  events: any[];
+  samples: any[];
+}
+
+export type CloudInMemorySpectacleDependenciesLoader = () => Promise<CloudInMemorySpectacleDependencies>;
+
+//@SYNC: useInMemorySpectacle
 export function useCloudInMemorySpectacle(
   loadDependencies: CloudInMemorySpectacleDependenciesLoader
-): AsyncStatus<InMemoryBaseSpectacle> {
-  return useInMemorySpectacle(loadDependencies);
+): AsyncStatus<CloudInMemoryBaseSpectacle> {
+  const opticEngine = useOpticEngine();
+  const [spectacle, setSpectacle] = useState<CloudInMemoryBaseSpectacle>();
+  const [inputs, setInputs] = useState<{
+    events: any[];
+    samples: any[];
+  } | null>(null);
+
+  useEffect(() => {
+    async function task() {
+      const result = await loadDependencies();
+      setInputs({
+        events: result.events,
+        samples: result.samples,
+      });
+    }
+
+    task();
+  }, [loadDependencies]);
+
+  useEffect(() => {
+    async function task() {
+      if (inputs === null) {
+        return;
+      }
+      const opticContext = await InMemoryOpticContextBuilder.fromEventsAndInteractions(
+        opticEngine,
+        inputs.events,
+        inputs.samples,
+        'example-session'
+      );
+      const inMemorySpectacle = new CloudInMemorySpectacle(
+        opticContext,
+        inputs.samples
+      );
+      inMemorySpectacle.opticContext.specRepository.notifications.on(
+        'change',
+        async () => {
+          const newEvents = await inMemorySpectacle.opticContext.specRepository.listEvents();
+          setInputs({ events: newEvents, samples: inputs.samples });
+        }
+      );
+      console.count('setSpectacle');
+      setSpectacle(inMemorySpectacle);
+    }
+
+    task();
+  }, [inputs, opticEngine]);
+
+  if (spectacle) {
+    return {
+      loading: false,
+      data: spectacle,
+    };
+  } else {
+    return {
+      loading: true,
+    };
+  }
 }

--- a/workspaces/ui-v2/src/spectacle-implementations/local-cli.tsx
+++ b/workspaces/ui-v2/src/spectacle-implementations/local-cli.tsx
@@ -31,11 +31,7 @@ import {
 } from '../optic-components/hooks/config/AppConfiguration';
 import { InMemoryOpticContextBuilder } from '@useoptic/spectacle/build/in-memory';
 import { InMemorySpectacle } from './public-examples';
-import { useEffect, useState } from 'react';
-import {
-  OpticEngineStore,
-  useOpticEngine,
-} from '../optic-components/hooks/useOpticEngine';
+import { useOpticEngine } from '../optic-components/hooks/useOpticEngine';
 
 const appConfig: OpticAppConfig = {
   featureFlags: {},

--- a/workspaces/ui-v2/src/spectacle-implementations/local-cli.tsx
+++ b/workspaces/ui-v2/src/spectacle-implementations/local-cli.tsx
@@ -32,7 +32,10 @@ import {
 import { InMemoryOpticContextBuilder } from '@useoptic/spectacle/build/in-memory';
 import { InMemorySpectacle } from './public-examples';
 import { useEffect, useState } from 'react';
-import { OpticEngineStore } from '../optic-components/hooks/useOpticEngine';
+import {
+  OpticEngineStore,
+  useOpticEngine,
+} from '../optic-components/hooks/useOpticEngine';
 
 const appConfig: OpticAppConfig = {
   featureFlags: {},
@@ -65,19 +68,17 @@ export default function LocalCli() {
   return (
     <AppConfigurationStore config={appConfig}>
       <SpectacleStore spectacle={data.spectacle}>
-        <OpticEngineStore>
-          <CapturesServiceStore capturesService={data.capturesService}>
-            <BaseUrlProvider value={{ url: match.url }}>
-              <Switch>
-                <>
-                  <DocumentationPages />
-                  <DiffReviewEnvironments />
-                  <ChangelogPages />
-                </>
-              </Switch>
-            </BaseUrlProvider>
-          </CapturesServiceStore>
-        </OpticEngineStore>
+        <CapturesServiceStore capturesService={data.capturesService}>
+          <BaseUrlProvider value={{ url: match.url }}>
+            <Switch>
+              <>
+                <DocumentationPages />
+                <DiffReviewEnvironments />
+                <ChangelogPages />
+              </>
+            </Switch>
+          </BaseUrlProvider>
+        </CapturesServiceStore>
       </SpectacleStore>
     </AppConfigurationStore>
   );
@@ -229,21 +230,7 @@ class LocalCliDiffService implements IOpticDiffService {
 export function useLocalCliServices(
   specId: string
 ): AsyncStatus<LocalCliServices> {
-  const [opticEngine, setOpticEngine] = useState<IOpticEngine | null>(null);
-  useEffect(() => {
-    async function task() {
-      const _opticEngine = await import(
-        '@useoptic/diff-engine-wasm/engine/browser'
-      );
-      setOpticEngine(_opticEngine);
-    }
-    task();
-  }, [specId]);
-  if (!opticEngine) {
-    return {
-      loading: true,
-    };
-  }
+  const opticEngine = useOpticEngine();
   const apiBaseUrl = `/api/specs/${specId}`;
   const spectacle = new LocalCliSpectacle(apiBaseUrl, opticEngine);
   const capturesService = new LocalCliCapturesService({

--- a/workspaces/ui-v2/src/spectacle-implementations/public-examples.tsx
+++ b/workspaces/ui-v2/src/spectacle-implementations/public-examples.tsx
@@ -137,16 +137,17 @@ export interface InMemoryBaseSpectacle extends IBaseSpectacle {
   samples: any[];
   opticContext: IOpticContext;
 }
-
+//@SYNC: useInMemorySpectacle
 export function useInMemorySpectacle(
   loadDependencies: InMemorySpectacleDependenciesLoader
 ): AsyncStatus<InMemoryBaseSpectacle> {
+  const opticEngine = useOpticEngine();
   const [spectacle, setSpectacle] = useState<InMemoryBaseSpectacle>();
   const [inputs, setInputs] = useState<{
     events: any[];
     samples: any[];
   } | null>(null);
-  const opticEngine = useOpticEngine();
+
   useEffect(() => {
     async function task() {
       const result = await loadDependencies();
@@ -157,7 +158,7 @@ export function useInMemorySpectacle(
     }
 
     task();
-  }, []);
+  }, [loadDependencies]);
 
   useEffect(() => {
     async function task() {
@@ -184,8 +185,9 @@ export function useInMemorySpectacle(
       console.count('setSpectacle');
       setSpectacle(inMemorySpectacle);
     }
+
     task();
-  }, [inputs]);
+  }, [inputs, opticEngine]);
 
   if (spectacle) {
     return {


### PR DESCRIPTION
## Why
Our ui needs access to the opticEngine, which needs to be imported asynchronously. Previously we were duplicating the logic and adding complexity to the data loading responsibilities

## What
- remove duplicate `OpticEngineStore`s
- use `useOpticEngine` hook
- restore simpler logic that was overwritten

## Validation
* [x] trust since there are no tests covering it
