### PR TITLE
Handle no learning results from initial learn

### DIFF
--- a/workspaces/cli-server/src/routers/capture-router.ts
+++ b/workspaces/cli-server/src/routers/capture-router.ts
@@ -89,13 +89,15 @@ export function makeRouter(dependencies: ICaptureRouterDependencies) {
         method,
       });
 
-      console.time('learn ' + pathId + method);
+      console.time('scheduling ' + pathId + method);
       // TODO: pass results stream straight through instead of buffering into memory
-      const result = dependencies.fileReadBottleneck.schedule(() =>
-        initialBodyGenerator.run()
-      );
+      const result = dependencies.fileReadBottleneck.schedule(() => {
+        console.timeEnd('scheduling ' + pathId + method);
+        console.time('executing learning ' + pathId + method);
+        return initialBodyGenerator.run();
+      });
       result.then((learnedBodies: ILearnedBodies) => {
-        console.timeEnd('learn ' + pathId + method);
+        console.timeEnd('executing learning ' + pathId + method);
         res.json(learnedBodies);
       });
       result.catch((e) => {

--- a/workspaces/cli-shared/src/diffs/initial-bodies-worker-rust.ts
+++ b/workspaces/cli-shared/src/diffs/initial-bodies-worker-rust.ts
@@ -81,7 +81,13 @@ export class InitialBodiesWorkerRust {
       return result;
     }
 
-    throw new Error('expected to receive a learning result');
+    // If there are no learningResults, we should return empty requests / responses
+    return {
+      pathId: this.config.pathId,
+      method: this.config.method,
+      requests: [],
+      responses: [],
+    };
   }
 }
 

--- a/workspaces/spectacle-shared/src/local-cli/client.ts
+++ b/workspaces/spectacle-shared/src/local-cli/client.ts
@@ -114,9 +114,6 @@ export class LocalCliDiffService implements IOpticDiffService {
         diffId: this.dependencies.diffId,
       }
     );
-    if (Object.keys(result).length === 0) {
-      debugger;
-    }
     //@aidan fixme
     return result;
   }

--- a/workspaces/ui-v2/src/optic-components/hooks/diffs/LearnInitialBodiesMachine.ts
+++ b/workspaces/ui-v2/src/optic-components/hooks/diffs/LearnInitialBodiesMachine.ts
@@ -160,7 +160,10 @@ export function recomputeCommands(ctx: InitialBodiesContext): any[] {
       isIgnored(i, true)
     );
 
-    if (allRequestBodiesIgnored && ctx.learnedBodies.responses.length > 0) {
+    if (
+      (allRequestBodiesIgnored && ctx.learnedBodies.responses.length > 0) ||
+      ctx.learnedBodies.responses.length === 0
+    ) {
       commands.push(AddRequest(ctx.method, ctx.pathId, ids.newRequestId()));
     }
 

--- a/workspaces/ui-v2/src/optic-components/pages/diffs/EndpointDocumentationPane.tsx
+++ b/workspaces/ui-v2/src/optic-components/pages/diffs/EndpointDocumentationPane.tsx
@@ -38,7 +38,6 @@ export const EndpointDocumentationPane: FC<
 }) => {
   const { endpoints, loading } = useEndpoints();
   const bodies = useEndpointBody(pathId, method, lastBatchCommit);
-
   const thisEndpoint = endpoints.find(
     (i) => i.pathId === pathId && i.method === method
   );

--- a/workspaces/ui-v2/src/optic-components/pages/diffs/PendingEndpointPage.tsx
+++ b/workspaces/ui-v2/src/optic-components/pages/diffs/PendingEndpointPage.tsx
@@ -143,13 +143,16 @@ export function PendingEndpointPage(props: any) {
                 onKeyPress={onKeyPress}
               />
 
-              <Typography
-                component="div"
-                variant="subtitle2"
-                style={{ color: AddedDarkGreen, marginBottom: 8 }}
-              >
-                Document the bodies for this endpoint:
-              </Typography>
+              {requestCheckboxes.length > 0 ||
+              learnedBodies!.responses.length > 0 ? (
+                <Typography
+                  component="div"
+                  variant="subtitle2"
+                  style={{ color: AddedDarkGreen, marginBottom: 8 }}
+                >
+                  Document the bodies for this endpoint:
+                </Typography>
+              ) : null}
 
               <FormControl component="fieldset" onKeyPress={onKeyPress}>
                 {requestCheckboxes.map((i, index) => {
@@ -223,7 +226,6 @@ export function PendingEndpointPage(props: any) {
             previewCommands={newEndpointCommands}
           >
             <EndpointDocumentationPane
-              // lastBatchCommit={lastBatchId}
               method={stagedCommandsIds.method}
               pathId={stagedCommandsIds.pathId}
               renderHeader={() => (


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

If rust does not find any requests/responses for urls (i'm not sure how this actually happens) - the learn initial bodies worker errors out with a `500`: `expected to receive a learning result`

## What
What's changing? Anything of note to call out?

Updated this to not error and return an empty state + also handle this empty state in the UI

Example of what this would look like
<img width="1023" alt="Screen Shot 2021-05-13 at 11 21 22 AM" src="https://user-images.githubusercontent.com/18374483/118169151-78288d80-b3dd-11eb-99ed-f34060d5be7f.png">


## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
