### PR TITLE
Update openapi in CLI

### DIFF
--- a/workspaces/local-cli/package.json
+++ b/workspaces/local-cli/package.json
@@ -25,6 +25,7 @@
     "@useoptic/cli-shared": "10.0.1",
     "@useoptic/client-utilities": "10.0.1",
     "@useoptic/spectacle": "10.0.1",
+    "@useoptic/diff-engine-wasm": "10.0.1",
     "@useoptic/domain": "10.0.67",
     "@useoptic/domain-utilities": "10.0.67",
     "analytics-node": "^3.4.0-beta.1",

--- a/workspaces/local-cli/package.json
+++ b/workspaces/local-cli/package.json
@@ -24,6 +24,7 @@
     "@useoptic/cli-server": "10.0.1",
     "@useoptic/cli-shared": "10.0.1",
     "@useoptic/client-utilities": "10.0.1",
+    "@useoptic/spectacle": "10.0.1",
     "@useoptic/domain": "10.0.67",
     "@useoptic/domain-utilities": "10.0.67",
     "analytics-node": "^3.4.0-beta.1",

--- a/workspaces/local-cli/src/commands/generate/oas.ts
+++ b/workspaces/local-cli/src/commands/generate/oas.ts
@@ -11,7 +11,7 @@ import * as OpticEngine from '@useoptic/diff-engine-wasm/engine/build';
 import { generateOpenApi, makeSpectacle } from '@useoptic/spectacle';
 
 export default class GenerateOas extends Command {
-  static description = 'export an OpenAPI 3.0.1 spec';
+  static description = 'export an OpenAPI 3.0.3 spec';
 
   static flags = {
     json: flags.boolean({}),

--- a/workspaces/local-cli/src/commands/generate/oas.ts
+++ b/workspaces/local-cli/src/commands/generate/oas.ts
@@ -6,7 +6,6 @@ import path from 'path';
 import yaml from 'js-yaml';
 import { fromOptic } from '@useoptic/cli-shared';
 import { getSpecEventsFrom } from '@useoptic/cli-config/build/helpers/read-specification-json';
-
 import { InMemoryOpticContextBuilder } from '@useoptic/spectacle/build/in-memory';
 import * as OpticEngine from '@useoptic/diff-engine-wasm/engine/build';
 import { generateOpenApi, makeSpectacle } from '@useoptic/spectacle';


### PR DESCRIPTION
This swaps out the OpenAPI generator from `@useoptic/domain` to the TypeScript one from `@useoptic/spectacle`. Note, I didn't update the `yarn.lock` here.