### PR TITLE
enable changelog on diff pages

### DIFF
--- a/workspaces/ui-v2/src/optic-components/pages/diffs/ReviewEndpointDiffPage/ReviewEndpointDiffPage.tsx
+++ b/workspaces/ui-v2/src/optic-components/pages/diffs/ReviewEndpointDiffPage/ReviewEndpointDiffPage.tsx
@@ -26,6 +26,7 @@ import {
   RenderedDiffHeader,
 } from './RenderedDiffHeader';
 import { EndpointDocumentationPane } from '../EndpointDocumentationPane';
+import { useLastBatchCommitId } from '<src>/optic-components/hooks/useBatchCommits';
 
 const useRedirectForDiffCompleted = (allDiffs: IInterpretation[]) => {
   const history = useHistory();
@@ -66,6 +67,8 @@ export const ReviewEndpointDiffPage: FC<ReviewEndpointDiffPageProps> = ({
     setCommitModalOpen,
     hasDiffChanges,
   } = useSharedDiffContext();
+
+  const batchCommit = useLastBatchCommitId();
 
   const debouncedSetName = useDebouncedFn(setGlobalDiffEndpointName, 200);
   const {
@@ -157,6 +160,7 @@ export const ReviewEndpointDiffPage: FC<ReviewEndpointDiffPageProps> = ({
           <EndpointDocumentationPane
             method={method}
             pathId={pathId}
+            lastBatchCommit={batchCommit}
             highlightedLocation={
               allDiffs[currentIndex].diffDescription?.location
             }


### PR DESCRIPTION
## Why
On the diff page, the simulated context can render the changes the user is staging to their spec. After they save it, they'll end up on the changelog page, where they can see what they just added. 

Now the same changelog queries that power the changelog page, power the review diff page, so you can see the changes better as you make them. 

https://www.loom.com/share/ecc249d6551c4e40af5d6f5f2d992752

## What
Added the lastBatchId (what the diff was run against) to the Documentation Pane

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
