### PR TITLE
Fix bug where shape diff affordances were aggregated for each instance, nstead of only the unique diffs

### DIFF
--- a/workspaces/diff-engine/src/projections/learners/shape_diff_affordances.rs
+++ b/workspaces/diff-engine/src/projections/learners/shape_diff_affordances.rs
@@ -88,8 +88,13 @@ impl LearnedShapeDiffAffordancesProjection {
 // allows iterator.collect() right into this projection
 impl FromIterator<InteractionDiffResult> for LearnedShapeDiffAffordancesProjection {
   fn from_iter<I: IntoIterator<Item = InteractionDiffResult>>(diff_results: I) -> Self {
+    let unique_diffs: HashMap<String, _> = diff_results
+      .into_iter()
+      .map(|diff_result| (diff_result.fingerprint(), diff_result))
+      .collect();
+
     let mut diffs_by_spec_id = HashMap::new();
-    for diff_result in diff_results {
+    for (fingerprint, diff_result) in unique_diffs {
       let spec_id = match &diff_result {
         InteractionDiffResult::UnmatchedRequestBodyShape(diff) => diff
           .requests_trail

--- a/workspaces/diff-engine/support/debug-capture-to-jsonl.js
+++ b/workspaces/diff-engine/support/debug-capture-to-jsonl.js
@@ -59,6 +59,10 @@ async function run(flags) {
     ? fs.createReadStream(inputFilePath)
     : process.stdin;
 
+  if (!inputFilePath) {
+    console.error('accepting debug capture over stdin');
+  }
+
   let processors = [];
 
   if (flags.events) {


### PR DESCRIPTION
## Why
While testing against a big debug capture with 50 mb of interactions, a 5mb spec and ~280 unique diffs, the shape diff affordances learner took more than 2 hours to complete. While there's a good amount of compute going on, that is excessive, with the diffs computing in around 25 seconds and being of a similar nature in many ways.

Instrumentation revealed that instead of applying the analysis result of each individual interaction per unique diff, it was being applied to as much as the total ~52,000 instances of the diffs. We saw cases where instead of applying the 500 observations from a single interaction to 20 diffs, it was applied to 32000 of them.

## What
We normalize the diffs upon ingestion per their fingerprint, keeping only 280 of them in memory, preventing all the unnecessary additional computation. This gets compute back into the ball-park, with the above example finishing in roughly 30 seconds.

## Validation
* [ ] CI passes
* [x] Compute time of shape diff affordances of same order of magnitude as compute of diffs. 
