### PR TITLE
remove extra cargo build

### DIFF
--- a/taskfiles/regression-tests/Taskfile.yml
+++ b/taskfiles/regression-tests/Taskfile.yml
@@ -25,7 +25,6 @@ tasks:
       - rm -rfv {{.API_PROJECT_DIR}}/.optic/captures/ccc/diffs/*
       - cd {{.API_PROJECT_DIR}} && node ../workspaces/local-cli/bin/run daemon:stop
       - cd {{.API_PROJECT_DIR}} && node ../workspaces/local-cli/bin/run spec
-      - cargo build
       - >
         node
         workspaces/snapshot-tests/build/regressions/index.js


### PR DESCRIPTION
## Why
The `cargo build` was already being run slightly differently above, so when it runs again here on mac it doesn't complete instantly, resulting in a timeout

## Validation
* [x] regression passes
