### PR TITLE
fix path grouping on documentation page

### DIFF
--- a/workspaces/ui-v2/src/optic-components/hooks/useEndpointsHook.ts
+++ b/workspaces/ui-v2/src/optic-components/hooks/useEndpointsHook.ts
@@ -63,7 +63,7 @@ export function endpointQueryResultsToJson(
   endpointsChangelog: any[] = []
 ): IEndpoint[] {
   const commonStart = sharedStart(
-    data.requests.map((req: any) => req.absolutePathPattern)
+    data.requests.map((req: any) => req.absolutePathPatternWithParameterNames)
   );
 
   const endpoints = data.requests.map(


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

If there is a single endpoint, that has path parameters, the endpoint doesn't match. E.g.

`/api/todos/{todoId}` -> does not match without the `todoId` - `absolutePathPattern` does not include the namedPath.

Updating this to include this

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
