### PR TITLE
Diff page improvements

### DIFF
--- a/workspaces/ui-v2/src/optic-components/diffs/contexts/CaptureSelectDropdown.tsx
+++ b/workspaces/ui-v2/src/optic-components/diffs/contexts/CaptureSelectDropdown.tsx
@@ -81,6 +81,7 @@ export function CaptureSelectDropdown(props: any) {
                 diffEnvironmentsRoot.linkTo('local', capture.captureId) +
                   '/review'
               );
+              handleClose();
             }}
           >
             <CaptureMenuItem capture={capture} />

--- a/workspaces/ui-v2/src/optic-components/hooks/diffs/SharedDiffContext.tsx
+++ b/workspaces/ui-v2/src/optic-components/hooks/diffs/SharedDiffContext.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext, useMemo, useState } from 'react';
+import React, { FC, useContext, useEffect, useMemo, useState } from 'react';
 import {
   IPendingEndpoint,
   IUndocumentedUrl,
@@ -116,6 +116,20 @@ export const SharedDiffStore: FC<SharedDiffStoreProps> = (props) => {
       config
     )
   );
+
+  useEffect(() => {
+    send({ type: 'RESET' });
+    send({
+      type: 'REFRESH',
+      currentSpecContext: currentSpecContext,
+      parsedDiffs: props.diffs,
+      undocumentedUrls: props.urls,
+      trailValues: props.diffTrails,
+    });
+    // TODO: currentSpecContext dependency is ignored for now.
+    // this could lead to some bugs in future, so we should wrap it in useMemo
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.diffTrails, props.diffs, props.urls, send]);
 
   const context: SharedDiffStateContext = state.context;
 

--- a/workspaces/ui-v2/src/optic-components/hooks/diffs/SharedDiffContext.tsx
+++ b/workspaces/ui-v2/src/optic-components/hooks/diffs/SharedDiffContext.tsx
@@ -96,15 +96,24 @@ export const SharedDiffStore: FC<SharedDiffStoreProps> = (props) => {
 
   const { config } = useConfigRepository();
 
-  const currentSpecContext: CurrentSpecContext = {
-    currentSpecPaths: props.allPaths,
-    currentSpecEndpoints: props.endpoints,
-    currentSpecRequests: props.requests,
-    currentSpecResponses: props.responses,
-    domainIds: newRandomIdGenerator(),
-    idGeneratorStrategy: 'random',
-    opticEngine,
-  };
+  const currentSpecContext: CurrentSpecContext = useMemo(
+    () => ({
+      currentSpecPaths: props.allPaths,
+      currentSpecEndpoints: props.endpoints,
+      currentSpecRequests: props.requests,
+      currentSpecResponses: props.responses,
+      domainIds: newRandomIdGenerator(),
+      idGeneratorStrategy: 'random',
+      opticEngine,
+    }),
+    [
+      opticEngine,
+      props.allPaths,
+      props.endpoints,
+      props.requests,
+      props.responses,
+    ]
+  );
 
   const [state, send]: any = useMachine(() =>
     newSharedDiffMachine(
@@ -126,10 +135,7 @@ export const SharedDiffStore: FC<SharedDiffStoreProps> = (props) => {
       undocumentedUrls: props.urls,
       trailValues: props.diffTrails,
     });
-    // TODO: currentSpecContext dependency is ignored for now.
-    // this could lead to some bugs in future, so we should wrap it in useMemo
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.diffTrails, props.diffs, props.urls, send]);
+  }, [currentSpecContext, props.diffTrails, props.diffs, props.urls, send]);
 
   const context: SharedDiffStateContext = state.context;
 

--- a/workspaces/ui-v2/src/optic-components/pages/diffs/CapturePage.tsx
+++ b/workspaces/ui-v2/src/optic-components/pages/diffs/CapturePage.tsx
@@ -16,6 +16,7 @@ import {
 } from '@material-ui/core';
 import { AddedDarkGreen, OpticBlue, OpticBlueReadable } from '../../theme';
 import { CaptureSelectDropdown } from '../../diffs/contexts/CaptureSelectDropdown';
