### PR TITLE
Add typings to spectacle queries

### DIFF
--- a/workspaces/ui-v2/src/lib/__tests/diff-helpers/universes/buildUniverse.ts
+++ b/workspaces/ui-v2/src/lib/__tests/diff-helpers/universes/buildUniverse.ts
@@ -1,10 +1,6 @@
 import { InMemoryOpticContextBuilder } from '@useoptic/spectacle/build/in-memory';
 import * as opticEngine from '@useoptic/diff-engine-wasm/engine/build';
-import {
-  IForkableSpectacle,
-  IOpticContext,
-  makeSpectacle,
-} from '@useoptic/spectacle';
+import { IOpticContext, makeSpectacle } from '@useoptic/spectacle';
 import { makeCurrentSpecContext } from '<src>/lib/__tests/diff-helpers/universes/makeCurrentSpecContext';
 import { CurrentSpecContext } from '<src>/lib/Interfaces';
 import { v4 as uuidv4 } from 'uuid';

--- a/workspaces/ui-v2/src/optic-components/hooks/useBatchCommits.tsx
+++ b/workspaces/ui-v2/src/optic-components/hooks/useBatchCommits.tsx
@@ -9,11 +9,21 @@ export const BatchCommitsQuery = `{
     }
 }`;
 
+export interface BatchCommit {
+  commitMessage: string;
+  batchId: string;
+  createdAt: string;
+}
+
+type BatchCommitResult = {
+  batchCommits: BatchCommit[];
+};
+
 export function useBatchCommits(): {
   loading: boolean;
   batchCommits: BatchCommit[];
 } {
-  const { data, loading, error } = useSpectacleQuery<any, any>({
+  const { data, loading, error } = useSpectacleQuery<BatchCommitResult>({
     query: BatchCommitsQuery,
     variables: {},
   });
@@ -51,10 +61,4 @@ export function useLastBatchCommitId(): string | undefined {
   } else {
     return undefined;
   }
-}
-
-export interface BatchCommit {
-  commitMessage: string;
-  batchId: string;
-  createdAt: string;
 }

--- a/workspaces/ui-v2/src/optic-components/hooks/useCapturesHook.tsx
+++ b/workspaces/ui-v2/src/optic-components/hooks/useCapturesHook.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { FC } from 'react';
 import { IOpticCapturesService, ICapture } from '@useoptic/spectacle';
 import { useContext, useEffect, useState } from 'react';
 
@@ -34,17 +34,16 @@ export function useCaptures(): {
 
 interface CapturesServiceStoreProps {
   capturesService: IOpticCapturesService;
-  children: any;
 }
 
 export const CapturesServiceContext = React.createContext<IOpticCapturesService | null>(
   null
 );
 
-export function CapturesServiceStore(props: CapturesServiceStoreProps) {
+export const CapturesServiceStore: FC<CapturesServiceStoreProps> = (props) => {
   return (
     <CapturesServiceContext.Provider value={props.capturesService}>
       {props.children}
     </CapturesServiceContext.Provider>
   );
-}
+};

--- a/workspaces/ui-v2/src/optic-components/hooks/useConfigHook.tsx
+++ b/workspaces/ui-v2/src/optic-components/hooks/useConfigHook.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { FC } from 'react';
 import { useContext } from 'react';
 import { IOpticConfigRepository } from '@useoptic/spectacle';
 
@@ -13,17 +13,16 @@ export function useConfigRepository(): {
 
 interface ConfigServiceStoreProps {
   config: IOpticConfigRepository;
-  children: any;
 }
 
 export const ConfigRepositoryContext = React.createContext<IOpticConfigRepository | null>(
   null
 );
 
-export function ConfigRepositoryStore(props: ConfigServiceStoreProps) {
+export const ConfigRepositoryStore: FC<ConfigServiceStoreProps> = (props) => {
   return (
     <ConfigRepositoryContext.Provider value={props.config}>
       {props.children}
     </ConfigRepositoryContext.Provider>
   );
-}
+};

--- a/workspaces/ui-v2/src/optic-components/hooks/useEndpointsChangelog.tsx
+++ b/workspaces/ui-v2/src/optic-components/hooks/useEndpointsChangelog.tsx
@@ -13,11 +13,19 @@ export const endpointChangeQuery = `query X($sinceBatchCommitId: String) {
     }
 }`;
 
-type Endpoints = any[];
+type ChangelogCategory = 'added' | 'updated' | 'removed';
+
+type EndpointChangelog = {
+  change: {
+    category: ChangelogCategory;
+  };
+  pathId: string;
+  method: string;
+};
 
 type EndpointChangeQueryResults = {
   endpointChanges: {
-    endpoints: Endpoints;
+    endpoints: EndpointChangelog[];
   };
 };
 
@@ -25,7 +33,9 @@ type EndpointChangeQueryInput = {
   sinceBatchCommitId?: string;
 };
 
-export function useEndpointsChangelog(sinceBatchCommitId?: string): Endpoints {
+export function useEndpointsChangelog(
+  sinceBatchCommitId?: string
+): EndpointChangelog[] {
   const queryResults = useSpectacleQuery<
     EndpointChangeQueryResults,
     EndpointChangeQueryInput

--- a/workspaces/ui-v2/src/optic-components/hooks/usePathsHook.ts
+++ b/workspaces/ui-v2/src/optic-components/hooks/usePathsHook.ts
@@ -11,26 +11,6 @@ export const AllPathsQuery = `{
     }
     }`;
 
-export function usePaths(): { paths: IPath[]; loading?: boolean } {
-  const queryInput = {
-    query: AllPathsQuery,
-    variables: {},
-  };
-
-  const { data, loading, error } = useSpectacleQuery<any>(queryInput);
-
-  if (error) {
-    console.error(error);
-    debugger;
-  }
-
-  if (data) {
-    return { paths: data.paths as IPath[], loading };
-  }
-
-  return { loading, paths: [] };
-}
-
 export interface IPath {
   absolutePathPattern: string;
   parentPathId: string | null;
@@ -38,4 +18,30 @@ export interface IPath {
   isParameterized: boolean;
   name: string;
   pathId: string;
+}
+
+export type PathQueryResponse = {
+  paths: IPath[];
+};
+
+export function usePaths(): { paths: IPath[]; loading?: boolean } {
+  const queryInput = {
+    query: AllPathsQuery,
+    variables: {},
+  };
+
+  const { data, loading, error } = useSpectacleQuery<PathQueryResponse>(
+    queryInput
+  );
+
+  if (error) {
+    console.error(error);
+    debugger;
+  }
+
+  if (data) {
+    return { paths: data.paths, loading };
+  }
+
+  return { loading, paths: [] };
 }

--- a/workspaces/ui-v2/src/optic-components/hooks/useShapeDescriptor.ts
+++ b/workspaces/ui-v2/src/optic-components/hooks/useShapeDescriptor.ts
@@ -145,7 +145,7 @@ export function useShapeDescriptor(
               })
             );
             choice.asObject.fields = newFields;
-            return choice;
+            return { ...choice, shapeId: choice.id };
 
           case 'Array':
             const results = await accumulateShapes(
@@ -157,15 +157,15 @@ export function useShapeDescriptor(
               ...i,
               shapeId: i.id,
             }));
-            return choice;
+            return { ...choice, shapeId: choice.id };
           default:
-            return choice;
+            return { ...choice, shapeId: choice.id };
         }
       })
     );
   }
 
-  const [x, setX] = useState<any[]>([]);
+  const [x, setX] = useState<IShapeRenderer[]>([]);
   useEffect(() => {
     async function task() {
       const seenSet: Set<string> = new Set();


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Slowly removing `any` typings - this time, I tackled all the spectacle queries and stuff. Given that I'm just updating typings, there shouldn't be any changes to the code (there's one place in the code that was changed, and that was related to the previous PR https://github.com/opticdev/optic/pull/807 around shapes which I forgot to update one part)

Adding typings should also make it easier to refactor + give us more confidence in refactoring

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
