### PR TITLE
Add `was_empty_array` and `was_empty_array_trails` to `InteractionAffordances` so UI can reason about not rendering empty array examples

### DIFF
--- a/workspaces/cli-shared/src/diffs/initial-types.ts
+++ b/workspaces/cli-shared/src/diffs/initial-types.ts
@@ -42,6 +42,7 @@ export interface IAffordanceInteractionPointers {
   wasArray: string[];
   wasObject: string[];
   wasMissing: string[];
+  wasEmptyArray: string[];
   wasStringTrails: { [key: string]: IJsonTrail[] };
   wasNumberTrails: { [key: string]: IJsonTrail[] };
   wasBooleanTrails: { [key: string]: IJsonTrail[] };
@@ -49,4 +50,5 @@ export interface IAffordanceInteractionPointers {
   wasArrayTrails: { [key: string]: IJsonTrail[] };
   wasObjectTrails: { [key: string]: IJsonTrail[] };
   wasMissingTrails: { [key: string]: IJsonTrail[] };
+  wasEmptyArrayTrails: { [key: string]: IJsonTrail[] };
 }

--- a/workspaces/diff-engine/src/projections/learners/shape_diff_affordances.rs
+++ b/workspaces/diff-engine/src/projections/learners/shape_diff_affordances.rs
@@ -174,13 +174,13 @@ pub struct InteractionsAffordances {
   was_array: InteractionPointers,
   was_object: InteractionPointers,
   was_missing: InteractionPointers,
-  was_string_trails: HashMap<String, Vec<JsonTrail>>,
-  was_number_trails: HashMap<String, Vec<JsonTrail>>,
-  was_boolean_trails: HashMap<String, Vec<JsonTrail>>,
-  was_null_trails: HashMap<String, Vec<JsonTrail>>,
-  was_array_trails: HashMap<String, Vec<JsonTrail>>,
-  was_object_trails: HashMap<String, Vec<JsonTrail>>,
-  was_missing_trails: HashMap<String, Vec<JsonTrail>>,
+  was_string_trails: HashMap<String, HashSet<JsonTrail>>,
+  was_number_trails: HashMap<String, HashSet<JsonTrail>>,
+  was_boolean_trails: HashMap<String, HashSet<JsonTrail>>,
+  was_null_trails: HashMap<String, HashSet<JsonTrail>>,
+  was_array_trails: HashMap<String, HashSet<JsonTrail>>,
+  was_object_trails: HashMap<String, HashSet<JsonTrail>>,
+  was_missing_trails: HashMap<String, HashSet<JsonTrail>>,
 }
 
 impl From<JsonTrail> for ShapeDiffAffordances {
@@ -220,36 +220,39 @@ impl ShapeDiffAffordances {
 impl InteractionsAffordances {
   pub fn push(&mut self, (trail_values, pointers): (&TrailValues, InteractionPointers)) {
     let json_trail = trail_values.trail.clone();
-    let json_trails_by_pointer_iter = || {
-      pointers
-        .iter()
-        .map(|pointer| (pointer.clone(), vec![json_trail.clone()]))
+    let add_trail = |collection: &mut HashMap<String, HashSet<JsonTrail>>| {
+      for pointer in &pointers {
+        let existing_trails = collection
+          .entry(pointer.clone())
+          .or_insert_with(|| HashSet::new());
+
+        existing_trails.insert(json_trail.clone());
+      }
     };
+
     if trail_values.was_string {
       self.was_string.extend(pointers.clone());
-      self.was_string_trails.extend(json_trails_by_pointer_iter());
+      add_trail(&mut self.was_string_trails);
     }
     if trail_values.was_number {
       self.was_number.extend(pointers.clone());
-      self.was_number_trails.extend(json_trails_by_pointer_iter());
+      add_trail(&mut self.was_number_trails);
     }
     if trail_values.was_null {
       self.was_null.extend(pointers.clone());
-      self.was_null_trails.extend(json_trails_by_pointer_iter());
+      add_trail(&mut self.was_null_trails);
     }
     if trail_values.was_array {
       self.was_array.extend(pointers.clone());
-      self.was_array_trails.extend(json_trails_by_pointer_iter());
+      add_trail(&mut self.was_array_trails);
     }
     if trail_values.was_object {
       self.was_object.extend(pointers.clone());
-      self.was_object_trails.extend(json_trails_by_pointer_iter());
+      add_trail(&mut self.was_object_trails);
     }
     if trail_values.was_unknown() {
       self.was_missing.extend(pointers.clone());
-      self
-        .was_missing_trails
-        .extend(json_trails_by_pointer_iter());
+      add_trail(&mut self.was_missing_trails);
     }
   }
 }
@@ -321,11 +324,15 @@ mod test {
 
     // interactions
     let was_string_trails = &shape_diff_affordances.interactions.was_string_trails;
-    assert_eq!(
-      &was_string_trails.get(&interaction_pointer).unwrap()[0],
-      &JsonTrail::empty()
-        .with_object_key(String::from("items"))
-        .with_array_item(1),
+    assert!(
+      &was_string_trails
+        .get(&interaction_pointer)
+        .unwrap()
+        .contains(
+          &JsonTrail::empty()
+            .with_object_key(String::from("items"))
+            .with_array_item(1)
+        ),
       "interaction affordance trails are denormalized"
     );
 
@@ -383,14 +390,18 @@ mod test {
     assert!(was_missing.contains(&interaction_pointer));
 
     let was_missing_trails = &shape_diff_affordances.interactions.was_missing_trails;
-    assert_eq!(
-      &was_missing_trails.get(&interaction_pointer).unwrap()[0],
-      &JsonTrail::empty()
-        .with_object_key(String::from("races"))
-        .with_array_item(1)
-        .with_object_key(String::from("results"))
-        .with_array_item(1)
-        .with_object_key(String::from("time")),
+    assert!(
+      &was_missing_trails
+        .get(&interaction_pointer)
+        .unwrap()
+        .contains(
+          &JsonTrail::empty()
+            .with_object_key(String::from("races"))
+            .with_array_item(1)
+            .with_object_key(String::from("results"))
+            .with_array_item(1)
+            .with_object_key(String::from("time"))
+        ),
       "trails where expected shapes were missing are recorded"
     );
   }
@@ -447,11 +458,14 @@ mod test {
     assert!(&shape_diff_affordances.interactions.was_missing.is_empty());
 
     let was_object = &shape_diff_affordances.interactions.was_object;
+    assert!(was_object.contains(&interaction_pointer));
 
     let was_object_trails = &shape_diff_affordances.interactions.was_object_trails;
-    assert_eq!(
-      &was_object_trails.get(&interaction_pointer).unwrap()[0],
-      &JsonTrail::empty(),
+    assert!(
+      &was_object_trails
+        .get(&interaction_pointer)
+        .unwrap()
+        .contains(&JsonTrail::empty()),
       "trails where expected shapes were objects are recorded"
     );
   }

--- a/workspaces/diff-engine/src/projections/learners/snapshots/optic_diff_engine__projections__learners__shape_diff_affordances__test__shape_diff_affordances_can_aggregate_affordances_for_array_item_diffs__shape_diff_affordances.snap
+++ b/workspaces/diff-engine/src/projections/learners/snapshots/optic_diff_engine__projections__learners__shape_diff_affordances__test__shape_diff_affordances_can_aggregate_affordances_for_array_item_diffs__shape_diff_affordances.snap
@@ -35,10 +35,11 @@ ShapeDiffAffordances {
         was_boolean: {},
         was_null: {},
         was_array: {},
+        was_empty_array: {},
         was_object: {},
         was_missing: {},
         was_string_trails: {
-            "test-interaction-0": [
+            "test-interaction-0": {
                 JsonTrail {
                     path: [
                         JsonObjectKey {
@@ -49,10 +50,10 @@ ShapeDiffAffordances {
                         },
                     ],
                 },
-            ],
+            },
         },
         was_number_trails: {
-            "test-interaction-0": [
+            "test-interaction-0": {
                 JsonTrail {
                     path: [
                         JsonObjectKey {
@@ -63,11 +64,12 @@ ShapeDiffAffordances {
                         },
                     ],
                 },
-            ],
+            },
         },
         was_boolean_trails: {},
         was_null_trails: {},
         was_array_trails: {},
+        was_empty_array_trails: {},
         was_object_trails: {},
         was_missing_trails: {},
     },

--- a/workspaces/diff-engine/tests/snapshots/shape_diff_use_cases__a_known_field_is_missing__affordances.snap
+++ b/workspaces/diff-engine/tests/snapshots/shape_diff_use_cases__a_known_field_is_missing__affordances.snap
@@ -31,6 +31,7 @@ expression: learned_shape_diff_affordances.into_iter()
                 was_boolean: {},
                 was_null: {},
                 was_array: {},
+                was_empty_array: {},
                 was_object: {},
                 was_missing: {
                     "test-interaction-1",
@@ -40,9 +41,10 @@ expression: learned_shape_diff_affordances.into_iter()
                 was_boolean_trails: {},
                 was_null_trails: {},
                 was_array_trails: {},
+                was_empty_array_trails: {},
                 was_object_trails: {},
                 was_missing_trails: {
-                    "test-interaction-1": [
+                    "test-interaction-1": {
                         JsonTrail {
                             path: [
                                 JsonObjectKey {
@@ -50,7 +52,7 @@ expression: learned_shape_diff_affordances.into_iter()
                                 },
                             ],
                         },
-                    ],
+                    },
                 },
             },
             root_trail: JsonTrail {

--- a/workspaces/ui-v2/src/lib/shape-diff-dsl-rust.ts
+++ b/workspaces/ui-v2/src/lib/shape-diff-dsl-rust.ts
@@ -15,6 +15,7 @@ import {
 } from '../../../cli-shared/build/diffs/initial-types';
 import invariant from 'invariant';
 import { namer } from './quick-namer';
+import { setDifference } from '<src>/lib/set-ops';
 
 export async function getExpectationsForShapeTrail(
   shapeTrail: IShapeTrail,
@@ -177,6 +178,7 @@ export class Actual {
       wasArray,
       wasObject,
       wasString,
+      wasEmptyArray,
       wasMissingTrails,
       wasNumberTrails,
       wasBooleanTrails,
@@ -221,13 +223,20 @@ export class Actual {
         interactions: wasNull,
         jsonTrailsByInteractions: wasNullTrails,
       });
-    if (wasArray.length)
+    if (wasArray.length || wasEmptyArray.length) {
+      const wasArraySet = new Set([...wasArray]);
+      const wasEmptyArraySet = new Set([...wasEmptyArray]);
+      const wasArrayWithItems = setDifference(wasArraySet, wasEmptyArraySet);
+
+      debugger;
       results.push({
         label: 'array',
         kind: ICoreShapeKinds.ListKind,
-        interactions: wasArray,
+        interactions:
+          wasArrayWithItems.size > 0 ? Array.from(wasArrayWithItems) : wasArray,
         jsonTrailsByInteractions: wasArrayTrails,
       });
+    }
     if (wasObject.length)
       results.push({
         label: 'object',


### PR DESCRIPTION
## Why
In the Diff Review UI we'll want to distinguish between examples that have just an empty array, or an array with actual values. While both make valid examples of an array, one with values takes preference over an empty one, as its more informative to the user. For the UI to be able to reason about this, the Shape Diff Affordances learner must tell it which interactions contains empty arrays.

## What
The result of the Shape Diff Affordance learner now has a `was_empty_array` and `was_empty_array_trails`, which are subsets of `was_array` and `was_array_trails` respectively. 

It also includes a bug fix where the `was_x_trails` would only ever include a single json trail per interaction pointer, which instantly stood out given the relation ship between arrays and empty arrays.

## Validation
* [ ] CI passes
* [x] `was_empty_array` and `was_empty_array_trails` are included in the ShapeDiffAffordance learner results
* [x] subset / superset relationship between arrays and empty arrays holds
