### PR TITLE
shapehash: Handle '{}' without crashing

### DIFF
--- a/workspaces/shape-hash/src/json-to-shape-hash.ts
+++ b/workspaces/shape-hash/src/json-to-shape-hash.ts
@@ -75,11 +75,12 @@ export function toJsonExample(hash: string): any {
 function toJson(item: any) {
   switch (item.type) {
     case types.OBJECT:
-      const newObj = {};
-      item.fields.forEach(({ key, hash }: any) => {
-        //@ts-ignore
-        newObj[key] = toJson(hash);
-      });
+      const newObj: Record<string, any> = {};
+      if (item.hasOwnProperty('fields')) { 
+        item.fields.forEach(({ key, hash }: any) => {
+          newObj[key] = toJson(hash);
+        });
+      }
       return newObj;
     case types.ARRAY:
       return [...item.items.map(toJson)];

--- a/workspaces/shape-hash/src/test/__snapshots__/shape-hash.test.ts.snap
+++ b/workspaces/shape-hash/src/test/__snapshots__/shape-hash.test.ts.snap
@@ -399,6 +399,16 @@ Object {
 
 exports[`can shape hash a json object 2`] = `"CAAS8AEKCGdsb3NzYXJ5EuMBCAASCwoFdGl0bGUSAggCEtEBCghHbG9zc0RpdhLEAQgAEgsKBXRpdGxlEgIIAhKyAQoJR2xvc3NMaXN0EqQBCAASnwEKCkdsb3NzRW50cnkSkAEIABIICgJJRBICCAUSDAoGU29ydEFzEgIIAhIPCglHbG9zc1Rlcm0SAggCEg0KB0Fjcm9ueW0SAggCEgwKBkFiYnJldhICCAISNgoIR2xvc3NEZWYSKggAEgoKBHBhcmESAggCEhoKDEdsb3NzU2VlQWxzbxIKCAEaAggCGgIIAhIOCghHbG9zc1NlZRICCAI="`;
 
+exports[`correctly encode "{}" 1`] = `
+Object {
+  "data": Array [
+    8,
+    0,
+  ],
+  "type": "Buffer",
+}
+`;
+
 exports[`shape hashes of string are secure 1`] = `
 Object {
   "data": Array [

--- a/workspaces/shape-hash/src/test/shape-hash.test.ts
+++ b/workspaces/shape-hash/src/test/shape-hash.test.ts
@@ -42,3 +42,7 @@ test('can create a sanitized example from the hash', async () => {
 test('shape hashes of string are secure', async () => {
   expect(toBytes('123,456,789')).toMatchSnapshot();
 });
+
+test('correctly encode "{}"', async () => {
+  expect(toBytes({})).toMatchSnapshot();
+});


### PR DESCRIPTION
## Why
toJson iterated over `item.fields` but this is empty when a JSON object is empty. The result was a crash while iterating on `undefined`.

## What
We now only iterate if the `.fields` is valid.

## Validation
`yarn ws:test` passes the new test without crashing