### PR TITLE
Add loading state to pending endpoints

### DIFF
--- a/workspaces/ui-v2/src/optic-components/diffs/contexts/SimulatedCommandContext.tsx
+++ b/workspaces/ui-v2/src/optic-components/diffs/contexts/SimulatedCommandContext.tsx
@@ -3,6 +3,8 @@ import { IForkableSpectacle } from '@useoptic/spectacle';
 import { SpectacleStore } from '<src>/spectacle-implementations/spectacle-provider';
 import { v4 as uuidv4 } from 'uuid';
 import { useSessionId } from '<src>/optic-components/hooks/useSessionId';
+import { Loading } from '<src>/optic-components/loaders/Loading';
+
 type SimulatedCommandStoreProps = {
   spectacle: IForkableSpectacle;
   previewCommands: any[];
@@ -56,7 +58,7 @@ mutation X($commands: [JSON], $batchCommitId: ID, $commitMessage: String, $clien
   }, [JSON.stringify(props.previewCommands)]);
 
   if (isProcessing) {
-    return <div>working...</div>;
+    return <Loading />;
   }
 
   const spectacleToUse = simulated ? simulated : props.spectacle;

--- a/workspaces/ui-v2/src/optic-components/pages/diffs/PendingEndpointPage.tsx
+++ b/workspaces/ui-v2/src/optic-components/pages/diffs/PendingEndpointPage.tsx
@@ -10,6 +10,7 @@ import { Redirect, useHistory } from 'react-router-dom';
 import { Box, Button, Divider, TextField, Typography } from '@material-ui/core';
 import { EndpointName } from '../../common';
 import { Loader } from '../../loaders/FullPageLoader';
+import { Loading } from '<src>/optic-components/loaders/Loading';
 import FormControl from '@material-ui/core/FormControl';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
@@ -225,15 +226,19 @@ export function PendingEndpointPage(props: any) {
             spectacle={spectacle as IForkableSpectacle}
             previewCommands={newEndpointCommands}
           >
-            <EndpointDocumentationPane
-              method={stagedCommandsIds.method}
-              pathId={stagedCommandsIds.pathId}
-              renderHeader={() => (
-                <Typography className={classes.nameDisplay}>
-                  {name === '' ? 'Unnamed Endpoint' : name}
-                </Typography>
-              )}
-            />
+            {isLoading ? (
+              <Loading />
+            ) : (
+              <EndpointDocumentationPane
+                method={stagedCommandsIds.method}
+                pathId={stagedCommandsIds.pathId}
+                renderHeader={() => (
+                  <Typography className={classes.nameDisplay}>
+                    {name === '' ? 'Unnamed Endpoint' : name}
+                  </Typography>
+                )}
+              />
+            )}
           </SimulatedCommandStore>
         </>
       }


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

On the pending endpoints viewer - we want to ensure we've learnt the correct body before we mount the endpoint doc viewer (since before then, we have no endpoint that's learnt in simulated commands)

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
