### PR TITLE
scripts.ts: script name now required, offers scripts when match fails

### DIFF
--- a/workspaces/local-cli/src/commands/scripts.ts
+++ b/workspaces/local-cli/src/commands/scripts.ts
@@ -31,7 +31,7 @@ export default class Scripts extends Command {
   static args = [
     {
       name: 'scriptName',
-      required: false,
+      required: true,
     },
   ];
 
@@ -44,11 +44,7 @@ export default class Scripts extends Command {
 
   async run() {
     const { args, flags } = this.parse(Scripts);
-    const scriptName: string | undefined = args.scriptName;
-
-    if (!scriptName) {
-      return console.log('list all scripts...');
-    }
+    const scriptName: string = args.scriptName;
 
     const script: IOpticScript | undefined = await niceTry(async () => {
       const paths = await getPathsRelativeToConfig();
@@ -56,6 +52,22 @@ export default class Scripts extends Command {
       const foundScript = config.scripts?.[scriptName!];
       if (foundScript) {
         return normalizeScript(foundScript);
+      } else {
+        cli.log(
+          fromOptic(
+            `Script ${colors.grey.bold(
+              scriptName
+            )} does not exist. Try one of these ${colors.grey.bold(
+              'api scripts <scriptname>'
+            )}`
+          )
+        );
+        return cli.log(
+          Object.keys(config.scripts || [])
+            .map((i) => '- ' + i)
+            .sort()
+            .join('\n')
+        );
       }
     });
 


### PR DESCRIPTION
## Why

- Scripts didn't require a script name, but there was no function to run it without a script. Now a script name is required.
- Scripts now offers a list of scripts when it can't match the script name provided on the CLI, like the run command.
 
## What

- scripts.ts 
  - scriptName required parameter, removed undefined definition.
  - scripts listed when no match found 

## Validation
* [ ] CI passes
* [ ] Verified in staging
