### PR TITLE
Force local cli learn undocumented bodies to run sequentially

### DIFF
--- a/workspaces/cli-server/package.json
+++ b/workspaces/cli-server/package.json
@@ -28,6 +28,7 @@
     "analytics-node": "^3.4.0-beta.2",
     "avsc": "^5.4.18",
     "body-parser": "^1.19.0",
+    "bottleneck": "^2.19.5",
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",

--- a/workspaces/cli-server/src/routers/capture-router.ts
+++ b/workspaces/cli-server/src/routers/capture-router.ts
@@ -69,6 +69,7 @@ export function makeRouter(dependencies: ICaptureRouterDependencies) {
     async (req, res) => {
       const { captureId } = req.params;
       const { pathId, method, additionalCommands } = req.body;
+      const { fileReadBottleneck } = req.optic;
 
       const events = await req.optic.specLoader();
 
@@ -89,7 +90,9 @@ export function makeRouter(dependencies: ICaptureRouterDependencies) {
 
       console.time('learn ' + pathId + method);
       // TODO: pass results stream straight through instead of buffering into memory
-      const result = initialBodyGenerator.run();
+      const result = fileReadBottleneck.schedule(() =>
+        initialBodyGenerator.run()
+      );
       result.then((learnedBodies: ILearnedBodies) => {
         console.timeEnd('learn ' + pathId + method);
         res.json(learnedBodies);

--- a/workspaces/cli-server/src/routers/spec-router.ts
+++ b/workspaces/cli-server/src/routers/spec-router.ts
@@ -166,7 +166,10 @@ export class ExampleRequestsHelpers {
   }
 }
 
-export async function makeRouter(sessions: SessionsManager) {
+export async function makeRouter(
+  sessions: SessionsManager,
+  fileReadBottleneck: Bottleneck
+) {
   async function ensureValidSpecId(
     req: express.Request,
     res: express.Response,
@@ -193,9 +196,6 @@ export async function makeRouter(sessions: SessionsManager) {
       const exampleRequestsHelpers = new ExampleRequestsHelpers(
         exampleRequestsPath
       );
-      const fileReadBottleneck = new Bottleneck({
-        maxConcurrent: 1,
-      });
 
       async function specLoader(): Promise<any[]> {
         const events = await getSpecEventsFrom(paths.specStorePath);
@@ -209,7 +209,6 @@ export async function makeRouter(sessions: SessionsManager) {
         exampleRequestsHelpers,
         session,
         specLoader,
-        fileReadBottleneck,
       };
       next();
     } catch (e) {
@@ -357,6 +356,7 @@ export async function makeRouter(sessions: SessionsManager) {
       captureId: CaptureId;
       captureBaseDirectory: string;
     }) => new LocalCaptureInteractionPointerConverter(config),
+    fileReadBottleneck: fileReadBottleneck,
   });
 
   router.use('/captures/:captureId', captureRouter);

--- a/workspaces/cli-server/src/routers/spec-router.ts
+++ b/workspaces/cli-server/src/routers/spec-router.ts
@@ -8,6 +8,7 @@ import express from 'express';
 import bodyParser from 'body-parser';
 import path from 'path';
 import fs from 'fs-extra';
+import Bottleneck from 'bottleneck';
 
 import sortBy from 'lodash.sortby';
 import { DefaultIdGenerator, developerDebugLogger } from '@useoptic/cli-shared';
@@ -192,6 +193,9 @@ export async function makeRouter(sessions: SessionsManager) {
       const exampleRequestsHelpers = new ExampleRequestsHelpers(
         exampleRequestsPath
       );
+      const fileReadBottleneck = new Bottleneck({
+        maxConcurrent: 1,
+      });
 
       async function specLoader(): Promise<any[]> {
         const events = await getSpecEventsFrom(paths.specStorePath);
@@ -205,6 +209,7 @@ export async function makeRouter(sessions: SessionsManager) {
         exampleRequestsHelpers,
         session,
         specLoader,
+        fileReadBottleneck,
       };
       next();
     } catch (e) {

--- a/workspaces/cli-server/src/server.ts
+++ b/workspaces/cli-server/src/server.ts
@@ -38,7 +38,6 @@ export interface IOpticExpressRequestAdditions {
   exampleRequestsHelpers: ExampleRequestsHelpers;
   session: Session;
   specLoader(): Promise<any[]>;
-  fileReadBottleneck: Bottleneck;
 }
 
 declare global {
@@ -92,6 +91,9 @@ class CliServer {
     app.use(cors(this.corsOptions));
     app.set('etag', false);
     const sessions = new SessionsManager();
+    const fileReadBottleneck = new Bottleneck({
+      maxConcurrent: 1,
+    });
     let user: object | null;
 
     const anonIdPromise = getOrCreateAnonId();
@@ -204,7 +206,7 @@ class CliServer {
     );
 
     // specRouter
-    const specRouter = await makeRouter(sessions);
+    const specRouter = await makeRouter(sessions, fileReadBottleneck);
     app.use('/api/specs/:specId', specRouter);
 
     // ui

--- a/workspaces/cli-server/src/server.ts
+++ b/workspaces/cli-server/src/server.ts
@@ -15,6 +15,7 @@ import {
   ExampleRequestsHelpers,
   makeRouter,
 } from './routers/spec-router';
+import Bottleneck from 'bottleneck';
 import { basePath } from '@useoptic/ui-v2';
 import { TrackingEventBase } from '@useoptic/analytics/lib/interfaces/TrackingEventBase';
 import { analyticsEvents, trackWithApiName } from './analytics';
@@ -37,6 +38,7 @@ export interface IOpticExpressRequestAdditions {
   exampleRequestsHelpers: ExampleRequestsHelpers;
   session: Session;
   specLoader(): Promise<any[]>;
+  fileReadBottleneck: Bottleneck;
 }
 
 declare global {

--- a/workspaces/spectacle-shared/src/local-cli/client.ts
+++ b/workspaces/spectacle-shared/src/local-cli/client.ts
@@ -131,11 +131,13 @@ export class LocalCliDiffService implements IOpticDiffService {
     // The local CLI instance will run learns sequentially - since we run this in parallel, there
     // is contention between learner workers reading arvo files
     // This forces this to run sequentially
-    await throttlerPromiseSingleton;
-    const promiseToReturn = JsonHttpClient.postJson(
-      `${this.dependencies.baseUrl}/captures/${this.dependencies.captureId}/initial-bodies`,
-      { pathId, method, additionalCommands: newPathCommands }
+    const promiseToReturn = throttlerPromiseSingleton.then(() =>
+      JsonHttpClient.postJson(
+        `${this.dependencies.baseUrl}/captures/${this.dependencies.captureId}/initial-bodies`,
+        { pathId, method, additionalCommands: newPathCommands }
+      )
     );
+
     throttlerPromiseSingleton = promiseToReturn.catch(() => {
       // We need to catch any errors the promise _could_ return so that a single failure does
       // not break the rest of these calls

--- a/workspaces/spectacle-shared/src/local-cli/client.ts
+++ b/workspaces/spectacle-shared/src/local-cli/client.ts
@@ -21,8 +21,6 @@ import {
   IValueAffordanceSerializationWithCounterGroupedByDiffHash,
 } from '@useoptic/cli-shared/build/diffs/initial-types';
 
-let throttlerPromiseSingleton = Promise.resolve();
-
 export class LocalCliSpectacle implements IForkableSpectacle {
   constructor(private baseUrl: string, private opticEngine: IOpticEngine) {}
   async fork(): Promise<IBaseSpectacle> {
@@ -128,21 +126,10 @@ export class LocalCliDiffService implements IOpticDiffService {
     method: string,
     newPathCommands: any[]
   ): Promise<ILearnedBodies> {
-    // The local CLI instance will run learns sequentially - since we run this in parallel, there
-    // is contention between learner workers reading arvo files
-    // This forces this to run sequentially
-    const promiseToReturn = throttlerPromiseSingleton.then(() =>
-      JsonHttpClient.postJson(
-        `${this.dependencies.baseUrl}/captures/${this.dependencies.captureId}/initial-bodies`,
-        { pathId, method, additionalCommands: newPathCommands }
-      )
+    return JsonHttpClient.postJson(
+      `${this.dependencies.baseUrl}/captures/${this.dependencies.captureId}/initial-bodies`,
+      { pathId, method, additionalCommands: newPathCommands }
     );
-
-    throttlerPromiseSingleton = promiseToReturn.catch(() => {
-      // We need to catch any errors the promise _could_ return so that a single failure does
-      // not break the rest of these calls
-    });
-    return promiseToReturn;
   }
 
   async listDiffs(): Promise<IListDiffsResponse> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4495,7 +4495,7 @@ boolbase@^1.0.0, boolbase@~1.0.0:
 
 bottleneck@^2.19.5:
   version "2.19.5"
-  resolved "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz#5df0b90f59fd47656ebe63c78a98419205cadd91"
+  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.19.5.tgz#5df0b90f59fd47656ebe63c78a98419205cadd91"
   integrity sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==
 
 boxen@^5.0.0:


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

When running optic against the local cli server, there's file contention with learning multiple instances

## What
What's changing? Anything of note to call out?

Throttle learnUndocumentedBodies so that we don't get file read contention. 

Queueing a bunch of requests here against the cli server (i think the 500s are a different bug - returned as `expected to receive a learning result`)
<img width="1565" alt="Screen Shot 2021-05-11 at 11 40 46 AM" src="https://user-images.githubusercontent.com/18374483/117868081-05d57300-b24e-11eb-9c30-1bc5b79af0e2.png">



## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
