### PR TITLE
Fix/busted diff engine build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,24 +689,24 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.17.0"
+version = "2.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb14183cc7f213ee2410067e1ceeadba2a7478a59432ff0747a335202798b1e2"
+checksum = "45604fc7a88158e7d514d8e22e14ac746081e7a70d7690074dd0029ee37458d6"
 
 [[package]]
 name = "protobuf-codegen"
-version = "2.17.0"
+version = "2.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3360a1e017386e7d9fc65f7425bef9bcf1e62871f8b5a7b0570ef2ff5073f9a0"
+checksum = "cb87f342b585958c1c086313dbc468dcac3edf5e90362111c26d7a58127ac095"
 dependencies = [
  "protobuf",
 ]
 
 [[package]]
 name = "protobuf-codegen-pure"
-version = "2.17.0"
+version = "2.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899e61d9d3db627471119baf57db06385c12723c2f47a03dd4244c693ca6d85e"
+checksum = "8ca6e0e2f898f7856a6328650abc9b2df71b7c1a5f39be0800d19051ad0214b2"
 dependencies = [
  "protobuf",
  "protobuf-codegen",

--- a/workspaces/diff-engine/Cargo.toml
+++ b/workspaces/diff-engine/Cargo.toml
@@ -22,12 +22,12 @@ cqrs-core = "0.2.2"
 futures = { version = "0.3.12", optional = true }
 num_cpus = "1.13.0"
 petgraph = "0.5.1"
-protobuf = "2.17.0"
+protobuf = "2.23.0"
 serde = { version = "1.0.106", features = ["derive"] }
 serde_json = "1.0.57"
 thiserror = "1.0.24"
 # all of tokio for now, until we figure out what we need exactly
-tokio = { version = "~1.1.1", features = ["full"], optional = true } 
+tokio = { version = "~1.1.1", features = ["full"], optional = true }
 tokio-util = { version = "0.6.3", features = ["codec"], optional = true }
 tokio-stream = { version= "0.1.2", features = ["fs", "io-util"], optional = true }
 uuid = { version = "0.8.2", features = ["v4", "wasm-bindgen"] }

--- a/workspaces/diff-engine/src/events/http_interaction.rs
+++ b/workspaces/diff-engine/src/events/http_interaction.rs
@@ -4,7 +4,7 @@ use crate::state::body::BodyDescriptor;
 use avro_rs;
 use base64;
 use cqrs_core::Event;
-use protobuf;
+use protobuf::Message;
 use serde::{Deserialize, Serialize};
 use serde_json;
 use std::io;
@@ -74,7 +74,7 @@ impl From<&ArbitraryData> for Option<serde_json::value::Value> {
     } else if let Some(shape_hash) = &data.shape_hash_v1_base64 {
       let decoded_hash = base64::decode(shape_hash)
         .expect("shape_hash_v1_base64 of ArbitraryData should always be valid base64");
-      let shape_descriptor: shapehash::ShapeDescriptor = protobuf::parse_from_bytes(&decoded_hash)
+      let shape_descriptor: shapehash::ShapeDescriptor = Message::parse_from_bytes(&decoded_hash)
         .expect("shape hash should be validly encoded shapehash proto");
       Some(serde_json::Value::from(shape_descriptor))
     } else {
@@ -89,7 +89,7 @@ impl From<&ArbitraryData> for Option<BodyDescriptor> {
       let decoded_hash = base64::decode(shape_hash)
         .expect("shape_hash_v1_base64 of ArbitraryData should always be valid base64");
       let shape_hash_descriptor: shapehash::ShapeDescriptor =
-        protobuf::parse_from_bytes(&decoded_hash)
+        Message::parse_from_bytes(&decoded_hash)
           .expect("shape hash should be validly encoded shapehash proto");
       Some(BodyDescriptor::from(shape_hash_descriptor))
     } else if let Some(json_string) = &data.as_json_string {


### PR DESCRIPTION
## Why
diff-engine builds are broken on the latest stable rust,

```
Error:  --> workspaces/diff-engine/src/protos/generated/shapehash.rs:9:4
  |
  | #![rustfmt::skip]
  |    ^^^^^^^^^^^^^
  |
  = note: `#[deny(soft_unstable)]` on by default
  = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
  = note: for more information, see issue #64266 <https://github.com/rust-lang/rust/issues/64266>
```

## What
Updates protobuff, and fixes a subsequent warning produced by the upgrade

## Validation
* [ ] CI passes
