### PR TITLE
correct api name now being used

### DIFF
--- a/workspaces/cli-server/src/spectacle/index.ts
+++ b/workspaces/cli-server/src/spectacle/index.ts
@@ -27,16 +27,12 @@ import {
 } from '@useoptic/spectacle/build/in-memory';
 import { getSpecEventsFrom } from '@useoptic/cli-config/build/helpers/read-specification-json';
 import {
-  IValueAffordanceSerializationWithCounterGroupedByDiffHash,
   ILearnedBodies,
+  IValueAffordanceSerializationWithCounterGroupedByDiffHash,
 } from '@useoptic/cli-shared/build/diffs/initial-types';
 import { InteractionDiffWorkerRust } from '@useoptic/cli-shared/build/diffs/interaction-diff-worker-rust';
-import { getPathsRelativeToCwd, IPathMapping } from '@useoptic/cli-config';
-import {
-  CapturesHelpers,
-  isValidCaptureState,
-  ValidCaptureState,
-} from '../routers/spec-router';
+import { IPathMapping, readApiConfig } from '@useoptic/cli-config';
+import { CapturesHelpers } from '../routers/spec-router';
 import { IgnoreFileHelper } from '@useoptic/cli-config/build/helpers/ignore-file-interface';
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -251,6 +247,11 @@ export class LocalCliConfigRepository implements IOpticConfigRepository {
   async listIgnoreRules(): Promise<string[]> {
     const rules = await this.ignoreFileHelper.getCurrentIgnoreRules();
     return rules.allRules;
+  }
+
+  async getApiName(): Promise<string> {
+    const apiConfig = await readApiConfig(this.dependencies.opticYmlPath);
+    return Promise.resolve(apiConfig.name);
   }
 }
 

--- a/workspaces/spectacle-shared/src/local-cli/client.ts
+++ b/workspaces/spectacle-shared/src/local-cli/client.ts
@@ -20,6 +20,7 @@ import {
   ILearnedBodies,
   IValueAffordanceSerializationWithCounterGroupedByDiffHash,
 } from '@useoptic/cli-shared/build/diffs/initial-types';
