### PR TITLE
Remove timeout on navigation

### DIFF
--- a/workspaces/ui-v2/src/optic-components/pages/diffs/AddEndpointsPage/AddEndpointsPage.tsx
+++ b/workspaces/ui-v2/src/optic-components/pages/diffs/AddEndpointsPage/AddEndpointsPage.tsx
@@ -83,7 +83,7 @@ export function DiffUrlsPage(props: any) {
             setBulkMode(bulkMode);
           } else {
             const link = diffReviewPagePendingEndpoint.linkTo(pendingId);
-            setTimeout(() => history.push(link), 500);
+            history.push(link);
           }
         }}
       />


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

I'm not sure why there was a timeout necessary here - but now that we have a completed state, this state temporarily shows. Either way the loading state should be handled on the page the user would land on here

## What
What's changing? Anything of note to call out?
Before this change, the user would see this for 0.5 seconds before being navigated to the pending endpoint page
<img width="549" alt="Screen Shot 2021-05-10 at 9 32 38 AM" src="https://user-images.githubusercontent.com/18374483/117693247-aa828280-b172-11eb-9172-e88bc8e2c187.png">



## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
