### PR TITLE
fix invalid command to change root shape

### DIFF
--- a/workspaces/spectacle/src/commands.ts
+++ b/workspaces/spectacle/src/commands.ts
@@ -144,11 +144,9 @@ export function ShapedBodyDescriptor(
   isRemoved: boolean = false
 ) {
   return {
-    ShapedBodyDescriptor: {
-      httpContentType,
-      shapeId,
-      isRemoved,
-    },
+    httpContentType,
+    shapeId,
+    isRemoved,
   };
 }
 export function SetResponseBodyShape(responseId: string, bodyDescriptor: any) {

--- a/workspaces/ui-v2/src/lib/__tests/diff-helpers/__snapshots__/shape-interpretations.test.ts.snap
+++ b/workspaces/ui-v2/src/lib/__tests/diff-helpers/__snapshots__/shape-interpretations.test.ts.snap
@@ -6376,11 +6376,9 @@ Object {
     Object {
       "SetResponseBodyShape": Object {
         "bodyDescriptor": Object {
-          "ShapedBodyDescriptor": Object {
-            "httpContentType": "application/json",
-            "isRemoved": false,
-            "shapeId": "shape_0",
-          },
+          "httpContentType": "application/json",
+          "isRemoved": false,
+          "shapeId": "shape_0",
         },
         "responseId": "response_1",
       },


### PR DESCRIPTION
## Why
A bug when changing the root shape of an object was found

## What
The command was invalid, causing the Rust engine to get confused. 

## Validation
* [ ] CI passes
* [ ] Verified in staging
