### PR TITLE
Add spec id contribution to examples

### DIFF
--- a/workspaces/ui-v2/public/cloud-examples/example-1.json
+++ b/workspaces/ui-v2/public/cloud-examples/example-1.json
@@ -2780,5 +2780,18 @@
         "createdAt": "2021-04-29T19:58:12.307Z"
       }
     }
+  },
+  {
+    "ContributionAdded": {
+      "id": "metadata",
+      "key": "id",
+      "value": "caed4cd9-b16b-4c6b-871b-1ce70f4d6fb2",
+      "eventContext": {
+        "clientId": "anonymous",
+        "clientSessionId": "bade46c4-86f6-4692-be22-07caca8f6f05",
+        "clientCommandBatchId": "524f5418-59a0-493a-9c19-89f9abcefb58",
+        "createdAt": "2021-04-27T14:12:58.467Z"
+      }
+    }
   }
 ]

--- a/workspaces/ui-v2/public/example-sessions/debug-github-capture.json
+++ b/workspaces/ui-v2/public/example-sessions/debug-github-capture.json
@@ -52578,6 +52578,19 @@
           "createdAt": "2021-04-27T14:12:58.467Z"
         }
       }
+    },
+    {
+      "ContributionAdded": {
+        "id": "metadata",
+        "key": "id",
+        "value": "fe49e0c5-51a7-482c-b404-09eb6e6c523e",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "bade46c4-86f6-4692-be22-07caca8f6f05",
+          "clientCommandBatchId": "524f5418-59a0-493a-9c19-89f9abcefb58",
+          "createdAt": "2021-04-27T14:12:58.467Z"
+        }
+      }
     }
   ],
   "session": {

--- a/workspaces/ui-v2/public/example-sessions/diff-use-cases-with-events.json
+++ b/workspaces/ui-v2/public/example-sessions/diff-use-cases-with-events.json
@@ -1,3016 +1,3169 @@
 {
-	"events": [{
-		"PathComponentAdded": {
-			"pathId": "path_aPqDtqTGQN",
-			"parentPathId": "root",
-			"name": "object-cases",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"RequestParameterAddedByPathAndMethod": {
-			"parameterId": "request-parameter_8liVYqBo88",
-			"pathId": "path_aPqDtqTGQN",
-			"httpMethod": "GET",
-			"parameterLocation": "query",
-			"name": "queryString",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_9I8mJp8URF",
-			"baseShapeId": "$object",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"RequestParameterShapeSet": {
-			"parameterId": "request-parameter_8liVYqBo88",
-			"parameterDescriptor": {
-				"shapeId": "shape_9I8mJp8URF",
-				"isRemoved": false
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"RequestAdded": {
-			"requestId": "request_OQ4xWs0s32",
-			"pathId": "path_aPqDtqTGQN",
-			"httpMethod": "GET",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ResponseAddedByPathAndMethod": {
-			"responseId": "response_Zomj5bzNBt",
-			"pathId": "path_aPqDtqTGQN",
-			"httpMethod": "GET",
-			"httpStatusCode": 200,
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_tNRgroSwLj",
-			"baseShapeId": "$object",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_qQT0krhOKn",
-			"baseShapeId": "$number",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"FieldAdded": {
-			"fieldId": "field_hnI7P1UdbB",
-			"shapeId": "shape_tNRgroSwLj",
-			"name": "age",
-			"shapeDescriptor": {
-				"FieldShapeFromShape": {
-					"fieldId": "field_hnI7P1UdbB",
-					"shapeId": "shape_qQT0krhOKn"
-				}
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_9OWZoB9AQp",
-			"baseShapeId": "$string",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_ZLv9FF57ot",
-			"baseShapeId": "$list",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"FieldAdded": {
-			"fieldId": "field_fjcgB9O1Gg",
-			"shapeId": "shape_tNRgroSwLj",
-			"name": "cities",
-			"shapeDescriptor": {
-				"FieldShapeFromShape": {
-					"fieldId": "field_fjcgB9O1Gg",
-					"shapeId": "shape_ZLv9FF57ot"
-				}
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_qDxLTuap52",
-			"baseShapeId": "$string",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"FieldAdded": {
-			"fieldId": "field_omQ4Bb39Ny",
-			"shapeId": "shape_tNRgroSwLj",
-			"name": "firstName",
-			"shapeDescriptor": {
-				"FieldShapeFromShape": {
-					"fieldId": "field_omQ4Bb39Ny",
-					"shapeId": "shape_qDxLTuap52"
-				}
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_vAxrdAagEj",
-			"baseShapeId": "$string",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"FieldAdded": {
-			"fieldId": "field_EXPFebUkPZ",
-			"shapeId": "shape_tNRgroSwLj",
-			"name": "lastName",
-			"shapeDescriptor": {
-				"FieldShapeFromShape": {
-					"fieldId": "field_EXPFebUkPZ",
-					"shapeId": "shape_vAxrdAagEj"
-				}
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeParameterShapeSet": {
-			"shapeDescriptor": {
-				"ProviderInShape": {
-					"shapeId": "shape_ZLv9FF57ot",
-					"providerDescriptor": {
-						"ShapeProvider": {
-							"shapeId": "shape_9OWZoB9AQp"
-						}
-					},
-					"consumingParameterId": "$listItem"
-				}
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ResponseBodySet": {
-			"responseId": "response_Zomj5bzNBt",
-			"bodyDescriptor": {
-				"httpContentType": "application/json",
-				"shapeId": "shape_tNRgroSwLj",
-				"isRemoved": false
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"PathComponentAdded": {
-			"pathId": "path_XEnuaiwyv5",
-			"parentPathId": "root",
-			"name": "objects-with-polymorphism",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"RequestParameterAddedByPathAndMethod": {
-			"parameterId": "request-parameter_NTvEezUEY8",
-			"pathId": "path_XEnuaiwyv5",
-			"httpMethod": "GET",
-			"parameterLocation": "query",
-			"name": "queryString",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_s8F6CLkcEw",
-			"baseShapeId": "$object",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"RequestParameterShapeSet": {
-			"parameterId": "request-parameter_NTvEezUEY8",
-			"parameterDescriptor": {
-				"shapeId": "shape_s8F6CLkcEw",
-				"isRemoved": false
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"RequestAdded": {
-			"requestId": "request_n9zG6yfB3K",
-			"pathId": "path_XEnuaiwyv5",
-			"httpMethod": "GET",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ResponseAddedByPathAndMethod": {
-			"responseId": "response_H7mgBDW3pA",
-			"pathId": "path_XEnuaiwyv5",
-			"httpMethod": "GET",
-			"httpStatusCode": 200,
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_kG1JHYgXIw",
-			"baseShapeId": "$object",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_0Rjwrc4XVQ",
-			"baseShapeId": "$object",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_c7nwdWQh7i",
-			"baseShapeId": "$object",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_U2jHOzauf7",
-			"baseShapeId": "$string",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"FieldAdded": {
-			"fieldId": "field_FDw7T8P1Gl",
-			"shapeId": "shape_c7nwdWQh7i",
-			"name": "city",
-			"shapeDescriptor": {
-				"FieldShapeFromShape": {
-					"fieldId": "field_FDw7T8P1Gl",
-					"shapeId": "shape_U2jHOzauf7"
-				}
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_LaPF9H2WkT",
-			"baseShapeId": "$object",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_ADzn5yEIWh",
-			"baseShapeId": "$string",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"FieldAdded": {
-			"fieldId": "field_amFoSPj0Yo",
-			"shapeId": "shape_LaPF9H2WkT",
-			"name": "lat",
-			"shapeDescriptor": {
-				"FieldShapeFromShape": {
-					"fieldId": "field_amFoSPj0Yo",
-					"shapeId": "shape_ADzn5yEIWh"
-				}
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_5pqWBXK957",
-			"baseShapeId": "$string",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"FieldAdded": {
-			"fieldId": "field_QVDqUvTV6F",
-			"shapeId": "shape_LaPF9H2WkT",
-			"name": "long",
-			"shapeDescriptor": {
-				"FieldShapeFromShape": {
-					"fieldId": "field_QVDqUvTV6F",
-					"shapeId": "shape_5pqWBXK957"
-				}
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_CMo2evf3EE",
-			"baseShapeId": "$optional",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"FieldAdded": {
-			"fieldId": "field_LsaJwQ6B3R",
-			"shapeId": "shape_c7nwdWQh7i",
-			"name": "coordinates",
-			"shapeDescriptor": {
-				"FieldShapeFromShape": {
-					"fieldId": "field_LsaJwQ6B3R",
-					"shapeId": "shape_CMo2evf3EE"
-				}
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_1VsVz1ldHm",
-			"baseShapeId": "$number",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"FieldAdded": {
-			"fieldId": "field_azOTr94eA4",
-			"shapeId": "shape_c7nwdWQh7i",
-			"name": "population",
-			"shapeDescriptor": {
-				"FieldShapeFromShape": {
-					"fieldId": "field_azOTr94eA4",
-					"shapeId": "shape_1VsVz1ldHm"
-				}
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"FieldAdded": {
-			"fieldId": "field_Tc108m0Nsy",
-			"shapeId": "shape_0Rjwrc4XVQ",
-			"name": "principality",
-			"shapeDescriptor": {
-				"FieldShapeFromShape": {
-					"fieldId": "field_Tc108m0Nsy",
-					"shapeId": "shape_c7nwdWQh7i"
-				}
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"FieldAdded": {
-			"fieldId": "field_bYgbrlhzFP",
-			"shapeId": "shape_kG1JHYgXIw",
-			"name": "location",
-			"shapeDescriptor": {
-				"FieldShapeFromShape": {
-					"fieldId": "field_bYgbrlhzFP",
-					"shapeId": "shape_0Rjwrc4XVQ"
-				}
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeParameterShapeSet": {
-			"shapeDescriptor": {
-				"ProviderInShape": {
-					"shapeId": "shape_CMo2evf3EE",
-					"providerDescriptor": {
-						"ShapeProvider": {
-							"shapeId": "shape_LaPF9H2WkT"
-						}
-					},
-					"consumingParameterId": "$optionalInner"
-				}
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ResponseBodySet": {
-			"responseId": "response_H7mgBDW3pA",
-			"bodyDescriptor": {
-				"httpContentType": "application/json",
-				"shapeId": "shape_kG1JHYgXIw",
-				"isRemoved": false
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"PathComponentAdded": {
-			"pathId": "path_A71l1LOES0",
-			"parentPathId": "root",
-			"name": "array-fields",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"RequestParameterAddedByPathAndMethod": {
-			"parameterId": "request-parameter_XtaymTHqde",
-			"pathId": "path_A71l1LOES0",
-			"httpMethod": "GET",
-			"parameterLocation": "query",
-			"name": "queryString",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_kPyodZ4Tic",
-			"baseShapeId": "$object",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"RequestParameterShapeSet": {
-			"parameterId": "request-parameter_XtaymTHqde",
-			"parameterDescriptor": {
-				"shapeId": "shape_kPyodZ4Tic",
-				"isRemoved": false
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"RequestAdded": {
-			"requestId": "request_Hmhp7AWRlF",
-			"pathId": "path_A71l1LOES0",
-			"httpMethod": "GET",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ResponseAddedByPathAndMethod": {
-			"responseId": "response_XkzGtHuniJ",
-			"pathId": "path_A71l1LOES0",
-			"httpMethod": "GET",
-			"httpStatusCode": 200,
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_BWimY31MBw",
-			"baseShapeId": "$object",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_4wTXC2brco",
-			"baseShapeId": "$object",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_DQ1MeMzNwO",
-			"baseShapeId": "$string",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"FieldAdded": {
-			"fieldId": "field_aFCbmry97x",
-			"shapeId": "shape_4wTXC2brco",
-			"name": "first",
-			"shapeDescriptor": {
-				"FieldShapeFromShape": {
-					"fieldId": "field_aFCbmry97x",
-					"shapeId": "shape_DQ1MeMzNwO"
-				}
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_ePM01PGijN",
-			"baseShapeId": "$string",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"FieldAdded": {
-			"fieldId": "field_MJxJUokUYA",
-			"shapeId": "shape_4wTXC2brco",
-			"name": "last",
-			"shapeDescriptor": {
-				"FieldShapeFromShape": {
-					"fieldId": "field_MJxJUokUYA",
-					"shapeId": "shape_ePM01PGijN"
-				}
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"FieldAdded": {
-			"fieldId": "field_WmF0jHCqFh",
-			"shapeId": "shape_BWimY31MBw",
-			"name": "name",
-			"shapeDescriptor": {
-				"FieldShapeFromShape": {
-					"fieldId": "field_WmF0jHCqFh",
-					"shapeId": "shape_4wTXC2brco"
-				}
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_k0u0Kstovv",
-			"baseShapeId": "$string",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_FAm5wD1PJP",
-			"baseShapeId": "$list",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"FieldAdded": {
-			"fieldId": "field_BbiTcbzz0p",
-			"shapeId": "shape_BWimY31MBw",
-			"name": "rivals",
-			"shapeDescriptor": {
-				"FieldShapeFromShape": {
-					"fieldId": "field_BbiTcbzz0p",
-					"shapeId": "shape_FAm5wD1PJP"
-				}
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_HzYyBRjlHl",
-			"baseShapeId": "$object",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_3Ay8F2W3GS",
-			"baseShapeId": "$number",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"FieldAdded": {
-			"fieldId": "field_HzVqitaYDq",
-			"shapeId": "shape_HzYyBRjlHl",
-			"name": "rank",
-			"shapeDescriptor": {
-				"FieldShapeFromShape": {
-					"fieldId": "field_HzVqitaYDq",
-					"shapeId": "shape_3Ay8F2W3GS"
-				}
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"FieldAdded": {
-			"fieldId": "field_31fR9LMutK",
-			"shapeId": "shape_BWimY31MBw",
-			"name": "stats",
-			"shapeDescriptor": {
-				"FieldShapeFromShape": {
-					"fieldId": "field_31fR9LMutK",
-					"shapeId": "shape_HzYyBRjlHl"
-				}
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeParameterShapeSet": {
-			"shapeDescriptor": {
-				"ProviderInShape": {
-					"shapeId": "shape_FAm5wD1PJP",
-					"providerDescriptor": {
-						"ShapeProvider": {
-							"shapeId": "shape_k0u0Kstovv"
-						}
-					},
-					"consumingParameterId": "$listItem"
-				}
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ResponseBodySet": {
-			"responseId": "response_XkzGtHuniJ",
-			"bodyDescriptor": {
-				"httpContentType": "application/json",
-				"shapeId": "shape_BWimY31MBw",
-				"isRemoved": false
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"PathComponentAdded": {
-			"pathId": "path_BKCtxJ5lMQ",
-			"parentPathId": "root",
-			"name": "root-arrays",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"RequestParameterAddedByPathAndMethod": {
-			"parameterId": "request-parameter_0OWaHJAew9",
-			"pathId": "path_BKCtxJ5lMQ",
-			"httpMethod": "GET",
-			"parameterLocation": "query",
-			"name": "queryString",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_j0PSviBb9e",
-			"baseShapeId": "$object",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"RequestParameterShapeSet": {
-			"parameterId": "request-parameter_0OWaHJAew9",
-			"parameterDescriptor": {
-				"shapeId": "shape_j0PSviBb9e",
-				"isRemoved": false
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"RequestAdded": {
-			"requestId": "request_Dne0Uvp054",
-			"pathId": "path_BKCtxJ5lMQ",
-			"httpMethod": "GET",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ResponseAddedByPathAndMethod": {
-			"responseId": "response_hnuIacJfkl",
-			"pathId": "path_BKCtxJ5lMQ",
-			"httpMethod": "GET",
-			"httpStatusCode": 200,
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_NQW7KNlDs8",
-			"baseShapeId": "$unknown",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_NjFGT8ElYj",
-			"baseShapeId": "$list",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeParameterShapeSet": {
-			"shapeDescriptor": {
-				"ProviderInShape": {
-					"shapeId": "shape_NjFGT8ElYj",
-					"providerDescriptor": {
-						"ShapeProvider": {
-							"shapeId": "shape_NQW7KNlDs8"
-						}
-					},
-					"consumingParameterId": "$listItem"
-				}
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ResponseBodySet": {
-			"responseId": "response_hnuIacJfkl",
-			"bodyDescriptor": {
-				"httpContentType": "application/json",
-				"shapeId": "shape_NjFGT8ElYj",
-				"isRemoved": false
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"PathComponentAdded": {
-			"pathId": "path_H0AUOucMZ6",
-			"parentPathId": "root",
-			"name": "object-as-array-items",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"RequestParameterAddedByPathAndMethod": {
-			"parameterId": "request-parameter_pWotHKllb1",
-			"pathId": "path_H0AUOucMZ6",
-			"httpMethod": "GET",
-			"parameterLocation": "query",
-			"name": "queryString",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_GwzyotIy4p",
-			"baseShapeId": "$object",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"RequestParameterShapeSet": {
-			"parameterId": "request-parameter_pWotHKllb1",
-			"parameterDescriptor": {
-				"shapeId": "shape_GwzyotIy4p",
-				"isRemoved": false
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"RequestAdded": {
-			"requestId": "request_v0sCV28mBz",
-			"pathId": "path_H0AUOucMZ6",
-			"httpMethod": "GET",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ResponseAddedByPathAndMethod": {
-			"responseId": "response_U9Ma4zEui4",
-			"pathId": "path_H0AUOucMZ6",
-			"httpMethod": "GET",
-			"httpStatusCode": 200,
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_LSzE6p0ick",
-			"baseShapeId": "$object",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_6CwLrwbise",
-			"baseShapeId": "$string",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"FieldAdded": {
-			"fieldId": "field_uSFm8IzsuO",
-			"shapeId": "shape_LSzE6p0ick",
-			"name": "age",
-			"shapeDescriptor": {
-				"FieldShapeFromShape": {
-					"fieldId": "field_uSFm8IzsuO",
-					"shapeId": "shape_6CwLrwbise"
-				}
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_7RPHWUNFwp",
-			"baseShapeId": "$string",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_o8q1TVrxeB",
-			"baseShapeId": "$list",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"FieldAdded": {
-			"fieldId": "field_Xozc5zyWHI",
-			"shapeId": "shape_LSzE6p0ick",
-			"name": "colors",
-			"shapeDescriptor": {
-				"FieldShapeFromShape": {
-					"fieldId": "field_Xozc5zyWHI",
-					"shapeId": "shape_o8q1TVrxeB"
-				}
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_29Ms5ZQ8uC",
-			"baseShapeId": "$string",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"FieldAdded": {
-			"fieldId": "field_XkyOiEDHFy",
-			"shapeId": "shape_LSzE6p0ick",
-			"name": "name",
-			"shapeDescriptor": {
-				"FieldShapeFromShape": {
-					"fieldId": "field_XkyOiEDHFy",
-					"shapeId": "shape_29Ms5ZQ8uC"
-				}
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "shape_QK42v9Q9jR",
-			"baseShapeId": "$list",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeParameterShapeSet": {
-			"shapeDescriptor": {
-				"ProviderInShape": {
-					"shapeId": "shape_o8q1TVrxeB",
-					"providerDescriptor": {
-						"ShapeProvider": {
-							"shapeId": "shape_7RPHWUNFwp"
-						}
-					},
-					"consumingParameterId": "$listItem"
-				}
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeParameterShapeSet": {
-			"shapeDescriptor": {
-				"ProviderInShape": {
-					"shapeId": "shape_QK42v9Q9jR",
-					"providerDescriptor": {
-						"ShapeProvider": {
-							"shapeId": "shape_LSzE6p0ick"
-						}
-					},
-					"consumingParameterId": "$listItem"
-				}
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ResponseBodySet": {
-			"responseId": "response_U9Ma4zEui4",
-			"bodyDescriptor": {
-				"httpContentType": "application/json",
-				"shapeId": "shape_QK42v9Q9jR",
-				"isRemoved": false
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"PathComponentAdded": {
-			"pathId": "baseline-path_1",
-			"parentPathId": "root",
-			"name": "nullables",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"RequestParameterAddedByPathAndMethod": {
-			"parameterId": "baseline-request-parameter_1",
-			"pathId": "baseline-path_1",
-			"httpMethod": "GET",
-			"parameterLocation": "query",
-			"name": "queryString",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "baseline-shape_10",
-			"baseShapeId": "$object",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"RequestParameterShapeSet": {
-			"parameterId": "baseline-request-parameter_1",
-			"parameterDescriptor": {
-				"shapeId": "baseline-shape_10",
-				"isRemoved": false
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"RequestAdded": {
-			"requestId": "baseline-request_1",
-			"pathId": "baseline-path_1",
-			"httpMethod": "GET",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ResponseAddedByPathAndMethod": {
-			"responseId": "baseline-response_1",
-			"pathId": "baseline-path_1",
-			"httpMethod": "GET",
-			"httpStatusCode": 200,
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "baseline-shape_8",
-			"baseShapeId": "$object",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "baseline-shape_5",
-			"baseShapeId": "$string",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"FieldAdded": {
-			"fieldId": "baseline-field_3",
-			"shapeId": "baseline-shape_8",
-			"name": "address",
-			"shapeDescriptor": {
-				"FieldShapeFromShape": {
-					"fieldId": "baseline-field_3",
-					"shapeId": "baseline-shape_5"
-				}
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "baseline-shape_6",
-			"baseShapeId": "$unknown",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "baseline-shape_7",
-			"baseShapeId": "$nullable",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"FieldAdded": {
-			"fieldId": "baseline-field_4",
-			"shapeId": "baseline-shape_8",
-			"name": "price",
-			"shapeDescriptor": {
-				"FieldShapeFromShape": {
-					"fieldId": "baseline-field_4",
-					"shapeId": "baseline-shape_7"
-				}
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeAdded": {
-			"shapeId": "baseline-shape_9",
-			"baseShapeId": "$list",
-			"parameters": {
-				"DynamicParameterList": {
-					"shapeParameterIds": []
-				}
-			},
-			"name": "",
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeParameterShapeSet": {
-			"shapeDescriptor": {
-				"ProviderInShape": {
-					"shapeId": "baseline-shape_7",
-					"providerDescriptor": {
-						"ShapeProvider": {
-							"shapeId": "baseline-shape_6"
-						}
-					},
-					"consumingParameterId": "$nullableInner"
-				}
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ShapeParameterShapeSet": {
-			"shapeDescriptor": {
-				"ProviderInShape": {
-					"shapeId": "baseline-shape_9",
-					"providerDescriptor": {
-						"ShapeProvider": {
-							"shapeId": "baseline-shape_8"
-						}
-					},
-					"consumingParameterId": "$listItem"
-				}
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}, {
-		"ResponseBodySet": {
-			"responseId": "baseline-response_1",
-			"bodyDescriptor": {
-				"httpContentType": "application/json",
-				"shapeId": "baseline-shape_9",
-				"isRemoved": false
-			},
-			"eventContext": {
-				"clientId": "ccc",
-				"clientSessionId": "sss",
-				"clientCommandBatchId": "bbb",
-				"createdAt": "NOW"
-			}
-		}
-	}],
-	"session": {
-		"samples": [{
-			"uuid": "id17",
-			"request": {
-				"host": "example.com",
-				"method": "GET",
-				"path": "/object-cases",
-				"query": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": null,
-					"value": {
-						"shapeHashV1Base64": null,
-						"asJsonString": null,
-						"asText": null
-					}
-				}
-			},
-			"response": {
-				"statusCode": 200,
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": "application/json",
-					"value": {
-						"shapeHashV1Base64": "Eg4KCGxhc3ROYW1lEgIIAhIJCgNhZ2USAggDEhgKBmNpdGllcxIOCAEaAggCGgIIAhoCCAI=",
-						"asJsonString": "{\"lastName\":\"C\",\"age\":26,\"cities\":[\"San Fransisco\",\"New York\",\"Durham\"]}",
-						"asText": "{\"lastName\":\"C\",\"age\":26,\"cities\":[\"San Fransisco\",\"New York\",\"Durham\"]}"
-					}
-				}
-			},
-			"tags": []
-		}, {
-			"uuid": "id18",
-			"request": {
-				"host": "example.com",
-				"method": "GET",
-				"path": "/object-cases",
-				"query": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": null,
-					"value": {
-						"shapeHashV1Base64": null,
-						"asJsonString": null,
-						"asText": null
-					}
-				}
-			},
-			"response": {
-				"statusCode": 200,
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": "application/json",
-					"value": {
-						"shapeHashV1Base64": "Eg8KCWZpcnN0TmFtZRICCAISDgoIbGFzdE5hbWUSAggCEgkKA2FnZRICCAISGAoGY2l0aWVzEg4IARoCCAIaAggCGgIIAg==",
-						"asJsonString": "{\"firstName\":\"Aidan\",\"lastName\":\"C\",\"age\":\"not a number\",\"cities\":[\"San Fransisco\",\"New York\",\"Durham\"]}",
-						"asText": "{\"firstName\":\"Aidan\",\"lastName\":\"C\",\"age\":\"not a number\",\"cities\":[\"San Fransisco\",\"New York\",\"Durham\"]}"
-					}
-				}
-			},
-			"tags": []
-		}, {
-			"uuid": "id19",
-			"request": {
-				"host": "example.com",
-				"method": "GET",
-				"path": "/objects-with-polymorphism",
-				"query": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": null,
-					"value": {
-						"shapeHashV1Base64": null,
-						"asJsonString": null,
-						"asText": null
-					}
-				}
-			},
-			"response": {
-				"statusCode": 200,
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": "application/json",
-					"value": {
-						"shapeHashV1Base64": "ElUKCGxvY2F0aW9uEkkSRwoMcHJpbmNpcGFsaXR5EjcSCgoEY2l0eRICCAISEAoKcG9wdWxhdGlvbhICCAMSFwoFYXJyYXkSDggBGgIIAxoCCAMaAggD",
-						"asJsonString": "{\"location\":{\"principality\":{\"city\":\"San Fransisco\",\"population\":830000,\"array\":[1,2,3]}}}",
-						"asText": "{\"location\":{\"principality\":{\"city\":\"San Fransisco\",\"population\":830000,\"array\":[1,2,3]}}}"
-					}
-				}
-			},
-			"tags": []
-		}, {
-			"uuid": "id20",
-			"request": {
-				"host": "example.com",
-				"method": "GET",
-				"path": "/objects-with-polymorphism",
-				"query": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": null,
-					"value": {
-						"shapeHashV1Base64": null,
-						"asJsonString": null,
-						"asText": null
-					}
-				}
-			},
-			"response": {
-				"statusCode": 200,
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": "application/json",
-					"value": {
-						"shapeHashV1Base64": "EkkKCGxvY2F0aW9uEj0SOwoMcHJpbmNpcGFsaXR5EisSCgoEY2l0eRICCAISEAoKcG9wdWxhdGlvbhICCAMSCwoFYXJyYXkSAggB",
-						"asJsonString": "{\"location\":{\"principality\":{\"city\":\"San Fransisco\",\"population\":830000,\"array\":[]}}}",
-						"asText": "{\"location\":{\"principality\":{\"city\":\"San Fransisco\",\"population\":830000,\"array\":[]}}}"
-					}
-				}
-			},
-			"tags": []
-		}, {
-			"uuid": "id21",
-			"request": {
-				"host": "example.com",
-				"method": "GET",
-				"path": "/objects-with-polymorphism",
-				"query": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": null,
-					"value": {
-						"shapeHashV1Base64": null,
-						"asJsonString": null,
-						"asText": null
-					}
-				}
-			},
-			"response": {
-				"statusCode": 200,
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": "application/json",
-					"value": {
-						"shapeHashV1Base64": "EkkKCGxvY2F0aW9uEj0SOwoMcHJpbmNpcGFsaXR5EisSCwoFbW90dG8SAggCEgoKBGNpdHkSAggCEhAKCnBvcHVsYXRpb24SAggD",
-						"asJsonString": "{\"location\":{\"principality\":{\"motto\":\"Experientia Docet\",\"city\":\"San Fransisco\",\"population\":830000}}}",
-						"asText": "{\"location\":{\"principality\":{\"motto\":\"Experientia Docet\",\"city\":\"San Fransisco\",\"population\":830000}}}"
-					}
-				}
-			},
-			"tags": []
-		}, {
-			"uuid": "id22",
-			"request": {
-				"host": "example.com",
-				"method": "GET",
-				"path": "/objects-with-polymorphism",
-				"query": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": null,
-					"value": {
-						"shapeHashV1Base64": null,
-						"asJsonString": null,
-						"asText": null
-					}
-				}
-			},
-			"response": {
-				"statusCode": 200,
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": "application/json",
-					"value": {
-						"shapeHashV1Base64": "EnIKCGxvY2F0aW9uEmYSZAoMcHJpbmNpcGFsaXR5ElQSCgoEY2l0eRICCAISEAoKcG9wdWxhdGlvbhICCAMSNAoLY29vcmRpbmF0ZXMSJRIMCgZmb3JtYXQSAggCEgkKA2xhdBICCAISCgoEbG9uZxICCAI=",
-						"asJsonString": "{\"location\":{\"principality\":{\"city\":\"San Fransisco\",\"population\":830000,\"coordinates\":{\"format\":\"DMS\",\"lat\":\"37.7749° N\",\"long\":\"122.4194° W\"}}}}",
-						"asText": "{\"location\":{\"principality\":{\"city\":\"San Fransisco\",\"population\":830000,\"coordinates\":{\"format\":\"DMS\",\"lat\":\"37.7749° N\",\"long\":\"122.4194° W\"}}}}"
-					}
-				}
-			},
-			"tags": []
-		}, {
-			"uuid": "id23",
-			"request": {
-				"host": "example.com",
-				"method": "GET",
-				"path": "/objects-with-polymorphism",
-				"query": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": null,
-					"value": {
-						"shapeHashV1Base64": null,
-						"asJsonString": null,
-						"asText": null
-					}
-				}
-			},
-			"response": {
-				"statusCode": 200,
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": "application/json",
-					"value": {
-						"shapeHashV1Base64": "Ek8KCGxvY2F0aW9uEkMSQQoMcHJpbmNpcGFsaXR5EjESCgoEY2l0eRICCAISEAoKcG9wdWxhdGlvbhICCAMSEQoLY29vcmRpbmF0ZXMSAggC",
-						"asJsonString": "{\"location\":{\"principality\":{\"city\":\"San Fransisco\",\"population\":830000,\"coordinates\":\"N/A\"}}}",
-						"asText": "{\"location\":{\"principality\":{\"city\":\"San Fransisco\",\"population\":830000,\"coordinates\":\"N/A\"}}}"
-					}
-				}
-			},
-			"tags": []
-		}, {
-			"uuid": "id24",
-			"request": {
-				"host": "example.com",
-				"method": "GET",
-				"path": "/array-fields",
-				"query": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": null,
-					"value": {
-						"shapeHashV1Base64": null,
-						"asJsonString": null,
-						"asText": null
-					}
-				}
-			},
-			"response": {
-				"statusCode": 200,
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": "application/json",
-					"value": {
-						"shapeHashV1Base64": "EiEKBG5hbWUSGRILCgVmaXJzdBICCAISCgoEbGFzdBICCAISDAoGcml2YWxzEgIIARIVCgVzdGF0cxIMEgoKBHJhbmsSAggD",
-						"asJsonString": "{\"name\":{\"first\":\"Bob\",\"last\":\"C\"},\"rivals\":[],\"stats\":{\"rank\":1}}",
-						"asText": "{\"name\":{\"first\":\"Bob\",\"last\":\"C\"},\"rivals\":[],\"stats\":{\"rank\":1}}"
-					}
-				}
-			},
-			"tags": []
-		}, {
-			"uuid": "id25",
-			"request": {
-				"host": "example.com",
-				"method": "GET",
-				"path": "/array-fields",
-				"query": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": null,
-					"value": {
-						"shapeHashV1Base64": null,
-						"asJsonString": null,
-						"asText": null
-					}
-				}
-			},
-			"response": {
-				"statusCode": 200,
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": "application/json",
-					"value": {
-						"shapeHashV1Base64": "EiEKBG5hbWUSGRILCgVmaXJzdBICCAISCgoEbGFzdBICCAISGQoGcml2YWxzEg8SDQoHbmVtZXNpcxICCAISFQoFc3RhdHMSDBIKCgRyYW5rEgIIAw==",
-						"asJsonString": "{\"name\":{\"first\":\"Bob\",\"last\":\"C\"},\"rivals\":{\"nemesis\":\"Brad\"},\"stats\":{\"rank\":1}}",
-						"asText": "{\"name\":{\"first\":\"Bob\",\"last\":\"C\"},\"rivals\":{\"nemesis\":\"Brad\"},\"stats\":{\"rank\":1}}"
-					}
-				}
-			},
-			"tags": []
-		}, {
-			"uuid": "id26",
-			"request": {
-				"host": "example.com",
-				"method": "GET",
-				"path": "/array-fields",
-				"query": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": null,
-					"value": {
-						"shapeHashV1Base64": null,
-						"asJsonString": null,
-						"asText": null
-					}
-				}
-			},
-			"response": {
-				"statusCode": 200,
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": "application/json",
-					"value": {
-						"shapeHashV1Base64": "EiEKBG5hbWUSGRILCgVmaXJzdBICCAISCgoEbGFzdBICCAISNgoGcml2YWxzEiwIARoMEgoKBGZvb2QSAggCGgwSCgoEZm9vZBICCAIaDBIKCgRmb29kEgIIAhIVCgVzdGF0cxIMEgoKBHJhbmsSAggD",
-						"asJsonString": "{\"name\":{\"first\":\"Bob\",\"last\":\"C\"},\"rivals\":[{\"food\":\"rice\"},{\"food\":\"cookies\"},{\"food\":\"chips\"}],\"stats\":{\"rank\":1}}",
-						"asText": "{\"name\":{\"first\":\"Bob\",\"last\":\"C\"},\"rivals\":[{\"food\":\"rice\"},{\"food\":\"cookies\"},{\"food\":\"chips\"}],\"stats\":{\"rank\":1}}"
-					}
-				}
-			},
-			"tags": []
-		}, {
-			"uuid": "id27",
-			"request": {
-				"host": "example.com",
-				"method": "GET",
-				"path": "/objects-with-polymorphism",
-				"query": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": null,
-					"value": {
-						"shapeHashV1Base64": null,
-						"asJsonString": null,
-						"asText": null
-					}
-				}
-			},
-			"response": {
-				"statusCode": 200,
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": "application/json",
-					"value": {
-						"shapeHashV1Base64": "ElsKCGxvY2F0aW9uEk8STQoMcHJpbmNpcGFsaXR5Ej0SCgoEY2l0eRICCAISEAoKcG9wdWxhdGlvbhICCAMSHQoLY29vcmRpbmF0ZXMSDggBGgIIAxoCCAMaAggD",
-						"asJsonString": "{\"location\":{\"principality\":{\"city\":\"San Fransisco\",\"population\":830000,\"coordinates\":[1,2,3]}}}",
-						"asText": "{\"location\":{\"principality\":{\"city\":\"San Fransisco\",\"population\":830000,\"coordinates\":[1,2,3]}}}"
-					}
-				}
-			},
-			"tags": []
-		}, {
-			"uuid": "id28",
-			"request": {
-				"host": "example.com",
-				"method": "GET",
-				"path": "/object-cases",
-				"query": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": null,
-					"value": {
-						"shapeHashV1Base64": null,
-						"asJsonString": null,
-						"asText": null
-					}
-				}
-			},
-			"response": {
-				"statusCode": 200,
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": "application/json",
-					"value": {
-						"shapeHashV1Base64": "EgkKA2FnZRICCAMSDgoIbGFzdE5hbWUSAggCEg8KCWZpcnN0TmFtZRICCAISLAoNZmF2b3JpdGVDb2xvchIbEgsKBWZpcnN0EgIIAhIMCgZzZWNvbmQSAggCEhgKBmNpdGllcxIOCAEaAggCGgIIAhoCCAI=",
-						"asJsonString": "{\"firstName\":\"Aidan\",\"lastName\":\"C\",\"age\":26,\"cities\":[\"San Fransisco\",\"New York\",\"Durham\"],\"favoriteColor\":{\"first\":\"orange\",\"second\":\"red\"}}",
-						"asText": "{\"firstName\":\"Aidan\",\"lastName\":\"C\",\"age\":26,\"cities\":[\"San Fransisco\",\"New York\",\"Durham\"],\"favoriteColor\":{\"first\":\"orange\",\"second\":\"red\"}}"
-					}
-				}
-			},
-			"tags": []
-		}, {
-			"uuid": "id29",
-			"request": {
-				"host": "example.com",
-				"method": "GET",
-				"path": "/object-cases",
-				"query": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": null,
-					"value": {
-						"shapeHashV1Base64": null,
-						"asJsonString": null,
-						"asText": null
-					}
-				}
-			},
-			"response": {
-				"statusCode": 200,
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": "application/json",
-					"value": {
-						"shapeHashV1Base64": "EgkKA2FnZRICCAMSDgoIbGFzdE5hbWUSAggCEg8KCWZpcnN0TmFtZRICCAISEwoNZmF2b3JpdGVDb2xvchICCAISGAoGY2l0aWVzEg4IARoCCAIaAggCGgIIAg==",
-						"asJsonString": "{\"firstName\":\"Aidan\",\"lastName\":\"C\",\"age\":26,\"cities\":[\"San Fransisco\",\"New York\",\"Durham\"],\"favoriteColor\":\"Syracuse-Orange\"}",
-						"asText": "{\"firstName\":\"Aidan\",\"lastName\":\"C\",\"age\":26,\"cities\":[\"San Fransisco\",\"New York\",\"Durham\"],\"favoriteColor\":\"Syracuse-Orange\"}"
-					}
-				}
-			},
-			"tags": []
-		}, {
-			"uuid": "id30",
-			"request": {
-				"host": "example.com",
-				"method": "GET",
-				"path": "/array-fields",
-				"query": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": null,
-					"value": {
-						"shapeHashV1Base64": null,
-						"asJsonString": null,
-						"asText": null
-					}
-				}
-			},
-			"response": {
-				"statusCode": 200,
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": "application/json",
-					"value": {
-						"shapeHashV1Base64": "EiEKBG5hbWUSGRILCgVmaXJzdBICCAISCgoEbGFzdBICCAISGAoGcml2YWxzEg4IARoCCAIaAggCGgIIAhILCgVzdGF0cxICCAU=",
-						"asJsonString": "{\"name\":{\"first\":\"Bob\",\"last\":\"C\"},\"rivals\":[\"user1\",\"user2\",\"user3\"],\"stats\":null}",
-						"asText": "{\"name\":{\"first\":\"Bob\",\"last\":\"C\"},\"rivals\":[\"user1\",\"user2\",\"user3\"],\"stats\":null}"
-					}
-				}
-			},
-			"tags": []
-		}, {
-			"uuid": "id1",
-			"request": {
-				"host": "example.com",
-				"method": "GET",
-				"path": "/array-fields",
-				"query": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": null,
-					"value": {
-						"shapeHashV1Base64": null,
-						"asJsonString": null,
-						"asText": null
-					}
-				}
-			},
-			"response": {
-				"statusCode": 200,
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": "application/json",
-					"value": {
-						"shapeHashV1Base64": "EiEKBG5hbWUSGRILCgVmaXJzdBICCAISCgoEbGFzdBICCAISGAoGcml2YWxzEg4IARoCCAIaAggCGgIIAg==",
-						"asJsonString": "{\"name\":{\"first\":\"Bob\",\"last\":\"C\"},\"rivals\":[\"user1\",\"user2\",\"user3\"]}",
-						"asText": "{\"name\":{\"first\":\"Bob\",\"last\":\"C\"},\"rivals\":[\"user1\",\"user2\",\"user3\"]}"
-					}
-				}
-			},
-			"tags": []
-		}, {
-			"uuid": "id2",
-			"request": {
-				"host": "example.com",
-				"method": "GET",
-				"path": "/array-fields",
-				"query": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": null,
-					"value": {
-						"shapeHashV1Base64": null,
-						"asJsonString": null,
-						"asText": null
-					}
-				}
-			},
-			"response": {
-				"statusCode": 200,
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": "application/json",
-					"value": {
-						"shapeHashV1Base64": "EiEKBG5hbWUSGRILCgVmaXJzdBICCAISCgoEbGFzdBICCAISGAoGcml2YWxzEg4IARoCCAIaAggCGgIIAhIJCgVzdGF0cxIA",
-						"asJsonString": "{\"name\":{\"first\":\"Bob\",\"last\":\"C\"},\"rivals\":[\"user1\",\"user2\",\"user3\"],\"stats\":{}}",
-						"asText": "{\"name\":{\"first\":\"Bob\",\"last\":\"C\"},\"rivals\":[\"user1\",\"user2\",\"user3\"],\"stats\":{}}"
-					}
-				}
-			},
-			"tags": []
-		}, {
-			"uuid": "id3",
-			"request": {
-				"host": "example.com",
-				"method": "GET",
-				"path": "/array-fields",
-				"query": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": null,
-					"value": {
-						"shapeHashV1Base64": null,
-						"asJsonString": null,
-						"asText": null
-					}
-				}
-			},
-			"response": {
-				"statusCode": 200,
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": "application/json",
-					"value": {
-						"shapeHashV1Base64": "EiEKBG5hbWUSGRILCgVmaXJzdBICCAISCgoEbGFzdBICCAISGAoGcml2YWxzEg4IARoCCAIaAggCGgIIAhITCgVzdGF0cxIKCAEaAggDGgIIAw==",
-						"asJsonString": "{\"name\":{\"first\":\"Bob\",\"last\":\"C\"},\"rivals\":[\"user1\",\"user2\",\"user3\"],\"stats\":[12,34]}",
-						"asText": "{\"name\":{\"first\":\"Bob\",\"last\":\"C\"},\"rivals\":[\"user1\",\"user2\",\"user3\"],\"stats\":[12,34]}"
-					}
-				}
-			},
-			"tags": []
-		}, {
-			"uuid": "id4",
-			"request": {
-				"host": "example.com",
-				"method": "GET",
-				"path": "/root-arrays",
-				"query": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": null,
-					"value": {
-						"shapeHashV1Base64": null,
-						"asJsonString": null,
-						"asText": null
-					}
-				}
-			},
-			"response": {
-				"statusCode": 200,
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": "application/json",
-					"value": {
-						"shapeHashV1Base64": "CAEaAggDGgIIAxoCCAMaAggDGgIIAw==",
-						"asJsonString": "[1,2,3,4,5]",
-						"asText": "[1,2,3,4,5]"
-					}
-				}
-			},
-			"tags": []
-		}, {
-			"uuid": "id5",
-			"request": {
-				"host": "example.com",
-				"method": "GET",
-				"path": "/root-arrays",
-				"query": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": null,
-					"value": {
-						"shapeHashV1Base64": null,
-						"asJsonString": null,
-						"asText": null
-					}
-				}
-			},
-			"response": {
-				"statusCode": 200,
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": "application/json",
-					"value": {
-						"shapeHashV1Base64": "CAE=",
-						"asJsonString": "[]",
-						"asText": "[]"
-					}
-				}
-			},
-			"tags": []
-		}, {
-			"uuid": "id6",
-			"request": {
-				"host": "example.com",
-				"method": "GET",
-				"path": "/object-as-array-items",
-				"query": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": null,
-					"value": {
-						"shapeHashV1Base64": null,
-						"asJsonString": null,
-						"asText": null
-					}
-				}
-			},
-			"response": {
-				"statusCode": 200,
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": "application/json",
-					"value": {
-						"shapeHashV1Base64": "CAEaAggB",
-						"asJsonString": "[[]]",
-						"asText": "[[]]"
-					}
-				}
-			},
-			"tags": []
-		}, {
-			"uuid": "id7",
-			"request": {
-				"host": "example.com",
-				"method": "GET",
-				"path": "/object-as-array-items",
-				"query": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": null,
-					"value": {
-						"shapeHashV1Base64": null,
-						"asJsonString": null,
-						"asText": null
-					}
-				}
-			},
-			"response": {
-				"statusCode": 200,
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": "application/json",
-					"value": {
-						"shapeHashV1Base64": "CAEaDggBGgIIAxoCCAMaAggD",
-						"asJsonString": "[[1,2,3]]",
-						"asText": "[[1,2,3]]"
-					}
-				}
-			},
-			"tags": []
-		}, {
-			"uuid": "id8",
-			"request": {
-				"host": "example.com",
-				"method": "GET",
-				"path": "/object-as-array-items",
-				"query": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": null,
-					"value": {
-						"shapeHashV1Base64": null,
-						"asJsonString": null,
-						"asText": null
-					}
-				}
-			},
-			"response": {
-				"statusCode": 200,
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": "application/json",
-					"value": {
-						"shapeHashV1Base64": "CAE=",
-						"asJsonString": "[]",
-						"asText": "[]"
-					}
-				}
-			},
-			"tags": []
-		}, {
-			"uuid": "id9",
-			"request": {
-				"host": "example.com",
-				"method": "GET",
-				"path": "/object-as-array-items",
-				"query": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": null,
-					"value": {
-						"shapeHashV1Base64": null,
-						"asJsonString": null,
-						"asText": null
-					}
-				}
-			},
-			"response": {
-				"statusCode": 200,
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": "application/json",
-					"value": {
-						"shapeHashV1Base64": "CAEaMRIKCgRuYW1lEgIIAhIJCgNhZ2USAggCEhgKBmNvbG9ycxIOCAEaAggCGgIIAhoCCAIaAggC",
-						"asJsonString": "[{\"name\":\"joe\",\"age\":\"thirty\",\"colors\":[\"red\",\"green\",\"yellow\"]},\"hello\"]",
-						"asText": "[{\"name\":\"joe\",\"age\":\"thirty\",\"colors\":[\"red\",\"green\",\"yellow\"]},\"hello\"]"
-					}
-				}
-			},
-			"tags": []
-		}, {
-			"uuid": "id10",
-			"request": {
-				"host": "example.com",
-				"method": "GET",
-				"path": "/object-as-array-items",
-				"query": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": null,
-					"value": {
-						"shapeHashV1Base64": null,
-						"asJsonString": null,
-						"asText": null
-					}
-				}
-			},
-			"response": {
-				"statusCode": 200,
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": "application/json",
-					"value": {
-						"shapeHashV1Base64": "CAEaMRIKCgRuYW1lEgIIAhIJCgNhZ2USAggCEhgKBmNvbG9ycxIOCAEaAggCGgIIAhoCCAI=",
-						"asJsonString": "[{\"name\":\"joe\",\"age\":\"thirty\",\"colors\":[\"red\",\"green\",\"yellow\"]}]",
-						"asText": "[{\"name\":\"joe\",\"age\":\"thirty\",\"colors\":[\"red\",\"green\",\"yellow\"]}]"
-					}
-				}
-			},
-			"tags": []
-		}, {
-			"uuid": "id11",
-			"request": {
-				"host": "example.com",
-				"method": "GET",
-				"path": "/object-cases",
-				"query": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": null,
-					"value": {
-						"shapeHashV1Base64": null,
-						"asJsonString": null,
-						"asText": null
-					}
-				}
-			},
-			"response": {
-				"statusCode": 200,
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": "application/json",
-					"value": {
-						"shapeHashV1Base64": "Eg8KCWZpcnN0TmFtZRICCAISDgoIbGFzdE5hbWUSAggCEgkKA2FnZRICCAMSGAoGY2l0aWVzEg4IARoCCAIaAggDGgIIAg==",
-						"asJsonString": "{\"firstName\":\"Aidan\",\"lastName\":\"C\",\"age\":26,\"cities\":[\"San Fransisco\",17584,\"Boston\"]}",
-						"asText": "{\"firstName\":\"Aidan\",\"lastName\":\"C\",\"age\":26,\"cities\":[\"San Fransisco\",17584,\"Boston\"]}"
-					}
-				}
-			},
-			"tags": []
-		}, {
-			"uuid": "id12",
-			"request": {
-				"host": "example.com",
-				"method": "GET",
-				"path": "/object-cases",
-				"query": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": null,
-					"value": {
-						"shapeHashV1Base64": null,
-						"asJsonString": null,
-						"asText": null
-					}
-				}
-			},
-			"response": {
-				"statusCode": 200,
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": "application/json",
-					"value": {
-						"shapeHashV1Base64": "Eg8KCWZpcnN0TmFtZRICCAISDgoIbGFzdE5hbWUSAggCEgkKA2FnZRICCAMSIAoGY2l0aWVzEhYIARoCCAIaAggDGgIIAhoCCAMaAggC",
-						"asJsonString": "{\"firstName\":\"Aidan\",\"lastName\":\"C\",\"age\":26,\"cities\":[\"San Fransisco\",17584,\"Boston\",16573,\"Chicago\"]}",
-						"asText": "{\"firstName\":\"Aidan\",\"lastName\":\"C\",\"age\":26,\"cities\":[\"San Fransisco\",17584,\"Boston\",16573,\"Chicago\"]}"
-					}
-				}
-			},
-			"tags": []
-		}, {
-			"uuid": "id13",
-			"request": {
-				"host": "example.com",
-				"method": "GET",
-				"path": "/object-cases",
-				"query": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": null,
-					"value": {
-						"shapeHashV1Base64": null,
-						"asJsonString": null,
-						"asText": null
-					}
-				}
-			},
-			"response": {
-				"statusCode": 200,
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": "application/json",
-					"value": {
-						"shapeHashV1Base64": "Eg8KCWZpcnN0TmFtZRICCAISDgoIbGFzdE5hbWUSAggCEgkKA2FnZRICCAMSGAoGY2l0aWVzEg4IARoCCAIaAggCGgIIAg==",
-						"asJsonString": "{\"firstName\":\"Aidan\",\"lastName\":\"C\",\"age\":26,\"cities\":[\"San Fransisco\",\"New York\",\"Durham\"]}",
-						"asText": "{\"firstName\":\"Aidan\",\"lastName\":\"C\",\"age\":26,\"cities\":[\"San Fransisco\",\"New York\",\"Durham\"]}"
-					}
-				}
-			},
-			"tags": []
-		}, {
-			"uuid": "id14",
-			"request": {
-				"host": "example.com",
-				"method": "GET",
-				"path": "/objects-with-polymorphism",
-				"query": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": null,
-					"value": {
-						"shapeHashV1Base64": null,
-						"asJsonString": null,
-						"asText": null
-					}
-				}
-			},
-			"response": {
-				"statusCode": 200,
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": "application/json",
-					"value": {
-						"shapeHashV1Base64": "Ek0KCGxvY2F0aW9uEkESPwoMcHJpbmNpcGFsaXR5Ei8SCgoEY2l0eRICCAISEAoKcG9wdWxhdGlvbhICCAMSDwoLY29vcmRpbmF0ZXMSAA==",
-						"asJsonString": "{\"location\":{\"principality\":{\"city\":\"San Fransisco\",\"population\":830000,\"coordinates\":{}}}}",
-						"asText": "{\"location\":{\"principality\":{\"city\":\"San Fransisco\",\"population\":830000,\"coordinates\":{}}}}"
-					}
-				}
-			},
-			"tags": []
-		}, {
-			"uuid": "id15",
-			"request": {
-				"host": "example.com",
-				"method": "GET",
-				"path": "/root-arrays",
-				"query": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": null,
-					"value": {
-						"shapeHashV1Base64": null,
-						"asJsonString": null,
-						"asText": null
-					}
-				}
-			},
-			"response": {
-				"statusCode": 200,
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": "application/json",
-					"value": {
-						"shapeHashV1Base64": "EgkKA2ZvbxICCAI=",
-						"asJsonString": "{\"foo\":\"bar\"}",
-						"asText": "{\"foo\":\"bar\"}"
-					}
-				}
-			},
-			"tags": []
-		}, {
-			"uuid": "id16",
-			"request": {
-				"host": "example.com",
-				"method": "GET",
-				"path": "/nullables",
-				"query": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": null,
-					"value": {
-						"shapeHashV1Base64": null,
-						"asJsonString": null,
-						"asText": null
-					}
-				}
-			},
-			"response": {
-				"statusCode": 200,
-				"headers": {
-					"shapeHashV1Base64": null,
-					"asJsonString": null,
-					"asText": null
-				},
-				"body": {
-					"contentType": "application/json",
-					"value": {
-						"shapeHashV1Base64": "CAEaHBINCgdhZGRyZXNzEgIIAhILCgVwcmljZRICCAMaHBINCgdhZGRyZXNzEgIIAhILCgVwcmljZRICCAM=",
-						"asJsonString": "[{\"address\":\"123\",\"price\":657},{\"address\":\"456\",\"price\":322}]",
-						"asText": "[{\"address\":\"123\",\"price\":657},{\"address\":\"456\",\"price\":322}]"
-					}
-				}
-			},
-			"tags": []
-		}]
-	}
+  "events": [
+    {
+      "PathComponentAdded": {
+        "pathId": "path_aPqDtqTGQN",
+        "parentPathId": "root",
+        "name": "object-cases",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "RequestParameterAddedByPathAndMethod": {
+        "parameterId": "request-parameter_8liVYqBo88",
+        "pathId": "path_aPqDtqTGQN",
+        "httpMethod": "GET",
+        "parameterLocation": "query",
+        "name": "queryString",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_9I8mJp8URF",
+        "baseShapeId": "$object",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "RequestParameterShapeSet": {
+        "parameterId": "request-parameter_8liVYqBo88",
+        "parameterDescriptor": {
+          "shapeId": "shape_9I8mJp8URF",
+          "isRemoved": false
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "RequestAdded": {
+        "requestId": "request_OQ4xWs0s32",
+        "pathId": "path_aPqDtqTGQN",
+        "httpMethod": "GET",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ResponseAddedByPathAndMethod": {
+        "responseId": "response_Zomj5bzNBt",
+        "pathId": "path_aPqDtqTGQN",
+        "httpMethod": "GET",
+        "httpStatusCode": 200,
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_tNRgroSwLj",
+        "baseShapeId": "$object",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_qQT0krhOKn",
+        "baseShapeId": "$number",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_hnI7P1UdbB",
+        "shapeId": "shape_tNRgroSwLj",
+        "name": "age",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_hnI7P1UdbB",
+            "shapeId": "shape_qQT0krhOKn"
+          }
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_9OWZoB9AQp",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_ZLv9FF57ot",
+        "baseShapeId": "$list",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_fjcgB9O1Gg",
+        "shapeId": "shape_tNRgroSwLj",
+        "name": "cities",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_fjcgB9O1Gg",
+            "shapeId": "shape_ZLv9FF57ot"
+          }
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_qDxLTuap52",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_omQ4Bb39Ny",
+        "shapeId": "shape_tNRgroSwLj",
+        "name": "firstName",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_omQ4Bb39Ny",
+            "shapeId": "shape_qDxLTuap52"
+          }
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_vAxrdAagEj",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_EXPFebUkPZ",
+        "shapeId": "shape_tNRgroSwLj",
+        "name": "lastName",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_EXPFebUkPZ",
+            "shapeId": "shape_vAxrdAagEj"
+          }
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeParameterShapeSet": {
+        "shapeDescriptor": {
+          "ProviderInShape": {
+            "shapeId": "shape_ZLv9FF57ot",
+            "providerDescriptor": {
+              "ShapeProvider": {
+                "shapeId": "shape_9OWZoB9AQp"
+              }
+            },
+            "consumingParameterId": "$listItem"
+          }
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ResponseBodySet": {
+        "responseId": "response_Zomj5bzNBt",
+        "bodyDescriptor": {
+          "httpContentType": "application/json",
+          "shapeId": "shape_tNRgroSwLj",
+          "isRemoved": false
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "PathComponentAdded": {
+        "pathId": "path_XEnuaiwyv5",
+        "parentPathId": "root",
+        "name": "objects-with-polymorphism",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "RequestParameterAddedByPathAndMethod": {
+        "parameterId": "request-parameter_NTvEezUEY8",
+        "pathId": "path_XEnuaiwyv5",
+        "httpMethod": "GET",
+        "parameterLocation": "query",
+        "name": "queryString",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_s8F6CLkcEw",
+        "baseShapeId": "$object",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "RequestParameterShapeSet": {
+        "parameterId": "request-parameter_NTvEezUEY8",
+        "parameterDescriptor": {
+          "shapeId": "shape_s8F6CLkcEw",
+          "isRemoved": false
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "RequestAdded": {
+        "requestId": "request_n9zG6yfB3K",
+        "pathId": "path_XEnuaiwyv5",
+        "httpMethod": "GET",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ResponseAddedByPathAndMethod": {
+        "responseId": "response_H7mgBDW3pA",
+        "pathId": "path_XEnuaiwyv5",
+        "httpMethod": "GET",
+        "httpStatusCode": 200,
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_kG1JHYgXIw",
+        "baseShapeId": "$object",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_0Rjwrc4XVQ",
+        "baseShapeId": "$object",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_c7nwdWQh7i",
+        "baseShapeId": "$object",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_U2jHOzauf7",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_FDw7T8P1Gl",
+        "shapeId": "shape_c7nwdWQh7i",
+        "name": "city",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_FDw7T8P1Gl",
+            "shapeId": "shape_U2jHOzauf7"
+          }
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_LaPF9H2WkT",
+        "baseShapeId": "$object",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_ADzn5yEIWh",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_amFoSPj0Yo",
+        "shapeId": "shape_LaPF9H2WkT",
+        "name": "lat",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_amFoSPj0Yo",
+            "shapeId": "shape_ADzn5yEIWh"
+          }
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_5pqWBXK957",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_QVDqUvTV6F",
+        "shapeId": "shape_LaPF9H2WkT",
+        "name": "long",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_QVDqUvTV6F",
+            "shapeId": "shape_5pqWBXK957"
+          }
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_CMo2evf3EE",
+        "baseShapeId": "$optional",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_LsaJwQ6B3R",
+        "shapeId": "shape_c7nwdWQh7i",
+        "name": "coordinates",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_LsaJwQ6B3R",
+            "shapeId": "shape_CMo2evf3EE"
+          }
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_1VsVz1ldHm",
+        "baseShapeId": "$number",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_azOTr94eA4",
+        "shapeId": "shape_c7nwdWQh7i",
+        "name": "population",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_azOTr94eA4",
+            "shapeId": "shape_1VsVz1ldHm"
+          }
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_Tc108m0Nsy",
+        "shapeId": "shape_0Rjwrc4XVQ",
+        "name": "principality",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_Tc108m0Nsy",
+            "shapeId": "shape_c7nwdWQh7i"
+          }
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_bYgbrlhzFP",
+        "shapeId": "shape_kG1JHYgXIw",
+        "name": "location",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_bYgbrlhzFP",
+            "shapeId": "shape_0Rjwrc4XVQ"
+          }
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeParameterShapeSet": {
+        "shapeDescriptor": {
+          "ProviderInShape": {
+            "shapeId": "shape_CMo2evf3EE",
+            "providerDescriptor": {
+              "ShapeProvider": {
+                "shapeId": "shape_LaPF9H2WkT"
+              }
+            },
+            "consumingParameterId": "$optionalInner"
+          }
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ResponseBodySet": {
+        "responseId": "response_H7mgBDW3pA",
+        "bodyDescriptor": {
+          "httpContentType": "application/json",
+          "shapeId": "shape_kG1JHYgXIw",
+          "isRemoved": false
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "PathComponentAdded": {
+        "pathId": "path_A71l1LOES0",
+        "parentPathId": "root",
+        "name": "array-fields",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "RequestParameterAddedByPathAndMethod": {
+        "parameterId": "request-parameter_XtaymTHqde",
+        "pathId": "path_A71l1LOES0",
+        "httpMethod": "GET",
+        "parameterLocation": "query",
+        "name": "queryString",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_kPyodZ4Tic",
+        "baseShapeId": "$object",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "RequestParameterShapeSet": {
+        "parameterId": "request-parameter_XtaymTHqde",
+        "parameterDescriptor": {
+          "shapeId": "shape_kPyodZ4Tic",
+          "isRemoved": false
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "RequestAdded": {
+        "requestId": "request_Hmhp7AWRlF",
+        "pathId": "path_A71l1LOES0",
+        "httpMethod": "GET",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ResponseAddedByPathAndMethod": {
+        "responseId": "response_XkzGtHuniJ",
+        "pathId": "path_A71l1LOES0",
+        "httpMethod": "GET",
+        "httpStatusCode": 200,
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_BWimY31MBw",
+        "baseShapeId": "$object",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_4wTXC2brco",
+        "baseShapeId": "$object",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_DQ1MeMzNwO",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_aFCbmry97x",
+        "shapeId": "shape_4wTXC2brco",
+        "name": "first",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_aFCbmry97x",
+            "shapeId": "shape_DQ1MeMzNwO"
+          }
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_ePM01PGijN",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_MJxJUokUYA",
+        "shapeId": "shape_4wTXC2brco",
+        "name": "last",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_MJxJUokUYA",
+            "shapeId": "shape_ePM01PGijN"
+          }
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_WmF0jHCqFh",
+        "shapeId": "shape_BWimY31MBw",
+        "name": "name",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_WmF0jHCqFh",
+            "shapeId": "shape_4wTXC2brco"
+          }
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_k0u0Kstovv",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_FAm5wD1PJP",
+        "baseShapeId": "$list",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_BbiTcbzz0p",
+        "shapeId": "shape_BWimY31MBw",
+        "name": "rivals",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_BbiTcbzz0p",
+            "shapeId": "shape_FAm5wD1PJP"
+          }
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_HzYyBRjlHl",
+        "baseShapeId": "$object",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_3Ay8F2W3GS",
+        "baseShapeId": "$number",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_HzVqitaYDq",
+        "shapeId": "shape_HzYyBRjlHl",
+        "name": "rank",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_HzVqitaYDq",
+            "shapeId": "shape_3Ay8F2W3GS"
+          }
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_31fR9LMutK",
+        "shapeId": "shape_BWimY31MBw",
+        "name": "stats",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_31fR9LMutK",
+            "shapeId": "shape_HzYyBRjlHl"
+          }
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeParameterShapeSet": {
+        "shapeDescriptor": {
+          "ProviderInShape": {
+            "shapeId": "shape_FAm5wD1PJP",
+            "providerDescriptor": {
+              "ShapeProvider": {
+                "shapeId": "shape_k0u0Kstovv"
+              }
+            },
+            "consumingParameterId": "$listItem"
+          }
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ResponseBodySet": {
+        "responseId": "response_XkzGtHuniJ",
+        "bodyDescriptor": {
+          "httpContentType": "application/json",
+          "shapeId": "shape_BWimY31MBw",
+          "isRemoved": false
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "PathComponentAdded": {
+        "pathId": "path_BKCtxJ5lMQ",
+        "parentPathId": "root",
+        "name": "root-arrays",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "RequestParameterAddedByPathAndMethod": {
+        "parameterId": "request-parameter_0OWaHJAew9",
+        "pathId": "path_BKCtxJ5lMQ",
+        "httpMethod": "GET",
+        "parameterLocation": "query",
+        "name": "queryString",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_j0PSviBb9e",
+        "baseShapeId": "$object",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "RequestParameterShapeSet": {
+        "parameterId": "request-parameter_0OWaHJAew9",
+        "parameterDescriptor": {
+          "shapeId": "shape_j0PSviBb9e",
+          "isRemoved": false
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "RequestAdded": {
+        "requestId": "request_Dne0Uvp054",
+        "pathId": "path_BKCtxJ5lMQ",
+        "httpMethod": "GET",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ResponseAddedByPathAndMethod": {
+        "responseId": "response_hnuIacJfkl",
+        "pathId": "path_BKCtxJ5lMQ",
+        "httpMethod": "GET",
+        "httpStatusCode": 200,
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_NQW7KNlDs8",
+        "baseShapeId": "$unknown",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_NjFGT8ElYj",
+        "baseShapeId": "$list",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeParameterShapeSet": {
+        "shapeDescriptor": {
+          "ProviderInShape": {
+            "shapeId": "shape_NjFGT8ElYj",
+            "providerDescriptor": {
+              "ShapeProvider": {
+                "shapeId": "shape_NQW7KNlDs8"
+              }
+            },
+            "consumingParameterId": "$listItem"
+          }
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ResponseBodySet": {
+        "responseId": "response_hnuIacJfkl",
+        "bodyDescriptor": {
+          "httpContentType": "application/json",
+          "shapeId": "shape_NjFGT8ElYj",
+          "isRemoved": false
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "PathComponentAdded": {
+        "pathId": "path_H0AUOucMZ6",
+        "parentPathId": "root",
+        "name": "object-as-array-items",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "RequestParameterAddedByPathAndMethod": {
+        "parameterId": "request-parameter_pWotHKllb1",
+        "pathId": "path_H0AUOucMZ6",
+        "httpMethod": "GET",
+        "parameterLocation": "query",
+        "name": "queryString",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_GwzyotIy4p",
+        "baseShapeId": "$object",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "RequestParameterShapeSet": {
+        "parameterId": "request-parameter_pWotHKllb1",
+        "parameterDescriptor": {
+          "shapeId": "shape_GwzyotIy4p",
+          "isRemoved": false
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "RequestAdded": {
+        "requestId": "request_v0sCV28mBz",
+        "pathId": "path_H0AUOucMZ6",
+        "httpMethod": "GET",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ResponseAddedByPathAndMethod": {
+        "responseId": "response_U9Ma4zEui4",
+        "pathId": "path_H0AUOucMZ6",
+        "httpMethod": "GET",
+        "httpStatusCode": 200,
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_LSzE6p0ick",
+        "baseShapeId": "$object",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_6CwLrwbise",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_uSFm8IzsuO",
+        "shapeId": "shape_LSzE6p0ick",
+        "name": "age",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_uSFm8IzsuO",
+            "shapeId": "shape_6CwLrwbise"
+          }
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_7RPHWUNFwp",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_o8q1TVrxeB",
+        "baseShapeId": "$list",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_Xozc5zyWHI",
+        "shapeId": "shape_LSzE6p0ick",
+        "name": "colors",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_Xozc5zyWHI",
+            "shapeId": "shape_o8q1TVrxeB"
+          }
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_29Ms5ZQ8uC",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_XkyOiEDHFy",
+        "shapeId": "shape_LSzE6p0ick",
+        "name": "name",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_XkyOiEDHFy",
+            "shapeId": "shape_29Ms5ZQ8uC"
+          }
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_QK42v9Q9jR",
+        "baseShapeId": "$list",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeParameterShapeSet": {
+        "shapeDescriptor": {
+          "ProviderInShape": {
+            "shapeId": "shape_o8q1TVrxeB",
+            "providerDescriptor": {
+              "ShapeProvider": {
+                "shapeId": "shape_7RPHWUNFwp"
+              }
+            },
+            "consumingParameterId": "$listItem"
+          }
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeParameterShapeSet": {
+        "shapeDescriptor": {
+          "ProviderInShape": {
+            "shapeId": "shape_QK42v9Q9jR",
+            "providerDescriptor": {
+              "ShapeProvider": {
+                "shapeId": "shape_LSzE6p0ick"
+              }
+            },
+            "consumingParameterId": "$listItem"
+          }
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ResponseBodySet": {
+        "responseId": "response_U9Ma4zEui4",
+        "bodyDescriptor": {
+          "httpContentType": "application/json",
+          "shapeId": "shape_QK42v9Q9jR",
+          "isRemoved": false
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "PathComponentAdded": {
+        "pathId": "baseline-path_1",
+        "parentPathId": "root",
+        "name": "nullables",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "RequestParameterAddedByPathAndMethod": {
+        "parameterId": "baseline-request-parameter_1",
+        "pathId": "baseline-path_1",
+        "httpMethod": "GET",
+        "parameterLocation": "query",
+        "name": "queryString",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "baseline-shape_10",
+        "baseShapeId": "$object",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "RequestParameterShapeSet": {
+        "parameterId": "baseline-request-parameter_1",
+        "parameterDescriptor": {
+          "shapeId": "baseline-shape_10",
+          "isRemoved": false
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "RequestAdded": {
+        "requestId": "baseline-request_1",
+        "pathId": "baseline-path_1",
+        "httpMethod": "GET",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ResponseAddedByPathAndMethod": {
+        "responseId": "baseline-response_1",
+        "pathId": "baseline-path_1",
+        "httpMethod": "GET",
+        "httpStatusCode": 200,
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "baseline-shape_8",
+        "baseShapeId": "$object",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "baseline-shape_5",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "baseline-field_3",
+        "shapeId": "baseline-shape_8",
+        "name": "address",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "baseline-field_3",
+            "shapeId": "baseline-shape_5"
+          }
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "baseline-shape_6",
+        "baseShapeId": "$unknown",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "baseline-shape_7",
+        "baseShapeId": "$nullable",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "baseline-field_4",
+        "shapeId": "baseline-shape_8",
+        "name": "price",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "baseline-field_4",
+            "shapeId": "baseline-shape_7"
+          }
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "baseline-shape_9",
+        "baseShapeId": "$list",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeParameterShapeSet": {
+        "shapeDescriptor": {
+          "ProviderInShape": {
+            "shapeId": "baseline-shape_7",
+            "providerDescriptor": {
+              "ShapeProvider": {
+                "shapeId": "baseline-shape_6"
+              }
+            },
+            "consumingParameterId": "$nullableInner"
+          }
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ShapeParameterShapeSet": {
+        "shapeDescriptor": {
+          "ProviderInShape": {
+            "shapeId": "baseline-shape_9",
+            "providerDescriptor": {
+              "ShapeProvider": {
+                "shapeId": "baseline-shape_8"
+              }
+            },
+            "consumingParameterId": "$listItem"
+          }
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ResponseBodySet": {
+        "responseId": "baseline-response_1",
+        "bodyDescriptor": {
+          "httpContentType": "application/json",
+          "shapeId": "baseline-shape_9",
+          "isRemoved": false
+        },
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    },
+    {
+      "ContributionAdded": {
+        "id": "metadata",
+        "key": "id",
+        "value": "e0ef7280-269c-461b-887d-1a973ab1448b",
+        "eventContext": {
+          "clientId": "ccc",
+          "clientSessionId": "sss",
+          "clientCommandBatchId": "bbb",
+          "createdAt": "NOW"
+        }
+      }
+    }
+  ],
+  "session": {
+    "samples": [
+      {
+        "uuid": "id17",
+        "request": {
+          "host": "example.com",
+          "method": "GET",
+          "path": "/object-cases",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": "Eg4KCGxhc3ROYW1lEgIIAhIJCgNhZ2USAggDEhgKBmNpdGllcxIOCAEaAggCGgIIAhoCCAI=",
+              "asJsonString": "{\"lastName\":\"C\",\"age\":26,\"cities\":[\"San Fransisco\",\"New York\",\"Durham\"]}",
+              "asText": "{\"lastName\":\"C\",\"age\":26,\"cities\":[\"San Fransisco\",\"New York\",\"Durham\"]}"
+            }
+          }
+        },
+        "tags": []
+      },
+      {
+        "uuid": "id18",
+        "request": {
+          "host": "example.com",
+          "method": "GET",
+          "path": "/object-cases",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": "Eg8KCWZpcnN0TmFtZRICCAISDgoIbGFzdE5hbWUSAggCEgkKA2FnZRICCAISGAoGY2l0aWVzEg4IARoCCAIaAggCGgIIAg==",
+              "asJsonString": "{\"firstName\":\"Aidan\",\"lastName\":\"C\",\"age\":\"not a number\",\"cities\":[\"San Fransisco\",\"New York\",\"Durham\"]}",
+              "asText": "{\"firstName\":\"Aidan\",\"lastName\":\"C\",\"age\":\"not a number\",\"cities\":[\"San Fransisco\",\"New York\",\"Durham\"]}"
+            }
+          }
+        },
+        "tags": []
+      },
+      {
+        "uuid": "id19",
+        "request": {
+          "host": "example.com",
+          "method": "GET",
+          "path": "/objects-with-polymorphism",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": "ElUKCGxvY2F0aW9uEkkSRwoMcHJpbmNpcGFsaXR5EjcSCgoEY2l0eRICCAISEAoKcG9wdWxhdGlvbhICCAMSFwoFYXJyYXkSDggBGgIIAxoCCAMaAggD",
+              "asJsonString": "{\"location\":{\"principality\":{\"city\":\"San Fransisco\",\"population\":830000,\"array\":[1,2,3]}}}",
+              "asText": "{\"location\":{\"principality\":{\"city\":\"San Fransisco\",\"population\":830000,\"array\":[1,2,3]}}}"
+            }
+          }
+        },
+        "tags": []
+      },
+      {
+        "uuid": "id20",
+        "request": {
+          "host": "example.com",
+          "method": "GET",
+          "path": "/objects-with-polymorphism",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": "EkkKCGxvY2F0aW9uEj0SOwoMcHJpbmNpcGFsaXR5EisSCgoEY2l0eRICCAISEAoKcG9wdWxhdGlvbhICCAMSCwoFYXJyYXkSAggB",
+              "asJsonString": "{\"location\":{\"principality\":{\"city\":\"San Fransisco\",\"population\":830000,\"array\":[]}}}",
+              "asText": "{\"location\":{\"principality\":{\"city\":\"San Fransisco\",\"population\":830000,\"array\":[]}}}"
+            }
+          }
+        },
+        "tags": []
+      },
+      {
+        "uuid": "id21",
+        "request": {
+          "host": "example.com",
+          "method": "GET",
+          "path": "/objects-with-polymorphism",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": "EkkKCGxvY2F0aW9uEj0SOwoMcHJpbmNpcGFsaXR5EisSCwoFbW90dG8SAggCEgoKBGNpdHkSAggCEhAKCnBvcHVsYXRpb24SAggD",
+              "asJsonString": "{\"location\":{\"principality\":{\"motto\":\"Experientia Docet\",\"city\":\"San Fransisco\",\"population\":830000}}}",
+              "asText": "{\"location\":{\"principality\":{\"motto\":\"Experientia Docet\",\"city\":\"San Fransisco\",\"population\":830000}}}"
+            }
+          }
+        },
+        "tags": []
+      },
+      {
+        "uuid": "id22",
+        "request": {
+          "host": "example.com",
+          "method": "GET",
+          "path": "/objects-with-polymorphism",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": "EnIKCGxvY2F0aW9uEmYSZAoMcHJpbmNpcGFsaXR5ElQSCgoEY2l0eRICCAISEAoKcG9wdWxhdGlvbhICCAMSNAoLY29vcmRpbmF0ZXMSJRIMCgZmb3JtYXQSAggCEgkKA2xhdBICCAISCgoEbG9uZxICCAI=",
+              "asJsonString": "{\"location\":{\"principality\":{\"city\":\"San Fransisco\",\"population\":830000,\"coordinates\":{\"format\":\"DMS\",\"lat\":\"37.7749° N\",\"long\":\"122.4194° W\"}}}}",
+              "asText": "{\"location\":{\"principality\":{\"city\":\"San Fransisco\",\"population\":830000,\"coordinates\":{\"format\":\"DMS\",\"lat\":\"37.7749° N\",\"long\":\"122.4194° W\"}}}}"
+            }
+          }
+        },
+        "tags": []
+      },
+      {
+        "uuid": "id23",
+        "request": {
+          "host": "example.com",
+          "method": "GET",
+          "path": "/objects-with-polymorphism",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": "Ek8KCGxvY2F0aW9uEkMSQQoMcHJpbmNpcGFsaXR5EjESCgoEY2l0eRICCAISEAoKcG9wdWxhdGlvbhICCAMSEQoLY29vcmRpbmF0ZXMSAggC",
+              "asJsonString": "{\"location\":{\"principality\":{\"city\":\"San Fransisco\",\"population\":830000,\"coordinates\":\"N/A\"}}}",
+              "asText": "{\"location\":{\"principality\":{\"city\":\"San Fransisco\",\"population\":830000,\"coordinates\":\"N/A\"}}}"
+            }
+          }
+        },
+        "tags": []
+      },
+      {
+        "uuid": "id24",
+        "request": {
+          "host": "example.com",
+          "method": "GET",
+          "path": "/array-fields",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": "EiEKBG5hbWUSGRILCgVmaXJzdBICCAISCgoEbGFzdBICCAISDAoGcml2YWxzEgIIARIVCgVzdGF0cxIMEgoKBHJhbmsSAggD",
+              "asJsonString": "{\"name\":{\"first\":\"Bob\",\"last\":\"C\"},\"rivals\":[],\"stats\":{\"rank\":1}}",
+              "asText": "{\"name\":{\"first\":\"Bob\",\"last\":\"C\"},\"rivals\":[],\"stats\":{\"rank\":1}}"
+            }
+          }
+        },
+        "tags": []
+      },
+      {
+        "uuid": "id25",
+        "request": {
+          "host": "example.com",
+          "method": "GET",
+          "path": "/array-fields",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": "EiEKBG5hbWUSGRILCgVmaXJzdBICCAISCgoEbGFzdBICCAISGQoGcml2YWxzEg8SDQoHbmVtZXNpcxICCAISFQoFc3RhdHMSDBIKCgRyYW5rEgIIAw==",
+              "asJsonString": "{\"name\":{\"first\":\"Bob\",\"last\":\"C\"},\"rivals\":{\"nemesis\":\"Brad\"},\"stats\":{\"rank\":1}}",
+              "asText": "{\"name\":{\"first\":\"Bob\",\"last\":\"C\"},\"rivals\":{\"nemesis\":\"Brad\"},\"stats\":{\"rank\":1}}"
+            }
+          }
+        },
+        "tags": []
+      },
+      {
+        "uuid": "id26",
+        "request": {
+          "host": "example.com",
+          "method": "GET",
+          "path": "/array-fields",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": "EiEKBG5hbWUSGRILCgVmaXJzdBICCAISCgoEbGFzdBICCAISNgoGcml2YWxzEiwIARoMEgoKBGZvb2QSAggCGgwSCgoEZm9vZBICCAIaDBIKCgRmb29kEgIIAhIVCgVzdGF0cxIMEgoKBHJhbmsSAggD",
+              "asJsonString": "{\"name\":{\"first\":\"Bob\",\"last\":\"C\"},\"rivals\":[{\"food\":\"rice\"},{\"food\":\"cookies\"},{\"food\":\"chips\"}],\"stats\":{\"rank\":1}}",
+              "asText": "{\"name\":{\"first\":\"Bob\",\"last\":\"C\"},\"rivals\":[{\"food\":\"rice\"},{\"food\":\"cookies\"},{\"food\":\"chips\"}],\"stats\":{\"rank\":1}}"
+            }
+          }
+        },
+        "tags": []
+      },
+      {
+        "uuid": "id27",
+        "request": {
+          "host": "example.com",
+          "method": "GET",
+          "path": "/objects-with-polymorphism",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": "ElsKCGxvY2F0aW9uEk8STQoMcHJpbmNpcGFsaXR5Ej0SCgoEY2l0eRICCAISEAoKcG9wdWxhdGlvbhICCAMSHQoLY29vcmRpbmF0ZXMSDggBGgIIAxoCCAMaAggD",
+              "asJsonString": "{\"location\":{\"principality\":{\"city\":\"San Fransisco\",\"population\":830000,\"coordinates\":[1,2,3]}}}",
+              "asText": "{\"location\":{\"principality\":{\"city\":\"San Fransisco\",\"population\":830000,\"coordinates\":[1,2,3]}}}"
+            }
+          }
+        },
+        "tags": []
+      },
+      {
+        "uuid": "id28",
+        "request": {
+          "host": "example.com",
+          "method": "GET",
+          "path": "/object-cases",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": "EgkKA2FnZRICCAMSDgoIbGFzdE5hbWUSAggCEg8KCWZpcnN0TmFtZRICCAISLAoNZmF2b3JpdGVDb2xvchIbEgsKBWZpcnN0EgIIAhIMCgZzZWNvbmQSAggCEhgKBmNpdGllcxIOCAEaAggCGgIIAhoCCAI=",
+              "asJsonString": "{\"firstName\":\"Aidan\",\"lastName\":\"C\",\"age\":26,\"cities\":[\"San Fransisco\",\"New York\",\"Durham\"],\"favoriteColor\":{\"first\":\"orange\",\"second\":\"red\"}}",
+              "asText": "{\"firstName\":\"Aidan\",\"lastName\":\"C\",\"age\":26,\"cities\":[\"San Fransisco\",\"New York\",\"Durham\"],\"favoriteColor\":{\"first\":\"orange\",\"second\":\"red\"}}"
+            }
+          }
+        },
+        "tags": []
+      },
+      {
+        "uuid": "id29",
+        "request": {
+          "host": "example.com",
+          "method": "GET",
+          "path": "/object-cases",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": "EgkKA2FnZRICCAMSDgoIbGFzdE5hbWUSAggCEg8KCWZpcnN0TmFtZRICCAISEwoNZmF2b3JpdGVDb2xvchICCAISGAoGY2l0aWVzEg4IARoCCAIaAggCGgIIAg==",
+              "asJsonString": "{\"firstName\":\"Aidan\",\"lastName\":\"C\",\"age\":26,\"cities\":[\"San Fransisco\",\"New York\",\"Durham\"],\"favoriteColor\":\"Syracuse-Orange\"}",
+              "asText": "{\"firstName\":\"Aidan\",\"lastName\":\"C\",\"age\":26,\"cities\":[\"San Fransisco\",\"New York\",\"Durham\"],\"favoriteColor\":\"Syracuse-Orange\"}"
+            }
+          }
+        },
+        "tags": []
+      },
+      {
+        "uuid": "id30",
+        "request": {
+          "host": "example.com",
+          "method": "GET",
+          "path": "/array-fields",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": "EiEKBG5hbWUSGRILCgVmaXJzdBICCAISCgoEbGFzdBICCAISGAoGcml2YWxzEg4IARoCCAIaAggCGgIIAhILCgVzdGF0cxICCAU=",
+              "asJsonString": "{\"name\":{\"first\":\"Bob\",\"last\":\"C\"},\"rivals\":[\"user1\",\"user2\",\"user3\"],\"stats\":null}",
+              "asText": "{\"name\":{\"first\":\"Bob\",\"last\":\"C\"},\"rivals\":[\"user1\",\"user2\",\"user3\"],\"stats\":null}"
+            }
+          }
+        },
+        "tags": []
+      },
+      {
+        "uuid": "id1",
+        "request": {
+          "host": "example.com",
+          "method": "GET",
+          "path": "/array-fields",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": "EiEKBG5hbWUSGRILCgVmaXJzdBICCAISCgoEbGFzdBICCAISGAoGcml2YWxzEg4IARoCCAIaAggCGgIIAg==",
+              "asJsonString": "{\"name\":{\"first\":\"Bob\",\"last\":\"C\"},\"rivals\":[\"user1\",\"user2\",\"user3\"]}",
+              "asText": "{\"name\":{\"first\":\"Bob\",\"last\":\"C\"},\"rivals\":[\"user1\",\"user2\",\"user3\"]}"
+            }
+          }
+        },
+        "tags": []
+      },
+      {
+        "uuid": "id2",
+        "request": {
+          "host": "example.com",
+          "method": "GET",
+          "path": "/array-fields",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": "EiEKBG5hbWUSGRILCgVmaXJzdBICCAISCgoEbGFzdBICCAISGAoGcml2YWxzEg4IARoCCAIaAggCGgIIAhIJCgVzdGF0cxIA",
+              "asJsonString": "{\"name\":{\"first\":\"Bob\",\"last\":\"C\"},\"rivals\":[\"user1\",\"user2\",\"user3\"],\"stats\":{}}",
+              "asText": "{\"name\":{\"first\":\"Bob\",\"last\":\"C\"},\"rivals\":[\"user1\",\"user2\",\"user3\"],\"stats\":{}}"
+            }
+          }
+        },
+        "tags": []
+      },
+      {
+        "uuid": "id3",
+        "request": {
+          "host": "example.com",
+          "method": "GET",
+          "path": "/array-fields",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": "EiEKBG5hbWUSGRILCgVmaXJzdBICCAISCgoEbGFzdBICCAISGAoGcml2YWxzEg4IARoCCAIaAggCGgIIAhITCgVzdGF0cxIKCAEaAggDGgIIAw==",
+              "asJsonString": "{\"name\":{\"first\":\"Bob\",\"last\":\"C\"},\"rivals\":[\"user1\",\"user2\",\"user3\"],\"stats\":[12,34]}",
+              "asText": "{\"name\":{\"first\":\"Bob\",\"last\":\"C\"},\"rivals\":[\"user1\",\"user2\",\"user3\"],\"stats\":[12,34]}"
+            }
+          }
+        },
+        "tags": []
+      },
+      {
+        "uuid": "id4",
+        "request": {
+          "host": "example.com",
+          "method": "GET",
+          "path": "/root-arrays",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": "CAEaAggDGgIIAxoCCAMaAggDGgIIAw==",
+              "asJsonString": "[1,2,3,4,5]",
+              "asText": "[1,2,3,4,5]"
+            }
+          }
+        },
+        "tags": []
+      },
+      {
+        "uuid": "id5",
+        "request": {
+          "host": "example.com",
+          "method": "GET",
+          "path": "/root-arrays",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": "CAE=",
+              "asJsonString": "[]",
+              "asText": "[]"
+            }
+          }
+        },
+        "tags": []
+      },
+      {
+        "uuid": "id6",
+        "request": {
+          "host": "example.com",
+          "method": "GET",
+          "path": "/object-as-array-items",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": "CAEaAggB",
+              "asJsonString": "[[]]",
+              "asText": "[[]]"
+            }
+          }
+        },
+        "tags": []
+      },
+      {
+        "uuid": "id7",
+        "request": {
+          "host": "example.com",
+          "method": "GET",
+          "path": "/object-as-array-items",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": "CAEaDggBGgIIAxoCCAMaAggD",
+              "asJsonString": "[[1,2,3]]",
+              "asText": "[[1,2,3]]"
+            }
+          }
+        },
+        "tags": []
+      },
+      {
+        "uuid": "id8",
+        "request": {
+          "host": "example.com",
+          "method": "GET",
+          "path": "/object-as-array-items",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": "CAE=",
+              "asJsonString": "[]",
+              "asText": "[]"
+            }
+          }
+        },
+        "tags": []
+      },
+      {
+        "uuid": "id9",
+        "request": {
+          "host": "example.com",
+          "method": "GET",
+          "path": "/object-as-array-items",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": "CAEaMRIKCgRuYW1lEgIIAhIJCgNhZ2USAggCEhgKBmNvbG9ycxIOCAEaAggCGgIIAhoCCAIaAggC",
+              "asJsonString": "[{\"name\":\"joe\",\"age\":\"thirty\",\"colors\":[\"red\",\"green\",\"yellow\"]},\"hello\"]",
+              "asText": "[{\"name\":\"joe\",\"age\":\"thirty\",\"colors\":[\"red\",\"green\",\"yellow\"]},\"hello\"]"
+            }
+          }
+        },
+        "tags": []
+      },
+      {
+        "uuid": "id10",
+        "request": {
+          "host": "example.com",
+          "method": "GET",
+          "path": "/object-as-array-items",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": "CAEaMRIKCgRuYW1lEgIIAhIJCgNhZ2USAggCEhgKBmNvbG9ycxIOCAEaAggCGgIIAhoCCAI=",
+              "asJsonString": "[{\"name\":\"joe\",\"age\":\"thirty\",\"colors\":[\"red\",\"green\",\"yellow\"]}]",
+              "asText": "[{\"name\":\"joe\",\"age\":\"thirty\",\"colors\":[\"red\",\"green\",\"yellow\"]}]"
+            }
+          }
+        },
+        "tags": []
+      },
+      {
+        "uuid": "id11",
+        "request": {
+          "host": "example.com",
+          "method": "GET",
+          "path": "/object-cases",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": "Eg8KCWZpcnN0TmFtZRICCAISDgoIbGFzdE5hbWUSAggCEgkKA2FnZRICCAMSGAoGY2l0aWVzEg4IARoCCAIaAggDGgIIAg==",
+              "asJsonString": "{\"firstName\":\"Aidan\",\"lastName\":\"C\",\"age\":26,\"cities\":[\"San Fransisco\",17584,\"Boston\"]}",
+              "asText": "{\"firstName\":\"Aidan\",\"lastName\":\"C\",\"age\":26,\"cities\":[\"San Fransisco\",17584,\"Boston\"]}"
+            }
+          }
+        },
+        "tags": []
+      },
+      {
+        "uuid": "id12",
+        "request": {
+          "host": "example.com",
+          "method": "GET",
+          "path": "/object-cases",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": "Eg8KCWZpcnN0TmFtZRICCAISDgoIbGFzdE5hbWUSAggCEgkKA2FnZRICCAMSIAoGY2l0aWVzEhYIARoCCAIaAggDGgIIAhoCCAMaAggC",
+              "asJsonString": "{\"firstName\":\"Aidan\",\"lastName\":\"C\",\"age\":26,\"cities\":[\"San Fransisco\",17584,\"Boston\",16573,\"Chicago\"]}",
+              "asText": "{\"firstName\":\"Aidan\",\"lastName\":\"C\",\"age\":26,\"cities\":[\"San Fransisco\",17584,\"Boston\",16573,\"Chicago\"]}"
+            }
+          }
+        },
+        "tags": []
+      },
+      {
+        "uuid": "id13",
+        "request": {
+          "host": "example.com",
+          "method": "GET",
+          "path": "/object-cases",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": "Eg8KCWZpcnN0TmFtZRICCAISDgoIbGFzdE5hbWUSAggCEgkKA2FnZRICCAMSGAoGY2l0aWVzEg4IARoCCAIaAggCGgIIAg==",
+              "asJsonString": "{\"firstName\":\"Aidan\",\"lastName\":\"C\",\"age\":26,\"cities\":[\"San Fransisco\",\"New York\",\"Durham\"]}",
+              "asText": "{\"firstName\":\"Aidan\",\"lastName\":\"C\",\"age\":26,\"cities\":[\"San Fransisco\",\"New York\",\"Durham\"]}"
+            }
+          }
+        },
+        "tags": []
+      },
+      {
+        "uuid": "id14",
+        "request": {
+          "host": "example.com",
+          "method": "GET",
+          "path": "/objects-with-polymorphism",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": "Ek0KCGxvY2F0aW9uEkESPwoMcHJpbmNpcGFsaXR5Ei8SCgoEY2l0eRICCAISEAoKcG9wdWxhdGlvbhICCAMSDwoLY29vcmRpbmF0ZXMSAA==",
+              "asJsonString": "{\"location\":{\"principality\":{\"city\":\"San Fransisco\",\"population\":830000,\"coordinates\":{}}}}",
+              "asText": "{\"location\":{\"principality\":{\"city\":\"San Fransisco\",\"population\":830000,\"coordinates\":{}}}}"
+            }
+          }
+        },
+        "tags": []
+      },
+      {
+        "uuid": "id15",
+        "request": {
+          "host": "example.com",
+          "method": "GET",
+          "path": "/root-arrays",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": "EgkKA2ZvbxICCAI=",
+              "asJsonString": "{\"foo\":\"bar\"}",
+              "asText": "{\"foo\":\"bar\"}"
+            }
+          }
+        },
+        "tags": []
+      },
+      {
+        "uuid": "id16",
+        "request": {
+          "host": "example.com",
+          "method": "GET",
+          "path": "/nullables",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": "CAEaHBINCgdhZGRyZXNzEgIIAhILCgVwcmljZRICCAMaHBINCgdhZGRyZXNzEgIIAhILCgVwcmljZRICCAM=",
+              "asJsonString": "[{\"address\":\"123\",\"price\":657},{\"address\":\"456\",\"price\":322}]",
+              "asText": "[{\"address\":\"123\",\"price\":657},{\"address\":\"456\",\"price\":322}]"
+            }
+          }
+        },
+        "tags": []
+      }
+    ]
+  }
 }

