### PR TITLE
change component->render on react-router route

### DIFF
--- a/workspaces/ui-v2/src/optic-components/navigation/NavigationRoute.tsx
+++ b/workspaces/ui-v2/src/optic-components/navigation/NavigationRoute.tsx
@@ -16,7 +16,7 @@ export function NavigationRoute(props: NavigationRouteProps) {
     <Route
       path={path}
       exact
-      component={(props: { match: any }) => {
+      render={(props: { match: any }) => {
         const { match } = props;
         return (
           <div className={classes.root}>


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Due to how react-router renders these, since we pass in a fn instead of a component, components are remounted instead of rerendered - similar to this https://github.com/opticdev/optic/pull/742

I think this is causing a couple of weird rendering issues when things resolve (when things change, the components get remounted and initial state is reset, e.g. bulk mode on, if there's something that causes a rerender at the top level, the entire tree gets remounted so bulk mode gets unset)

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
