### PR TITLE
Fix bug where learned Shape Diff Affordances did not include affordances for nested values

### DIFF
--- a/workspaces/diff-engine/src/shapes/traverser.rs
+++ b/workspaces/diff-engine/src/shapes/traverser.rs
@@ -342,6 +342,15 @@ impl JsonTrail {
         .collect(),
     }
   }
+
+  pub fn is_child_of(&self, parent_trail: &JsonTrail) -> bool {
+    self.path.len() > parent_trail.path.len()
+      && self
+        .path
+        .iter()
+        .take(parent_trail.path.len())
+        .eq(parent_trail.path.iter())
+  }
 }
 
 impl PartialEq for JsonTrail {
@@ -416,5 +425,31 @@ mod test {
     trails.sort();
 
     assert_json_snapshot!("json_trails_order_root_to_leaf__sorted", trails);
+  }
+
+  #[test]
+  pub fn json_trails_is_child_of() {
+    let root_trail = JsonTrail::empty().with_object_key(String::from("a"));
+    let child_trail = JsonTrail::empty()
+      .with_object_key(String::from("a"))
+      .with_object_key(String::from("aa"));
+    let other_child_trail = JsonTrail::empty()
+      .with_object_key(String::from("c"))
+      .with_object_key(String::from("aa"));
+
+    let array_trail = JsonTrail::empty().with_array_item(0);
+    let object_in_array_trail = JsonTrail::empty()
+      .with_array_item(0)
+      .with_object_key(String::from("a"));
+    let object_in_other_array_trail = JsonTrail::empty()
+      .with_array_item(1)
+      .with_object_key(String::from("a"));
+
+    assert!(child_trail.is_child_of(&root_trail));
+    assert!(!root_trail.is_child_of(&child_trail));
+    assert!(!root_trail.is_child_of(&root_trail));
+    assert!(!other_child_trail.is_child_of(&root_trail));
+    assert!(object_in_array_trail.is_child_of(&array_trail));
+    assert!(!object_in_other_array_trail.is_child_of(&array_trail));
   }
 }

--- a/workspaces/ui-v2/src/lib/shape-diff-dsl-rust.ts
+++ b/workspaces/ui-v2/src/lib/shape-diff-dsl-rust.ts
@@ -137,10 +137,7 @@ export class Actual {
     private shapeTrail: IShapeTrail,
     public jsonTrail: IJsonTrail
   ) {
-    this.trailAffordances = learnedTrails.affordances.filter((i) => {
-      const compared = equals(normalize(i.trail), normalize(jsonTrail));
-      return compared;
-    });
+    this.trailAffordances = learnedTrails.affordances;
   }
 
   isField(): boolean {

--- a/workspaces/ui-v2/src/lib/shape-diff-dsl-rust.ts
+++ b/workspaces/ui-v2/src/lib/shape-diff-dsl-rust.ts
@@ -1,9 +1,7 @@
 import {
   IJsonObjectKey,
   IJsonTrail,
-  normalize,
 } from '@useoptic/cli-shared/build/diffs/json-trail';
-import equals from 'lodash.isequal';
 import sortBy from 'lodash.sortby';
 import { IShapeTrail } from '@useoptic/cli-shared/build/diffs/shape-trail';
 import { CurrentSpecContext, ICoreShapeKinds } from './Interfaces';

--- a/workspaces/ui-v2/src/lib/shape-diffs/build-inner-shape.ts
+++ b/workspaces/ui-v2/src/lib/shape-diffs/build-inner-shape.ts
@@ -5,6 +5,7 @@ import {
   IPatchChoices,
 } from '../Interfaces';
 import { Actual } from '../shape-diff-dsl-rust';
+import equals from 'lodash.isequal';
 import {
   AddShape,
   AddShapeParameter,
@@ -40,16 +41,21 @@ export function builderInnerShapeFromChoices(
       return foundShapeId[0];
     } else {
       const filterToTarget = actual.trailAffordances.map((affordance) => {
-        return {
-          ...affordance,
-          wasString: i === ICoreShapeKinds.StringKind,
-          wasNumber: i === ICoreShapeKinds.NumberKind,
-          wasBoolean: i === ICoreShapeKinds.BooleanKind,
-          wasNull: i === ICoreShapeKinds.NullableKind,
-          wasArray: i === ICoreShapeKinds.ListKind,
-          wasObject: i === ICoreShapeKinds.ObjectKind,
-          fieldSet: i === ICoreShapeKinds.ObjectKind ? affordance.fieldSet : [],
-        };
+        if (equals(affordance.trail, actual.jsonTrail)) {
+          return {
+            ...affordance,
+            wasString: i === ICoreShapeKinds.StringKind,
+            wasNumber: i === ICoreShapeKinds.NumberKind,
+            wasBoolean: i === ICoreShapeKinds.BooleanKind,
+            wasNull: i === ICoreShapeKinds.NullableKind,
+            wasArray: i === ICoreShapeKinds.ListKind,
+            wasObject: i === ICoreShapeKinds.ObjectKind,
+            fieldSet:
+              i === ICoreShapeKinds.ObjectKind ? affordance.fieldSet : [],
+          };
+        } else {
+          return affordance;
+        }
       });
 
       const [commands, newShapeId] = JSON.parse(


### PR DESCRIPTION
## Why
When the subject of a shape diff is something like an object or an array, we want to learn about what they contain as well. In the porting of the learners to Rust, we forgot about this use case, returning only ever the single affordance for the "root" shape.

## What
The nested values were already being observed and learned, just not included in the output. The `LearnedShapeDiffAffordancesProjection` now not only takes the `JsonTrail` described in the shape diff, but also learned results for any children trails. The `InteractionAffordances` remains the single one, only describing the original diff trail. 

## Validation
* [x] CI passes
* [x] Output verified in UI example session
* [x] No more panics in converting affordances -> commands from UI