### PR TITLE
Fix load on diff page

### DIFF
--- a/workspaces/ui-v2/src/entry-points/local/TopLevelRoutes.tsx
+++ b/workspaces/ui-v2/src/entry-points/local/TopLevelRoutes.tsx
@@ -19,7 +19,7 @@ export default function TopLevelRoutes() {
           strict
           //@TODO: centralize this path pattern
           path="/examples/:exampleId"
-          component={(props: any) => (
+          render={(props: any) => (
             <PublicExamples {...props} lookupDir={'example-sessions'} />
           )}
         />
@@ -27,7 +27,7 @@ export default function TopLevelRoutes() {
           strict
           //@TODO: centralize this path pattern
           path="/private-sessions/:exampleId"
-          component={(props: any) => (
+          render={(props: any) => (
             <PublicExamples {...props} lookupDir={'private-sessions'} />
           )}
         />


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Component renders children using `React.createElement` (or using JSX which effectively calls this)
Render uses a function (and i believe it's memoized)

What happens here is that if we use component, and use a function - react thinks that the same inline function is actually different which causes the component to be unmounted -> remounted causing an infinite loop 🙃 

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
