### PR TITLE
diff-engine: removed unused export

### DIFF
--- a/workspaces/diff-engine/lib/index.js
+++ b/workspaces/diff-engine/lib/index.js
@@ -359,7 +359,6 @@ class DiffEngineError extends Error {
 }
 
 exports.diffInteractions = diffInteractions;
-exports.spawn = spawn;
 exports.readSpec = readSpec;
 exports.commit = commit;
 exports.learnShapeDiffAffordances = learnShapeDiffAffordances;


### PR DESCRIPTION
## Why

Unused export causes CLI command failure

## What

Removed dead export, per Dev

## Validation
* [ ] CI passes
* [ ] Verified in staging

