### PR TITLE
Fix ignore rules

### DIFF
--- a/website/docs/using/advanced-configuration.mdx
+++ b/website/docs/using/advanced-configuration.mdx
@@ -149,8 +149,8 @@ You can add ignore rules to your `.optic/ignore` file:
 ``` txt
 # Default Ignore Rules
 # Learn to configure your own at http://localhost:4000/docs/using/advanced-configuration#ignoring-api-paths
-OPTIONS *
-HEAD *
+OPTIONS (.*)
+HEAD (.*)
 GET (.*).htm
 GET (.*).html
 GET (.*).css

--- a/workspaces/cli-shared/src/diffs/interaction-diff-worker-rust.ts
+++ b/workspaces/cli-shared/src/diffs/interaction-diff-worker-rust.ts
@@ -55,7 +55,7 @@ export class InteractionDiffWorkerRust {
     const ignoreFilter = parseIgnore(this.config.ignoreRules);
 
     const interactionFilter = (i: any) => {
-      return !ignoreFilter.shouldIgnore(i.request.path, i.request.method);
+      return !ignoreFilter.shouldIgnore(i.request.method, i.request.path);
     };
 
     const interactionIterator = CaptureInteractionIterator(


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Fix the ignore rules - @acunniffe found this while giving a walkthrough of the code - also the default ignore rules in my test project was incorrect (but it looks like the [default ignore rules](https://github.com/opticdev/optic/blob/develop/workspaces/cli-config/src/helpers/default-ignore-rules.ts) are fixed in the ts generation) - i.e. should be `(.*)` instead of `*`

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
