### PR TITLE
Remove changelog styling on documentation page

### DIFF
--- a/workspaces/ui-v2/src/optic-components/pages/docs/DocumentationPage.tsx
+++ b/workspaces/ui-v2/src/optic-components/pages/docs/DocumentationPage.tsx
@@ -152,7 +152,9 @@ export function DocumentationRootPage(props: {
                       props.onEndpointClicked(endpoint.pathId, endpoint.method)
                     }
                     className={
-                      endpoint.changelog?.added ? changelogStyles.added : ''
+                      isChangelogPage && endpoint.changelog?.added
+                        ? changelogStyles.added
+                        : ''
                     }
                   >
                     <div style={{ flex: 1 }}>


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Before, the changelog styling was applied to the documentation page. This is because the useEndpointsChangelog hook returns all changed items when undefined is passed in (which is I think correct) - we should fork the changelog and documentation pages as they fetch different data.

## What
What's changing? Anything of note to call out?
Before all endpoint rows were green
<img width="1695" alt="Screen Shot 2021-05-06 at 9 21 55 AM" src="https://user-images.githubusercontent.com/18374483/117332625-ea80f700-ae4c-11eb-89f0-694f9c26cbef.png">


## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
