### PR TITLE
Fix bug where Shape Diff Affordance learner would not generate affordances for missing fields

### DIFF
--- a/workspaces/diff-engine/Cargo.toml
+++ b/workspaces/diff-engine/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 
 [lib]
 crate-type = ["lib"]
+edition = "2018"
 
 [features]
 default = ["streams"]

--- a/workspaces/diff-engine/src/events/http_interaction.rs
+++ b/workspaces/diff-engine/src/events/http_interaction.rs
@@ -12,7 +12,7 @@ use std::iter::FromIterator;
 
 // TODO: consider whether these aren't actually Events and the Traverser not an Aggregator
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Clone, Deserialize, Serialize, Debug)]
 pub struct HttpInteraction {
   pub uuid: String,
   pub request: Request,
@@ -20,13 +20,13 @@ pub struct HttpInteraction {
   pub tags: Vec<HttpInteractionTag>,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Clone, Deserialize, Serialize, Debug)]
 pub struct HttpInteractionTag {
   name: String,
   value: String,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Clone, Deserialize, Serialize, Debug)]
 pub struct Request {
   pub host: String,
   pub method: String,
@@ -37,7 +37,7 @@ pub struct Request {
   pub body: Body,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Clone, Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Response {
   pub status_code: u16,
@@ -46,7 +46,7 @@ pub struct Response {
   pub body: Body,
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Clone, Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Body {
   pub content_type: Option<String>,
@@ -54,7 +54,7 @@ pub struct Body {
   pub value: ArbitraryData,
 }
 
-#[derive(Deserialize, Serialize, Debug, Default)]
+#[derive(Clone, Deserialize, Serialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ArbitraryData {
   pub shape_hash_v1_base64: Option<String>,

--- a/workspaces/diff-engine/src/projections/learners/shape_diff_affordances.rs
+++ b/workspaces/diff-engine/src/projections/learners/shape_diff_affordances.rs
@@ -56,8 +56,15 @@ impl LearnedShapeDiffAffordancesProjection {
         .entry(fingerprint)
         .or_insert_with(|| ShapeDiffAffordances::from(diff_json_trail.clone()));
 
+      let mut counter = 0;
       for trail_result in trail_results {
         affordances.push((trail_result, interaction_pointers.clone()));
+        counter += 1;
+      }
+
+      if counter == 0 {
+        let unknown_trail = TrailValues::from(diff_json_trail.clone());
+        affordances.push((unknown_trail, interaction_pointers.clone()));
       }
     }
   }

--- a/workspaces/diff-engine/tests/fixtures/shape-diff-use-cases/a known field is missing.json
+++ b/workspaces/diff-engine/tests/fixtures/shape-diff-use-cases/a known field is missing.json
@@ -1,0 +1,413 @@
+{
+  "events" : [
+    {
+      "PathComponentAdded" : {
+        "pathId" : "baseline-path_1",
+        "parentPathId" : "root",
+        "name" : "users",
+        "eventContext" : {
+          "clientId" : "ccc",
+          "clientSessionId" : "sss",
+          "clientCommandBatchId" : "bbb",
+          "createdAt" : "NOW"
+        }
+      }
+    },
+    {
+      "PathParameterAdded" : {
+        "pathId" : "baseline-path_2",
+        "parentPathId" : "baseline-path_1",
+        "name" : ":userId",
+        "eventContext" : null
+      }
+    },
+    {
+      "ShapeAdded" : {
+        "shapeId" : "baseline-shape_9",
+        "baseShapeId" : "$string",
+        "parameters" : {
+          "DynamicParameterList" : {
+            "shapeParameterIds" : [
+            ]
+          }
+        },
+        "name" : "",
+        "eventContext" : null
+      }
+    },
+    {
+      "PathParameterShapeSet" : {
+        "pathId" : "baseline-path_2",
+        "shapeDescriptor" : {
+          "shapeId" : "baseline-shape_9",
+          "isRemoved" : false
+        },
+        "eventContext" : null
+      }
+    },
+    {
+      "PathComponentAdded" : {
+        "pathId" : "baseline-path_3",
+        "parentPathId" : "baseline-path_2",
+        "name" : "profile",
+        "eventContext" : {
+          "clientId" : "ccc",
+          "clientSessionId" : "sss",
+          "clientCommandBatchId" : "bbb",
+          "createdAt" : "NOW"
+        }
+      }
+    },
+    {
+      "RequestParameterAddedByPathAndMethod" : {
+        "parameterId" : "baseline-request-parameter_1",
+        "pathId" : "baseline-path_3",
+        "httpMethod" : "GET",
+        "parameterLocation" : "query",
+        "name" : "queryString",
+        "eventContext" : {
+          "clientId" : "ccc",
+          "clientSessionId" : "sss",
+          "clientCommandBatchId" : "bbb",
+          "createdAt" : "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded" : {
+        "shapeId" : "baseline-shape_10",
+        "baseShapeId" : "$object",
+        "parameters" : {
+          "DynamicParameterList" : {
+            "shapeParameterIds" : [
+            ]
+          }
+        },
+        "name" : "",
+        "eventContext" : {
+          "clientId" : "ccc",
+          "clientSessionId" : "sss",
+          "clientCommandBatchId" : "bbb",
+          "createdAt" : "NOW"
+        }
+      }
+    },
+    {
+      "RequestParameterShapeSet" : {
+        "parameterId" : "baseline-request-parameter_1",
+        "parameterDescriptor" : {
+          "shapeId" : "baseline-shape_10",
+          "isRemoved" : false
+        },
+        "eventContext" : {
+          "clientId" : "ccc",
+          "clientSessionId" : "sss",
+          "clientCommandBatchId" : "bbb",
+          "createdAt" : "NOW"
+        }
+      }
+    },
+    {
+      "RequestAdded" : {
+        "requestId" : "baseline-request_1",
+        "pathId" : "baseline-path_3",
+        "httpMethod" : "GET",
+        "eventContext" : {
+          "clientId" : "ccc",
+          "clientSessionId" : "sss",
+          "clientCommandBatchId" : "bbb",
+          "createdAt" : "NOW"
+        }
+      }
+    },
+    {
+      "ResponseAddedByPathAndMethod" : {
+        "responseId" : "baseline-response_1",
+        "pathId" : "baseline-path_3",
+        "httpMethod" : "GET",
+        "httpStatusCode" : 200,
+        "eventContext" : {
+          "clientId" : "ccc",
+          "clientSessionId" : "sss",
+          "clientCommandBatchId" : "bbb",
+          "createdAt" : "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded" : {
+        "shapeId" : "baseline-shape_8",
+        "baseShapeId" : "$object",
+        "parameters" : {
+          "DynamicParameterList" : {
+            "shapeParameterIds" : [
+            ]
+          }
+        },
+        "name" : "",
+        "eventContext" : {
+          "clientId" : "ccc",
+          "clientSessionId" : "sss",
+          "clientCommandBatchId" : "bbb",
+          "createdAt" : "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded" : {
+        "shapeId" : "baseline-shape_2",
+        "baseShapeId" : "$number",
+        "parameters" : {
+          "DynamicParameterList" : {
+            "shapeParameterIds" : [
+            ]
+          }
+        },
+        "name" : "",
+        "eventContext" : {
+          "clientId" : "ccc",
+          "clientSessionId" : "sss",
+          "clientCommandBatchId" : "bbb",
+          "createdAt" : "NOW"
+        }
+      }
+    },
+    {
+      "FieldAdded" : {
+        "fieldId" : "baseline-field_1",
+        "shapeId" : "baseline-shape_8",
+        "name" : "age",
+        "shapeDescriptor" : {
+          "FieldShapeFromShape" : {
+            "fieldId" : "baseline-field_1",
+            "shapeId" : "baseline-shape_2"
+          }
+        },
+        "eventContext" : {
+          "clientId" : "ccc",
+          "clientSessionId" : "sss",
+          "clientCommandBatchId" : "bbb",
+          "createdAt" : "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded" : {
+        "shapeId" : "baseline-shape_4",
+        "baseShapeId" : "$string",
+        "parameters" : {
+          "DynamicParameterList" : {
+            "shapeParameterIds" : [
+            ]
+          }
+        },
+        "name" : "",
+        "eventContext" : {
+          "clientId" : "ccc",
+          "clientSessionId" : "sss",
+          "clientCommandBatchId" : "bbb",
+          "createdAt" : "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded" : {
+        "shapeId" : "baseline-shape_5",
+        "baseShapeId" : "$list",
+        "parameters" : {
+          "DynamicParameterList" : {
+            "shapeParameterIds" : [
+            ]
+          }
+        },
+        "name" : "",
+        "eventContext" : {
+          "clientId" : "ccc",
+          "clientSessionId" : "sss",
+          "clientCommandBatchId" : "bbb",
+          "createdAt" : "NOW"
+        }
+      }
+    },
+    {
+      "FieldAdded" : {
+        "fieldId" : "baseline-field_2",
+        "shapeId" : "baseline-shape_8",
+        "name" : "cities",
+        "shapeDescriptor" : {
+          "FieldShapeFromShape" : {
+            "fieldId" : "baseline-field_2",
+            "shapeId" : "baseline-shape_5"
+          }
+        },
+        "eventContext" : {
+          "clientId" : "ccc",
+          "clientSessionId" : "sss",
+          "clientCommandBatchId" : "bbb",
+          "createdAt" : "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded" : {
+        "shapeId" : "baseline-shape_6",
+        "baseShapeId" : "$string",
+        "parameters" : {
+          "DynamicParameterList" : {
+            "shapeParameterIds" : [
+            ]
+          }
+        },
+        "name" : "",
+        "eventContext" : {
+          "clientId" : "ccc",
+          "clientSessionId" : "sss",
+          "clientCommandBatchId" : "bbb",
+          "createdAt" : "NOW"
+        }
+      }
+    },
+    {
+      "FieldAdded" : {
+        "fieldId" : "baseline-field_3",
+        "shapeId" : "baseline-shape_8",
+        "name" : "firstName",
+        "shapeDescriptor" : {
+          "FieldShapeFromShape" : {
+            "fieldId" : "baseline-field_3",
+            "shapeId" : "baseline-shape_6"
+          }
+        },
+        "eventContext" : {
+          "clientId" : "ccc",
+          "clientSessionId" : "sss",
+          "clientCommandBatchId" : "bbb",
+          "createdAt" : "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded" : {
+        "shapeId" : "baseline-shape_7",
+        "baseShapeId" : "$string",
+        "parameters" : {
+          "DynamicParameterList" : {
+            "shapeParameterIds" : [
+            ]
+          }
+        },
+        "name" : "",
+        "eventContext" : {
+          "clientId" : "ccc",
+          "clientSessionId" : "sss",
+          "clientCommandBatchId" : "bbb",
+          "createdAt" : "NOW"
+        }
+      }
+    },
+    {
+      "FieldAdded" : {
+        "fieldId" : "baseline-field_4",
+        "shapeId" : "baseline-shape_8",
+        "name" : "lastName",
+        "shapeDescriptor" : {
+          "FieldShapeFromShape" : {
+            "fieldId" : "baseline-field_4",
+            "shapeId" : "baseline-shape_7"
+          }
+        },
+        "eventContext" : {
+          "clientId" : "ccc",
+          "clientSessionId" : "sss",
+          "clientCommandBatchId" : "bbb",
+          "createdAt" : "NOW"
+        }
+      }
+    },
+    {
+      "ShapeParameterShapeSet" : {
+        "shapeDescriptor" : {
+          "ProviderInShape" : {
+            "shapeId" : "baseline-shape_5",
+            "providerDescriptor" : {
+              "ShapeProvider" : {
+                "shapeId" : "baseline-shape_4"
+              }
+            },
+            "consumingParameterId" : "$listItem"
+          }
+        },
+        "eventContext" : {
+          "clientId" : "ccc",
+          "clientSessionId" : "sss",
+          "clientCommandBatchId" : "bbb",
+          "createdAt" : "NOW"
+        }
+      }
+    },
+    {
+      "ResponseBodySet" : {
+        "responseId" : "baseline-response_1",
+        "bodyDescriptor" : {
+          "httpContentType" : "application/json",
+          "shapeId" : "baseline-shape_8",
+          "isRemoved" : false
+        },
+        "eventContext" : {
+          "clientId" : "ccc",
+          "clientSessionId" : "sss",
+          "clientCommandBatchId" : "bbb",
+          "createdAt" : "NOW"
+        }
+      }
+    }
+  ],
+  "session" : {
+    "samples" : [
+      {
+        "uuid" : "id",
+        "request" : {
+          "host" : "example.com",
+          "method" : "GET",
+          "path" : "/users/1234/profile",
+          "query" : {
+            "shapeHashV1Base64" : null,
+            "asJsonString" : null,
+            "asText" : null
+          },
+          "headers" : {
+            "shapeHashV1Base64" : null,
+            "asJsonString" : null,
+            "asText" : null
+          },
+          "body" : {
+            "contentType" : null,
+            "value" : {
+              "shapeHashV1Base64" : null,
+              "asJsonString" : null,
+              "asText" : null
+            }
+          }
+        },
+        "response" : {
+          "statusCode" : 200,
+          "headers" : {
+            "shapeHashV1Base64" : null,
+            "asJsonString" : null,
+            "asText" : null
+          },
+          "body" : {
+            "contentType" : "application/json",
+            "value" : {
+              "shapeHashV1Base64" : "Eg4KCGxhc3ROYW1lEgIIAhIJCgNhZ2USAggDEhgKBmNpdGllcxIOCAEaAggCGgIIAhoCCAI=",
+              "asJsonString" : "{\"lastName\":\"C\",\"age\":26,\"cities\":[\"San Fransisco\",\"New York\",\"Durham\"]}",
+              "asText" : "{\"lastName\":\"C\",\"age\":26,\"cities\":[\"San Fransisco\",\"New York\",\"Durham\"]}"
+            }
+          }
+        },
+        "tags" : [
+        ]
+      }
+    ]
+  }
+}

--- a/workspaces/diff-engine/tests/shape-diff-use-cases.rs
+++ b/workspaces/diff-engine/tests/shape-diff-use-cases.rs
@@ -1,0 +1,68 @@
+use insta::assert_debug_snapshot;
+use serde::Deserialize;
+use std::collections::HashSet;
+use std::path::Path;
+use tokio::fs::read_to_string;
+
+use optic_diff_engine::{
+  analyze_documented_bodies, diff_interaction, Aggregate, HttpInteraction,
+  LearnedShapeDiffAffordancesProjection, SpecEvent, SpecProjection, TaggedInput,
+};
+
+#[tokio::main]
+#[test]
+async fn a_known_field_is_missing() {
+  let mut capture = DebugCapture::from_name("a known field is missing.json").await;
+
+  let spec = SpecProjection::from(capture.events);
+  let interaction = capture.session.samples.remove(0);
+  let interaction_pointers: HashSet<_> =
+    std::iter::once(String::from("test-interaction-1")).collect();
+  let diff_results = diff_interaction(&spec, interaction.clone());
+
+  let mut learned_shape_diff_affordances =
+    LearnedShapeDiffAffordancesProjection::from(diff_results);
+
+  let analysis = analyze_documented_bodies(&spec, interaction)
+    .collect::<Vec<_>>()
+    .pop()
+    .unwrap();
+
+  let tagged_analysis = TaggedInput(analysis, interaction_pointers);
+  learned_shape_diff_affordances.apply(tagged_analysis);
+
+  assert_debug_snapshot!(
+    "a_known_field_is_missing__affordances",
+    learned_shape_diff_affordances.into_iter()
+  );
+}
+
+#[derive(Deserialize, Debug)]
+struct DebugCapture {
+  events: Vec<SpecEvent>,
+  session: DebugCaptureSession,
+}
+
+impl DebugCapture {
+  async fn from_name(capture_name: &str) -> Self {
+    let capture_path = std::env::current_dir()
+      .unwrap()
+      .join("tests/fixtures/shape-diff-use-cases")
+      .join(capture_name);
+
+    Self::from_file(capture_path).await
+  }
+
+  async fn from_file(capture_path: impl AsRef<Path>) -> Self {
+    let capture_json = read_to_string(capture_path)
+      .await
+      .expect("should be able to read the debug capture");
+
+    serde_json::from_str(&capture_json).expect("should be able to deserialize the debug capture")
+  }
+}
+
+#[derive(Deserialize, Debug)]
+struct DebugCaptureSession {
+  samples: Vec<HttpInteraction>,
+}

--- a/workspaces/diff-engine/tests/snapshots/shape_diff_use_cases__a_known_field_is_missing__affordances.snap
+++ b/workspaces/diff-engine/tests/snapshots/shape_diff_use_cases__a_known_field_is_missing__affordances.snap
@@ -1,0 +1,65 @@
+---
+source: workspaces/diff-engine/tests/shape-diff-use-cases.rs
+expression: learned_shape_diff_affordances.into_iter()
+---
+[
+    (
+        "cd78e5d03251f88",
+        ShapeDiffAffordances {
+            affordances: [
+                TrailValues {
+                    trail: JsonTrail {
+                        path: [
+                            JsonObjectKey {
+                                key: "firstName",
+                            },
+                        ],
+                    },
+                    was_string: false,
+                    was_number: false,
+                    was_boolean: false,
+                    was_null: false,
+                    was_array: false,
+                    was_object: false,
+                    was_empty_array: false,
+                    field_sets: [],
+                },
+            ],
+            interactions: InteractionsAffordances {
+                was_string: {},
+                was_number: {},
+                was_boolean: {},
+                was_null: {},
+                was_array: {},
+                was_object: {},
+                was_missing: {
+                    "test-interaction-1",
+                },
+                was_string_trails: {},
+                was_number_trails: {},
+                was_boolean_trails: {},
+                was_null_trails: {},
+                was_array_trails: {},
+                was_object_trails: {},
+                was_missing_trails: {
+                    "test-interaction-1": [
+                        JsonTrail {
+                            path: [
+                                JsonObjectKey {
+                                    key: "firstName",
+                                },
+                            ],
+                        },
+                    ],
+                },
+            },
+            root_trail: JsonTrail {
+                path: [
+                    JsonObjectKey {
+                        key: "firstName",
+                    },
+                ],
+            },
+        },
+    ),
+]


### PR DESCRIPTION
## Why
One possible shape diff is for the body of an interaction is missing a field. The Shape Diff Affordance learner should include an affordance for such an interaction to indicate that this is an observed occurrence (to then to suggest removing the field or making it optional). The Shape Diff Affordance learner not yielding any affordances or `was_missing` trails, makes the UI unable to let the user handle this type of diff.

## What
This fixes the `ShapeDiffAffordanceProjection` to create the appropriate empty `TrailValues` instance that indicates a missing value, when no results were observed for matching diffs. A new integration test based on an existing debug capture helped debug and verify this happening correctly.

## Validation
* [ ] CI passes
* [ ] Generates the correct affordance for missing fields
