### PR TITLE
Add Spectacle documentation

### DIFF
--- a/website/docs/apiops/scripts.mdx
+++ b/website/docs/apiops/scripts.mdx
@@ -29,7 +29,9 @@ A script is invoked by name with `api scripts <name>`. Once invoked, it:
 - [optional] checks for any defined dependencies in `dependsOn`.
 - [optional] If defined dependencies are not present and an `install` parameter is supplied, the installation command is run. In this example, `install` is not defined as there are no dependencies defined.
 - generates OAS files in both YAML and JSON format.
-- provides environment variables to the script command: `OPENAPI_JSON` and `OPENAPI_YAML`. These contain the paths to the OAS files.
+- provides environment variables to the script command
+    - `OPENAPI_JSON` and `OPENAPI_YAML` - Contain the paths to the OAS files.
+    - `SPECTACLE_URL` - Contains the URL to the running Spectacle server
 - run the `command`
 
 Running the `publish-readme` script defined above will look like:

--- a/website/docs/using/spectacle.mdx
+++ b/website/docs/using/spectacle.mdx
@@ -1,0 +1,84 @@
+---
+title: Using Spectacle
+---
+
+Optic provides you with the ability to build [scripts](/docs/apiops/scripts/) around your API Ops process. Sometimes you may want to access data that Optic gathers as it's documenting your APIs in your scripts. This might include the spec itself or changes to the spec. Optic provides a tool called Spectacle to make this possible.
+
+Spectacle is a GraphQL API that enables you to interact with Optic's data, either through exploring it in your browser with GraphiQL or querying in your code using Optic scripts.
+
+## Accessing Spectacle through GraphiQL
+
+To open GraphiQL for your locally-running instance of Spectacle, run the CLI command:
+
+```sh
+api spectacle
+```
+
+This will ensure Spectacle is running and open your browser to the Spectacle URL where you can explore the API and its documentation.
+
+## Building scripts around Spectacle
+
+The Optic scripts expose an environment variable `SPECTACLE_URL` for querying Spectacle. You can use this in your scripts to query the locally-running API.
+
+We'll look at an example using a Node.js script. The one below is using the `requests` query to get information about requests and responses in the spec. It's using `node-fetch` as the library to query Spectacle.
+
+```javascript
+const fetch = require("node-fetch");
+
+main();
+
+async function main() {
+  const result = await querySpectacle({
+    query: `{
+      requests {
+        method
+        absolutePathPatternWithParameterNames
+        bodies {
+          contentType
+          rootShapeId
+        }
+        responses {
+          statusCode
+          bodies {
+            contentType
+            rootShapeId
+          }
+        }
+      }
+    }`,
+    variables: {},
+  });
+  console.log(JSON.stringify(result, null, 2));
+}
+
+async function querySpectacle(body) {
+  // Fetch uses the SPECTACLE_URL environment as the URL
+  const result = await fetch(process.env.SPECTACLE_URL, {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+  return await result.json();
+}
+```
+
+1. Install [Node.js](https://nodejs.org/en/) if you haven't already
+1. Save this code above as `spectacle.js`
+1. Install `node-fetch` with `npm install node-fetch`
+
+Next we need to define an Optic script to run our code.
+
+```yaml
+# ... add this to your existing optic.yml file
+scripts:
+  get-spec-data:
+    command: node spectacle.js
+```
+
+Now run the script using:
+
+```sh
+api scripts get-spec-data
+```
+
+After running this, you should see the data printed in the terminal.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -18,6 +18,7 @@ module.exports = {
       'using/advanced-configuration',
       'using/troubleshooting',
       'using/cli-commands',
+      'using/spectacle',
     ],
     'Optic in Real Environments': [
       'deploy/live',

--- a/workspaces/local-cli/src/commands/spectacle.ts
+++ b/workspaces/local-cli/src/commands/spectacle.ts
@@ -1,0 +1,60 @@
+import { Command } from '@oclif/command';
+import { Client } from '@useoptic/cli-client';
+import {
+  getPathsRelativeToConfig,
+  IApiCliConfig,
+  readApiConfig,
+} from '@useoptic/cli-config';
+import { IPathMapping } from '@useoptic/cli-config';
+import { ensureDaemonStarted } from '@useoptic/cli-server';
+import { lockFilePath } from '../shared/paths';
+import colors from 'colors';
+import openBrowser from 'react-dev-utils/openBrowser';
+import {
+  cleanupAndExit,
+  developerDebugLogger,
+  fromOptic,
+  userDebugLogger,
+} from '@useoptic/cli-shared';
+import { getUser } from '../shared/analytics';
+import { Config } from '../config';
+export default class Spectacle extends Command {
+  static description = 'open GraphiQL for Spectacle';
+
+  async run() {
+    let paths: IPathMapping;
+    let config: IApiCliConfig;
+    try {
+      paths = await getPathsRelativeToConfig();
+      config = await readApiConfig(paths.configPath);
+    } catch (e) {
+      userDebugLogger(e);
+      this.log(
+        fromOptic(
+          `No optic.yml file found. Add Optic to your API by running ${colors.bold(
+            'api init'
+          )}`
+        )
+      );
+      process.exit(0);
+    }
+    developerDebugLogger(paths);
+    await this.helper(paths.cwd, config);
+  }
+
+  async helper(basePath: string, config: IApiCliConfig) {
+    const daemonState = await ensureDaemonStarted(
+      lockFilePath,
+      Config.apiBaseUrl
+    );
+    const apiBaseUrl = `http://localhost:${daemonState.port}/api`;
+    developerDebugLogger(`api base url: ${apiBaseUrl}`);
+    const cliClient = new Client(apiBaseUrl);
+    cliClient.setIdentity(await getUser());
+    const cliSession = await cliClient.findSession(basePath, null, null);
+    developerDebugLogger({ cliSession });
+    const spectacleUrl = `${apiBaseUrl}/specs/${cliSession.session.id}/spectacle`;
+    openBrowser(spectacleUrl);
+    cleanupAndExit();
+  }
+}

--- a/workspaces/spectacle/src/graphql/schema.ts
+++ b/workspaces/spectacle/src/graphql/schema.ts
@@ -16,12 +16,27 @@ type StartDiffResult {
   listDiffsQuery: String
   listUnrecognizedUrlsQuery: String
 }
-type Query {
+
+"""
+Queries for Spectacle
+"""
+type Query {  
+  # All HTTP requests defined in the spec
   requests: [HttpRequest]
+
+  # URI paths for endpoints
   paths: [Path]
+  
+  # Shape choices based on shape ID
   shapeChoices(shapeId: ID): [OpticShape]
+  
+  # Endpoint changes since a given batch commit ID
   endpointChanges(sinceBatchCommitId: String): EndpointChanges
+  
+  # All batch commits defined in a spec
   batchCommits: [BatchCommit]
+  
+  # Diffs for existing endpoints and unrecognized URLs
   diff(diffId: ID): DiffState
 }
 type DiffState {
@@ -29,88 +44,227 @@ type DiffState {
   unrecognizedUrls: JSON
 }
 type Path {
+  # URL path pattern without parameter names
   absolutePathPattern: String
+  
+  # URI path pattern with parameter names included 
   absolutePathPatternWithParameterNames: String
+  
+  # Whether or not the path component is a parameter or not
   isParameterized: Boolean
+  
+  # Parent path ID
   parentPathId: String
+  
+  # Name of path or name of parameter if parameterized
   name: String
+  
+  # Path ID
   pathId: String
 }
+
+"""
+HTTP Body, which could be for a request or response
+"""
 type HttpBody {
+  # Content type of the given HTTP body
   contentType: String
+  
+  # Root shape ID for the HTTP body. Look at the shapeChoices query getting more information about the root shape
   rootShapeId: String
 }
+
+"""
+HTTP Request
+"""
 type HttpRequest {
   id: ID
+  
+  # Path components for the HTTP request
   pathComponents: [PathComponent]
+  
+  # URL path pattern without parameter names
   absolutePathPattern: String
+  
+  # URI path pattern with parameter names included 
   absolutePathPatternWithParameterNames: String
+  
+  # Path ID
   pathId: ID
+  
+  # HTTP method for the HTTP request
   method: String
+  
+  # Request bodies associated with this HTTP request
   bodies: [HttpBody]
+  
+  # Responses associated with this HTTP request
   responses: [HttpResponse]
+  
+  # Changes for the HTTP request based on the give batch commit ID
   changes(sinceBatchCommitId: String): ChangesResult
+  
+  # Path contributions which define descriptions
   pathContributions: JSON
+  
+  # Request contributions which define descriptions
   requestContributions: JSON
 }
+
+"""
+Path Component
+The URL /users/{id} would have three path components, one for the root, one for users and one for the parameter id.
+"""
 type PathComponent {
   id: ID
+  
+  # Name of the path component or path parameter
   name: String
+  
+  # Defines whether or not the path component is parameterized
   isParameterized: Boolean
+  
+  # Path component contributions which define descriptions
   contributions: JSON
 }
+
+"""
+HTTP Response
+"""
 type HttpResponse {
   id: ID
+  
+  # HTTP status code for the HTTP response
   statusCode: Int
+  
+  # Response bodies associated with this HTTP response
   bodies: [HttpBody]
+  
+  # Changes for the HTTP response based on the give batch commit ID
   changes(sinceBatchCommitId: String): ChangesResult
+  
+  # HTTP response contributions which define descriptions
   contributions: JSON
 }
+
+"""
+Object Field Metadata, which provides information about a field
+"""
 type ObjectFieldMetadata {
   name: String
+  
+  # Field ID for the given field
   fieldId: ID
-  # query shapeChoices(shapeId) to recurse
+  
+  # Changes for the field based on the give batch commit ID
   changes(sinceBatchCommitId: String): ChangesResult
+  
+  # Shape ID of field. Use the shapeChoice query to get shape information.
   shapeId: ID
+  
+  # Field contributions which define descriptions
   contributions: JSON
 }
+
+"""
+Object Metadata, which provides information about an object
+"""
 type ObjectMetadata {
+  # Fields for the given object
   fields: [ObjectFieldMetadata]
 }
+
+"""
+Array Metadata, which provides information about an array
+"""
 type ArrayMetadata {
-  # query shapeChoices(shapeId) to recurse
+  # Changes for the array based on the give batch commit ID
   changes(sinceBatchCommitId: String): ChangesResult
+  
+  # Shape ID of the array. Use the shapeChoice query to get shape information.
   shapeId: ID
 }
+
+"""
+Optic Shape
+"""
 type OpticShape {
   id: ID
+  
+  # JSON type of shape. Could be string, number, boolean, null, object, or array.
   jsonType: String
+  
+  # Metadata if jsonType is object
   asObject: ObjectMetadata
+  
+  # Metadata if jsonType is array
   asArray: ArrayMetadata
+  
   # changes(sinceBatchCommitId: String): ChangesResult
   # exampleValue: [JSON]
 }
+
+"""
+Change Result, which defines whether if something was added or updated
+"""
 type ChangesResult {
+  # Whether or not the change was one that was added
   added: Boolean
+  
+  # Whether or not the change was one that was updated
   changed: Boolean
 }
+
+"""
+Endpoint Changes
+"""
 type EndpointChanges {
+  # URL for Optic change documentation
   opticUrl: String
+  
+  # Changed endpoints for the batch commit ID provided to query
   endpoints: [EndpointChange]
 }
+
+"""
+Endpoint Change, which provides information about an endpoint change found since the given batch commit ID
+"""
 type EndpointChange {
+  # Metadata about the endpoint change
   change: EndpointChangeMetadata
+  
+  # Path ID related to the given change
   pathId: String
+  
+  # Absolute path pattern with parameters
   path: String
+  
+  # HTTP method for the given endpoint change
   method: String
+  
+  # Descriptions for the endpoint change
   contributions: JSON
 }
+
+"""
+Endpoint Change Metadata
+"""
 type EndpointChangeMetadata {
+  # Defines how the endpoint changed
   category: String
 }
+
+"""
+Batch Commit, which provides information about changes in the spec captured as batch commits
+"""
 type BatchCommit {
+  # When the batch commit was created
   createdAt: String
+  
+  # Batch commit ID
   batchId: String
+  
+  # Batch commit message
   commitMessage: String
 }
 `;


### PR DESCRIPTION
This PR focuses on Spectacle documentation and making GraphiQL more accessible to the users.

* Adds a CLI command `api spectacle` for opening up GraphiQL in the browser
* Adds documentation to the GraphQL schema
* Adds a page in the Optic documentation
* Adds a note in the Scripting documentation page about the `SPECTACLE_URL` environment variable

Note: there are a few places in the schema that I wasn't for sure about the description, so I've left them out for now.