### PR TITLE
Add cancel button on pending diff page

### DIFF
--- a/workspaces/ui-v2/src/optic-components/pages/diffs/PendingEndpointPage.tsx
+++ b/workspaces/ui-v2/src/optic-components/pages/diffs/PendingEndpointPage.tsx
@@ -93,6 +93,8 @@ export function PendingEndpointPage(props: any) {
     initialValue: endpointName,
     sideEffect: debouncedSetName,
   });
+  const history = useHistory();
+  const diffUndocumentedUrlsPageLink = useDiffUndocumentedUrlsPageLink();
 
   const requestCheckboxes = (learnedBodies?.requests || []).filter((i) =>
     Boolean(i.contentType)
@@ -202,18 +204,35 @@ export function PendingEndpointPage(props: any) {
               </FormControl>
 
               <div className={classes.buttons}>
-                <Button size="small" color="default" onClick={discardEndpoint}>
-                  Discard Endpoint
-                </Button>
-                <Button
-                  size="small"
-                  variant="contained"
-                  color="primary"
-                  style={{ marginLeft: 10 }}
-                  onClick={stageEndpoint}
-                >
-                  Add Endpoint
-                </Button>
+                <div>
+                  <Button
+                    size="small"
+                    color="default"
+                    onClick={() =>
+                      history.push(diffUndocumentedUrlsPageLink.linkTo())
+                    }
+                  >
+                    Cancel
+                  </Button>
+                </div>
+                <div>
+                  <Button
+                    size="small"
+                    color="secondary"
+                    onClick={discardEndpoint}
+                  >
+                    Discard Endpoint
+                  </Button>
+                  <Button
+                    size="small"
+                    variant="contained"
+                    color="primary"
+                    style={{ marginLeft: 10 }}
+                    onClick={stageEndpoint}
+                  >
+                    Add Endpoint
+                  </Button>
+                </div>
               </div>
             </div>
           )}
@@ -300,8 +319,7 @@ const useStyles = makeStyles((theme) => ({
   buttons: {
     marginTop: 25,
     display: 'flex',
-    alignItems: 'flex-end',
-    justifyContent: 'flex-end',
+    justifyContent: 'space-between;',
   },
   nameDisplay: {
     fontSize: '1.25rem',


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

On the pending diff page - a user can navigate to this page from a newly staged url or a already staged url - there's currently add and discard, however there's no cancel. 

If a user stages a url, clicks into the pending endpoint to land back on this page, and makes changes - it's not obvious how to "go back to the previous page without making changes"

Added a cancel button to be able to unblock this flow

<img width="632" alt="Screen Shot 2021-05-18 at 5 11 46 PM" src="https://user-images.githubusercontent.com/18374483/118738585-3f811d80-b7fc-11eb-90e0-c506e7c43b80.png">

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...

