### PR TITLE
Removed OPTIC_UI_HOST env var

### DIFF
--- a/sourceme.sh
+++ b/sourceme.sh
@@ -4,7 +4,7 @@ export OPTIC_SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && p
 echo "Optic development scripts will run from $OPTIC_SRC_DIR"
 export OPTIC_DEBUG_ENV_FILE="$OPTIC_SRC_DIR/.env"
 
-alias apidev="OPTIC_DAEMON_ENABLE_DEBUGGING=yes OPTIC_DEVELOPMENT=yes OPTIC_UI_HOST=http://localhost:3000 OPTIC_AUTH_UI_HOST=http://localhost:4005 $OPTIC_SRC_DIR/workspaces/local-cli/bin/run"
+alias apidev="OPTIC_DAEMON_ENABLE_DEBUGGING=yes OPTIC_DEVELOPMENT=yes OPTIC_AUTH_UI_HOST=http://localhost:4005 $OPTIC_SRC_DIR/workspaces/local-cli/bin/run"
 alias apistage="OPTIC_DAEMON_ENABLE_DEBUGGING=yes $OPTIC_SRC_DIR/workspaces/local-cli/bin/run"
 
 otask() {

--- a/workspaces/cli-shared/src/index.ts
+++ b/workspaces/cli-shared/src/index.ts
@@ -55,9 +55,6 @@ export interface ICliDaemonState {
 }
 
 export function makeUiBaseUrl(daemonState: ICliDaemonState) {
-  if (process.env.OPTIC_UI_HOST) {
-    return process.env.OPTIC_UI_HOST;
-  }
   return `http://localhost:${daemonState.port}`;
 }
 


### PR DESCRIPTION
Hi, and thank you for developing such a nice tool.
I want to get involved a bit, so I'm running `develop` branch on one of my projects

## Why
I noticed wrong UI URL when I start my project, and I'm suspecting this was left out when you migrated to `ui-v2`.
Feel free to close this PR if you think this is not the right way to fix it, or let me know if you want me to update it.

## What
Just a dev command fix and cleanup

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
