### PR TITLE
spectacle should rebuild projections when the spec changes

### DIFF
--- a/workspaces/cli-server/src/spectacle/index.ts
+++ b/workspaces/cli-server/src/spectacle/index.ts
@@ -34,6 +34,7 @@ import { InteractionDiffWorkerRust } from '@useoptic/cli-shared/build/diffs/inte
 import { IPathMapping, readApiConfig } from '@useoptic/cli-config';
 import { CapturesHelpers } from '../routers/spec-router';
 import { IgnoreFileHelper } from '@useoptic/cli-config/build/helpers/ignore-file-interface';
+import fs from 'fs-extra';
 
 ////////////////////////////////////////////////////////////////////////////////
 export interface LocalCliSpecState {}
@@ -50,8 +51,22 @@ export class LocalCliSpecRepository implements IOpticSpecReadWriteRepository {
 
   constructor(private dependencies: LocalCliSpecRepositoryDependencies) {
     this.notifications = dependencies.notifications;
+    this.initialize();
   }
 
+  initialize() {
+    fs.watch(
+      this.dependencies.specStorePath,
+      {
+        encoding: 'utf8',
+        persistent: false,
+        recursive: false,
+      },
+      (event, filename) => {
+        this.notifications.emit('change');
+      }
+    );
+  }
   async applyCommands(
     commands: any[],
     batchCommitId: string,

--- a/workspaces/spectacle/src/graphql/schema.ts
+++ b/workspaces/spectacle/src/graphql/schema.ts
@@ -7,6 +7,10 @@ schema {
 type Mutation {
   applyCommands(commands: [JSON], batchCommitId: ID, commitMessage: String, clientId: ID, clientSessionId: ID): AppliedCommandsResult
   startDiff(diffId: ID, captureId: ID): StartDiffResult
+  invalidateCaches: InvalidateCachesResult
+}
+type InvalidateCachesResult {
+  batchCommitId: ID
 }
 type AppliedCommandsResult {
   batchCommitId: ID

--- a/workspaces/spectacle/src/index.ts
+++ b/workspaces/spectacle/src/index.ts
@@ -216,6 +216,11 @@ export async function makeSpectacle(opticContext: IOpticContext) {
     return projections;
   }
 
+  opticContext.specRepository.notifications.on('change', () => {
+    console.count('reloading because of specRepository change');
+    reload(opticContext);
+  });
+
   await reload(opticContext);
 
   const resolvers = {
@@ -264,6 +269,9 @@ export async function makeSpectacle(opticContext: IOpticContext) {
         return {
           notificationsUrl: '',
         };
+      },
+      invalidateCaches: async (parent: any, args: any, context: any) => {
+        await reload(context.spectacleContext().opticContext);
       },
     },
     Query: {

--- a/workspaces/ui-v2/src/lib/__tests/diff-helpers/__snapshots__/new-regions-interpretations.test.ts.snap
+++ b/workspaces/ui-v2/src/lib/__tests/diff-helpers/__snapshots__/new-regions-interpretations.test.ts.snap
@@ -238,42 +238,42 @@ Object {
       "AddShape": Object {
         "baseShapeId": "$string",
         "name": "",
-        "shapeId": "shape_6731",
+        "shapeId": "shape_6703",
       },
     },
     Object {
       "AddShape": Object {
         "baseShapeId": "$boolean",
         "name": "",
-        "shapeId": "shape_6732",
+        "shapeId": "shape_6704",
       },
     },
     Object {
       "AddShape": Object {
         "baseShapeId": "$string",
         "name": "",
-        "shapeId": "shape_6733",
+        "shapeId": "shape_6705",
       },
     },
     Object {
       "AddShape": Object {
         "baseShapeId": "$string",
         "name": "",
-        "shapeId": "shape_6734",
+        "shapeId": "shape_6706",
       },
     },
     Object {
       "AddShape": Object {
         "baseShapeId": "$object",
         "name": "",
-        "shapeId": "shape_6740",
+        "shapeId": "shape_6712",
       },
     },
     Object {
       "AddShape": Object {
         "baseShapeId": "$optional",
         "name": "",
-        "shapeId": "shape_6736",
+        "shapeId": "shape_6708",
       },
     },
     Object {
@@ -283,71 +283,71 @@ Object {
             "consumingParameterId": "$optionalInner",
             "providerDescriptor": Object {
               "ShapeProvider": Object {
-                "shapeId": "shape_6734",
+                "shapeId": "shape_6706",
               },
             },
-            "shapeId": "shape_6736",
+            "shapeId": "shape_6708",
           },
         },
       },
     },
     Object {
       "AddField": Object {
-        "fieldId": "field_6735",
+        "fieldId": "field_6707",
         "name": "dueDate",
         "shapeDescriptor": Object {
           "FieldShapeFromShape": Object {
-            "fieldId": "field_6735",
-            "shapeId": "shape_6736",
+            "fieldId": "field_6707",
+            "shapeId": "shape_6708",
           },
         },
-        "shapeId": "shape_6740",
+        "shapeId": "shape_6712",
       },
     },
     Object {
       "AddField": Object {
-        "fieldId": "field_6737",
+        "fieldId": "field_6709",
         "name": "id",
         "shapeDescriptor": Object {
           "FieldShapeFromShape": Object {
-            "fieldId": "field_6737",
-            "shapeId": "shape_6733",
+            "fieldId": "field_6709",
+            "shapeId": "shape_6705",
           },
         },
-        "shapeId": "shape_6740",
+        "shapeId": "shape_6712",
       },
     },
     Object {
       "AddField": Object {
-        "fieldId": "field_6738",
+        "fieldId": "field_6710",
         "name": "isDone",
         "shapeDescriptor": Object {
           "FieldShapeFromShape": Object {
-            "fieldId": "field_6738",
-            "shapeId": "shape_6732",
+            "fieldId": "field_6710",
+            "shapeId": "shape_6704",
           },
         },
-        "shapeId": "shape_6740",
+        "shapeId": "shape_6712",
       },
     },
     Object {
       "AddField": Object {
-        "fieldId": "field_6739",
+        "fieldId": "field_6711",
         "name": "task",
         "shapeDescriptor": Object {
           "FieldShapeFromShape": Object {
-            "fieldId": "field_6739",
-            "shapeId": "shape_6731",
+            "fieldId": "field_6711",
+            "shapeId": "shape_6703",
           },
         },
-        "shapeId": "shape_6740",
+        "shapeId": "shape_6712",
       },
     },
     Object {
       "AddShape": Object {
         "baseShapeId": "$list",
         "name": "",
-        "shapeId": "shape_6741",
+        "shapeId": "shape_6713",
       },
     },
     Object {
@@ -357,10 +357,10 @@ Object {
             "consumingParameterId": "$listItem",
             "providerDescriptor": Object {
               "ShapeProvider": Object {
-                "shapeId": "shape_6740",
+                "shapeId": "shape_6712",
               },
             },
-            "shapeId": "shape_6741",
+            "shapeId": "shape_6713",
           },
         },
       },
@@ -370,7 +370,7 @@ Object {
         "httpMethod": "GET",
         "httpStatusCode": 200,
         "pathId": "path_it2OyjUysW",
-        "responseId": "response_6742",
+        "responseId": "response_6714",
       },
     },
     Object {
@@ -378,9 +378,9 @@ Object {
         "bodyDescriptor": Object {
           "httpContentType": "application/json",
           "isRemoved": false,
-          "shapeId": "shape_6741",
+          "shapeId": "shape_6713",
         },
-        "responseId": "response_6742",
+        "responseId": "response_6714",
       },
     },
   ],

