### PR TITLE
Add loading state onto bulk edit load flow

### DIFF
--- a/workspaces/ui-v2/src/optic-components/diffs/render/AskForCommitMessage.tsx
+++ b/workspaces/ui-v2/src/optic-components/diffs/render/AskForCommitMessage.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { FC } from 'react';
 import { useHistory } from 'react-router-dom';
-import Button from '@material-ui/core/Button';
+import { Button, Tooltip } from '@material-ui/core';
 import { v4 as uuidv4 } from 'uuid';
 import { CommitMessageModal } from '../../common';
 
@@ -40,6 +40,21 @@ const useStagedChangesCount = () => {
   };
 };
 
+const ButtonWrapper: FC<{ isLearning: boolean }> = ({
+  isLearning,
+  children,
+}) => {
+  if (isLearning) {
+    return (
+      <Tooltip title="Currently learning endpoints" placement="bottom">
+        <span>{children}</span>
+      </Tooltip>
+    );
+  } else {
+    return <>{children}</>;
+  }
+};
+
 export default function AskForCommitMessageDiffPage(props: {
   hasChanges: boolean;
 }) {
@@ -54,6 +69,7 @@ export default function AskForCommitMessageDiffPage(props: {
     startedFinalizing,
     commitModalOpen,
     setCommitModalOpen,
+    isCurrentlyLearningPendingEndpoints,
   } = useSharedDiffContext();
 
   const {
@@ -94,18 +110,20 @@ export default function AskForCommitMessageDiffPage(props: {
 
   return (
     <>
-      <Button
-        disabled={!props.hasChanges}
-        onClick={() => {
-          setCommitModalOpen(true);
-          startedFinalizing();
-        }}
-        size="small"
-        variant="contained"
-        color="primary"
-      >
-        Save Changes
-      </Button>
+      <ButtonWrapper isLearning={isCurrentlyLearningPendingEndpoints()}>
+        <Button
+          disabled={!props.hasChanges || isCurrentlyLearningPendingEndpoints()}
+          onClick={() => {
+            setCommitModalOpen(true);
+            startedFinalizing();
+          }}
+          size="small"
+          variant="contained"
+          color="primary"
+        >
+          Save Changes
+        </Button>
+      </ButtonWrapper>
       {commitModalOpen ? (
         <CommitMessageModal
           open={commitModalOpen}

--- a/workspaces/ui-v2/src/optic-components/hooks/diffs/SharedDiffContext.tsx
+++ b/workspaces/ui-v2/src/optic-components/hooks/diffs/SharedDiffContext.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext, useMemo, useState } from 'react';
+import React, { FC, useCallback, useContext, useMemo, useState } from 'react';
 import {
   IPendingEndpoint,
   newSharedDiffMachine,
@@ -56,6 +56,8 @@ type ISharedDiffContext = {
   commitModalOpen: boolean;
   setCommitModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
   hasDiffChanges: () => boolean;
+  forceRerender: () => void;
+  isCurrentlyLearningPendingEndpoints: () => boolean;
 };
 
 type SharedDiffStoreProps = {
@@ -129,6 +131,7 @@ export const SharedDiffStore: FC<SharedDiffStoreProps> = (props) => {
   }>({});
 
   const [commitModalOpen, setCommitModalOpen] = useState(false);
+  const [, setInternalState] = useState(false);
 
   const value: ISharedDiffContext = {
     context,
@@ -216,6 +219,11 @@ export const SharedDiffStore: FC<SharedDiffStoreProps> = (props) => {
       Object.keys(context.choices.existingEndpointNameContributions).length >
         0 ||
       Object.keys(context.choices.existingEndpointPathContributions).length > 0,
+    forceRerender: useCallback(() => setInternalState((x) => !x), []),
+    isCurrentlyLearningPendingEndpoints: () =>
+      context.pendingEndpoints.some(
+        (endpoint) => !endpoint.ref.state.matches('ready')
+      ),
   };
 
   return (


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

The selection + bulk mode has an async portion to this we aren't taking into account. If a user saves changes before these endpoints are learnt, the endpoints don't actually get added. To solve this, we are adding in a loading state with a lock out.

## What
What's changing? Anything of note to call out?
<img width="1065" alt="Screen Shot 2021-05-10 at 3 43 23 PM" src="https://user-images.githubusercontent.com/18374483/117734314-0d424100-b1a8-11eb-807f-7213414359f0.png">

There's some kinda annoying stuff with xstate where there's some hacky stuff to get certain bits of state to update due to how the subscriptions / refs work. I think again this could be modified with modeling state in a different way (probably a fair amount of work here). Perhaps I'm also missing a much easier way to do this (couldn't figure out how to pull out / reference the `loading` promise on the [LearnEndpoint loading function](https://github.com/opticdev/optic/blob/e818d75bf3457d3256c176248e4bd5ff1082a8aa/workspaces/ui-v2/src/optic-components/hooks/diffs/LearnInitialBodiesMachine.ts#L89)

To follow this PR - there's work to be done to speed up learning of a large number of endpoints. Due to how node works, there's slowness with processing in parallel and it's faster to do this in series

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
