### PR TITLE
Specify rustfmt.tml on precommit lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
       "yarn prettier --write"
     ],
     "**/*.rs": [
-      "rustfmt"
+      "rustfmt --config-path ./rustfmt.toml"
     ]
   }
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,2 @@
+edition = "2018"
 tab_spaces = 2 # spaces per tab, held at 2 as that's what most of the code was written in originally


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Rustfml tries to infer edition (when it's run in different contexts) - this causes certain contexts to fail on runs. Lint-staged also doesn't automatically pick up these changes so we need to point the lint-staged command to pick this up.

I'm also not sure how we specify editions in cargo.toml files, etc. This currently unblocks git commits but ideally we have a centralized place to trigger these

The problematic file was `workspaces/diff-engine/tests/shape-diff-use-cases.rs` which had `async await` - which i tried formatting through `yarn run lint-staged` and it formatted

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
