### PR TITLE
tempfix/shape rendering

### DIFF
--- a/workspaces/ui-v2/src/optic-components/hooks/useShapeDescriptor.ts
+++ b/workspaces/ui-v2/src/optic-components/hooks/useShapeDescriptor.ts
@@ -55,15 +55,15 @@ export function useShapeDescriptor(
 ): IShapeRenderer[] {
   const spectacle = useContext(SpectacleContext)!;
 
-  async function accumulateShapes(rootShapeId: string, idLookups: string[]) {
+  async function accumulateShapes(rootShapeId: string, seenSet: Set<string>) {
     //@todo figure out why some shapes loop recursively and remove those events / fix these specs
-    if (idLookups.includes(rootShapeId)) {
+    if (seenSet.has(rootShapeId)) {
       console.warn(
         'trying to lookup shape w/ a circular reference ' + rootShapeId
       );
       return [];
     } else {
-      idLookups.push(rootShapeId);
+      seenSet.add(rootShapeId);
     }
     const input =
       typeof renderChangesSinceBatchCommitId !== 'undefined'
@@ -99,7 +99,7 @@ export function useShapeDescriptor(
               choice.asObject.fields.map(async (field: any) => {
                 const shapeChoices = await accumulateShapes(
                   field.shapeId,
-                  idLookups
+                  seenSet
                 );
                 field.required = !shapeChoices.some(
                   (i: any) => i.jsonType === JsonLike.UNDEFINED
@@ -121,7 +121,7 @@ export function useShapeDescriptor(
           case 'Array':
             const results = await accumulateShapes(
               choice.asArray.shapeId,
-              idLookups
+              seenSet
             );
             const shapeChoices = await Promise.all(results);
             choice.asArray.shapeChoices = shapeChoices;
@@ -136,8 +136,8 @@ export function useShapeDescriptor(
   const [x, setX] = useState<any[]>([]);
   useEffect(() => {
     async function task() {
-      const idLookups: string[] = [];
-      const result = await accumulateShapes(rootShapeId, idLookups);
+      const seenSet: Set<string> = new Set();
+      const result = await accumulateShapes(rootShapeId, seenSet);
       setX(result);
     }
 

--- a/workspaces/ui-v2/src/optic-components/pages/docs/DocumentationPage.tsx
+++ b/workspaces/ui-v2/src/optic-components/pages/docs/DocumentationPage.tsx
@@ -135,8 +135,8 @@ export function DocumentationRootPage(props: {
           return (
             <div key={tocKey}>
               <Typography
-                variant="h6"
-                style={{ fontFamily: 'Ubuntu Mono', fontWeight: 600 }}
+                variant="subtitle2"
+                style={{ fontFamily: 'Ubuntu Mono' }}
               >
                 {tocKey}
               </Typography>

--- a/workspaces/ui-v2/src/optic-components/pages/docs/DocumentationPage.tsx
+++ b/workspaces/ui-v2/src/optic-components/pages/docs/DocumentationPage.tsx
@@ -135,8 +135,8 @@ export function DocumentationRootPage(props: {
           return (
             <div key={tocKey}>
               <Typography
-                variant="subtitle2"
-                style={{ fontFamily: 'Ubuntu Mono' }}
+                variant="h6"
+                style={{ fontFamily: 'Ubuntu Mono', fontWeight: 600 }}
               >
                 {tocKey}
               </Typography>


### PR DESCRIPTION
## Why
There are cases in old specs where our choice queries are returning references to ancestors, causing infinite loops. 
 
## What
- diffs appear to work (unaffected) 
- changelogs work (unaffected)
- docs use cases were the only affected ones. 

^ there are probably some changes we need to make to the shape project, but @devdoshi and I think this is a good temp fix. I set up warnings, and have Sentry configured to log those back to use so we don't swallow the warnings in real world. 

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
