### PR TITLE
Fix undocumented url disappearing when navigate away

### DIFF
--- a/workspaces/ui-v2/src/optic-components/hooks/diffs/SharedDiffState.ts
+++ b/workspaces/ui-v2/src/optic-components/hooks/diffs/SharedDiffState.ts
@@ -80,7 +80,13 @@ export const newSharedDiffMachine = (
                     end: true,
                   });
                   return [
-                    ...ctx.pendingEndpoints,
+                    ...ctx.pendingEndpoints.filter(
+                      (pendingEndpoint) =>
+                        !(
+                          pendingEndpoint.method === event.method &&
+                          pendingEndpoint.pathPattern === event.pattern
+                        )
+                    ),
                     {
                       pathPattern: event.pattern,
                       method: event.method,
@@ -356,7 +362,9 @@ function filterDisplayedUndocumentedUrls(
 
   return all.map((value) => {
     if (
-      pending.some((i) => i.matchesPattern(value.path, value.method)) ||
+      pending.some(
+        (i) => i.matchesPattern(value.path, value.method) && i.staged
+      ) ||
       allIgnores.shouldIgnore(value.method, value.path)
     ) {
       return { ...value, hide: true };


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Reproduction steps (before this change):
- Go to diff page -> Show undocumented urls
- Add an undocumented endpoint
- Navigate back to show remaining diffs (in navigation) i.e. navigate without using the `Add Endpoint` or `Discard Endpoint` buttons
- Noticed that the endpoint has not been staged, and is not longer in the add documented 

## What
What's changing? Anything of note to call out?

Fixes logic to include staged to hide endpoint in UI (technically it's now treated as a staged endpoint in a different part of the UI) + dedupe pending endpoint UI datastructure

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
