### PR TITLE
spectacle: override default body size to allow for 'large' bulk-learned specs

### DIFF
--- a/workspaces/cli-server/src/routers/spec-router.ts
+++ b/workspaces/cli-server/src/routers/spec-router.ts
@@ -228,6 +228,7 @@ export async function makeRouter(sessions: SessionsManager) {
   });
 
   const instances: Map<string, any> = new Map();
+  router.use(bodyParser.json({ limit: '10mb' }));
   router.use('/spectacle', async (req, res) => {
     let handler = instances.get(req.optic.session.id);
     if (!handler) {


### PR DESCRIPTION
Per discussion

## Why

- 'Large' specifications may have enough data when bulk-learning to exceed the default body size limit.

## What

- Added a limit override to the body parser for spectacle

## Validation
* [ ] CI passes
* [ ] Verified in staging

