### PR TITLE
Fix submit diff enter press

### DIFF
--- a/workspaces/ui-v2/src/optic-components/common/CommitMessageModal.tsx
+++ b/workspaces/ui-v2/src/optic-components/common/CommitMessageModal.tsx
@@ -31,7 +31,6 @@ export const CommitMessageModal: FC<CommitMessageModalProps> = ({
     () => {
       if (canSubmit) {
         onSave(commitMessage);
-        onClose();
       }
     },
     {


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Before the fix, a user would see:
<img width="847" alt="Screen Shot 2021-05-20 at 4 46 10 PM" src="https://user-images.githubusercontent.com/18374483/119062148-e4316580-b98a-11eb-9a6a-a116bbf2d9d0.png">

When in the diff flow, we want to be able to press enter - this fix was added previously (PR: https://github.com/opticdev/optic/pull/719#discussion_r626994148), but the enter flow was missed :(

A user should be able to press enter now.

## What
What's changing? Anything of note to call out?

- Removing the onClose on the keyPress. This is handled outside of the CommitMessageModal in both flows (in docs, the consumer of this component closes the model, in diff, the consumer does not close the modal as it uses it to determine if the PromptNavigation should show up)

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
