### PR TITLE
fix edit performance on documentation page

### DIFF
--- a/workspaces/ui-v2/src/optic-components/common/CommitMessageModal.tsx
+++ b/workspaces/ui-v2/src/optic-components/common/CommitMessageModal.tsx
@@ -1,6 +1,7 @@
 import React, { ChangeEvent, FC, useState } from 'react';
 import {
   Button,
+  CircularProgress,
   TextField,
   Dialog,
   DialogActions,
@@ -14,7 +15,7 @@ import { useRunOnKeypress } from '<src>/optic-components/hooks/util';
 type CommitMessageModalProps = {
   open: boolean;
   onClose: () => void;
-  onSave: (commitMessage: string) => void;
+  onSave: (commitMessage: string) => Promise<void>;
   dialogText: string;
 };
 
@@ -25,6 +26,7 @@ export const CommitMessageModal: FC<CommitMessageModalProps> = ({
   dialogText,
 }) => {
   const [commitMessage, setCommitMessage] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
   const classes = useStyles();
   const canSubmit = commitMessage.length > 0;
   const onKeyPress = useRunOnKeypress(
@@ -72,14 +74,19 @@ export const CommitMessageModal: FC<CommitMessageModalProps> = ({
           Cancel
         </Button>
         <Button
-          disabled={!canSubmit}
-          onClick={() => {
-            onSave(commitMessage);
+          disabled={!canSubmit || isSaving}
+          onClick={async () => {
+            setIsSaving(true);
+            await onSave(commitMessage);
             onClose();
           }}
           color="primary"
         >
-          Save
+          {isSaving ? (
+            <CircularProgress style={{ marginLeft: 5 }} size={20} />
+          ) : (
+            'Save'
+          )}
         </Button>
       </DialogActions>
     </Dialog>

--- a/workspaces/ui-v2/src/optic-components/hooks/edit/Contributions.tsx
+++ b/workspaces/ui-v2/src/optic-components/hooks/edit/Contributions.tsx
@@ -3,7 +3,10 @@ import { FC, useCallback, useContext, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { useSpectacleCommand } from '<src>/spectacle-implementations/spectacle-provider';
 import { AddContribution } from '<src>/lib/command-factory';
-import { useStateWithSideEffect } from '<src>/optic-components/hooks/util';
+import {
+  useDebouncedFn,
+  useStateWithSideEffect,
+} from '<src>/optic-components/hooks/util';
 
 export const ContributionEditContext = React.createContext({});
 
@@ -12,7 +15,7 @@ type ContributionEditContextValue = {
   setEditing: React.Dispatch<React.SetStateAction<boolean>>;
   commitModalOpen: boolean;
   setCommitModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
-  save: (commitMessage: string) => void;
+  save: (commitMessage: string) => Promise<void>;
   pendingCount: number;
   stagePendingContribution: (
     id: string,
@@ -38,11 +41,20 @@ export const useValueWithStagedContributions = (
   initialValue: string
 ) => {
   const { stagePendingContribution } = useContributionEditing();
+  const debouncedStagePendingContribution = useDebouncedFn(
+    stagePendingContribution,
+    200
+  );
 
   const { value, setValue } = useStateWithSideEffect({
     initialValue,
     sideEffect: (newValue: string) =>
-      stagePendingContribution(id, contributionKey, newValue, initialValue),
+      debouncedStagePendingContribution(
+        id,
+        contributionKey,
+        newValue,
+        initialValue
+      ),
   });
 
   return {


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

On editing and on save the performance is slow and there is poor user feedback. There's two underlying issues here:

Editing:
- Every time we update, the store updates, which everywhere we `useContext(ContributionEditContext)` those components get rerendered - there's two underlying issues here, we are excessively rerendering (the state solution I am going to propose will hopefully address this) and update the store (staged contributions) on every input change.
- It's technically correct to update the store (staged contributions) on every update, but because of excessive rerendering, we are blocking UI updates + it's slow
- The core issue here is that we are rerendering excessively, which would take some structural changes

Save:
- We need to make mutations and requery spectacle - this can be slow. Throwing a loading state here will help with UI feedback
- The biggest problem here is that the inMemorySpectacle instance runs on the same thread as the JS/React rendering - which means in the examples + demo, you don't see the loading state (UI render just freezes) - this is fixable if we move the inMemory implementation to a web worker.

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