--- a/workspaces/ui-v2/src/lib/__tests/diff-helpers/__snapshots__/shape-interpretations.test.ts.snap
+++ b/workspaces/ui-v2/src/lib/__tests/diff-helpers/__snapshots__/shape-interpretations.test.ts.snap
@@ -4825,7 +4825,7 @@ Object {
                 },
                 Object {
                   "JsonArrayItem": Object {
-                    "index": 16,
+                    "index": 0,
                   },
                 },
                 Object {
@@ -4864,7 +4864,7 @@ Object {
                 },
                 Object {
                   "JsonArrayItem": Object {
-                    "index": 0,
+                    "index": 16,
                   },
                 },
                 Object {
@@ -5518,7 +5518,7 @@ Object {
               },
               Object {
                 "JsonArrayItem": Object {
-                  "index": 16,
+                  "index": 0,
                 },
               },
               Object {
@@ -5557,7 +5557,7 @@ Object {
               },
               Object {
                 "JsonArrayItem": Object {
-                  "index": 0,
+                  "index": 16,
                 },
               },
               Object {


### PR DESCRIPTION
## Why
The .optic/api/specification.json file may change for various reasons, mainly when a user changes their git state. 

## What
Now when the .optic/api/specification.json file changes, spectacle will reload its projections. You can observe the console.count behavior in your console. You may also directly invalidate the projections through the graphql mutation

## Validation
* [ ] CI passes
