### PR TITLE
docs and sourceme changes

### DIFF
--- a/Developer-setup.md
+++ b/Developer-setup.md
@@ -47,12 +47,23 @@ Each workspace should have a package.json file with a name field like `@useoptic
 
 ## Validate Setup to contribute to Optic’s Local CLI
 
-- If you haven't added the `[sourceme.sh](http://sourceme.sh)` to your `.profile` or equivalent yet and invoked a new terminal, you may want to navigate to the project root and run `source sourceme.sh` to assure you have the local development aliases created. Amongst other aliases it creates  `apidev`, which takes the place of `api` against your local development build.
+- You may want to navigate to the project root and run `source sourceme.sh` to ensure you have the local development aliases created. 
+  - It creates `apidev` and `uidev`, which takes the place of `api` against your local development build.
+  - If you are iterating on the UI and `api` CLI, use `uidev`, which expects the UI to be started on port 3000 and proxy api requests to the `cli-server`; otherwise use `apidev` 
+  ```
+  terminal 1:
+  $ cd workspaces/ui-v2
+  $ yarn start:local
+  
+  terminal 2:
+  $ source sourceme.sh
+  $ uidev start
+  ```
 - Determine a visible change to make to the workspace. For example, when `api start` is run in a directory without an `optic.yml` file, you'll get an error message telling you the project is not found.
 - Confirm the current behavior of the code by running the `apidev` command (in this case, `apidev start`).
 - Run `task workspaces:build --watch` to watch and rebuild your workspace as you make changes.
 - Navigate to the target workspace, and make a visible change.
-    - For example, in `workspaces\cli-shared\index.ts`, you can change the start failure messages.
+    - For example, in `workspaces/cli-shared/src/index.ts`, you can change the start failure messages.
     - Search for "*No Optic project found in this directory.*" which is the start of the error message you get when no `optic.yml` file is present.
     - Make a small change to the string, such as "***Success!*** *No Optic project found in this directory.*"
 - Re-run the `apidev` command to verify the change is made (in this case, `apidev start`).

--- a/sourceme.sh
+++ b/sourceme.sh
@@ -4,13 +4,16 @@ export OPTIC_SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && p
 echo "Optic development scripts will run from $OPTIC_SRC_DIR"
 export OPTIC_DEBUG_ENV_FILE="$OPTIC_SRC_DIR/.env"
 
-alias apidev="OPTIC_DAEMON_ENABLE_DEBUGGING=yes OPTIC_DEVELOPMENT=yes OPTIC_UI_HOST=http://localhost:3000 OPTIC_AUTH_UI_HOST=http://localhost:4005 $OPTIC_SRC_DIR/workspaces/local-cli/bin/run"
+alias uidev="OPTIC_DAEMON_ENABLE_DEBUGGING=yes OPTIC_DEVELOPMENT=yes OPTIC_UI_HOST=http://localhost:3000 OPTIC_AUTH_UI_HOST=http://localhost:4005 $OPTIC_SRC_DIR/workspaces/local-cli/bin/run"
+alias apidev="OPTIC_DAEMON_ENABLE_DEBUGGING=yes OPTIC_DEVELOPMENT=yes OPTIC_AUTH_UI_HOST=http://localhost:4005 $OPTIC_SRC_DIR/workspaces/local-cli/bin/run"
 alias apistage="OPTIC_DAEMON_ENABLE_DEBUGGING=yes $OPTIC_SRC_DIR/workspaces/local-cli/bin/run"
 
+# echo "You can run otask from anywhere to run task from $OPTIC_SRC_DIR"
 otask() {
   cd "$OPTIC_SRC_DIR" && task "$@"
 }
 
+# echo "You can run optic_export_env <ENV_FILE_PATH> from anywhere to export all the variables from <ENV_FILE_PATH>"
 optic_export_env() {
   set -u
 


### PR DESCRIPTION

## Why
@bojan88 brought up that our defaults can be confusing if you follow the docs. the aliases exposed in sourceme   should allow for developers to iterate on ui alone, cli alone, and both ui and cli together.

## What
if you were using `apidev` while iterating on the ui, you should switch to `uidev` (I don't have strong opinions about the names, and since we are developers we're free to make our own aliases)

## Validation
* [ ] CI passes
* [ ] consensus on naming