--- a/workspaces/ui-v2/public/example-sessions/empty.json
+++ b/workspaces/ui-v2/public/example-sessions/empty.json
@@ -1,3 +1,22 @@
 {
-  "events": []
+  "events": [
+    {
+      "ContributionAdded": {
+        "id": "metadata",
+        "key": "id",
+        "value": "0ed242a3-79b8-4b01-8a7c-352bfd1f73b5",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a72c2710-1a0d-46d2-9a3f-c6c85f03798e",
+          "clientCommandBatchId": "9296cd05-8c2e-4079-bfaa-d56aad29aacd",
+          "createdAt": "2020-10-20T20:52:31.794Z"
+        }
+      }
+    }
+  ],
+  "session": {
+    "samples": [],
+    "metadata": {}
+  },
+  "examples": {}
 }

--- a/workspaces/ui-v2/public/example-sessions/partial-universe.json
+++ b/workspaces/ui-v2/public/example-sessions/partial-universe.json
@@ -1785,6 +1785,19 @@
           "createdAt": "2020-10-20T20:52:31.794Z"
         }
       }
+    },
+    {
+      "ContributionAdded": {
+        "id": "metadata",
+        "key": "id",
+        "value": "82d03ea2-dad2-4198-83da-8dc918f81cba",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a72c2710-1a0d-46d2-9a3f-c6c85f03798e",
+          "clientCommandBatchId": "9296cd05-8c2e-4079-bfaa-d56aad29aacd",
+          "createdAt": "2020-10-20T20:52:31.794Z"
+        }
+      }
     }
   ],
   "session": {

--- a/workspaces/ui-v2/public/example-sessions/todos-partial.json
+++ b/workspaces/ui-v2/public/example-sessions/todos-partial.json
@@ -1873,6 +1873,19 @@
           "createdAt": "2020-10-20T20:52:31.789Z"
         }
       }
