### PR TITLE
Prevent shape commands / events to be generated for learned shape affordances not selected by the user

### DIFF
--- a/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_can_generate_for_non_root_json_trails__collection_results.snap
+++ b/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_can_generate_for_non_root_json_trails__collection_results.snap
@@ -10,15 +10,6 @@ expression: "&collections_results"
         ShapeCommand(
             AddShape(
                 AddShape {
-                    shape_id: "test-id-0",
-                    base_shape_id: "$boolean",
-                    name: "",
-                },
-            ),
-        ),
-        ShapeCommand(
-            AddShape(
-                AddShape {
                     shape_id: "test-id-1",
                     base_shape_id: "$number",
                     name: "",
@@ -118,69 +109,6 @@ expression: "&collections_results"
                         FieldShapeFromShape {
                             field_id: "test-id-7",
                             shape_id: "test-id-2",
-                        },
-                    ),
-                },
-            ),
-        ),
-        ShapeCommand(
-            AddShape(
-                AddShape {
-                    shape_id: "test-id-10",
-                    base_shape_id: "$object",
-                    name: "",
-                },
-            ),
-        ),
-        ShapeCommand(
-            AddField(
-                AddField {
-                    field_id: "test-id-9",
-                    shape_id: "test-id-10",
-                    name: "nested-object",
-                    shape_descriptor: FieldShapeFromShape(
-                        FieldShapeFromShape {
-                            field_id: "test-id-9",
-                            shape_id: "test-id-8",
-                        },
-                    ),
-                },
-            ),
-        ),
-        ShapeCommand(
-            AddShape(
-                AddShape {
-                    shape_id: "test-id-13",
-                    base_shape_id: "$object",
-                    name: "",
-                },
-            ),
-        ),
-        ShapeCommand(
-            AddField(
-                AddField {
-                    field_id: "test-id-11",
-                    shape_id: "test-id-13",
-                    name: "nested",
-                    shape_descriptor: FieldShapeFromShape(
-                        FieldShapeFromShape {
-                            field_id: "test-id-11",
-                            shape_id: "test-id-10",
-                        },
-                    ),
-                },
-            ),
-        ),
-        ShapeCommand(
-            AddField(
-                AddField {
-                    field_id: "test-id-12",
-                    shape_id: "test-id-13",
-                    name: "other-field",
-                    shape_descriptor: FieldShapeFromShape(
-                        FieldShapeFromShape {
-                            field_id: "test-id-12",
-                            shape_id: "test-id-0",
                         },
                     ),
                 },

--- a/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_does_not_generate_commands_for_orphaned_shapes__array_item_results.snap
+++ b/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_does_not_generate_commands_for_orphaned_shapes__array_item_results.snap
@@ -1,0 +1,20 @@
+---
+source: workspaces/diff-engine/src/learn_shape/result.rs
+expression: "&array_item_results"
+---
+(
+    Some(
+        "test-id-8",
+    ),
+    [
+        ShapeCommand(
+            AddShape(
+                AddShape {
+                    shape_id: "test-id-8",
+                    base_shape_id: "$string",
+                    name: "",
+                },
+            ),
+        ),
+    ],
+)

--- a/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_does_not_generate_commands_for_orphaned_shapes__nested_results.snap
+++ b/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_does_not_generate_commands_for_orphaned_shapes__nested_results.snap
@@ -1,0 +1,20 @@
+---
+source: workspaces/diff-engine/src/learn_shape/result.rs
+expression: "&nested_results"
+---
+(
+    Some(
+        "test-id-4",
+    ),
+    [
+        ShapeCommand(
+            AddShape(
+                AddShape {
+                    shape_id: "test-id-4",
+                    base_shape_id: "$string",
+                    name: "",
+                },
+            ),
+        ),
+    ],
+)

--- a/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_does_not_generate_commands_for_orphaned_shapes__root_results.snap
+++ b/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_does_not_generate_commands_for_orphaned_shapes__root_results.snap
@@ -1,0 +1,20 @@
+---
+source: workspaces/diff-engine/src/learn_shape/result.rs
+expression: "&root_results"
+---
+(
+    Some(
+        "test-id-2",
+    ),
+    [
+        ShapeCommand(
+            AddShape(
+                AddShape {
+                    shape_id: "test-id-2",
+                    base_shape_id: "$string",
+                    name: "",
+                },
+            ),
+        ),
+    ],
+)

--- a/workspaces/ui-v2/src/lib/__tests/diff-helpers/__snapshots__/new-regions-interpretations.test.ts.snap
+++ b/workspaces/ui-v2/src/lib/__tests/diff-helpers/__snapshots__/new-regions-interpretations.test.ts.snap
@@ -238,42 +238,42 @@ Object {
       "AddShape": Object {
         "baseShapeId": "$string",
         "name": "",
-        "shapeId": "shape_6713",
+        "shapeId": "shape_6731",
       },
     },
     Object {
       "AddShape": Object {
         "baseShapeId": "$boolean",
         "name": "",
-        "shapeId": "shape_6714",
+        "shapeId": "shape_6732",
       },
     },
     Object {
       "AddShape": Object {
         "baseShapeId": "$string",
         "name": "",
-        "shapeId": "shape_6715",
+        "shapeId": "shape_6733",
       },
     },
     Object {
       "AddShape": Object {
         "baseShapeId": "$string",
         "name": "",
-        "shapeId": "shape_6716",
+        "shapeId": "shape_6734",
       },
     },
     Object {
       "AddShape": Object {
         "baseShapeId": "$object",
         "name": "",
-        "shapeId": "shape_6722",
+        "shapeId": "shape_6740",
       },
     },
     Object {
       "AddShape": Object {
         "baseShapeId": "$optional",
         "name": "",
-        "shapeId": "shape_6718",
+        "shapeId": "shape_6736",
       },
     },
     Object {
@@ -283,71 +283,71 @@ Object {
             "consumingParameterId": "$optionalInner",
             "providerDescriptor": Object {
               "ShapeProvider": Object {
-                "shapeId": "shape_6716",
+                "shapeId": "shape_6734",
               },
             },
-            "shapeId": "shape_6718",
+            "shapeId": "shape_6736",
           },
         },
       },
     },
     Object {
       "AddField": Object {
-        "fieldId": "field_6717",
+        "fieldId": "field_6735",
         "name": "dueDate",
         "shapeDescriptor": Object {
           "FieldShapeFromShape": Object {
-            "fieldId": "field_6717",
-            "shapeId": "shape_6718",
+            "fieldId": "field_6735",
+            "shapeId": "shape_6736",
           },
         },
-        "shapeId": "shape_6722",
+        "shapeId": "shape_6740",
       },
     },
     Object {
       "AddField": Object {
-        "fieldId": "field_6719",
+        "fieldId": "field_6737",
         "name": "id",
         "shapeDescriptor": Object {
           "FieldShapeFromShape": Object {
-            "fieldId": "field_6719",
-            "shapeId": "shape_6715",
+            "fieldId": "field_6737",
+            "shapeId": "shape_6733",
           },
         },
-        "shapeId": "shape_6722",
+        "shapeId": "shape_6740",
       },
     },
     Object {
       "AddField": Object {
-        "fieldId": "field_6720",
+        "fieldId": "field_6738",
         "name": "isDone",
         "shapeDescriptor": Object {
           "FieldShapeFromShape": Object {
-            "fieldId": "field_6720",
-            "shapeId": "shape_6714",
+            "fieldId": "field_6738",
+            "shapeId": "shape_6732",
           },
         },
-        "shapeId": "shape_6722",
+        "shapeId": "shape_6740",
       },
     },
     Object {
       "AddField": Object {
-        "fieldId": "field_6721",
+        "fieldId": "field_6739",
         "name": "task",
         "shapeDescriptor": Object {
           "FieldShapeFromShape": Object {
-            "fieldId": "field_6721",
-            "shapeId": "shape_6713",
+            "fieldId": "field_6739",
+            "shapeId": "shape_6731",
           },
         },
-        "shapeId": "shape_6722",
+        "shapeId": "shape_6740",
       },
     },
     Object {
       "AddShape": Object {
         "baseShapeId": "$list",
         "name": "",
-        "shapeId": "shape_6723",
+        "shapeId": "shape_6741",
       },
     },
     Object {
@@ -357,10 +357,10 @@ Object {
             "consumingParameterId": "$listItem",
             "providerDescriptor": Object {
               "ShapeProvider": Object {
-                "shapeId": "shape_6722",
+                "shapeId": "shape_6740",
               },
             },
-            "shapeId": "shape_6723",
+            "shapeId": "shape_6741",
           },
         },
       },
