### PR TITLE
Fix bug where commands empty list is generated when array was only observed empty once

### DIFF
--- a/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_can_generate_commands_for_array_bodies__empty_and_primitive_array_results.snap
+++ b/workspaces/diff-engine/src/learn_shape/snapshots/optic_diff_engine__learn_shape__result__test__trail_observations_can_generate_commands_for_array_bodies__empty_and_primitive_array_results.snap
@@ -1,0 +1,46 @@
+---
+source: workspaces/diff-engine/src/learn_shape/result.rs
+expression: "&empty_and_primitive_array_results"
+---
+(
+    Some(
+        "test-id-11",
+    ),
+    [
+        ShapeCommand(
+            AddShape(
+                AddShape {
+                    shape_id: "test-id-10",
+                    base_shape_id: "$string",
+                    name: "",
+                },
+            ),
+        ),
+        ShapeCommand(
+            AddShape(
+                AddShape {
+                    shape_id: "test-id-11",
+                    base_shape_id: "$list",
+                    name: "",
+                },
+            ),
+        ),
+        ShapeCommand(
+            SetParameterShape(
+                SetParameterShape {
+                    shape_descriptor: ProviderInShape(
+                        ProviderInShape {
+                            shape_id: "test-id-11",
+                            provider_descriptor: ShapeProvider(
+                                ShapeProvider {
+                                    shape_id: "test-id-10",
+                                },
+                            ),
+                            consuming_parameter_id: "$listItem",
+                        },
+                    ),
+                },
+            ),
+        ),
+    ],
+)

--- a/workspaces/ui-v2/src/lib/shape-diff-dsl-rust.ts
+++ b/workspaces/ui-v2/src/lib/shape-diff-dsl-rust.ts
@@ -233,7 +233,6 @@ export class Actual {
       const wasEmptyArraySet = new Set([...wasEmptyArray]);
       const wasArrayWithItems = setDifference(wasArraySet, wasEmptyArraySet);
 
-      debugger;
       results.push({
         label: 'list',
         kind: ICoreShapeKinds.ListKind,


### PR DESCRIPTION
## Why
In QA we've found an issue where the commands for an empty list is generated from the observation of a single empty array, even if there's also examples where the array _did_ have a clear type. This affects the `specification.json` and how array-item types are inferred.

## What
Commands for a list of unknowns are only generated where no more concrete item types were observed. As soon as there are any, it's no longer unknown.

## Validation
* [x] CI passes
* [x] No longer generates unnecessary shape commands for an list of unknowns
* [x] /objects-with-polymorphism 1/6 updated example spec contains an array of numbers