+    },
+    {
+      "ContributionAdded": {
+        "id": "metadata",
+        "key": "id",
+        "value": "b47d8f6e-d0e4-4814-9db6-add26b96ddd2",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "ec3dd58b-bdf3-42b0-88a8-7e8f85f49e74",
+          "clientCommandBatchId": "b8aa13c5-a333-4cb2-90d0-ef1c6ba79865",
+          "createdAt": "2020-10-20T20:52:31.789Z"
+        }
+      }
     }
   ],
   "session": {

--- a/workspaces/ui-v2/public/example-sessions/todos-with-paths.json
+++ b/workspaces/ui-v2/public/example-sessions/todos-with-paths.json
@@ -1,5 +1,1664 @@
 {
-  "events": [{"PathComponentAdded":{"pathId":"path_jNlbaVZ0Ar","parentPathId":"root","name":"todos","eventContext":{"clientId":"anonymous","clientSessionId":"bcfad727-81fd-4552-b0fb-82828f7b05f2","clientCommandBatchId":"ad4c2dd3-feb9-443a-b506-a64603d8185a","createdAt":"2020-04-02T18:52:25.989Z"}}},{"ContributionAdded":{"id":"path_jNlbaVZ0Ar.GET","key":"purpose","value":"todos","eventContext":{"clientId":"anonymous","clientSessionId":"bcfad727-81fd-4552-b0fb-82828f7b05f2","clientCommandBatchId":"ad4c2dd3-feb9-443a-b506-a64603d8185a","createdAt":"2020-04-02T18:52:25.994Z"}}},{"BatchCommitStarted":{"batchId":"4852cc8a-83cd-4803-b237-d7bf77b0933b","commitMessage":"dsasa","eventContext":{"clientId":"anonymous","clientSessionId":"bcfad727-81fd-4552-b0fb-82828f7b05f2","clientCommandBatchId":"860e177a-39ce-4ebf-b6e8-6d7c09247c2b","createdAt":"2020-04-02T18:52:35.863Z"}}},{"RequestParameterAddedByPathAndMethod":{"parameterId":"parameter_IHN2kDSLbI","pathId":"path_jNlbaVZ0Ar","httpMethod":"GET","parameterLocation":"query","name":"queryString","eventContext":{"clientId":"anonymous","clientSessionId":"bcfad727-81fd-4552-b0fb-82828f7b05f2","clientCommandBatchId":"03813f28-d8af-4647-b70a-16c533393098","createdAt":"2020-04-02T18:52:35.864Z"}}},{"ShapeAdded":{"shapeId":"shape_W0JK7E2Z3Z","baseShapeId":"$object","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"bcfad727-81fd-4552-b0fb-82828f7b05f2","clientCommandBatchId":"03813f28-d8af-4647-b70a-16c533393098","createdAt":"2020-04-02T18:52:35.864Z"}}},{"RequestParameterShapeSet":{"parameterId":"parameter_IHN2kDSLbI","parameterDescriptor":{"shapeId":"shape_W0JK7E2Z3Z","isRemoved":false},"eventContext":{"clientId":"anonymous","clientSessionId":"bcfad727-81fd-4552-b0fb-82828f7b05f2","clientCommandBatchId":"03813f28-d8af-4647-b70a-16c533393098","createdAt":"2020-04-02T18:52:35.864Z"}}},{"RequestAdded":{"requestId":"request_sQzzwQ8hQB","pathId":"path_jNlbaVZ0Ar","httpMethod":"GET","eventContext":{"clientId":"anonymous","clientSessionId":"bcfad727-81fd-4552-b0fb-82828f7b05f2","clientCommandBatchId":"03813f28-d8af-4647-b70a-16c533393098","createdAt":"2020-04-02T18:52:35.864Z"}}},{"ResponseAddedByPathAndMethod":{"responseId":"response_ruRhRU7VwB","pathId":"path_jNlbaVZ0Ar","httpMethod":"GET","httpStatusCode":200,"eventContext":{"clientId":"anonymous","clientSessionId":"bcfad727-81fd-4552-b0fb-82828f7b05f2","clientCommandBatchId":"7428db16-89bc-4184-a3bf-d19352ee0c62","createdAt":"2020-04-02T18:52:35.865Z"}}},{"ShapeAdded":{"shapeId":"JR1dZS_0","baseShapeId":"$object","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"bcfad727-81fd-4552-b0fb-82828f7b05f2","clientCommandBatchId":"7428db16-89bc-4184-a3bf-d19352ee0c62","createdAt":"2020-04-02T18:52:35.865Z"}}},{"ShapeAdded":{"shapeId":"JR1dZS_2","baseShapeId":"$boolean","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"bcfad727-81fd-4552-b0fb-82828f7b05f2","clientCommandBatchId":"7428db16-89bc-4184-a3bf-d19352ee0c62","createdAt":"2020-04-02T18:52:35.865Z"}}},{"FieldAdded":{"fieldId":"JR1dZS_1","shapeId":"JR1dZS_0","name":"isDone","shapeDescriptor":{"FieldShapeFromShape":{"fieldId":"JR1dZS_1","shapeId":"JR1dZS_2"}},"eventContext":{"clientId":"anonymous","clientSessionId":"bcfad727-81fd-4552-b0fb-82828f7b05f2","clientCommandBatchId":"7428db16-89bc-4184-a3bf-d19352ee0c62","createdAt":"2020-04-02T18:52:35.865Z"}}},{"ShapeAdded":{"shapeId":"JR1dZS_4","baseShapeId":"$string","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"bcfad727-81fd-4552-b0fb-82828f7b05f2","clientCommandBatchId":"7428db16-89bc-4184-a3bf-d19352ee0c62","createdAt":"2020-04-02T18:52:35.866Z"}}},{"FieldAdded":{"fieldId":"JR1dZS_3","shapeId":"JR1dZS_0","name":"task","shapeDescriptor":{"FieldShapeFromShape":{"fieldId":"JR1dZS_3","shapeId":"JR1dZS_4"}},"eventContext":{"clientId":"anonymous","clientSessionId":"bcfad727-81fd-4552-b0fb-82828f7b05f2","clientCommandBatchId":"7428db16-89bc-4184-a3bf-d19352ee0c62","createdAt":"2020-04-02T18:52:35.866Z"}}},{"ResponseBodySet":{"responseId":"response_ruRhRU7VwB","bodyDescriptor":{"httpContentType":"application/json","shapeId":"JR1dZS_0","isRemoved":false},"eventContext":{"clientId":"anonymous","clientSessionId":"bcfad727-81fd-4552-b0fb-82828f7b05f2","clientCommandBatchId":"7428db16-89bc-4184-a3bf-d19352ee0c62","createdAt":"2020-04-02T18:52:35.866Z"}}},{"ShapeAdded":{"shapeId":"ESOkbg_0","baseShapeId":"$string","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"bcfad727-81fd-4552-b0fb-82828f7b05f2","clientCommandBatchId":"08f37604-bf90-44b4-85f7-b0f466d4b5e4","createdAt":"2020-04-02T18:52:35.867Z"}}},{"FieldAdded":{"fieldId":"field_i0RPTArMFH","shapeId":"JR1dZS_0","name":"dueData","shapeDescriptor":{"FieldShapeFromShape":{"fieldId":"field_i0RPTArMFH","shapeId":"ESOkbg_0"}},"eventContext":{"clientId":"anonymous","clientSessionId":"bcfad727-81fd-4552-b0fb-82828f7b05f2","clientCommandBatchId":"08f37604-bf90-44b4-85f7-b0f466d4b5e4","createdAt":"2020-04-02T18:52:35.867Z"}}},{"BatchCommitEnded":{"batchId":"4852cc8a-83cd-4803-b237-d7bf77b0933b","eventContext":{"clientId":"anonymous","clientSessionId":"bcfad727-81fd-4552-b0fb-82828f7b05f2","clientCommandBatchId":"cc14b1ed-f31d-44d9-950b-2c38277a8648","createdAt":"2020-04-02T18:52:35.868Z"}}},{"PathParameterAdded":{"pathId":"path_4DpQAqvkOA","parentPathId":"path_jNlbaVZ0Ar","name":"todoId","eventContext":null}},{"ShapeAdded":{"shapeId":"shape_4bul4hj0a1","baseShapeId":"$string","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":null}},{"PathParameterShapeSet":{"pathId":"path_4DpQAqvkOA","shapeDescriptor":{"shapeId":"shape_4bul4hj0a1","isRemoved":false},"eventContext":null}},{"ContributionAdded":{"id":"path_4DpQAqvkOA.PUT","key":"purpose","value":"Update todo by ID","eventContext":{"clientId":"anonymous","clientSessionId":"5239c93d-502f-4a89-9cbb-734ace2bfc8e","clientCommandBatchId":"9baf44da-6593-476a-a58c-49b427fbca8b","createdAt":"2020-04-07T13:07:31.317Z"}}},{"BatchCommitStarted":{"batchId":"0566e48d-ac86-4a91-b148-3dccda573c09","commitMessage":"Added New Endpoint\n\nChanges:\n- Added Request with No Body\n- Added 200 Response with application/json Body","eventContext":{"clientId":"anonymous","clientSessionId":"5239c93d-502f-4a89-9cbb-734ace2bfc8e","clientCommandBatchId":"4210fe7a-1f54-49c4-82b9-5f58dddcb8fa","createdAt":"2020-04-07T13:07:41.103Z"}}},{"RequestParameterAddedByPathAndMethod":{"parameterId":"parameter_fqtP8Twvv9","pathId":"path_4DpQAqvkOA","httpMethod":"PUT","parameterLocation":"query","name":"queryString","eventContext":{"clientId":"anonymous","clientSessionId":"5239c93d-502f-4a89-9cbb-734ace2bfc8e","clientCommandBatchId":"084adc11-0999-43da-bfb2-db3e49584452","createdAt":"2020-04-07T13:07:41.104Z"}}},{"ShapeAdded":{"shapeId":"shape_IvrrBkWGV6","baseShapeId":"$object","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"5239c93d-502f-4a89-9cbb-734ace2bfc8e","clientCommandBatchId":"084adc11-0999-43da-bfb2-db3e49584452","createdAt":"2020-04-07T13:07:41.104Z"}}},{"RequestParameterShapeSet":{"parameterId":"parameter_fqtP8Twvv9","parameterDescriptor":{"shapeId":"shape_IvrrBkWGV6","isRemoved":false},"eventContext":{"clientId":"anonymous","clientSessionId":"5239c93d-502f-4a89-9cbb-734ace2bfc8e","clientCommandBatchId":"084adc11-0999-43da-bfb2-db3e49584452","createdAt":"2020-04-07T13:07:41.104Z"}}},{"RequestAdded":{"requestId":"request_58N3sKJep4","pathId":"path_4DpQAqvkOA","httpMethod":"PUT","eventContext":{"clientId":"anonymous","clientSessionId":"5239c93d-502f-4a89-9cbb-734ace2bfc8e","clientCommandBatchId":"084adc11-0999-43da-bfb2-db3e49584452","createdAt":"2020-04-07T13:07:41.104Z"}}},{"ShapeAdded":{"shapeId":"cmbM7N_0","baseShapeId":"$object","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"5239c93d-502f-4a89-9cbb-734ace2bfc8e","clientCommandBatchId":"084adc11-0999-43da-bfb2-db3e49584452","createdAt":"2020-04-07T13:07:41.105Z"}}},{"ShapeAdded":{"shapeId":"cmbM7N_2","baseShapeId":"$string","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"5239c93d-502f-4a89-9cbb-734ace2bfc8e","clientCommandBatchId":"084adc11-0999-43da-bfb2-db3e49584452","createdAt":"2020-04-07T13:07:41.105Z"}}},{"FieldAdded":{"fieldId":"cmbM7N_1","shapeId":"cmbM7N_0","name":"dueData","shapeDescriptor":{"FieldShapeFromShape":{"fieldId":"cmbM7N_1","shapeId":"cmbM7N_2"}},"eventContext":{"clientId":"anonymous","clientSessionId":"5239c93d-502f-4a89-9cbb-734ace2bfc8e","clientCommandBatchId":"084adc11-0999-43da-bfb2-db3e49584452","createdAt":"2020-04-07T13:07:41.105Z"}}},{"ShapeAdded":{"shapeId":"cmbM7N_4","baseShapeId":"$boolean","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"5239c93d-502f-4a89-9cbb-734ace2bfc8e","clientCommandBatchId":"084adc11-0999-43da-bfb2-db3e49584452","createdAt":"2020-04-07T13:07:41.105Z"}}},{"FieldAdded":{"fieldId":"cmbM7N_3","shapeId":"cmbM7N_0","name":"isDone","shapeDescriptor":{"FieldShapeFromShape":{"fieldId":"cmbM7N_3","shapeId":"cmbM7N_4"}},"eventContext":{"clientId":"anonymous","clientSessionId":"5239c93d-502f-4a89-9cbb-734ace2bfc8e","clientCommandBatchId":"084adc11-0999-43da-bfb2-db3e49584452","createdAt":"2020-04-07T13:07:41.106Z"}}},{"ShapeAdded":{"shapeId":"cmbM7N_6","baseShapeId":"$string","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"5239c93d-502f-4a89-9cbb-734ace2bfc8e","clientCommandBatchId":"084adc11-0999-43da-bfb2-db3e49584452","createdAt":"2020-04-07T13:07:41.106Z"}}},{"FieldAdded":{"fieldId":"cmbM7N_5","shapeId":"cmbM7N_0","name":"task","shapeDescriptor":{"FieldShapeFromShape":{"fieldId":"cmbM7N_5","shapeId":"cmbM7N_6"}},"eventContext":{"clientId":"anonymous","clientSessionId":"5239c93d-502f-4a89-9cbb-734ace2bfc8e","clientCommandBatchId":"084adc11-0999-43da-bfb2-db3e49584452","createdAt":"2020-04-07T13:07:41.106Z"}}},{"RequestBodySet":{"requestId":"request_58N3sKJep4","bodyDescriptor":{"httpContentType":"application/json","shapeId":"cmbM7N_0","isRemoved":false},"eventContext":{"clientId":"anonymous","clientSessionId":"5239c93d-502f-4a89-9cbb-734ace2bfc8e","clientCommandBatchId":"084adc11-0999-43da-bfb2-db3e49584452","createdAt":"2020-04-07T13:07:41.106Z"}}},{"ResponseAddedByPathAndMethod":{"responseId":"response_LmNq2E73PM","pathId":"path_4DpQAqvkOA","httpMethod":"PUT","httpStatusCode":200,"eventContext":{"clientId":"anonymous","clientSessionId":"5239c93d-502f-4a89-9cbb-734ace2bfc8e","clientCommandBatchId":"bceab60a-3f5b-42c2-85f6-da6bc1a95a2f","createdAt":"2020-04-07T13:07:41.109Z"}}},{"ShapeAdded":{"shapeId":"Yen51t_0","baseShapeId":"$object","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"5239c93d-502f-4a89-9cbb-734ace2bfc8e","clientCommandBatchId":"bceab60a-3f5b-42c2-85f6-da6bc1a95a2f","createdAt":"2020-04-07T13:07:41.109Z"}}},{"ShapeAdded":{"shapeId":"Yen51t_2","baseShapeId":"$string","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"5239c93d-502f-4a89-9cbb-734ace2bfc8e","clientCommandBatchId":"bceab60a-3f5b-42c2-85f6-da6bc1a95a2f","createdAt":"2020-04-07T13:07:41.109Z"}}},{"FieldAdded":{"fieldId":"Yen51t_1","shapeId":"Yen51t_0","name":"dueData","shapeDescriptor":{"FieldShapeFromShape":{"fieldId":"Yen51t_1","shapeId":"Yen51t_2"}},"eventContext":{"clientId":"anonymous","clientSessionId":"5239c93d-502f-4a89-9cbb-734ace2bfc8e","clientCommandBatchId":"bceab60a-3f5b-42c2-85f6-da6bc1a95a2f","createdAt":"2020-04-07T13:07:41.109Z"}}},{"ShapeAdded":{"shapeId":"Yen51t_4","baseShapeId":"$boolean","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"5239c93d-502f-4a89-9cbb-734ace2bfc8e","clientCommandBatchId":"bceab60a-3f5b-42c2-85f6-da6bc1a95a2f","createdAt":"2020-04-07T13:07:41.110Z"}}},{"FieldAdded":{"fieldId":"Yen51t_3","shapeId":"Yen51t_0","name":"isDone","shapeDescriptor":{"FieldShapeFromShape":{"fieldId":"Yen51t_3","shapeId":"Yen51t_4"}},"eventContext":{"clientId":"anonymous","clientSessionId":"5239c93d-502f-4a89-9cbb-734ace2bfc8e","clientCommandBatchId":"bceab60a-3f5b-42c2-85f6-da6bc1a95a2f","createdAt":"2020-04-07T13:07:41.110Z"}}},{"ShapeAdded":{"shapeId":"Yen51t_6","baseShapeId":"$string","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"5239c93d-502f-4a89-9cbb-734ace2bfc8e","clientCommandBatchId":"bceab60a-3f5b-42c2-85f6-da6bc1a95a2f","createdAt":"2020-04-07T13:07:41.110Z"}}},{"FieldAdded":{"fieldId":"Yen51t_5","shapeId":"Yen51t_0","name":"task","shapeDescriptor":{"FieldShapeFromShape":{"fieldId":"Yen51t_5","shapeId":"Yen51t_6"}},"eventContext":{"clientId":"anonymous","clientSessionId":"5239c93d-502f-4a89-9cbb-734ace2bfc8e","clientCommandBatchId":"bceab60a-3f5b-42c2-85f6-da6bc1a95a2f","createdAt":"2020-04-07T13:07:41.110Z"}}},{"ResponseBodySet":{"responseId":"response_LmNq2E73PM","bodyDescriptor":{"httpContentType":"application/json","shapeId":"Yen51t_0","isRemoved":false},"eventContext":{"clientId":"anonymous","clientSessionId":"5239c93d-502f-4a89-9cbb-734ace2bfc8e","clientCommandBatchId":"bceab60a-3f5b-42c2-85f6-da6bc1a95a2f","createdAt":"2020-04-07T13:07:41.110Z"}}},{"BatchCommitEnded":{"batchId":"0566e48d-ac86-4a91-b148-3dccda573c09","eventContext":{"clientId":"anonymous","clientSessionId":"5239c93d-502f-4a89-9cbb-734ace2bfc8e","clientCommandBatchId":"ffe789c8-10b6-4717-be9b-89c4fb765d17","createdAt":"2020-04-07T13:07:41.111Z"}}},{"BatchCommitStarted":{"batchId":"0a6d3edd-4ebe-4f2b-84fe-81fbf6e71e25","commitMessage":"Updated Todos Endpoint\n\nChanges:\n- Made field 'dueData' optional","eventContext":{"clientId":"anonymous","clientSessionId":"5239c93d-502f-4a89-9cbb-734ace2bfc8e","clientCommandBatchId":"079adbab-f9a9-4464-9e8e-b61e09ac9e4f","createdAt":"2020-04-07T13:07:53.653Z"}}},{"ShapeAdded":{"shapeId":"shape_jjqKM2kZXa","baseShapeId":"$optional","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"5239c93d-502f-4a89-9cbb-734ace2bfc8e","clientCommandBatchId":"34f77c80-1d8b-4ba4-8289-261b3732b022","createdAt":"2020-04-07T13:07:53.654Z"}}},{"ShapeParameterShapeSet":{"shapeDescriptor":{"ProviderInShape":{"shapeId":"shape_jjqKM2kZXa","providerDescriptor":{"ShapeProvider":{"shapeId":"ESOkbg_0"}},"consumingParameterId":"$optionalInner"}},"eventContext":{"clientId":"anonymous","clientSessionId":"5239c93d-502f-4a89-9cbb-734ace2bfc8e","clientCommandBatchId":"34f77c80-1d8b-4ba4-8289-261b3732b022","createdAt":"2020-04-07T13:07:53.654Z"}}},{"FieldShapeSet":{"shapeDescriptor":{"FieldShapeFromShape":{"fieldId":"field_i0RPTArMFH","shapeId":"shape_jjqKM2kZXa"}},"eventContext":{"clientId":"anonymous","clientSessionId":"5239c93d-502f-4a89-9cbb-734ace2bfc8e","clientCommandBatchId":"34f77c80-1d8b-4ba4-8289-261b3732b022","createdAt":"2020-04-07T13:07:53.654Z"}}},{"BatchCommitEnded":{"batchId":"0a6d3edd-4ebe-4f2b-84fe-81fbf6e71e25","eventContext":{"clientId":"anonymous","clientSessionId":"5239c93d-502f-4a89-9cbb-734ace2bfc8e","clientCommandBatchId":"9047d322-0ba7-41f7-85c6-dd1b6d4b063f","createdAt":"2020-04-07T13:07:53.655Z"}}},{"PathComponentAdded":{"pathId":"path_u2SxMpeXl7","parentPathId":"root","name":"complex-types","eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"306fe106-9d49-442d-9048-ed1acf66b766","createdAt":"2020-04-17T23:06:37.293Z"}}},{"ContributionAdded":{"id":"path_u2SxMpeXl7.GET","key":"purpose","value":"complex","eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"306fe106-9d49-442d-9048-ed1acf66b766","createdAt":"2020-04-17T23:06:37.298Z"}}},{"BatchCommitStarted":{"batchId":"bc4d0fe2-0113-4674-80f4-c43d7e1c1344","commitMessage":"\n\nChanges:\n- Added Request with No Body\n- Added 200 Response with application/json Body\n- Made field 'america' nullable","eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"680ed06f-79cf-4685-8cad-c6af3b6b92c5","createdAt":"2020-04-17T23:06:44.972Z"}}},{"RequestParameterAddedByPathAndMethod":{"parameterId":"parameter_B3H70aHhh9","pathId":"path_u2SxMpeXl7","httpMethod":"GET","parameterLocation":"query","name":"queryString","eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"bd479ceb-bffe-4302-a660-3c39e989df7d","createdAt":"2020-04-17T23:06:44.973Z"}}},{"ShapeAdded":{"shapeId":"shape_TbDgP5sQHV","baseShapeId":"$object","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"bd479ceb-bffe-4302-a660-3c39e989df7d","createdAt":"2020-04-17T23:06:44.973Z"}}},{"RequestParameterShapeSet":{"parameterId":"parameter_B3H70aHhh9","parameterDescriptor":{"shapeId":"shape_TbDgP5sQHV","isRemoved":false},"eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"bd479ceb-bffe-4302-a660-3c39e989df7d","createdAt":"2020-04-17T23:06:44.973Z"}}},{"RequestAdded":{"requestId":"request_jYQPxI5cV3","pathId":"path_u2SxMpeXl7","httpMethod":"GET","eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"bd479ceb-bffe-4302-a660-3c39e989df7d","createdAt":"2020-04-17T23:06:44.973Z"}}},{"ResponseAddedByPathAndMethod":{"responseId":"response_bPAj16GQlK","pathId":"path_u2SxMpeXl7","httpMethod":"GET","httpStatusCode":200,"eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"394f1e89-4d3c-4927-848a-1b888bb2cce3","createdAt":"2020-04-17T23:06:44.974Z"}}},{"ShapeAdded":{"shapeId":"nKP46f_0","baseShapeId":"$object","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"394f1e89-4d3c-4927-848a-1b888bb2cce3","createdAt":"2020-04-17T23:06:44.974Z"}}},{"ShapeAdded":{"shapeId":"nKP46f_2","baseShapeId":"$boolean","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"394f1e89-4d3c-4927-848a-1b888bb2cce3","createdAt":"2020-04-17T23:06:44.974Z"}}},{"FieldAdded":{"fieldId":"nKP46f_1","shapeId":"nKP46f_0","name":"america","shapeDescriptor":{"FieldShapeFromShape":{"fieldId":"nKP46f_1","shapeId":"nKP46f_2"}},"eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"394f1e89-4d3c-4927-848a-1b888bb2cce3","createdAt":"2020-04-17T23:06:44.974Z"}}},{"ShapeAdded":{"shapeId":"nKP46f_4","baseShapeId":"$list","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"394f1e89-4d3c-4927-848a-1b888bb2cce3","createdAt":"2020-04-17T23:06:44.974Z"}}},{"ShapeAdded":{"shapeId":"nKP46f_5","baseShapeId":"$number","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"394f1e89-4d3c-4927-848a-1b888bb2cce3","createdAt":"2020-04-17T23:06:44.974Z"}}},{"FieldAdded":{"fieldId":"nKP46f_3","shapeId":"nKP46f_0","name":"color","shapeDescriptor":{"FieldShapeFromShape":{"fieldId":"nKP46f_3","shapeId":"nKP46f_4"}},"eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"394f1e89-4d3c-4927-848a-1b888bb2cce3","createdAt":"2020-04-17T23:06:44.975Z"}}},{"ShapeAdded":{"shapeId":"nKP46f_7","baseShapeId":"$object","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"394f1e89-4d3c-4927-848a-1b888bb2cce3","createdAt":"2020-04-17T23:06:44.975Z"}}},{"ShapeAdded":{"shapeId":"nKP46f_9","baseShapeId":"$string","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"394f1e89-4d3c-4927-848a-1b888bb2cce3","createdAt":"2020-04-17T23:06:44.975Z"}}},{"FieldAdded":{"fieldId":"nKP46f_8","shapeId":"nKP46f_7","name":"hello","shapeDescriptor":{"FieldShapeFromShape":{"fieldId":"nKP46f_8","shapeId":"nKP46f_9"}},"eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"394f1e89-4d3c-4927-848a-1b888bb2cce3","createdAt":"2020-04-17T23:06:44.975Z"}}},{"FieldAdded":{"fieldId":"nKP46f_6","shapeId":"nKP46f_0","name":"nested","shapeDescriptor":{"FieldShapeFromShape":{"fieldId":"nKP46f_6","shapeId":"nKP46f_7"}},"eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"394f1e89-4d3c-4927-848a-1b888bb2cce3","createdAt":"2020-04-17T23:06:44.975Z"}}},{"ShapeParameterShapeSet":{"shapeDescriptor":{"ProviderInShape":{"shapeId":"nKP46f_4","providerDescriptor":{"ShapeProvider":{"shapeId":"nKP46f_5"}},"consumingParameterId":"$listItem"}},"eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"394f1e89-4d3c-4927-848a-1b888bb2cce3","createdAt":"2020-04-17T23:06:44.975Z"}}},{"ResponseBodySet":{"responseId":"response_bPAj16GQlK","bodyDescriptor":{"httpContentType":"application/json","shapeId":"nKP46f_0","isRemoved":false},"eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"394f1e89-4d3c-4927-848a-1b888bb2cce3","createdAt":"2020-04-17T23:06:44.975Z"}}},{"ShapeAdded":{"shapeId":"shape_sPlWNbwI8x","baseShapeId":"$nullable","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"71502677-1019-486a-891f-519189b473bf","createdAt":"2020-04-17T23:06:44.977Z"}}},{"ShapeParameterShapeSet":{"shapeDescriptor":{"ProviderInShape":{"shapeId":"shape_sPlWNbwI8x","providerDescriptor":{"ShapeProvider":{"shapeId":"nKP46f_2"}},"consumingParameterId":"$nullableInner"}},"eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"71502677-1019-486a-891f-519189b473bf","createdAt":"2020-04-17T23:06:44.977Z"}}},{"FieldShapeSet":{"shapeDescriptor":{"FieldShapeFromShape":{"fieldId":"nKP46f_1","shapeId":"shape_sPlWNbwI8x"}},"eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"71502677-1019-486a-891f-519189b473bf","createdAt":"2020-04-17T23:06:44.977Z"}}},{"BatchCommitEnded":{"batchId":"bc4d0fe2-0113-4674-80f4-c43d7e1c1344","eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"eab00f8b-5cf6-4519-bf3d-5cd39ce6b7f8","createdAt":"2020-04-17T23:06:44.979Z"}}},{"PathComponentAdded":{"pathId":"path_KfgfQ24ALA","parentPathId":"root","name":"nested","eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"b850ac36-7ca2-4597-a6a9-bfa1c8af4cb8","createdAt":"2020-04-17T23:06:49.719Z"}}},{"ContributionAdded":{"id":"path_KfgfQ24ALA.GET","key":"purpose","value":"nested","eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"b850ac36-7ca2-4597-a6a9-bfa1c8af4cb8","createdAt":"2020-04-17T23:06:49.719Z"}}},{"BatchCommitStarted":{"batchId":"e10ee301-6e56-4167-b3f2-0ec15fffaee2","commitMessage":"\n\nChanges:\n- Added Request with No Body\n- Added 200 Response with application/json Body\n- Made field 'abc' optional\n- Made field 'fieldB' optional\n- Allowed field 'hello' to be either a Object or String","eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"0c9e77b6-39b4-45ac-84d4-6891cd6a9674","createdAt":"2020-04-17T23:07:08.964Z"}}},{"RequestParameterAddedByPathAndMethod":{"parameterId":"parameter_NMR5ysKFyz","pathId":"path_KfgfQ24ALA","httpMethod":"GET","parameterLocation":"query","name":"queryString","eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"e67ea4f7-2bc9-441e-ad37-a8c2354c18d0","createdAt":"2020-04-17T23:07:08.965Z"}}},{"ShapeAdded":{"shapeId":"shape_bad2uCMKoj","baseShapeId":"$object","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"e67ea4f7-2bc9-441e-ad37-a8c2354c18d0","createdAt":"2020-04-17T23:07:08.965Z"}}},{"RequestParameterShapeSet":{"parameterId":"parameter_NMR5ysKFyz","parameterDescriptor":{"shapeId":"shape_bad2uCMKoj","isRemoved":false},"eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"e67ea4f7-2bc9-441e-ad37-a8c2354c18d0","createdAt":"2020-04-17T23:07:08.965Z"}}},{"RequestAdded":{"requestId":"request_BEvbtW01Fz","pathId":"path_KfgfQ24ALA","httpMethod":"GET","eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"e67ea4f7-2bc9-441e-ad37-a8c2354c18d0","createdAt":"2020-04-17T23:07:08.965Z"}}},{"ResponseAddedByPathAndMethod":{"responseId":"response_0Oko7f6vUK","pathId":"path_KfgfQ24ALA","httpMethod":"GET","httpStatusCode":200,"eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"4f957257-e3cc-47ab-b2e2-70a8324de6ec","createdAt":"2020-04-17T23:07:08.966Z"}}},{"ShapeAdded":{"shapeId":"GLquYH_0","baseShapeId":"$object","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"4f957257-e3cc-47ab-b2e2-70a8324de6ec","createdAt":"2020-04-17T23:07:08.966Z"}}},{"ShapeAdded":{"shapeId":"GLquYH_2","baseShapeId":"$boolean","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"4f957257-e3cc-47ab-b2e2-70a8324de6ec","createdAt":"2020-04-17T23:07:08.966Z"}}},{"FieldAdded":{"fieldId":"GLquYH_1","shapeId":"GLquYH_0","name":"abc","shapeDescriptor":{"FieldShapeFromShape":{"fieldId":"GLquYH_1","shapeId":"GLquYH_2"}},"eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"4f957257-e3cc-47ab-b2e2-70a8324de6ec","createdAt":"2020-04-17T23:07:08.967Z"}}},{"ShapeAdded":{"shapeId":"GLquYH_4","baseShapeId":"$object","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"4f957257-e3cc-47ab-b2e2-70a8324de6ec","createdAt":"2020-04-17T23:07:08.967Z"}}},{"ShapeAdded":{"shapeId":"GLquYH_6","baseShapeId":"$object","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"4f957257-e3cc-47ab-b2e2-70a8324de6ec","createdAt":"2020-04-17T23:07:08.967Z"}}},{"ShapeAdded":{"shapeId":"GLquYH_8","baseShapeId":"$number","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"4f957257-e3cc-47ab-b2e2-70a8324de6ec","createdAt":"2020-04-17T23:07:08.967Z"}}},{"FieldAdded":{"fieldId":"GLquYH_7","shapeId":"GLquYH_6","name":"n","shapeDescriptor":{"FieldShapeFromShape":{"fieldId":"GLquYH_7","shapeId":"GLquYH_8"}},"eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"4f957257-e3cc-47ab-b2e2-70a8324de6ec","createdAt":"2020-04-17T23:07:08.967Z"}}},{"FieldAdded":{"fieldId":"GLquYH_5","shapeId":"GLquYH_4","name":"hello","shapeDescriptor":{"FieldShapeFromShape":{"fieldId":"GLquYH_5","shapeId":"GLquYH_6"}},"eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"4f957257-e3cc-47ab-b2e2-70a8324de6ec","createdAt":"2020-04-17T23:07:08.967Z"}}},{"FieldAdded":{"fieldId":"GLquYH_3","shapeId":"GLquYH_0","name":"fieldA","shapeDescriptor":{"FieldShapeFromShape":{"fieldId":"GLquYH_3","shapeId":"GLquYH_4"}},"eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"4f957257-e3cc-47ab-b2e2-70a8324de6ec","createdAt":"2020-04-17T23:07:08.968Z"}}},{"ShapeAdded":{"shapeId":"GLquYH_10","baseShapeId":"$object","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"4f957257-e3cc-47ab-b2e2-70a8324de6ec","createdAt":"2020-04-17T23:07:08.968Z"}}},{"ShapeAdded":{"shapeId":"GLquYH_12","baseShapeId":"$boolean","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"4f957257-e3cc-47ab-b2e2-70a8324de6ec","createdAt":"2020-04-17T23:07:08.968Z"}}},{"FieldAdded":{"fieldId":"GLquYH_11","shapeId":"GLquYH_10","name":"nested","shapeDescriptor":{"FieldShapeFromShape":{"fieldId":"GLquYH_11","shapeId":"GLquYH_12"}},"eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"4f957257-e3cc-47ab-b2e2-70a8324de6ec","createdAt":"2020-04-17T23:07:08.968Z"}}},{"FieldAdded":{"fieldId":"GLquYH_9","shapeId":"GLquYH_0","name":"fieldB","shapeDescriptor":{"FieldShapeFromShape":{"fieldId":"GLquYH_9","shapeId":"GLquYH_10"}},"eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"4f957257-e3cc-47ab-b2e2-70a8324de6ec","createdAt":"2020-04-17T23:07:08.968Z"}}},{"ResponseBodySet":{"responseId":"response_0Oko7f6vUK","bodyDescriptor":{"httpContentType":"application/json","shapeId":"GLquYH_0","isRemoved":false},"eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"4f957257-e3cc-47ab-b2e2-70a8324de6ec","createdAt":"2020-04-17T23:07:08.968Z"}}},{"ShapeAdded":{"shapeId":"shape_srPrzEF1RL","baseShapeId":"$optional","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"809e5afa-e1b9-48b8-a93c-2fbd4f15a84e","createdAt":"2020-04-17T23:07:08.969Z"}}},{"ShapeParameterShapeSet":{"shapeDescriptor":{"ProviderInShape":{"shapeId":"shape_srPrzEF1RL","providerDescriptor":{"ShapeProvider":{"shapeId":"GLquYH_2"}},"consumingParameterId":"$optionalInner"}},"eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"809e5afa-e1b9-48b8-a93c-2fbd4f15a84e","createdAt":"2020-04-17T23:07:08.969Z"}}},{"FieldShapeSet":{"shapeDescriptor":{"FieldShapeFromShape":{"fieldId":"GLquYH_1","shapeId":"shape_srPrzEF1RL"}},"eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"809e5afa-e1b9-48b8-a93c-2fbd4f15a84e","createdAt":"2020-04-17T23:07:08.969Z"}}},{"ShapeAdded":{"shapeId":"shape_NUMCe9K2lO","baseShapeId":"$optional","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"5b19a97a-c873-4001-878d-ecbd76778e80","createdAt":"2020-04-17T23:07:08.970Z"}}},{"ShapeParameterShapeSet":{"shapeDescriptor":{"ProviderInShape":{"shapeId":"shape_NUMCe9K2lO","providerDescriptor":{"ShapeProvider":{"shapeId":"GLquYH_10"}},"consumingParameterId":"$optionalInner"}},"eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"5b19a97a-c873-4001-878d-ecbd76778e80","createdAt":"2020-04-17T23:07:08.970Z"}}},{"FieldShapeSet":{"shapeDescriptor":{"FieldShapeFromShape":{"fieldId":"GLquYH_9","shapeId":"shape_NUMCe9K2lO"}},"eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"5b19a97a-c873-4001-878d-ecbd76778e80","createdAt":"2020-04-17T23:07:08.970Z"}}},{"ShapeAdded":{"shapeId":"GQWbmO_0","baseShapeId":"$string","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"0213648c-48b2-4049-b92d-e5b218b24049","createdAt":"2020-04-17T23:07:08.971Z"}}},{"ShapeAdded":{"shapeId":"shape_yjMgmK8Hld","baseShapeId":"$oneOf","parameters":{"DynamicParameterList":{"shapeParameterIds":[]}},"name":"","eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"0213648c-48b2-4049-b92d-e5b218b24049","createdAt":"2020-04-17T23:07:08.971Z"}}},{"ShapeParameterAdded":{"shapeParameterId":"shape-parameter_P7tMyb2otE","shapeId":"shape_yjMgmK8Hld","name":"","shapeDescriptor":{"ProviderInShape":{"shapeId":"shape_yjMgmK8Hld","providerDescriptor":{"NoProvider":{}},"consumingParameterId":"shape-parameter_P7tMyb2otE"}},"eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"0213648c-48b2-4049-b92d-e5b218b24049","createdAt":"2020-04-17T23:07:08.971Z"}}},{"ShapeParameterAdded":{"shapeParameterId":"shape-parameter_Kib0iEn99p","shapeId":"shape_yjMgmK8Hld","name":"","shapeDescriptor":{"ProviderInShape":{"shapeId":"shape_yjMgmK8Hld","providerDescriptor":{"NoProvider":{}},"consumingParameterId":"shape-parameter_Kib0iEn99p"}},"eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"0213648c-48b2-4049-b92d-e5b218b24049","createdAt":"2020-04-17T23:07:08.972Z"}}},{"ShapeParameterShapeSet":{"shapeDescriptor":{"ProviderInShape":{"shapeId":"shape_yjMgmK8Hld","providerDescriptor":{"ShapeProvider":{"shapeId":"GQWbmO_0"}},"consumingParameterId":"shape-parameter_Kib0iEn99p"}},"eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"0213648c-48b2-4049-b92d-e5b218b24049","createdAt":"2020-04-17T23:07:08.972Z"}}},{"ShapeParameterShapeSet":{"shapeDescriptor":{"ProviderInShape":{"shapeId":"shape_yjMgmK8Hld","providerDescriptor":{"ShapeProvider":{"shapeId":"GLquYH_6"}},"consumingParameterId":"shape-parameter_P7tMyb2otE"}},"eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"0213648c-48b2-4049-b92d-e5b218b24049","createdAt":"2020-04-17T23:07:08.972Z"}}},{"FieldShapeSet":{"shapeDescriptor":{"FieldShapeFromShape":{"fieldId":"GLquYH_5","shapeId":"shape_yjMgmK8Hld"}},"eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"0213648c-48b2-4049-b92d-e5b218b24049","createdAt":"2020-04-17T23:07:08.972Z"}}},{"BatchCommitEnded":{"batchId":"e10ee301-6e56-4167-b3f2-0ec15fffaee2","eventContext":{"clientId":"anonymous","clientSessionId":"9769d3f8-1177-40a6-85a3-5c66a6bb3a2e","clientCommandBatchId":"578c99ef-1102-46da-a82c-b250050824ab","createdAt":"2020-04-17T23:07:08.974Z"}}}],
+  "events": [
+    {
+      "PathComponentAdded": {
+        "pathId": "path_jNlbaVZ0Ar",
+        "parentPathId": "root",
+        "name": "todos",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "bcfad727-81fd-4552-b0fb-82828f7b05f2",
+          "clientCommandBatchId": "ad4c2dd3-feb9-443a-b506-a64603d8185a",
+          "createdAt": "2020-04-02T18:52:25.989Z"
+        }
+      }
+    },
+    {
+      "ContributionAdded": {
+        "id": "path_jNlbaVZ0Ar.GET",
+        "key": "purpose",
+        "value": "todos",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "bcfad727-81fd-4552-b0fb-82828f7b05f2",
+          "clientCommandBatchId": "ad4c2dd3-feb9-443a-b506-a64603d8185a",
+          "createdAt": "2020-04-02T18:52:25.994Z"
+        }
+      }
+    },
+    {
+      "BatchCommitStarted": {
+        "batchId": "4852cc8a-83cd-4803-b237-d7bf77b0933b",
+        "commitMessage": "dsasa",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "bcfad727-81fd-4552-b0fb-82828f7b05f2",
+          "clientCommandBatchId": "860e177a-39ce-4ebf-b6e8-6d7c09247c2b",
+          "createdAt": "2020-04-02T18:52:35.863Z"
+        }
+      }
+    },
+    {
+      "RequestParameterAddedByPathAndMethod": {
+        "parameterId": "parameter_IHN2kDSLbI",
+        "pathId": "path_jNlbaVZ0Ar",
+        "httpMethod": "GET",
+        "parameterLocation": "query",
+        "name": "queryString",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "bcfad727-81fd-4552-b0fb-82828f7b05f2",
+          "clientCommandBatchId": "03813f28-d8af-4647-b70a-16c533393098",
+          "createdAt": "2020-04-02T18:52:35.864Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_W0JK7E2Z3Z",
+        "baseShapeId": "$object",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "bcfad727-81fd-4552-b0fb-82828f7b05f2",
+          "clientCommandBatchId": "03813f28-d8af-4647-b70a-16c533393098",
+          "createdAt": "2020-04-02T18:52:35.864Z"
+        }
+      }
+    },
+    {
+      "RequestParameterShapeSet": {
+        "parameterId": "parameter_IHN2kDSLbI",
+        "parameterDescriptor": {
+          "shapeId": "shape_W0JK7E2Z3Z",
+          "isRemoved": false
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "bcfad727-81fd-4552-b0fb-82828f7b05f2",
+          "clientCommandBatchId": "03813f28-d8af-4647-b70a-16c533393098",
+          "createdAt": "2020-04-02T18:52:35.864Z"
+        }
+      }
+    },
+    {
+      "RequestAdded": {
+        "requestId": "request_sQzzwQ8hQB",
+        "pathId": "path_jNlbaVZ0Ar",
+        "httpMethod": "GET",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "bcfad727-81fd-4552-b0fb-82828f7b05f2",
+          "clientCommandBatchId": "03813f28-d8af-4647-b70a-16c533393098",
+          "createdAt": "2020-04-02T18:52:35.864Z"
+        }
+      }
+    },
+    {
+      "ResponseAddedByPathAndMethod": {
+        "responseId": "response_ruRhRU7VwB",
+        "pathId": "path_jNlbaVZ0Ar",
+        "httpMethod": "GET",
+        "httpStatusCode": 200,
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "bcfad727-81fd-4552-b0fb-82828f7b05f2",
+          "clientCommandBatchId": "7428db16-89bc-4184-a3bf-d19352ee0c62",
+          "createdAt": "2020-04-02T18:52:35.865Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "JR1dZS_0",
+        "baseShapeId": "$object",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "bcfad727-81fd-4552-b0fb-82828f7b05f2",
+          "clientCommandBatchId": "7428db16-89bc-4184-a3bf-d19352ee0c62",
+          "createdAt": "2020-04-02T18:52:35.865Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "JR1dZS_2",
+        "baseShapeId": "$boolean",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "bcfad727-81fd-4552-b0fb-82828f7b05f2",
+          "clientCommandBatchId": "7428db16-89bc-4184-a3bf-d19352ee0c62",
+          "createdAt": "2020-04-02T18:52:35.865Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "JR1dZS_1",
+        "shapeId": "JR1dZS_0",
+        "name": "isDone",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "JR1dZS_1",
+            "shapeId": "JR1dZS_2"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "bcfad727-81fd-4552-b0fb-82828f7b05f2",
+          "clientCommandBatchId": "7428db16-89bc-4184-a3bf-d19352ee0c62",
+          "createdAt": "2020-04-02T18:52:35.865Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "JR1dZS_4",
+        "baseShapeId": "$string",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "bcfad727-81fd-4552-b0fb-82828f7b05f2",
+          "clientCommandBatchId": "7428db16-89bc-4184-a3bf-d19352ee0c62",
+          "createdAt": "2020-04-02T18:52:35.866Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "JR1dZS_3",
+        "shapeId": "JR1dZS_0",
+        "name": "task",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "JR1dZS_3",
+            "shapeId": "JR1dZS_4"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "bcfad727-81fd-4552-b0fb-82828f7b05f2",
+          "clientCommandBatchId": "7428db16-89bc-4184-a3bf-d19352ee0c62",
+          "createdAt": "2020-04-02T18:52:35.866Z"
+        }
+      }
+    },
+    {
+      "ResponseBodySet": {
+        "responseId": "response_ruRhRU7VwB",
+        "bodyDescriptor": {
+          "httpContentType": "application/json",
+          "shapeId": "JR1dZS_0",
+          "isRemoved": false
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "bcfad727-81fd-4552-b0fb-82828f7b05f2",
+          "clientCommandBatchId": "7428db16-89bc-4184-a3bf-d19352ee0c62",
+          "createdAt": "2020-04-02T18:52:35.866Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "ESOkbg_0",
+        "baseShapeId": "$string",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "bcfad727-81fd-4552-b0fb-82828f7b05f2",
+          "clientCommandBatchId": "08f37604-bf90-44b4-85f7-b0f466d4b5e4",
+          "createdAt": "2020-04-02T18:52:35.867Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_i0RPTArMFH",
+        "shapeId": "JR1dZS_0",
+        "name": "dueData",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_i0RPTArMFH",
+            "shapeId": "ESOkbg_0"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "bcfad727-81fd-4552-b0fb-82828f7b05f2",
+          "clientCommandBatchId": "08f37604-bf90-44b4-85f7-b0f466d4b5e4",
+          "createdAt": "2020-04-02T18:52:35.867Z"
+        }
+      }
+    },
+    {
+      "BatchCommitEnded": {
+        "batchId": "4852cc8a-83cd-4803-b237-d7bf77b0933b",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "bcfad727-81fd-4552-b0fb-82828f7b05f2",
+          "clientCommandBatchId": "cc14b1ed-f31d-44d9-950b-2c38277a8648",
+          "createdAt": "2020-04-02T18:52:35.868Z"
+        }
+      }
+    },
+    {
+      "PathParameterAdded": {
+        "pathId": "path_4DpQAqvkOA",
+        "parentPathId": "path_jNlbaVZ0Ar",
+        "name": "todoId",
+        "eventContext": null
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_4bul4hj0a1",
+        "baseShapeId": "$string",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": null
+      }
+    },
+    {
+      "PathParameterShapeSet": {
+        "pathId": "path_4DpQAqvkOA",
+        "shapeDescriptor": {
+          "shapeId": "shape_4bul4hj0a1",
+          "isRemoved": false
+        },
+        "eventContext": null
+      }
+    },
+    {
+      "ContributionAdded": {
+        "id": "path_4DpQAqvkOA.PUT",
+        "key": "purpose",
+        "value": "Update todo by ID",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "5239c93d-502f-4a89-9cbb-734ace2bfc8e",
+          "clientCommandBatchId": "9baf44da-6593-476a-a58c-49b427fbca8b",
+          "createdAt": "2020-04-07T13:07:31.317Z"
+        }
+      }
+    },
+    {
+      "BatchCommitStarted": {
+        "batchId": "0566e48d-ac86-4a91-b148-3dccda573c09",
+        "commitMessage": "Added New Endpoint\n\nChanges:\n- Added Request with No Body\n- Added 200 Response with application/json Body",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "5239c93d-502f-4a89-9cbb-734ace2bfc8e",
+          "clientCommandBatchId": "4210fe7a-1f54-49c4-82b9-5f58dddcb8fa",
+          "createdAt": "2020-04-07T13:07:41.103Z"
+        }
+      }
+    },
+    {
+      "RequestParameterAddedByPathAndMethod": {
+        "parameterId": "parameter_fqtP8Twvv9",
+        "pathId": "path_4DpQAqvkOA",
+        "httpMethod": "PUT",
+        "parameterLocation": "query",
+        "name": "queryString",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "5239c93d-502f-4a89-9cbb-734ace2bfc8e",
+          "clientCommandBatchId": "084adc11-0999-43da-bfb2-db3e49584452",
+          "createdAt": "2020-04-07T13:07:41.104Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_IvrrBkWGV6",
+        "baseShapeId": "$object",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "5239c93d-502f-4a89-9cbb-734ace2bfc8e",
+          "clientCommandBatchId": "084adc11-0999-43da-bfb2-db3e49584452",
+          "createdAt": "2020-04-07T13:07:41.104Z"
+        }
+      }
+    },
+    {
+      "RequestParameterShapeSet": {
+        "parameterId": "parameter_fqtP8Twvv9",
+        "parameterDescriptor": {
+          "shapeId": "shape_IvrrBkWGV6",
+          "isRemoved": false
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "5239c93d-502f-4a89-9cbb-734ace2bfc8e",
+          "clientCommandBatchId": "084adc11-0999-43da-bfb2-db3e49584452",
+          "createdAt": "2020-04-07T13:07:41.104Z"
+        }
+      }
+    },
+    {
+      "RequestAdded": {
+        "requestId": "request_58N3sKJep4",
+        "pathId": "path_4DpQAqvkOA",
+        "httpMethod": "PUT",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "5239c93d-502f-4a89-9cbb-734ace2bfc8e",
+          "clientCommandBatchId": "084adc11-0999-43da-bfb2-db3e49584452",
+          "createdAt": "2020-04-07T13:07:41.104Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "cmbM7N_0",
+        "baseShapeId": "$object",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "5239c93d-502f-4a89-9cbb-734ace2bfc8e",
+          "clientCommandBatchId": "084adc11-0999-43da-bfb2-db3e49584452",
+          "createdAt": "2020-04-07T13:07:41.105Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "cmbM7N_2",
+        "baseShapeId": "$string",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "5239c93d-502f-4a89-9cbb-734ace2bfc8e",
+          "clientCommandBatchId": "084adc11-0999-43da-bfb2-db3e49584452",
+          "createdAt": "2020-04-07T13:07:41.105Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "cmbM7N_1",
+        "shapeId": "cmbM7N_0",
+        "name": "dueData",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "cmbM7N_1",
+            "shapeId": "cmbM7N_2"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "5239c93d-502f-4a89-9cbb-734ace2bfc8e",
+          "clientCommandBatchId": "084adc11-0999-43da-bfb2-db3e49584452",
+          "createdAt": "2020-04-07T13:07:41.105Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "cmbM7N_4",
+        "baseShapeId": "$boolean",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "5239c93d-502f-4a89-9cbb-734ace2bfc8e",
+          "clientCommandBatchId": "084adc11-0999-43da-bfb2-db3e49584452",
+          "createdAt": "2020-04-07T13:07:41.105Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "cmbM7N_3",
+        "shapeId": "cmbM7N_0",
+        "name": "isDone",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "cmbM7N_3",
+            "shapeId": "cmbM7N_4"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "5239c93d-502f-4a89-9cbb-734ace2bfc8e",
+          "clientCommandBatchId": "084adc11-0999-43da-bfb2-db3e49584452",
+          "createdAt": "2020-04-07T13:07:41.106Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "cmbM7N_6",
+        "baseShapeId": "$string",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "5239c93d-502f-4a89-9cbb-734ace2bfc8e",
+          "clientCommandBatchId": "084adc11-0999-43da-bfb2-db3e49584452",
+          "createdAt": "2020-04-07T13:07:41.106Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "cmbM7N_5",
+        "shapeId": "cmbM7N_0",
+        "name": "task",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "cmbM7N_5",
+            "shapeId": "cmbM7N_6"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "5239c93d-502f-4a89-9cbb-734ace2bfc8e",
+          "clientCommandBatchId": "084adc11-0999-43da-bfb2-db3e49584452",
+          "createdAt": "2020-04-07T13:07:41.106Z"
+        }
+      }
+    },
+    {
+      "RequestBodySet": {
+        "requestId": "request_58N3sKJep4",
+        "bodyDescriptor": {
+          "httpContentType": "application/json",
+          "shapeId": "cmbM7N_0",
+          "isRemoved": false
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "5239c93d-502f-4a89-9cbb-734ace2bfc8e",
+          "clientCommandBatchId": "084adc11-0999-43da-bfb2-db3e49584452",
+          "createdAt": "2020-04-07T13:07:41.106Z"
+        }
+      }
+    },
+    {
+      "ResponseAddedByPathAndMethod": {
+        "responseId": "response_LmNq2E73PM",
+        "pathId": "path_4DpQAqvkOA",
+        "httpMethod": "PUT",
+        "httpStatusCode": 200,
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "5239c93d-502f-4a89-9cbb-734ace2bfc8e",
+          "clientCommandBatchId": "bceab60a-3f5b-42c2-85f6-da6bc1a95a2f",
+          "createdAt": "2020-04-07T13:07:41.109Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "Yen51t_0",
+        "baseShapeId": "$object",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "5239c93d-502f-4a89-9cbb-734ace2bfc8e",
+          "clientCommandBatchId": "bceab60a-3f5b-42c2-85f6-da6bc1a95a2f",
+          "createdAt": "2020-04-07T13:07:41.109Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "Yen51t_2",
+        "baseShapeId": "$string",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "5239c93d-502f-4a89-9cbb-734ace2bfc8e",
+          "clientCommandBatchId": "bceab60a-3f5b-42c2-85f6-da6bc1a95a2f",
+          "createdAt": "2020-04-07T13:07:41.109Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "Yen51t_1",
+        "shapeId": "Yen51t_0",
+        "name": "dueData",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "Yen51t_1",
+            "shapeId": "Yen51t_2"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "5239c93d-502f-4a89-9cbb-734ace2bfc8e",
+          "clientCommandBatchId": "bceab60a-3f5b-42c2-85f6-da6bc1a95a2f",
+          "createdAt": "2020-04-07T13:07:41.109Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "Yen51t_4",
+        "baseShapeId": "$boolean",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "5239c93d-502f-4a89-9cbb-734ace2bfc8e",
+          "clientCommandBatchId": "bceab60a-3f5b-42c2-85f6-da6bc1a95a2f",
+          "createdAt": "2020-04-07T13:07:41.110Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "Yen51t_3",
+        "shapeId": "Yen51t_0",
+        "name": "isDone",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "Yen51t_3",
+            "shapeId": "Yen51t_4"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "5239c93d-502f-4a89-9cbb-734ace2bfc8e",
+          "clientCommandBatchId": "bceab60a-3f5b-42c2-85f6-da6bc1a95a2f",
+          "createdAt": "2020-04-07T13:07:41.110Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "Yen51t_6",
+        "baseShapeId": "$string",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "5239c93d-502f-4a89-9cbb-734ace2bfc8e",
+          "clientCommandBatchId": "bceab60a-3f5b-42c2-85f6-da6bc1a95a2f",
+          "createdAt": "2020-04-07T13:07:41.110Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "Yen51t_5",
+        "shapeId": "Yen51t_0",
+        "name": "task",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "Yen51t_5",
+            "shapeId": "Yen51t_6"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "5239c93d-502f-4a89-9cbb-734ace2bfc8e",
+          "clientCommandBatchId": "bceab60a-3f5b-42c2-85f6-da6bc1a95a2f",
+          "createdAt": "2020-04-07T13:07:41.110Z"
+        }
+      }
+    },
+    {
+      "ResponseBodySet": {
+        "responseId": "response_LmNq2E73PM",
+        "bodyDescriptor": {
+          "httpContentType": "application/json",
+          "shapeId": "Yen51t_0",
+          "isRemoved": false
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "5239c93d-502f-4a89-9cbb-734ace2bfc8e",
+          "clientCommandBatchId": "bceab60a-3f5b-42c2-85f6-da6bc1a95a2f",
+          "createdAt": "2020-04-07T13:07:41.110Z"
+        }
+      }
+    },
+    {
+      "BatchCommitEnded": {
+        "batchId": "0566e48d-ac86-4a91-b148-3dccda573c09",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "5239c93d-502f-4a89-9cbb-734ace2bfc8e",
+          "clientCommandBatchId": "ffe789c8-10b6-4717-be9b-89c4fb765d17",
+          "createdAt": "2020-04-07T13:07:41.111Z"
+        }
+      }
+    },
+    {
+      "BatchCommitStarted": {
+        "batchId": "0a6d3edd-4ebe-4f2b-84fe-81fbf6e71e25",
+        "commitMessage": "Updated Todos Endpoint\n\nChanges:\n- Made field 'dueData' optional",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "5239c93d-502f-4a89-9cbb-734ace2bfc8e",
+          "clientCommandBatchId": "079adbab-f9a9-4464-9e8e-b61e09ac9e4f",
+          "createdAt": "2020-04-07T13:07:53.653Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_jjqKM2kZXa",
+        "baseShapeId": "$optional",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "5239c93d-502f-4a89-9cbb-734ace2bfc8e",
+          "clientCommandBatchId": "34f77c80-1d8b-4ba4-8289-261b3732b022",
+          "createdAt": "2020-04-07T13:07:53.654Z"
+        }
+      }
+    },
+    {
+      "ShapeParameterShapeSet": {
+        "shapeDescriptor": {
+          "ProviderInShape": {
+            "shapeId": "shape_jjqKM2kZXa",
+            "providerDescriptor": {
+              "ShapeProvider": { "shapeId": "ESOkbg_0" }
+            },
+            "consumingParameterId": "$optionalInner"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "5239c93d-502f-4a89-9cbb-734ace2bfc8e",
+          "clientCommandBatchId": "34f77c80-1d8b-4ba4-8289-261b3732b022",
+          "createdAt": "2020-04-07T13:07:53.654Z"
+        }
+      }
+    },
+    {
+      "FieldShapeSet": {
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_i0RPTArMFH",
+            "shapeId": "shape_jjqKM2kZXa"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "5239c93d-502f-4a89-9cbb-734ace2bfc8e",
+          "clientCommandBatchId": "34f77c80-1d8b-4ba4-8289-261b3732b022",
+          "createdAt": "2020-04-07T13:07:53.654Z"
+        }
+      }
+    },
+    {
+      "BatchCommitEnded": {
+        "batchId": "0a6d3edd-4ebe-4f2b-84fe-81fbf6e71e25",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "5239c93d-502f-4a89-9cbb-734ace2bfc8e",
+          "clientCommandBatchId": "9047d322-0ba7-41f7-85c6-dd1b6d4b063f",
+          "createdAt": "2020-04-07T13:07:53.655Z"
+        }
+      }
+    },
+    {
+      "PathComponentAdded": {
+        "pathId": "path_u2SxMpeXl7",
+        "parentPathId": "root",
+        "name": "complex-types",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "306fe106-9d49-442d-9048-ed1acf66b766",
+          "createdAt": "2020-04-17T23:06:37.293Z"
+        }
+      }
+    },
+    {
+      "ContributionAdded": {
+        "id": "path_u2SxMpeXl7.GET",
+        "key": "purpose",
+        "value": "complex",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "306fe106-9d49-442d-9048-ed1acf66b766",
+          "createdAt": "2020-04-17T23:06:37.298Z"
+        }
+      }
+    },
+    {
+      "BatchCommitStarted": {
+        "batchId": "bc4d0fe2-0113-4674-80f4-c43d7e1c1344",
+        "commitMessage": "\n\nChanges:\n- Added Request with No Body\n- Added 200 Response with application/json Body\n- Made field 'america' nullable",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "680ed06f-79cf-4685-8cad-c6af3b6b92c5",
+          "createdAt": "2020-04-17T23:06:44.972Z"
+        }
+      }
+    },
+    {
+      "RequestParameterAddedByPathAndMethod": {
+        "parameterId": "parameter_B3H70aHhh9",
+        "pathId": "path_u2SxMpeXl7",
+        "httpMethod": "GET",
+        "parameterLocation": "query",
+        "name": "queryString",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "bd479ceb-bffe-4302-a660-3c39e989df7d",
+          "createdAt": "2020-04-17T23:06:44.973Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_TbDgP5sQHV",
+        "baseShapeId": "$object",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "bd479ceb-bffe-4302-a660-3c39e989df7d",
+          "createdAt": "2020-04-17T23:06:44.973Z"
+        }
+      }
+    },
+    {
+      "RequestParameterShapeSet": {
+        "parameterId": "parameter_B3H70aHhh9",
+        "parameterDescriptor": {
+          "shapeId": "shape_TbDgP5sQHV",
+          "isRemoved": false
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "bd479ceb-bffe-4302-a660-3c39e989df7d",
+          "createdAt": "2020-04-17T23:06:44.973Z"
+        }
+      }
+    },
+    {
+      "RequestAdded": {
+        "requestId": "request_jYQPxI5cV3",
+        "pathId": "path_u2SxMpeXl7",
+        "httpMethod": "GET",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "bd479ceb-bffe-4302-a660-3c39e989df7d",
+          "createdAt": "2020-04-17T23:06:44.973Z"
+        }
+      }
+    },
+    {
+      "ResponseAddedByPathAndMethod": {
+        "responseId": "response_bPAj16GQlK",
+        "pathId": "path_u2SxMpeXl7",
+        "httpMethod": "GET",
+        "httpStatusCode": 200,
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "394f1e89-4d3c-4927-848a-1b888bb2cce3",
+          "createdAt": "2020-04-17T23:06:44.974Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "nKP46f_0",
+        "baseShapeId": "$object",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "394f1e89-4d3c-4927-848a-1b888bb2cce3",
+          "createdAt": "2020-04-17T23:06:44.974Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "nKP46f_2",
+        "baseShapeId": "$boolean",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "394f1e89-4d3c-4927-848a-1b888bb2cce3",
+          "createdAt": "2020-04-17T23:06:44.974Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "nKP46f_1",
+        "shapeId": "nKP46f_0",
+        "name": "america",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "nKP46f_1",
+            "shapeId": "nKP46f_2"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "394f1e89-4d3c-4927-848a-1b888bb2cce3",
+          "createdAt": "2020-04-17T23:06:44.974Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "nKP46f_4",
+        "baseShapeId": "$list",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "394f1e89-4d3c-4927-848a-1b888bb2cce3",
+          "createdAt": "2020-04-17T23:06:44.974Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "nKP46f_5",
+        "baseShapeId": "$number",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "394f1e89-4d3c-4927-848a-1b888bb2cce3",
+          "createdAt": "2020-04-17T23:06:44.974Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "nKP46f_3",
+        "shapeId": "nKP46f_0",
+        "name": "color",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "nKP46f_3",
+            "shapeId": "nKP46f_4"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "394f1e89-4d3c-4927-848a-1b888bb2cce3",
+          "createdAt": "2020-04-17T23:06:44.975Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "nKP46f_7",
+        "baseShapeId": "$object",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "394f1e89-4d3c-4927-848a-1b888bb2cce3",
+          "createdAt": "2020-04-17T23:06:44.975Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "nKP46f_9",
+        "baseShapeId": "$string",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "394f1e89-4d3c-4927-848a-1b888bb2cce3",
+          "createdAt": "2020-04-17T23:06:44.975Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "nKP46f_8",
+        "shapeId": "nKP46f_7",
+        "name": "hello",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "nKP46f_8",
+            "shapeId": "nKP46f_9"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "394f1e89-4d3c-4927-848a-1b888bb2cce3",
+          "createdAt": "2020-04-17T23:06:44.975Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "nKP46f_6",
+        "shapeId": "nKP46f_0",
+        "name": "nested",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "nKP46f_6",
+            "shapeId": "nKP46f_7"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "394f1e89-4d3c-4927-848a-1b888bb2cce3",
+          "createdAt": "2020-04-17T23:06:44.975Z"
+        }
+      }
+    },
+    {
+      "ShapeParameterShapeSet": {
+        "shapeDescriptor": {
+          "ProviderInShape": {
+            "shapeId": "nKP46f_4",
+            "providerDescriptor": {
+              "ShapeProvider": { "shapeId": "nKP46f_5" }
+            },
+            "consumingParameterId": "$listItem"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "394f1e89-4d3c-4927-848a-1b888bb2cce3",
+          "createdAt": "2020-04-17T23:06:44.975Z"
+        }
+      }
+    },
+    {
+      "ResponseBodySet": {
+        "responseId": "response_bPAj16GQlK",
+        "bodyDescriptor": {
+          "httpContentType": "application/json",
+          "shapeId": "nKP46f_0",
+          "isRemoved": false
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "394f1e89-4d3c-4927-848a-1b888bb2cce3",
+          "createdAt": "2020-04-17T23:06:44.975Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_sPlWNbwI8x",
+        "baseShapeId": "$nullable",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "71502677-1019-486a-891f-519189b473bf",
+          "createdAt": "2020-04-17T23:06:44.977Z"
+        }
+      }
+    },
+    {
+      "ShapeParameterShapeSet": {
+        "shapeDescriptor": {
+          "ProviderInShape": {
+            "shapeId": "shape_sPlWNbwI8x",
+            "providerDescriptor": {
+              "ShapeProvider": { "shapeId": "nKP46f_2" }
+            },
+            "consumingParameterId": "$nullableInner"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "71502677-1019-486a-891f-519189b473bf",
+          "createdAt": "2020-04-17T23:06:44.977Z"
+        }
+      }
+    },
+    {
+      "FieldShapeSet": {
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "nKP46f_1",
+            "shapeId": "shape_sPlWNbwI8x"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "71502677-1019-486a-891f-519189b473bf",
+          "createdAt": "2020-04-17T23:06:44.977Z"
+        }
+      }
+    },
+    {
+      "BatchCommitEnded": {
+        "batchId": "bc4d0fe2-0113-4674-80f4-c43d7e1c1344",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "eab00f8b-5cf6-4519-bf3d-5cd39ce6b7f8",
+          "createdAt": "2020-04-17T23:06:44.979Z"
+        }
+      }
+    },
+    {
+      "PathComponentAdded": {
+        "pathId": "path_KfgfQ24ALA",
+        "parentPathId": "root",
+        "name": "nested",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "b850ac36-7ca2-4597-a6a9-bfa1c8af4cb8",
+          "createdAt": "2020-04-17T23:06:49.719Z"
+        }
+      }
+    },
+    {
+      "ContributionAdded": {
+        "id": "path_KfgfQ24ALA.GET",
+        "key": "purpose",
+        "value": "nested",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "b850ac36-7ca2-4597-a6a9-bfa1c8af4cb8",
+          "createdAt": "2020-04-17T23:06:49.719Z"
+        }
+      }
+    },
+    {
+      "BatchCommitStarted": {
+        "batchId": "e10ee301-6e56-4167-b3f2-0ec15fffaee2",
+        "commitMessage": "\n\nChanges:\n- Added Request with No Body\n- Added 200 Response with application/json Body\n- Made field 'abc' optional\n- Made field 'fieldB' optional\n- Allowed field 'hello' to be either a Object or String",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "0c9e77b6-39b4-45ac-84d4-6891cd6a9674",
+          "createdAt": "2020-04-17T23:07:08.964Z"
+        }
+      }
+    },
+    {
+      "RequestParameterAddedByPathAndMethod": {
+        "parameterId": "parameter_NMR5ysKFyz",
+        "pathId": "path_KfgfQ24ALA",
+        "httpMethod": "GET",
+        "parameterLocation": "query",
+        "name": "queryString",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "e67ea4f7-2bc9-441e-ad37-a8c2354c18d0",
+          "createdAt": "2020-04-17T23:07:08.965Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_bad2uCMKoj",
+        "baseShapeId": "$object",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "e67ea4f7-2bc9-441e-ad37-a8c2354c18d0",
+          "createdAt": "2020-04-17T23:07:08.965Z"
+        }
+      }
+    },
+    {
+      "RequestParameterShapeSet": {
+        "parameterId": "parameter_NMR5ysKFyz",
+        "parameterDescriptor": {
+          "shapeId": "shape_bad2uCMKoj",
+          "isRemoved": false
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "e67ea4f7-2bc9-441e-ad37-a8c2354c18d0",
+          "createdAt": "2020-04-17T23:07:08.965Z"
+        }
+      }
+    },
+    {
+      "RequestAdded": {
+        "requestId": "request_BEvbtW01Fz",
+        "pathId": "path_KfgfQ24ALA",
+        "httpMethod": "GET",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "e67ea4f7-2bc9-441e-ad37-a8c2354c18d0",
+          "createdAt": "2020-04-17T23:07:08.965Z"
+        }
+      }
+    },
+    {
+      "ResponseAddedByPathAndMethod": {
+        "responseId": "response_0Oko7f6vUK",
+        "pathId": "path_KfgfQ24ALA",
+        "httpMethod": "GET",
+        "httpStatusCode": 200,
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "4f957257-e3cc-47ab-b2e2-70a8324de6ec",
+          "createdAt": "2020-04-17T23:07:08.966Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "GLquYH_0",
+        "baseShapeId": "$object",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "4f957257-e3cc-47ab-b2e2-70a8324de6ec",
+          "createdAt": "2020-04-17T23:07:08.966Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "GLquYH_2",
+        "baseShapeId": "$boolean",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "4f957257-e3cc-47ab-b2e2-70a8324de6ec",
+          "createdAt": "2020-04-17T23:07:08.966Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "GLquYH_1",
+        "shapeId": "GLquYH_0",
+        "name": "abc",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "GLquYH_1",
+            "shapeId": "GLquYH_2"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "4f957257-e3cc-47ab-b2e2-70a8324de6ec",
+          "createdAt": "2020-04-17T23:07:08.967Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "GLquYH_4",
+        "baseShapeId": "$object",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "4f957257-e3cc-47ab-b2e2-70a8324de6ec",
+          "createdAt": "2020-04-17T23:07:08.967Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "GLquYH_6",
+        "baseShapeId": "$object",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "4f957257-e3cc-47ab-b2e2-70a8324de6ec",
+          "createdAt": "2020-04-17T23:07:08.967Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "GLquYH_8",
+        "baseShapeId": "$number",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "4f957257-e3cc-47ab-b2e2-70a8324de6ec",
+          "createdAt": "2020-04-17T23:07:08.967Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "GLquYH_7",
+        "shapeId": "GLquYH_6",
+        "name": "n",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "GLquYH_7",
+            "shapeId": "GLquYH_8"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "4f957257-e3cc-47ab-b2e2-70a8324de6ec",
+          "createdAt": "2020-04-17T23:07:08.967Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "GLquYH_5",
+        "shapeId": "GLquYH_4",
+        "name": "hello",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "GLquYH_5",
+            "shapeId": "GLquYH_6"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "4f957257-e3cc-47ab-b2e2-70a8324de6ec",
+          "createdAt": "2020-04-17T23:07:08.967Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "GLquYH_3",
+        "shapeId": "GLquYH_0",
+        "name": "fieldA",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "GLquYH_3",
+            "shapeId": "GLquYH_4"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "4f957257-e3cc-47ab-b2e2-70a8324de6ec",
+          "createdAt": "2020-04-17T23:07:08.968Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "GLquYH_10",
+        "baseShapeId": "$object",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "4f957257-e3cc-47ab-b2e2-70a8324de6ec",
+          "createdAt": "2020-04-17T23:07:08.968Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "GLquYH_12",
+        "baseShapeId": "$boolean",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "4f957257-e3cc-47ab-b2e2-70a8324de6ec",
+          "createdAt": "2020-04-17T23:07:08.968Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "GLquYH_11",
+        "shapeId": "GLquYH_10",
+        "name": "nested",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "GLquYH_11",
+            "shapeId": "GLquYH_12"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "4f957257-e3cc-47ab-b2e2-70a8324de6ec",
+          "createdAt": "2020-04-17T23:07:08.968Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "GLquYH_9",
+        "shapeId": "GLquYH_0",
+        "name": "fieldB",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "GLquYH_9",
+            "shapeId": "GLquYH_10"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "4f957257-e3cc-47ab-b2e2-70a8324de6ec",
+          "createdAt": "2020-04-17T23:07:08.968Z"
+        }
+      }
+    },
+    {
+      "ResponseBodySet": {
+        "responseId": "response_0Oko7f6vUK",
+        "bodyDescriptor": {
+          "httpContentType": "application/json",
+          "shapeId": "GLquYH_0",
+          "isRemoved": false
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "4f957257-e3cc-47ab-b2e2-70a8324de6ec",
+          "createdAt": "2020-04-17T23:07:08.968Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_srPrzEF1RL",
+        "baseShapeId": "$optional",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "809e5afa-e1b9-48b8-a93c-2fbd4f15a84e",
+          "createdAt": "2020-04-17T23:07:08.969Z"
+        }
+      }
+    },
+    {
+      "ShapeParameterShapeSet": {
+        "shapeDescriptor": {
+          "ProviderInShape": {
+            "shapeId": "shape_srPrzEF1RL",
+            "providerDescriptor": {
+              "ShapeProvider": { "shapeId": "GLquYH_2" }
+            },
+            "consumingParameterId": "$optionalInner"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "809e5afa-e1b9-48b8-a93c-2fbd4f15a84e",
+          "createdAt": "2020-04-17T23:07:08.969Z"
+        }
+      }
+    },
+    {
+      "FieldShapeSet": {
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "GLquYH_1",
+            "shapeId": "shape_srPrzEF1RL"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "809e5afa-e1b9-48b8-a93c-2fbd4f15a84e",
+          "createdAt": "2020-04-17T23:07:08.969Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_NUMCe9K2lO",
+        "baseShapeId": "$optional",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "5b19a97a-c873-4001-878d-ecbd76778e80",
+          "createdAt": "2020-04-17T23:07:08.970Z"
+        }
+      }
+    },
+    {
+      "ShapeParameterShapeSet": {
+        "shapeDescriptor": {
+          "ProviderInShape": {
+            "shapeId": "shape_NUMCe9K2lO",
+            "providerDescriptor": {
+              "ShapeProvider": { "shapeId": "GLquYH_10" }
+            },
+            "consumingParameterId": "$optionalInner"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "5b19a97a-c873-4001-878d-ecbd76778e80",
+          "createdAt": "2020-04-17T23:07:08.970Z"
+        }
+      }
+    },
+    {
+      "FieldShapeSet": {
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "GLquYH_9",
+            "shapeId": "shape_NUMCe9K2lO"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "5b19a97a-c873-4001-878d-ecbd76778e80",
+          "createdAt": "2020-04-17T23:07:08.970Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "GQWbmO_0",
+        "baseShapeId": "$string",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "0213648c-48b2-4049-b92d-e5b218b24049",
+          "createdAt": "2020-04-17T23:07:08.971Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_yjMgmK8Hld",
+        "baseShapeId": "$oneOf",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "0213648c-48b2-4049-b92d-e5b218b24049",
+          "createdAt": "2020-04-17T23:07:08.971Z"
+        }
+      }
+    },
+    {
+      "ShapeParameterAdded": {
+        "shapeParameterId": "shape-parameter_P7tMyb2otE",
+        "shapeId": "shape_yjMgmK8Hld",
+        "name": "",
+        "shapeDescriptor": {
+          "ProviderInShape": {
+            "shapeId": "shape_yjMgmK8Hld",
+            "providerDescriptor": { "NoProvider": {} },
+            "consumingParameterId": "shape-parameter_P7tMyb2otE"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "0213648c-48b2-4049-b92d-e5b218b24049",
+          "createdAt": "2020-04-17T23:07:08.971Z"
+        }
+      }
+    },
+    {
+      "ShapeParameterAdded": {
+        "shapeParameterId": "shape-parameter_Kib0iEn99p",
+        "shapeId": "shape_yjMgmK8Hld",
+        "name": "",
+        "shapeDescriptor": {
+          "ProviderInShape": {
+            "shapeId": "shape_yjMgmK8Hld",
+            "providerDescriptor": { "NoProvider": {} },
+            "consumingParameterId": "shape-parameter_Kib0iEn99p"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "0213648c-48b2-4049-b92d-e5b218b24049",
+          "createdAt": "2020-04-17T23:07:08.972Z"
+        }
+      }
+    },
+    {
+      "ShapeParameterShapeSet": {
+        "shapeDescriptor": {
+          "ProviderInShape": {
+            "shapeId": "shape_yjMgmK8Hld",
+            "providerDescriptor": {
+              "ShapeProvider": { "shapeId": "GQWbmO_0" }
+            },
+            "consumingParameterId": "shape-parameter_Kib0iEn99p"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "0213648c-48b2-4049-b92d-e5b218b24049",
+          "createdAt": "2020-04-17T23:07:08.972Z"
+        }
+      }
+    },
+    {
+      "ShapeParameterShapeSet": {
+        "shapeDescriptor": {
+          "ProviderInShape": {
+            "shapeId": "shape_yjMgmK8Hld",
+            "providerDescriptor": {
+              "ShapeProvider": { "shapeId": "GLquYH_6" }
+            },
+            "consumingParameterId": "shape-parameter_P7tMyb2otE"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "0213648c-48b2-4049-b92d-e5b218b24049",
+          "createdAt": "2020-04-17T23:07:08.972Z"
+        }
+      }
+    },
+    {
+      "FieldShapeSet": {
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "GLquYH_5",
+            "shapeId": "shape_yjMgmK8Hld"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "0213648c-48b2-4049-b92d-e5b218b24049",
+          "createdAt": "2020-04-17T23:07:08.972Z"
+        }
+      }
+    },
+    {
+      "BatchCommitEnded": {
+        "batchId": "e10ee301-6e56-4167-b3f2-0ec15fffaee2",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "578c99ef-1102-46da-a82c-b250050824ab",
+          "createdAt": "2020-04-17T23:07:08.974Z"
+        }
+      }
+    },
+    {
+      "ContributionAdded": {
+        "id": "metadata",
+        "key": "id",
+        "value": "0cbbe708-cd05-407b-ab79-99e5891097ca",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "9769d3f8-1177-40a6-85a3-5c66a6bb3a2e",
+          "clientCommandBatchId": "578c99ef-1102-46da-a82c-b250050824ab",
+          "createdAt": "2020-04-17T23:07:08.974Z"
+        }
+      }
+    }
+  ],
   "session": {
     "metadata": {
       "completed": false

--- a/workspaces/ui-v2/public/example-sessions/todos.json
+++ b/workspaces/ui-v2/public/example-sessions/todos.json
@@ -1,5 +1,19 @@
 {
-  "events":[],
+  "events": [
+    {
+      "ContributionAdded": {
+        "id": "metadata",
+        "key": "id",
+        "value": "6190dbc1-8e2b-4409-a8c7-7b073db8f2b5",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a72c2710-1a0d-46d2-9a3f-c6c85f03798e",
+          "clientCommandBatchId": "9296cd05-8c2e-4079-bfaa-d56aad29aacd",
+          "createdAt": "2020-10-20T20:52:31.794Z"
+        }
+      }
+    }
+  ],
   "session": {
     "samples": [
       {


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Added AddContribution for spec ids so that we can have deterministic ids when interacting with public examples. Added this outside of batch commit blocks - this shouldn't really affect the overall behavior

## What
What's changing? Anything of note to call out?

## Validation
Tested by opening examples - notice that spectacle only loads once. If it can't find a spec id, spectacle will mutate and reload.