### PR TITLE
verify.ts: check help was wrong, redundant for start task

### DIFF
--- a/workspaces/local-cli/src/shared/verify/verify.ts
+++ b/workspaces/local-cli/src/shared/verify/verify.ts
@@ -193,10 +193,10 @@ export async function verifyTask(
               )
             )
         );
+        const runCommand =
+          taskName === 'start' ? 'api start' : 'api run ' + taskName;
         cli.log(
-          fromOptic(
-            `To start this task, run: ${colors.bold('api start ' + taskName)}`
-          )
+          fromOptic(`To start this task, run: ${colors.bold(runCommand)}`)
         );
       } else {
         cli.log(


### PR DESCRIPTION
## Why

I used `start` when I should've used `run`. Also, for the start task, the suggestion was `api start start`. Both are fixed.

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
