### PR TITLE
factored private-session support

### DIFF
--- a/workspaces/ui-v2/.gitignore
+++ b/workspaces/ui-v2/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+public/private-sessions

--- a/workspaces/ui-v2/src/entry-points/local/TopLevelRoutes.tsx
+++ b/workspaces/ui-v2/src/entry-points/local/TopLevelRoutes.tsx
@@ -19,7 +19,17 @@ export default function TopLevelRoutes() {
           strict
           //@TODO: centralize this path pattern
           path="/examples/:exampleId"
-          component={PublicExamples}
+          component={(props: any) => (
+            <PublicExamples {...props} lookupDir={'example-sessions'} />
+          )}
+        />
+        <Route
+          strict
+          //@TODO: centralize this path pattern
+          path="/private-sessions/:exampleId"
+          component={(props: any) => (
+            <PublicExamples {...props} lookupDir={'private-sessions'} />
+          )}
         />
 
         <Route strict path={'/'} component={WelcomePage} />

--- a/workspaces/ui-v2/src/spectacle-implementations/public-examples.tsx
+++ b/workspaces/ui-v2/src/spectacle-implementations/public-examples.tsx
@@ -37,13 +37,14 @@ const appConfig: OpticAppConfig = {
   },
 };
 
-export default function PublicExamples() {
+export default function PublicExamples(props: { lookupDir: string }) {
   const match = useRouteMatch();
   const params = useParams<{ exampleId: string }>();
+
   const { exampleId } = params;
   const task: InMemorySpectacleDependenciesLoader = useCallback(async () => {
     const loadExample = async () => {
-      const response = await fetch(`/example-sessions/${exampleId}.json`, {
+      const response = await fetch(`/${props.lookupDir}/${exampleId}.json`, {
         headers: { accept: 'application/json' },
       });
       if (!response.ok) {

--- a/workspaces/ui-v2/src/spectacle-implementations/public-examples.tsx
+++ b/workspaces/ui-v2/src/spectacle-implementations/public-examples.tsx
@@ -59,7 +59,7 @@ export default function PublicExamples(props: { lookupDir: string }) {
       events: example.events,
       samples: example.session.samples,
     };
-  }, [exampleId]);
+  }, [exampleId, props.lookupDir]);
 
   const { loading, error, data } = useInMemorySpectacle(task);
   if (loading) {


### PR DESCRIPTION
## Why
We need a safe way to try debug sessions within Optic again

## What
I added a prop to PublicExample entry point that points to different directories to load examples from, and brought over our .gitignore rules from before to prevent us from checking any of these examples into the repo. 

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
