### PR TITLE
Fix infinite load on example

### DIFF
--- a/workspaces/ui-v2/src/spectacle-implementations/public-examples.tsx
+++ b/workspaces/ui-v2/src/spectacle-implementations/public-examples.tsx
@@ -1,5 +1,4 @@
-import * as React from 'react';
-import { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Switch, useParams, useRouteMatch } from 'react-router-dom';
 import { Provider as BaseUrlProvider } from '../optic-components/hooks/useBaseUrl';
 import {
@@ -41,7 +40,7 @@ export default function PublicExamples() {
   const match = useRouteMatch();
   const params = useParams<{ exampleId: string }>();
   const { exampleId } = params;
-  const task: InMemorySpectacleDependenciesLoader = async () => {
+  const task: InMemorySpectacleDependenciesLoader = useCallback(async () => {
     const loadExample = async () => {
       const response = await fetch(`/example-sessions/${exampleId}.json`, {
         headers: { accept: 'application/json' },
@@ -58,7 +57,8 @@ export default function PublicExamples() {
       events: example.events,
       samples: example.session.samples,
     };
-  };
+  }, [exampleId]);
+
   const { loading, error, data } = useInMemorySpectacle(task);
   if (loading) {
     return <Loading />;


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

useEffect strikes again! But this was causing infinite loading loops since the dependency changes
<img width="628" alt="Screen Shot 2021-05-05 at 2 09 07 PM" src="https://user-images.githubusercontent.com/18374483/117209647-7c382800-adab-11eb-92a1-e9419195e06a.png">


## What
What's changing? Anything of note to call out?
Memoizing `task` since it's used in this https://github.com/opticdev/optic/blob/develop/workspaces/ui-v2/src/spectacle-implementations/public-examples.tsx#L161

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