+import { LoadingDiffReview } from '../../diffs/LoadingDiffReview';
 import { useSharedDiffContext } from '../../hooks/diffs/SharedDiffContext';
 import {
   useDiffEnvironmentsRoot,
@@ -34,13 +35,11 @@ export function CapturePage(props: { showDiff?: boolean }) {
 
   const noCaptures =
     !capturesState.loading && capturesState.captures.length === 0;
+  const shouldRedirect =
+    !capturesState.loading && !props.showDiff && !!capturesState.captures[0];
 
   useEffect(() => {
-    if (
-      !capturesState.loading &&
-      !props.showDiff &&
-      capturesState.captures[0]
-    ) {
+    if (shouldRedirect) {
       history.push(
         diffEnvironmentsRoot.linkTo(
           'local',
@@ -48,7 +47,15 @@ export function CapturePage(props: { showDiff?: boolean }) {
         )
       );
     }
-  }, [capturesState, history, diffEnvironmentsRoot, props.showDiff]);
+  }, [history, diffEnvironmentsRoot, shouldRedirect, capturesState.captures]);
+
+  if (capturesState.loading) {
+    return <LoadingDiffReview />;
+  }
+
+  if (shouldRedirect) {
+    return null;
+  }
 
   return (
     <CenteredColumn maxWidth="md" style={{ paddingTop: 50, paddingBottom: 50 }}>

--- a/workspaces/ui-v2/src/optic-components/pages/diffs/CapturePage.tsx
+++ b/workspaces/ui-v2/src/optic-components/pages/diffs/CapturePage.tsx
@@ -129,6 +129,10 @@ export function CapturePage(props: { showDiff?: boolean }) {
   );
 }
 
+export const CapturePageWithDiff = (props: any) => (
+  <CapturePage {...props} showDiff={true} />
+);
+
 function DiffCaptureResults() {
   const classes = useStyles();
   const {

--- a/workspaces/ui-v2/src/optic-components/pages/diffs/ReviewDiffPages.tsx
+++ b/workspaces/ui-v2/src/optic-components/pages/diffs/ReviewDiffPages.tsx
@@ -46,9 +46,6 @@ export function DiffReviewPages(props: any) {
     allPaths.loading ||
     allRequestsAndResponsesOfBaseSpec.loading;
 
-  // TODO: we have a problem here because isLoading is false on mount,
-  // then true on next render and after that it becomes false upon loadin
-  // this results in a page content flash before it starts loading data
   if (isLoading) {
     return (
       <LoadingPage>

--- a/workspaces/ui-v2/src/optic-components/pages/diffs/ReviewDiffPages.tsx
+++ b/workspaces/ui-v2/src/optic-components/pages/diffs/ReviewDiffPages.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useState } from 'react';
+import { useMemo } from 'react';
 import { NavigationRoute } from '../../navigation/NavigationRoute';
 import {
   useDiffEnvironmentsRoot,
@@ -19,7 +19,7 @@ import { useDiffsForCapture } from '../../hooks/useDiffForCapture';
 import { v4 as uuidv4 } from 'uuid';
 import { useAllRequestsAndResponses } from '../../hooks/diffs/useAllRequestsAndResponses';
 import { useEndpoints } from '../../hooks/useEndpointsHook';
-import { CapturePage } from './CapturePage';
+import { CapturePage, CapturePageWithDiff } from './CapturePage';
 import { LoadingPage } from '../../loaders/Loading';
 import { LoadingDiffReview } from '../../diffs/LoadingDiffReview';
 import { usePaths } from '<src>/optic-components/hooks/usePathsHook';
@@ -27,7 +27,7 @@ import { usePaths } from '<src>/optic-components/hooks/usePathsHook';
 export function DiffReviewPages(props: any) {
   const { match } = props;
   const { boundaryId } = match.params;
-  const [diffId] = useState(uuidv4());
+  const diffId = useMemo(() => uuidv4(), []);
 
   //dependencies
   const diff = useDiffsForCapture(boundaryId, diffId);
@@ -46,6 +46,9 @@ export function DiffReviewPages(props: any) {
     allPaths.loading ||
     allRequestsAndResponsesOfBaseSpec.loading;
 
+  // TODO: we have a problem here because isLoading is false on mount,
+  // then true on next render and after that it becomes false upon loadin
+  // this results in a page content flash before it starts loading data
   if (isLoading) {
     return (
       <LoadingPage>
@@ -68,7 +71,7 @@ export function DiffReviewPages(props: any) {
     >
       <NavigationRoute
         path={diffReviewCapturePageLink.path}
-        Component={() => <CapturePage showDiff={true} />}
+        Component={CapturePageWithDiff}
         AccessoryNavigation={() => <DiffAccessoryNavigation />}
       />
       <NavigationRoute

--- a/workspaces/ui-v2/src/spectacle-implementations/local-cli.tsx
+++ b/workspaces/ui-v2/src/spectacle-implementations/local-cli.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useMemo } from 'react';
 import { useRouteMatch, useParams, Switch } from 'react-router-dom';
 import { AsyncStatus } from '<src>/types';
 import { Provider as BaseUrlProvider } from '<src>/optic-components/hooks/useBaseUrl';
@@ -84,11 +85,18 @@ export function useLocalCliServices(
 ): AsyncStatus<LocalCliServices> {
   const opticEngine = useOpticEngine();
   const apiBaseUrl = `/api/specs/${specId}`;
-  const spectacle = new LocalCliSpectacle(apiBaseUrl, opticEngine);
-  const capturesService = new LocalCliCapturesService({
-    baseUrl: apiBaseUrl,
-    spectacle,
-  });
+  const spectacle = useMemo(
+    () => new LocalCliSpectacle(apiBaseUrl, opticEngine),
+    [apiBaseUrl, opticEngine]
+  );
+  const capturesService = React.useMemo(
+    () =>
+      new LocalCliCapturesService({
+        baseUrl: apiBaseUrl,
+        spectacle,
+      }),
+    [apiBaseUrl, spectacle]
+  );
   const configRepository = new LocalCliConfigRepository({
     baseUrl: apiBaseUrl,
     spectacle,


### PR DESCRIPTION
## Why
* Capture dropdown was not working (diffs below it were not being updated on change). That's fixed here
* Nervous dropdown button fix. Please check the video to see how it works without this change (CPU was throttled on the video to 6x to make it a bit slower and easier to spot)
* Rendering performance improvements. There were a lot of excess re-renders, and unmounts (that's why the dropdown button was so nervous). See the screenshots attached (Chrome exports are a bit big, but I can attach them too if you need them)


https://user-images.githubusercontent.com/1783133/118403815-3b0f0600-b63e-11eb-9eb5-7be18793cbae.mp4

--
--

### Changing capture from the dropdown, and going back to the previous value
#### Before
![optic-capture-change-develop](https://user-images.githubusercontent.com/1783133/118403966-ef109100-b63e-11eb-8e16-fdd617ca32d1.png)

#### After
![optic-capture-change-fix](https://user-images.githubusercontent.com/1783133/118403979-00599d80-b63f-11eb-9abf-d09b9dc605f6.png)


## What
Just some bug fixes for Diff page, and performance improvements

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
