### PR TITLE
refactor: `ci` flag always implies coverage, exit code

### DIFF
--- a/workspaces/local-cli/src/shared/local-cli-task-runner.ts
+++ b/workspaces/local-cli/src/shared/local-cli-task-runner.ts
@@ -107,10 +107,9 @@ export async function LocalTaskSessionWrapper(
   deprecationLogger.enabled = true;
 
   if (flags['ci']) {
-    // Change the defaults to true. You can still manually turn them off.
-    flags['print-coverage'] ??= true;
-    flags['pass-exit-code'] ??= true;
-    flags['collect-diffs'] ??= true;
+    flags['print-coverage'] = true;
+    flags['pass-exit-code'] = true;
+    flags['collect-diffs'] = true;
   }
 
   const usesTaskSpecificBoundary = flags['ci'] || flags['exit-on-diff'];


### PR DESCRIPTION
I had wanted to allow explicitly disabling these features (`print-coverage`, `pass-exit-code`, etc). But since they have defaults specified, there's no way to know whether they were explicitly set to false, or defaulted to false as a result of not being set (and so they weren't getting the `true` default here).

Instead, let's just have `--ci` imply them. Is this a bad idea?