### PR TITLE
Remove text field error state when empty

### DIFF
--- a/workspaces/ui-v2/src/optic-components/common/EditableTextField.tsx
+++ b/workspaces/ui-v2/src/optic-components/common/EditableTextField.tsx
@@ -63,7 +63,6 @@ export const EditableTextField: FC<EditableTextFieldProps> = ({
         className: variants[variant].className,
         ...variants[variant].inputProps,
       }}
-      error={isEmpty}
       helperText={isEmpty ? helperText : undefined}
       fullWidth
       style={variants[variant].textFieldStyle}


### PR DESCRIPTION
## Why
Error states should really be used when there is _invalid_ input, and given that we don't have anything we consider invalid, we shouldn't show this state. Currently it's being shown as error when it's empty - which is potentially jarring to users. The pattern of using an input field here should be a sufficient prompt to show that this field is editable.

## What

<img width="1100" alt="Screen Shot 2021-05-06 at 10 02 56 AM" src="https://user-images.githubusercontent.com/18374483/117337583-65004580-ae52-11eb-94cc-2523d745cb88.png">
<img width="1676" alt="Screen Shot 2021-05-06 at 10 03 36 AM" src="https://user-images.githubusercontent.com/18374483/117337589-66ca0900-ae52-11eb-822e-7bfe33435b73.png">


## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
