### PR TITLE
Stop cli-server on exit

### DIFF
--- a/workspaces/local-cli/src/shared/local-cli-task-runner.ts
+++ b/workspaces/local-cli/src/shared/local-cli-task-runner.ts
@@ -1,5 +1,5 @@
 import { Command, flags } from '@oclif/command';
-import { ensureDaemonStarted } from '@useoptic/cli-server';
+import { ensureDaemonStarted, ensureDaemonStopped } from '@useoptic/cli-server';
 import path from 'path';
 import colors from 'colors';
 import {
@@ -168,6 +168,8 @@ export async function LocalTaskSessionWrapper(
   if (runner.foundDiff && flags['exit-on-diff']) {
     return await cleanupAndExit(1);
   }
+
+  await ensureDaemonStopped(lockFilePath);
 
   return await cleanupAndExit(
     flags['pass-exit-code'] !== false ? runner.exitWithCode : 0


### PR DESCRIPTION
## Why
I noticed that cli-server is not being stopped on `api` process exit, and I guess that's not intentional.

## What
Just a bug fix, I hope.

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
