### PR TITLE
feature: Implement spec hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,6 +153,15 @@ dependencies = [
  "terminal_size",
  "termios",
  "winapi",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed00c67cb5d0a7d64a44f6ad2668db7e7530311dd53ea79bcd4fb022c64911c8"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -541,6 +559,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
 name = "optic_diff"
 version = "0.1.0"
 dependencies = [
@@ -578,7 +602,9 @@ dependencies = [
  "protobuf",
  "protobuf-codegen-pure",
  "serde",
+ "serde-hashkey",
  "serde_json",
+ "sha2",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -825,18 +851,27 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.115"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54c9a88f2da7238af84b5101443f0c0d0a3bbdc455e34a5c9497b1903ed55d5"
+checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.115"
+name = "serde-hashkey"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
+checksum = "b8522017d4ffbdae83d9aaecc08e9dbff31c6e3044e8137397b4a008b2c37a27"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -864,6 +899,19 @@ dependencies = [
  "linked-hash-map",
  "serde",
  "yaml-rust",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
+dependencies = [
+ "block-buffer",
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]

--- a/workspaces/diff-engine-wasm/engine/Cargo.lock
+++ b/workspaces/diff-engine-wasm/engine/Cargo.lock
@@ -66,6 +66,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +143,15 @@ checksum = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
 dependencies = [
  "cfg-if 0.1.10",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed00c67cb5d0a7d64a44f6ad2668db7e7530311dd53ea79bcd4fb022c64911c8"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -333,6 +351,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
 name = "optic_diff_engine"
 version = "0.1.0"
 dependencies = [
@@ -348,7 +372,9 @@ dependencies = [
  "protobuf",
  "protobuf-codegen-pure",
  "serde",
+ "serde-hashkey",
  "serde_json",
+ "sha2",
  "thiserror",
  "uuid",
 ]
@@ -528,6 +554,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-hashkey"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8522017d4ffbdae83d9aaecc08e9dbff31c6e3044e8137397b4a008b2c37a27"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,6 +582,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
+dependencies = [
+ "block-buffer",
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]

--- a/workspaces/diff-engine-wasm/engine/src/lib.rs
+++ b/workspaces/diff-engine-wasm/engine/src/lib.rs
@@ -5,9 +5,9 @@ use nanoid::nanoid;
 use optic_diff_engine::{
   analyze_undocumented_bodies, Aggregate, Body, BodyAnalysisResult, CommandContext,
   EndpointQueries, HttpInteraction, InteractionDiffResult, JsonTrail,
-  LearnedShapeDiffAffordancesProjection, LearnedUndocumentedBodiesProjection, SpecCommand,
-  SpecEvent, SpecIdGenerator, SpecProjection, TaggedInput, TrailObservationsResult, TrailValues,
-  ResponseBodyDescriptor, ResponseId
+  LearnedShapeDiffAffordancesProjection, LearnedUndocumentedBodiesProjection,
+  ResponseBodyDescriptor, ResponseId, SpecCommand, SpecEvent, SpecIdGenerator, SpecProjection,
+  TaggedInput, TrailObservationsResult, TrailValues,
 };
 use std::collections::HashMap;
 use uuid::Uuid;
@@ -246,6 +246,10 @@ impl WasmSpecProjection {
   pub fn endpoint_queries(&self) -> EndpointQueries {
     EndpointQueries::new(self.projection.endpoint())
   }
+
+  pub fn calculate_hash(&self) -> String {
+    self.projection.hash().to_string()
+  }
 }
 
 impl From<SpecProjection> for WasmSpecProjection {
@@ -307,6 +311,11 @@ pub fn spec_resolve_path_id(spec: &WasmSpecProjection, path: String) -> Option<S
 }
 
 #[wasm_bindgen]
+pub fn spec_hash(spec: &WasmSpecProjection) -> String {
+  spec.calculate_hash()
+}
+
+#[wasm_bindgen]
 pub fn spec_resolve_requests(
   spec: &WasmSpecProjection,
   path_id: String,
@@ -318,7 +327,7 @@ pub fn spec_resolve_requests(
     .resolve_requests(&path_id, &method)
     .map(|it| it.collect())
     .unwrap_or(vec![]);
-  
+
   serde_json::to_string(&requests)
     .map_err(|err| JsValue::from(format!("requests could not be serialized: {:?}", err)))
 }
@@ -328,12 +337,15 @@ pub fn spec_resolve_request(
   spec: &WasmSpecProjection,
   path_id: String,
   method: String,
-  content_type: Option<String>
+  content_type: Option<String>,
 ) -> Result<String, JsValue> {
   let endpoint_queries = spec.endpoint_queries();
 
-  let response = endpoint_queries
-    .resolve_request_by_method_and_content_type(&path_id, &method, content_type.as_ref());
+  let response = endpoint_queries.resolve_request_by_method_and_content_type(
+    &path_id,
+    &method,
+    content_type.as_ref(),
+  );
 
   serde_json::to_string(&response)
     .map_err(|err| JsValue::from(format!("responses could not be serialized: {:?}", err)))
@@ -362,12 +374,16 @@ pub fn spec_resolve_response(
   method: String,
   status_code: u16,
   path_id: String,
-  content_type: Option<String>
+  content_type: Option<String>,
 ) -> Result<String, JsValue> {
   let endpoint_queries = spec.endpoint_queries();
 
-  let response = endpoint_queries
-    .resolve_response_by_method_status_code_and_content_type(&path_id, &method, status_code, content_type.as_ref());
+  let response = endpoint_queries.resolve_response_by_method_status_code_and_content_type(
+    &path_id,
+    &method,
+    status_code,
+    content_type.as_ref(),
+  );
 
   serde_json::to_string(&response)
     .map_err(|err| JsValue::from(format!("responses could not be serialized: {:?}", err)))

--- a/workspaces/diff-engine/Cargo.toml
+++ b/workspaces/diff-engine/Cargo.toml
@@ -33,6 +33,8 @@ tokio = { version = "~1.1.1", features = ["full"], optional = true }
 tokio-util = { version = "0.6.3", features = ["codec"], optional = true }
 tokio-stream = { version= "0.1.2", features = ["fs", "io-util"], optional = true }
 uuid = { version = "0.8.2", features = ["v4", "wasm-bindgen"] }
+serde-hashkey = "0.4.0"
+sha2 = "0.9.5"
 
 [dev-dependencies]
 insta = "0.16.1"

--- a/workspaces/diff-engine/src/projections/endpoint.rs
+++ b/workspaces/diff-engine/src/projections/endpoint.rs
@@ -1,6 +1,5 @@
 use crate::events::endpoint as endpoint_events;
 use crate::events::{EndpointEvent, SpecEvent};
-use serde::Serialize;
 use crate::state::endpoint::*;
 use crate::{
   commands::{endpoint, EndpointCommand, SpecCommand, SpecCommandError},
@@ -8,6 +7,7 @@ use crate::{
 };
 use cqrs_core::{Aggregate, AggregateCommand, AggregateEvent, Event};
 use petgraph::graph::{Graph, NodeIndex};
+use serde::Serialize;
 use std::collections::HashMap;
 
 pub const ROOT_PATH_ID: &str = "root";

--- a/workspaces/diff-engine/src/projections/hash.rs
+++ b/workspaces/diff-engine/src/projections/hash.rs
@@ -1,0 +1,58 @@
+use crate::{RfcEvent, SpecEvent};
+use cqrs_core::{Aggregate, AggregateEvent, Event};
+use serde_hashkey::to_key;
+use sha2::{Digest, Sha256};
+use std::{collections::BTreeMap, hash::Hash};
+
+#[derive(Debug, Clone)]
+pub struct SpecHashProjection {
+  hasher: Sha256,
+}
+
+impl SpecHashProjection {
+  pub fn to_string(&self) -> String {
+    format!("{:x}", self.hasher.clone().finalize())
+  }
+
+  pub fn with_event(&mut self, evt: SpecEvent) {
+    let key = to_key(&evt).unwrap();
+    let key_str = serde_json::to_string(&key).expect("should be able to serialize");
+
+    self.hasher.update(key_str);
+  }
+}
+
+impl Default for SpecHashProjection {
+  fn default() -> Self {
+    SpecHashProjection {
+      hasher: Sha256::new(),
+    }
+  }
+}
+
+impl Aggregate for SpecHashProjection {
+  fn aggregate_type() -> &'static str {
+    "spec_hash_projection"
+  }
+}
+
+impl<I> From<I> for SpecHashProjection
+where
+  I: IntoIterator,
+  I::Item: AggregateEvent<Self>,
+{
+  fn from(events: I) -> Self {
+    let mut projection = SpecHashProjection::default();
+    for event in events.into_iter() {
+      projection.apply(event);
+    }
+    projection
+  }
+}
+
+// Events
+impl AggregateEvent<SpecHashProjection> for SpecEvent {
+  fn apply_to(self, projection: &mut SpecHashProjection) {
+    projection.with_event(self);
+  }
+}

--- a/workspaces/spectacle/src/graphql/schema.ts
+++ b/workspaces/spectacle/src/graphql/schema.ts
@@ -23,6 +23,7 @@ type Query {
   endpointChanges(sinceBatchCommitId: String): EndpointChanges
   batchCommits: [BatchCommit]
   diff(diffId: ID): DiffState
+  hash: String
 }
 type DiffState {
   diffs: JSON

--- a/workspaces/spectacle/src/index.ts
+++ b/workspaces/spectacle/src/index.ts
@@ -57,6 +57,8 @@ export interface IOpticEngine {
   ): string;
 
   spec_from_events(eventsJson: string): any;
+
+  spec_hash(spec: any): string;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -197,6 +199,7 @@ async function buildProjections(opticContext: IOpticContext) {
     shapesQueries,
     shapeViewerProjection,
     contributionsProjection,
+    specHash: () => opticContext.opticEngine.spec_hash(spec),
   };
 }
 
@@ -204,7 +207,8 @@ export async function makeSpectacle(opticContext: IOpticContext) {
   let endpointsQueries: endpoints.GraphQueries,
     shapeQueries: shapes.GraphQueries,
     shapeViewerProjection: any,
-    contributionsProjection: ContributionsProjection;
+    contributionsProjection: ContributionsProjection,
+    specHash: () => string;
 
   async function reload(opticContext: IOpticContext) {
     const projections = await buildProjections(opticContext);
@@ -212,6 +216,7 @@ export async function makeSpectacle(opticContext: IOpticContext) {
     shapeQueries = projections.shapesQueries;
     shapeViewerProjection = projections.shapeViewerProjection;
     contributionsProjection = projections.contributionsProjection;
+    specHash = projections.specHash;
     return projections;
   }
 
@@ -310,6 +315,9 @@ export async function makeSpectacle(opticContext: IOpticContext) {
         return context
           .spectacleContext()
           .opticContext.diffRepository.findById(diffId);
+      },
+      hash: async (parent: any, args: any, context: any, info: any) => {
+        return context.spectacleContext().specHash();
       },
     },
     DiffState: {
@@ -557,6 +565,7 @@ export async function makeSpectacle(opticContext: IOpticContext) {
       shapeViewerProjection,
       // @ts-ignore
       contributionsProjection,
+      specHash,
     };
   };
   const queryWrapper = function <Result, Input = {}>(

--- a/workspaces/spectacle/tap-snapshots/test-index.ts-TAP.test.js
+++ b/workspaces/spectacle/tap-snapshots/test-index.ts-TAP.test.js
@@ -6,6 +6,216 @@
  */
 'use strict';
 exports[
+  `test/index.ts TAP spec hash query add contributions > must match snapshot 1`
+] = `
+Object {
+  "data": Null Object {
+    "hash": "ba16a98372dbc375280e385c9573fbd7a7b7f69ec63e9331fd1040f18642aa45",
+  },
+}
+`;
+
+exports[
+  `test/index.ts TAP spec hash query add endpoint to existing spec > must match snapshot 1`
+] = `
+Object {
+  "data": Null Object {
+    "hash": "598ac1fa68637beff3553f0d2b2156504dc642a5cc00d20584ab1d6a7ca515c4",
+  },
+}
+`;
+
+exports[
+  `test/index.ts TAP spec hash query add nested response field > must match snapshot 1`
+] = `
+Object {
+  "data": Null Object {
+    "hash": "9f02664e0c05369414ba39f7cfebe658e5a130490ae342711a98a0c20e338fb5",
+  },
+}
+`;
+
+exports[
+  `test/index.ts TAP spec hash query add new endpoint > must match snapshot 1`
+] = `
+Object {
+  "data": Null Object {
+    "hash": "819f9e95e07f3c23308979d42ee37c956aa99b3e1cfb0308fba7fa3cfc3f8200",
+  },
+}
+`;
+
+exports[
+  `test/index.ts TAP spec hash query add optional response field > must match snapshot 1`
+] = `
+Object {
+  "data": Null Object {
+    "hash": "e0a81d4943162ceae1557e76c144a1dabf8980b942d7f0a9114d0dd7daa54d13",
+  },
+}
+`;
+
+exports[
+  `test/index.ts TAP spec hash query add request and response > must match snapshot 1`
+] = `
+Object {
+  "data": Null Object {
+    "hash": "bf3eca7585f9c8e58f8939ba072e0f6f1b6b1aeca3db41589e405ae0da232a0b",
+  },
+}
+`;
+
+exports[
+  `test/index.ts TAP spec hash query add request field > must match snapshot 1`
+] = `
+Object {
+  "data": Null Object {
+    "hash": "6cd94405c9c5255db58512623bca2d7ed82e4df15a36b2be856251b9271bfe5f",
+  },
+}
+`;
+
+exports[
+  `test/index.ts TAP spec hash query add request nested field > must match snapshot 1`
+] = `
+Object {
+  "data": Null Object {
+    "hash": "4b33edda11fe5f8f1e469fe82669dc725a03665035bc2a53a1e54535abadcd8c",
+  },
+}
+`;
+
+exports[
+  `test/index.ts TAP spec hash query add required response field > must match snapshot 1`
+] = `
+Object {
+  "data": Null Object {
+    "hash": "24d0d064efa1be6aa4a2dc861fae05fa03630374019f478e708d350b2d74c665",
+  },
+}
+`;
+
+exports[
+  `test/index.ts TAP spec hash query add response array field > must match snapshot 1`
+] = `
+Object {
+  "data": Null Object {
+    "hash": "55b7303c817983252f30bb2b50c23432a24e948cbf3940411673567dc54eaeac",
+  },
+}
+`;
+
+exports[
+  `test/index.ts TAP spec hash query add response as an array > must match snapshot 1`
+] = `
+Object {
+  "data": Null Object {
+    "hash": "c45e0e62e08daa64aaf94e9f4afb6a349779f2b95fe28ca51ab9e38bc99cac99",
+  },
+}
+`;
+
+exports[
+  `test/index.ts TAP spec hash query add response as an array with object > must match snapshot 1`
+] = `
+Object {
+  "data": Null Object {
+    "hash": "b2855dd774584a948f2384abef6f6551839efb6c485c6057b70de4e474fca17f",
+  },
+}
+`;
+
+exports[
+  `test/index.ts TAP spec hash query add response status code > must match snapshot 1`
+] = `
+Object {
+  "data": Null Object {
+    "hash": "d8e7606412f5fccaa4cac7e09bdd91c4bc4766ce2df8a3f65a17471b3b6cf6ee",
+  },
+}
+`;
+
+exports[
+  `test/index.ts TAP spec hash query complex changes > must match snapshot 1`
+] = `
+Object {
+  "data": Null Object {
+    "hash": "2e531da163e9f5b5749e47b00620b1d8845b351288ef52bc1450fa219fd9cd15",
+  },
+}
+`;
+
+exports[
+  `test/index.ts TAP spec hash query mark request field optional > must match snapshot 1`
+] = `
+Object {
+  "data": Null Object {
+    "hash": "d95334761e9af49d3bf6cba96498ea55eed265f8b465f4de8e0a22154f76ba04",
+  },
+}
+`;
+
+exports[
+  `test/index.ts TAP spec hash query mark request nested field optional > must match snapshot 1`
+] = `
+Object {
+  "data": Null Object {
+    "hash": "e9ce15812ab974f57cdf16d5779255c1425bff7726802b59b91ae6ea752b78e4",
+  },
+}
+`;
+
+exports[
+  `test/index.ts TAP spec hash query no changes > must match snapshot 1`
+] = `
+Object {
+  "data": Null Object {
+    "hash": "598ac1fa68637beff3553f0d2b2156504dc642a5cc00d20584ab1d6a7ca515c4",
+  },
+}
+`;
+
+exports[
+  `test/index.ts TAP spec hash query update nested response field > must match snapshot 1`
+] = `
+Object {
+  "data": Null Object {
+    "hash": "2706583a7dff8fc7f6c3177e1a3b3d91bcfb4fcd6a357227eda98d8ba361b909",
+  },
+}
+`;
+
+exports[
+  `test/index.ts TAP spec hash query update optional response field > must match snapshot 1`
+] = `
+Object {
+  "data": Null Object {
+    "hash": "d48e605603fda424bef7d8f3a18aaad3da003c5bf36988c470ebb810b21796b4",
+  },
+}
+`;
+
+exports[
+  `test/index.ts TAP spec hash query update request field type > must match snapshot 1`
+] = `
+Object {
+  "data": Null Object {
+    "hash": "a8d9d84bc51fadfa51f99e7a9ac97b7bbf2576a22c987c81eadee88c6a10c17f",
+  },
+}
+`;
+
+exports[
+  `test/index.ts TAP spec hash query updated response as an array > must match snapshot 1`
+] = `
+Object {
+  "data": Null Object {
+    "hash": "b2a46e97953736eedce43f6cb4a94a5f8b0eabd1fcfd3735c1f68b4cee4b5da0",
+  },
+}
+`;
+
+exports[
   `test/index.ts TAP spectacle batchCommits query > must match snapshot 1`
 ] = `
 Object {
@@ -497,48 +707,56 @@ Object {
     "paths": Array [
       Null Object {
         "absolutePathPattern": "/",
+        "absolutePathPatternWithParameterNames": "",
         "isParameterized": false,
         "name": "",
         "pathId": "root",
       },
       Null Object {
         "absolutePathPattern": "/healthcheck",
+        "absolutePathPatternWithParameterNames": "/healthcheck",
         "isParameterized": false,
         "name": "healthcheck",
         "pathId": "path_to6GIY7tL3",
       },
       Null Object {
         "absolutePathPattern": "/api",
+        "absolutePathPatternWithParameterNames": "/api",
         "isParameterized": false,
         "name": "api",
         "pathId": "path_inB9snEwIX",
       },
       Null Object {
         "absolutePathPattern": "/api/account",
+        "absolutePathPatternWithParameterNames": "/api/account",
         "isParameterized": false,
         "name": "account",
         "pathId": "path_UGayMWEUve",
       },
       Null Object {
         "absolutePathPattern": "/api/account/tokens",
+        "absolutePathPatternWithParameterNames": "/api/account/tokens",
         "isParameterized": false,
         "name": "tokens",
         "pathId": "path_Zbx2qte52s",
       },
       Null Object {
         "absolutePathPattern": "/api/account/specs",
+        "absolutePathPatternWithParameterNames": "/api/account/specs",
         "isParameterized": false,
         "name": "specs",
         "pathId": "path_jleYfnE1Ru",
       },
       Null Object {
         "absolutePathPattern": "/api/specs",
+        "absolutePathPatternWithParameterNames": "/api/specs",
         "isParameterized": false,
         "name": "specs",
         "pathId": "path_g0KKrcDA4C",
       },
       Null Object {
         "absolutePathPattern": "/api/specs/{}",
+        "absolutePathPatternWithParameterNames": "/api/specs/{specId}",
         "isParameterized": true,
         "name": "specId",
         "pathId": "path_td6dXtR2C5",
@@ -556,12 +774,14 @@ Object {
     "paths": Array [
       Null Object {
         "absolutePathPattern": "/",
+        "absolutePathPatternWithParameterNames": "",
         "isParameterized": false,
         "name": "",
         "pathId": "root",
       },
       Null Object {
         "absolutePathPattern": "/user",
+        "absolutePathPatternWithParameterNames": "/user",
         "isParameterized": false,
         "name": "user",
         "pathId": "path_Rbkw7kMyjT",
@@ -579,12 +799,14 @@ Object {
     "paths": Array [
       Null Object {
         "absolutePathPattern": "/",
+        "absolutePathPatternWithParameterNames": "",
         "isParameterized": false,
         "name": "",
         "pathId": "root",
       },
       Null Object {
         "absolutePathPattern": "/user",
+        "absolutePathPatternWithParameterNames": "/user",
         "isParameterized": false,
         "name": "user",
         "pathId": "path_jhNaeRecHD",
@@ -602,12 +824,14 @@ Object {
     "paths": Array [
       Null Object {
         "absolutePathPattern": "/",
+        "absolutePathPatternWithParameterNames": "",
         "isParameterized": false,
         "name": "",
         "pathId": "root",
       },
       Null Object {
         "absolutePathPattern": "/user",
+        "absolutePathPatternWithParameterNames": "/user",
         "isParameterized": false,
         "name": "user",
         "pathId": "path_Rbkw7kMyjT",
@@ -625,12 +849,14 @@ Object {
     "paths": Array [
       Null Object {
         "absolutePathPattern": "/",
+        "absolutePathPatternWithParameterNames": "",
         "isParameterized": false,
         "name": "",
         "pathId": "root",
       },
       Null Object {
         "absolutePathPattern": "/user",
+        "absolutePathPatternWithParameterNames": "/user",
         "isParameterized": false,
         "name": "user",
         "pathId": "path_Rbkw7kMyjT",
@@ -648,12 +874,14 @@ Object {
     "paths": Array [
       Null Object {
         "absolutePathPattern": "/",
+        "absolutePathPatternWithParameterNames": "",
         "isParameterized": false,
         "name": "",
         "pathId": "root",
       },
       Null Object {
         "absolutePathPattern": "/user",
+        "absolutePathPatternWithParameterNames": "/user",
         "isParameterized": false,
         "name": "user",
         "pathId": "path_jhNaeRecHD",
@@ -671,12 +899,14 @@ Object {
     "paths": Array [
       Null Object {
         "absolutePathPattern": "/",
+        "absolutePathPatternWithParameterNames": "",
         "isParameterized": false,
         "name": "",
         "pathId": "root",
       },
       Null Object {
         "absolutePathPattern": "/user",
+        "absolutePathPatternWithParameterNames": "/user",
         "isParameterized": false,
         "name": "user",
         "pathId": "path_jhNaeRecHD",
@@ -694,12 +924,14 @@ Object {
     "paths": Array [
       Null Object {
         "absolutePathPattern": "/",
+        "absolutePathPatternWithParameterNames": "",
         "isParameterized": false,
         "name": "",
         "pathId": "root",
       },
       Null Object {
         "absolutePathPattern": "/user",
+        "absolutePathPatternWithParameterNames": "/user",
         "isParameterized": false,
         "name": "user",
         "pathId": "path_jhNaeRecHD",
@@ -717,12 +949,14 @@ Object {
     "paths": Array [
       Null Object {
         "absolutePathPattern": "/",
+        "absolutePathPatternWithParameterNames": "",
         "isParameterized": false,
         "name": "",
         "pathId": "root",
       },
       Null Object {
         "absolutePathPattern": "/user",
+        "absolutePathPatternWithParameterNames": "/user",
         "isParameterized": false,
         "name": "user",
         "pathId": "path_Rbkw7kMyjT",
@@ -740,12 +974,14 @@ Object {
     "paths": Array [
       Null Object {
         "absolutePathPattern": "/",
+        "absolutePathPatternWithParameterNames": "",
         "isParameterized": false,
         "name": "",
         "pathId": "root",
       },
       Null Object {
         "absolutePathPattern": "/user",
+        "absolutePathPatternWithParameterNames": "/user",
         "isParameterized": false,
         "name": "user",
         "pathId": "path_jhNaeRecHD",
@@ -763,18 +999,21 @@ Object {
     "paths": Array [
       Null Object {
         "absolutePathPattern": "/",
+        "absolutePathPatternWithParameterNames": "",
         "isParameterized": false,
         "name": "",
         "pathId": "root",
       },
       Null Object {
         "absolutePathPattern": "/user",
+        "absolutePathPatternWithParameterNames": "/user",
         "isParameterized": false,
         "name": "user",
         "pathId": "path_jhNaeRecHD",
       },
       Null Object {
         "absolutePathPattern": "/items",
+        "absolutePathPatternWithParameterNames": "/items",
         "isParameterized": false,
         "name": "items",
         "pathId": "path_H8I4tQ9R0s",
@@ -792,24 +1031,28 @@ Object {
     "paths": Array [
       Null Object {
         "absolutePathPattern": "/",
+        "absolutePathPatternWithParameterNames": "",
         "isParameterized": false,
         "name": "",
         "pathId": "root",
       },
       Null Object {
         "absolutePathPattern": "/user",
+        "absolutePathPatternWithParameterNames": "/user",
         "isParameterized": false,
         "name": "user",
         "pathId": "path_jhNaeRecHD",
       },
       Null Object {
         "absolutePathPattern": "/items",
+        "absolutePathPatternWithParameterNames": "/items",
         "isParameterized": false,
         "name": "items",
         "pathId": "path_H8I4tQ9R0s",
       },
       Null Object {
         "absolutePathPattern": "/items2",
+        "absolutePathPatternWithParameterNames": "/items2",
         "isParameterized": false,
         "name": "items2",
         "pathId": "path_cvQ3CMEF5h",
@@ -827,12 +1070,14 @@ Object {
     "paths": Array [
       Null Object {
         "absolutePathPattern": "/",
+        "absolutePathPatternWithParameterNames": "",
         "isParameterized": false,
         "name": "",
         "pathId": "root",
       },
       Null Object {
         "absolutePathPattern": "/user",
+        "absolutePathPatternWithParameterNames": "/user",
         "isParameterized": false,
         "name": "user",
         "pathId": "path_Rbkw7kMyjT",
@@ -850,30 +1095,35 @@ Object {
     "paths": Array [
       Null Object {
         "absolutePathPattern": "/",
+        "absolutePathPatternWithParameterNames": "",
         "isParameterized": false,
         "name": "",
         "pathId": "root",
       },
       Null Object {
         "absolutePathPattern": "/user",
+        "absolutePathPatternWithParameterNames": "/user",
         "isParameterized": false,
         "name": "user",
         "pathId": "path_Rbkw7kMyjT",
       },
       Null Object {
         "absolutePathPattern": "/test2",
+        "absolutePathPatternWithParameterNames": "/test2",
         "isParameterized": false,
         "name": "test2",
         "pathId": "path_UTBFhSCjRy",
       },
       Null Object {
         "absolutePathPattern": "/test1",
+        "absolutePathPatternWithParameterNames": "/test1",
         "isParameterized": false,
         "name": "test1",
         "pathId": "path_OC3glljopB",
       },
       Null Object {
         "absolutePathPattern": "/test1/{}",
+        "absolutePathPatternWithParameterNames": "/test1/{id}",
         "isParameterized": true,
         "name": "id",
         "pathId": "path_NbM6PpK4t8",
@@ -891,12 +1141,14 @@ Object {
     "paths": Array [
       Null Object {
         "absolutePathPattern": "/",
+        "absolutePathPatternWithParameterNames": "",
         "isParameterized": false,
         "name": "",
         "pathId": "root",
       },
       Null Object {
         "absolutePathPattern": "/user",
+        "absolutePathPatternWithParameterNames": "/user",
         "isParameterized": false,
         "name": "user",
         "pathId": "path_jhNaeRecHD",
@@ -914,12 +1166,14 @@ Object {
     "paths": Array [
       Null Object {
         "absolutePathPattern": "/",
+        "absolutePathPatternWithParameterNames": "",
         "isParameterized": false,
         "name": "",
         "pathId": "root",
       },
       Null Object {
         "absolutePathPattern": "/user",
+        "absolutePathPatternWithParameterNames": "/user",
         "isParameterized": false,
         "name": "user",
         "pathId": "path_jhNaeRecHD",
@@ -937,12 +1191,14 @@ Object {
     "paths": Array [
       Null Object {
         "absolutePathPattern": "/",
+        "absolutePathPatternWithParameterNames": "",
         "isParameterized": false,
         "name": "",
         "pathId": "root",
       },
       Null Object {
         "absolutePathPattern": "/user",
+        "absolutePathPatternWithParameterNames": "/user",
         "isParameterized": false,
         "name": "user",
         "pathId": "path_Rbkw7kMyjT",
@@ -960,12 +1216,14 @@ Object {
     "paths": Array [
       Null Object {
         "absolutePathPattern": "/",
+        "absolutePathPatternWithParameterNames": "",
         "isParameterized": false,
         "name": "",
         "pathId": "root",
       },
       Null Object {
         "absolutePathPattern": "/user",
+        "absolutePathPatternWithParameterNames": "/user",
         "isParameterized": false,
         "name": "user",
         "pathId": "path_jhNaeRecHD",
@@ -983,12 +1241,14 @@ Object {
     "paths": Array [
       Null Object {
         "absolutePathPattern": "/",
+        "absolutePathPatternWithParameterNames": "",
         "isParameterized": false,
         "name": "",
         "pathId": "root",
       },
       Null Object {
         "absolutePathPattern": "/user",
+        "absolutePathPatternWithParameterNames": "/user",
         "isParameterized": false,
         "name": "user",
         "pathId": "path_Rbkw7kMyjT",
@@ -1006,12 +1266,14 @@ Object {
     "paths": Array [
       Null Object {
         "absolutePathPattern": "/",
+        "absolutePathPatternWithParameterNames": "",
         "isParameterized": false,
         "name": "",
         "pathId": "root",
       },
       Null Object {
         "absolutePathPattern": "/user",
+        "absolutePathPatternWithParameterNames": "/user",
         "isParameterized": false,
         "name": "user",
         "pathId": "path_jhNaeRecHD",
@@ -1029,18 +1291,21 @@ Object {
     "paths": Array [
       Null Object {
         "absolutePathPattern": "/",
+        "absolutePathPatternWithParameterNames": "",
         "isParameterized": false,
         "name": "",
         "pathId": "root",
       },
       Null Object {
         "absolutePathPattern": "/user",
+        "absolutePathPatternWithParameterNames": "/user",
         "isParameterized": false,
         "name": "user",
         "pathId": "path_jhNaeRecHD",
       },
       Null Object {
         "absolutePathPattern": "/items",
+        "absolutePathPatternWithParameterNames": "/items",
         "isParameterized": false,
         "name": "items",
         "pathId": "path_H8I4tQ9R0s",

--- a/workspaces/spectacle/tap-snapshots/test-openapi-index.ts-TAP.test.js
+++ b/workspaces/spectacle/tap-snapshots/test-openapi-index.ts-TAP.test.js
@@ -137,7 +137,7 @@ Object {
                 },
               },
             },
-            "description": "This is the 200 response description",
+            "description": "",
           },
         },
       },

--- a/workspaces/spectacle/test/index.ts
+++ b/workspaces/spectacle/test/index.ts
@@ -230,4 +230,13 @@ specs.forEach(async (spec) => {
     const results = await spectacle.queryWrapper({ query, variables: {} });
     test.matchSnapshot(results);
   });
+
+  Tap.test(`spec hash query ${spec.name}`, async (test) => {
+    const query = `{
+      hash
+    }`;
+
+    const results = await spectacle.queryWrapper({ query, variables: {} });
+    test.matchSnapshot(results);
+  });
 });


### PR DESCRIPTION
## Why
Running with the analogy of Optic as git for APIs, one important feature of git is the fact that each atomic unit of change has a content-addressable ID that will always refer to that and only that exact point in "repo space" (exact diff, ontop of the exact set of commits, by exactly that author, etc). In order for us to start talking about Optic's concept of APIs, we need a similar content-addressable identifier for a specific point in "API space", which is what this PR is all about.

The most immediate use of the spec hash will be to support uploading coverage reports associated with a particular spec. Soon afterwards, those specs will all become part of "named APIs", akin to how your arbitrary git commits are all associated with a particular repo in github. All of that depends on having stable unique IDs for a particular point in the timeline of a particular spec. We _could_ just randomly generate them, but the added quality of being able to statelessly derive the ID from the spec simplifies a bunch of things, and feels quite elegant to boot.

## What
I originally thought (as @devdoshi suggested) that I could just serialize each `SpecEvent` to a JSON string, hash it, and be done with. Unfortunately, the ordering of object keys in JSON is explicitly undefined, so I needed to find some way of getting a stable JSON string out. I evaluated two different libraries for this:

* https://borsh.io/
* https://crates.io/crates/serde-hashkey

I would have liked to use Borsh, since it seems faster and more of a whole _project_ rather than "just" a library that somebody put together. But unfortunately since Borsh explicitly avoids working in Serde land (for performance, among other things), I would have had to add a `BorshSerialize` impl to _every_ variant of `SpecEvent`, of which there are quite a few.

Instead, I went with `serde-hashkey` which effectively gives you a stable equivalent to `serde_json::serialize()`.

The hash is propagated out through a spectacle query, so it can be used anywhere Spectacle may be found.

## Validation
* [x] Tests pass
* [ ] Verified in staging
* etc...