+import { IApiCliConfig } from '@useoptic/cli-config';
 
 export class LocalCliSpectacle implements IForkableSpectacle {
   constructor(private baseUrl: string, private opticEngine: IOpticEngine) {}
@@ -174,5 +175,13 @@ export class LocalCliConfigRepository implements IOpticConfigRepository {
 
   async listIgnoreRules(): Promise<string[]> {
     throw new Error('should never be called');
+  }
+
+  async getApiName(): Promise<string> {
+    const result = await JsonHttpClient.getJson(
+      `${this.dependencies.baseUrl}/config`
+    );
+    const config: IApiCliConfig = result.config;
+    return config.name;
   }
 }

--- a/workspaces/spectacle/src/index.ts
+++ b/workspaces/spectacle/src/index.ts
@@ -136,7 +136,7 @@ export interface IOpticDiffRepository {
 ////////////////////////////////////////////////////////////////////////////////
 export interface IOpticConfigRepository {
   addIgnoreRule(rule: string): Promise<void>;
-
+  getApiName(): Promise<string>;
   listIgnoreRules(): Promise<string[]>;
 }
 

--- a/workspaces/ui-v2/src/analytics/index.tsx
+++ b/workspaces/ui-v2/src/analytics/index.tsx
@@ -17,6 +17,7 @@ import { Client } from '@useoptic/cli-client';
 import * as Sentry from '@sentry/react';
 import * as FullStory from '@fullstory/browser';
 import { LogLevel } from '@sentry/types';
+import { useApiName } from '<src>/optic-components/hooks/useApiNameHook';
 
 const packageJson = require('../../package.json');
 const clientId = `local_cli_${packageJson.version}`;
@@ -50,6 +51,7 @@ export function useClientAgent() {
 
 export function AnalyticsStore({ children }: { children: ReactNode }) {
   const appConfig = useAppConfig();
+  const apiName = useApiName();
   //@ts-ignore
   const analytics = useRef(new Analytics());
   const clientAgent = useClientAgent();
@@ -96,7 +98,7 @@ export function AnalyticsStore({ children }: { children: ReactNode }) {
       if (appConfig.analytics.enabled) {
         if (analytics.current) {
           analytics.current.track(event.name, {
-            properties: { ...event.properties, clientId },
+            properties: { ...event.properties, clientId, apiName },
           });
           try {
             FullStory.event(event.name, event.properties);

--- a/workspaces/ui-v2/src/optic-components/hooks/useApiNameHook.ts
+++ b/workspaces/ui-v2/src/optic-components/hooks/useApiNameHook.ts
@@ -1,3 +1,16 @@
+import { useConfigRepository } from '<src>/optic-components/hooks/useConfigHook';
+import { useEffect, useState } from 'react';
+
 export function useApiName() {
-  return 'optic-api';
+  const { config } = useConfigRepository();
+  const [name, setName] = useState('');
+  useEffect(() => {
+    async function task() {
+      if (!name) {
+        setName(await config.getApiName());
+      }
+    }
+    task();
+  }, [config, name, setName]);
+  return name;
 }

--- a/workspaces/ui-v2/src/spectacle-implementations/cloud-viewer.tsx
+++ b/workspaces/ui-v2/src/spectacle-implementations/cloud-viewer.tsx
@@ -101,13 +101,13 @@ export default function CloudViewer() {
   //@SYNC public-examples.tsx cloud-viewer.tsx local-cli.tsx
   return (
     <AppConfigurationStore config={appConfig}>
-      <AnalyticsStore>
-        <SpectacleStore spectacle={data}>
-          <ConfigRepositoryStore config={data.opticContext.configRepository}>
-            <CapturesServiceStore
-              capturesService={data.opticContext.capturesService}
-            >
-              <BaseUrlProvider value={{ url: match.url }}>
+      <SpectacleStore spectacle={data}>
+        <ConfigRepositoryStore config={data.opticContext.configRepository}>
+          <CapturesServiceStore
+            capturesService={data.opticContext.capturesService}
+          >
+            <BaseUrlProvider value={{ url: match.url }}>
+              <AnalyticsStore>
                 <Switch>
                   <>
                     <DiffReviewEnvironments />
@@ -115,11 +115,11 @@ export default function CloudViewer() {
                     <ChangelogPages />
                   </>
                 </Switch>
-              </BaseUrlProvider>
-            </CapturesServiceStore>
-          </ConfigRepositoryStore>
-        </SpectacleStore>
-      </AnalyticsStore>
+              </AnalyticsStore>
+            </BaseUrlProvider>
+          </CapturesServiceStore>
+        </ConfigRepositoryStore>
+      </SpectacleStore>
     </AppConfigurationStore>
   );
 }

--- a/workspaces/ui-v2/src/spectacle-implementations/local-cli.tsx
+++ b/workspaces/ui-v2/src/spectacle-implementations/local-cli.tsx
@@ -58,11 +58,11 @@ export default function LocalCli() {
 
   return (
     <AppConfigurationStore config={appConfig}>
-      <AnalyticsStore>
-        <SpectacleStore spectacle={data.spectacle}>
-          <ConfigRepositoryStore config={data.configRepository}>
-            <CapturesServiceStore capturesService={data.capturesService}>
-              <BaseUrlProvider value={{ url: match.url }}>
+      <SpectacleStore spectacle={data.spectacle}>
+        <ConfigRepositoryStore config={data.configRepository}>
+          <CapturesServiceStore capturesService={data.capturesService}>
+            <BaseUrlProvider value={{ url: match.url }}>
+              <AnalyticsStore>
                 <Switch>
                   <>
                     <DocumentationPages />
@@ -70,11 +70,11 @@ export default function LocalCli() {
                     <ChangelogPages />
                   </>
                 </Switch>
-              </BaseUrlProvider>
-            </CapturesServiceStore>
-          </ConfigRepositoryStore>
-        </SpectacleStore>
-      </AnalyticsStore>
+              </AnalyticsStore>
+            </BaseUrlProvider>
+          </CapturesServiceStore>
+        </ConfigRepositoryStore>
+      </SpectacleStore>
     </AppConfigurationStore>
   );
 }

--- a/workspaces/ui-v2/src/spectacle-implementations/public-examples.tsx
+++ b/workspaces/ui-v2/src/spectacle-implementations/public-examples.tsx
@@ -59,6 +59,7 @@ export default function PublicExamples(props: { lookupDir: string }) {
     return {
       events: example.events,
       samples: example.session.samples,
+      apiName: exampleId,
     };
   }, [exampleId, props.lookupDir]);
 
@@ -76,13 +77,13 @@ export default function PublicExamples(props: { lookupDir: string }) {
   //@SYNC public-examples.tsx cloud-viewer.tsx local-cli.tsx
   return (
     <AppConfigurationStore config={appConfig}>
-      <AnalyticsStore>
-        <SpectacleStore spectacle={data}>
-          <ConfigRepositoryStore config={data.opticContext.configRepository}>
-            <CapturesServiceStore
-              capturesService={data.opticContext.capturesService}
-            >
-              <BaseUrlProvider value={{ url: match.url }}>
+      <SpectacleStore spectacle={data}>
+        <ConfigRepositoryStore config={data.opticContext.configRepository}>
+          <CapturesServiceStore
+            capturesService={data.opticContext.capturesService}
+          >
+            <BaseUrlProvider value={{ url: match.url }}>
+              <AnalyticsStore>
                 <Switch>
                   <>
                     <DocumentationPages />
@@ -90,11 +91,11 @@ export default function PublicExamples(props: { lookupDir: string }) {
                     <ChangelogPages />
                   </>
                 </Switch>
-              </BaseUrlProvider>
-            </CapturesServiceStore>
-          </ConfigRepositoryStore>
-        </SpectacleStore>
-      </AnalyticsStore>
+              </AnalyticsStore>
+            </BaseUrlProvider>
+          </CapturesServiceStore>
+        </ConfigRepositoryStore>
+      </SpectacleStore>
     </AppConfigurationStore>
   );
 }
@@ -102,6 +103,7 @@ export default function PublicExamples(props: { lookupDir: string }) {
 export interface InMemorySpectacleDependencies {
   events: any[];
   samples: any[];
+  apiName: string;
 }
 
 export type InMemorySpectacleDependenciesLoader = () => Promise<InMemorySpectacleDependencies>;
@@ -115,6 +117,7 @@ export function useInMemorySpectacle(
   const [inputs, setInputs] = useState<{
     events: any[];
     samples: any[];
+    apiName: string;
   } | null>(null);
 
   useEffect(() => {
@@ -123,6 +126,7 @@ export function useInMemorySpectacle(
       setInputs({
         events: result.events,
         samples: result.samples,
+        apiName: result.apiName,
       });
     }
 
@@ -138,7 +142,8 @@ export function useInMemorySpectacle(
         opticEngine,
         inputs.events,
         inputs.samples,
-        'example-session'
+        'example-session',
+        { name: inputs.apiName, tasks: {} }
       );
       const inMemorySpectacle = new InMemorySpectacle(
         opticContext,
@@ -148,7 +153,11 @@ export function useInMemorySpectacle(
         'change',
         async () => {
           const newEvents = await inMemorySpectacle.opticContext.specRepository.listEvents();
-          setInputs({ events: newEvents, samples: inputs.samples });
+          setInputs({
+            events: newEvents,
+            samples: inputs.samples,
+            apiName: inputs.apiName,
+          });
         }
       );
       console.count('setSpectacle');


### PR DESCRIPTION
## Why
The API Name from one's optic.yml wasn't showing up in the UI or in analytics. 

## What
Added a query to get the name from the configRepository

## Validation
* [x] CI passes
* [x] Verified in staging