@@ -370,7 +370,7 @@ Object {
         "httpMethod": "GET",
         "httpStatusCode": 200,
         "pathId": "path_it2OyjUysW",
-        "responseId": "response_6724",
+        "responseId": "response_6742",
       },
     },
     Object {
@@ -378,9 +378,9 @@ Object {
         "bodyDescriptor": Object {
           "httpContentType": "application/json",
           "isRemoved": false,
-          "shapeId": "shape_6723",
+          "shapeId": "shape_6741",
         },
-        "responseId": "response_6724",
+        "responseId": "response_6742",
       },
     },
   ],

--- a/workspaces/ui-v2/src/lib/__tests/diff-helpers/__snapshots__/shape-interpretations.test.ts.snap
+++ b/workspaces/ui-v2/src/lib/__tests/diff-helpers/__snapshots__/shape-interpretations.test.ts.snap
@@ -4308,49 +4308,6 @@ Object {
       "AddShape": Object {
         "baseShapeId": "$string",
         "name": "",
-        "shapeId": "shape_10000",
-      },
-    },
-    Object {
-      "AddShape": Object {
-        "baseShapeId": "$string",
-        "name": "",
-        "shapeId": "shape_10001",
-      },
-    },
-    Object {
-      "AddShape": Object {
-        "baseShapeId": "$list",
-        "name": "",
-        "shapeId": "shape_10002",
-      },
-    },
-    Object {
-      "SetParameterShape": Object {
-        "shapeDescriptor": Object {
-          "ProviderInShape": Object {
-            "consumingParameterId": "$listItem",
-            "providerDescriptor": Object {
-              "ShapeProvider": Object {
-                "shapeId": "shape_10001",
-              },
-            },
-            "shapeId": "shape_10002",
-          },
-        },
-      },
-    },
-    Object {
-      "AddShape": Object {
-        "baseShapeId": "$string",
-        "name": "",
-        "shapeId": "shape_10003",
-      },
-    },
-    Object {
-      "AddShape": Object {
-        "baseShapeId": "$string",
-        "name": "",
         "shapeId": "shape_10004",
       },
     },


### PR DESCRIPTION
## Why
As #720 was fixed, @acunniffe highlighted how commands could be generated for shapes that the user disabled in the UI: 

> the way the UI lets users 'choose' the changes they're making is by mutating the affordances. We only want to mutate the root one.

> imagine a case where you have 'string' and 'object', then deselect 'object'. It will only create the string.

## What
Upon the generation of commands we now only include commands for those that make sense given the generated shapes. This goes in two directions:

- descendant shapes only have commands generated for them if their parents can host them (e.g. are an object or list)
- ancestor shapes are only included if they are part of the root for which commands are being generated

It's implemented by looking up the root shape prototype (intermediate type from observation result -> commands) and recursively walking the tree it represents to find all reachable json trails and filtering all shape prototypes by it. The implementation is covered by multiple snapshot tests, including the original failing one that highlighted the bug.

## Validation
* [x] CI passes
* [x] No longer generates superfluous shape commands
