### PR TITLE
Increase parallelism for file read to 3

### DIFF
--- a/workspaces/cli-server/src/server.ts
+++ b/workspaces/cli-server/src/server.ts
@@ -92,7 +92,7 @@ class CliServer {
     app.set('etag', false);
     const sessions = new SessionsManager();
     const fileReadBottleneck = new Bottleneck({
-      maxConcurrent: 1,
+      maxConcurrent: 3,
     });
     let user: object | null;
 


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

@acunniffe said that we could probably try bump this up to 3 without hitting file contention. I haven't had a chance to look into details of node / specifically what causes this, but a very unscientific test seems to agree with this.

Running the same endpoints to bulk learn (ran this "experiment" 3 times)
- 1 parallel ~21-24 seconds
- 3 parallel ~15-18seconds

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
