### PR TITLE
Eliminate potential racing and performance issues in reloading spec projections from spec changes

### DIFF
--- a/workspaces/cli-server/package.json
+++ b/workspaces/cli-server/package.json
@@ -30,6 +30,7 @@
     "avsc": "^5.4.18",
     "body-parser": "^1.19.0",
     "bottleneck": "^2.19.5",
+    "chokidar": "^3.5.1",
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",

--- a/workspaces/spectacle/src/in-memory/index.ts
+++ b/workspaces/spectacle/src/in-memory/index.ts
@@ -50,7 +50,7 @@ export interface InMemorySpecRepositoryDependencies {
 export class InMemorySpecRepository implements IOpticSpecReadWriteRepository {
   private events: any[] = [];
   public notifications: EventEmitter;
-  public changes: AsyncGenerator<void>;
+  public changes: AsyncGenerator<number>;
 
   constructor(private dependencies: InMemorySpecRepositoryDependencies) {
     this.notifications = dependencies.notifications;

--- a/workspaces/spectacle/src/in-memory/index.ts
+++ b/workspaces/spectacle/src/in-memory/index.ts
@@ -50,10 +50,14 @@ export interface InMemorySpecRepositoryDependencies {
 export class InMemorySpecRepository implements IOpticSpecReadWriteRepository {
   private events: any[] = [];
   public notifications: EventEmitter;
+  public changes: AsyncGenerator<void>;
 
   constructor(private dependencies: InMemorySpecRepositoryDependencies) {
     this.notifications = dependencies.notifications;
     this.events.push(...dependencies.initialState.events);
+    this.changes = (async function* () {
+      // purely in-memory specs are not expected to change from any other source than ourselves
+    })();
   }
 
   async appendEvents(events: any[]): Promise<void> {

--- a/workspaces/spectacle/src/index.ts
+++ b/workspaces/spectacle/src/index.ts
@@ -74,6 +74,8 @@ export interface IOpticSpecReadWriteRepository extends IOpticSpecRepository {
     commandContext: IOpticCommandContext
   ): Promise<void>;
 
+  changes: AsyncGenerator<void>;
+
   notifications: EventEmitter;
 }
 
@@ -207,6 +209,7 @@ export async function makeSpectacle(opticContext: IOpticContext) {
     shapeViewerProjection: any,
     contributionsProjection: ContributionsProjection;
 
+  // TODO: consider debouncing reloads (head and tail?)
   async function reload(opticContext: IOpticContext) {
     const projections = await buildProjections(opticContext);
     endpointsQueries = projections.endpointsQueries;
@@ -216,12 +219,23 @@ export async function makeSpectacle(opticContext: IOpticContext) {
     return projections;
   }
 
-  opticContext.specRepository.notifications.on('change', () => {
-    console.count('reloading because of specRepository change');
-    reload(opticContext);
-  });
+  async function reloadFromSpecChange(
+    specChanges: AsyncGenerator<void>,
+    opticContext: IOpticContext
+  ) {
+    await reload(opticContext);
 
-  await reload(opticContext);
+    for await (let change of specChanges) {
+      console.count('reloading because of specRepository change');
+      await reload(opticContext);
+    }
+  }
+
+  // TODO: make sure this Promise is consumed somewhere so errors are handled. Return from makeSpectacle perhaps?
+  const reloadingSpecs = reloadFromSpecChange(
+    opticContext.specRepository.changes,
+    opticContext
+  );
 
   const resolvers = {
     JSON: GraphQLJSON,

--- a/workspaces/spectacle/src/index.ts
+++ b/workspaces/spectacle/src/index.ts
@@ -74,7 +74,7 @@ export interface IOpticSpecReadWriteRepository extends IOpticSpecRepository {
     commandContext: IOpticCommandContext
   ): Promise<void>;
 
-  changes: AsyncGenerator<void>;
+  changes: AsyncGenerator<number>;
 
   notifications: EventEmitter;
 }
@@ -220,16 +220,16 @@ export async function makeSpectacle(opticContext: IOpticContext) {
   }
 
   async function reloadFromSpecChange(
-    specChanges: AsyncGenerator<void>,
+    specChanges: AsyncGenerator<number>,
     opticContext: IOpticContext
   ) {
-    await reload(opticContext);
-
-    for await (let change of specChanges) {
-      console.count('reloading because of specRepository change');
+    for await (let generation of specChanges) {
+      console.log('reloading because of specRepository change', generation);
       await reload(opticContext);
     }
   }
+
+  await reload(opticContext);
 
   // TODO: make sure this Promise is consumed somewhere so errors are handled. Return from makeSpectacle perhaps?
   const reloadingSpecs = reloadFromSpecChange(

--- a/workspaces/ui-v2/src/lib/__tests/diff-helpers/__snapshots__/new-regions-interpretations.test.ts.snap
+++ b/workspaces/ui-v2/src/lib/__tests/diff-helpers/__snapshots__/new-regions-interpretations.test.ts.snap
@@ -238,42 +238,42 @@ Object {
       "AddShape": Object {
         "baseShapeId": "$string",
         "name": "",
-        "shapeId": "shape_6703",
+        "shapeId": "shape_6731",
       },
     },
     Object {
       "AddShape": Object {
         "baseShapeId": "$boolean",
         "name": "",
-        "shapeId": "shape_6704",
+        "shapeId": "shape_6732",
       },
     },
     Object {
       "AddShape": Object {
         "baseShapeId": "$string",
         "name": "",
-        "shapeId": "shape_6705",
+        "shapeId": "shape_6733",
       },
     },
     Object {
       "AddShape": Object {
         "baseShapeId": "$string",
         "name": "",
-        "shapeId": "shape_6706",
+        "shapeId": "shape_6734",
       },
     },
     Object {
       "AddShape": Object {
         "baseShapeId": "$object",
         "name": "",
-        "shapeId": "shape_6712",
+        "shapeId": "shape_6740",
       },
     },
     Object {
       "AddShape": Object {
         "baseShapeId": "$optional",
         "name": "",
-        "shapeId": "shape_6708",
+        "shapeId": "shape_6736",
       },
     },
     Object {
@@ -283,71 +283,71 @@ Object {
             "consumingParameterId": "$optionalInner",
             "providerDescriptor": Object {
               "ShapeProvider": Object {
-                "shapeId": "shape_6706",
+                "shapeId": "shape_6734",
               },
             },
-            "shapeId": "shape_6708",
+            "shapeId": "shape_6736",
           },
         },
       },
     },
     Object {
       "AddField": Object {
-        "fieldId": "field_6707",
+        "fieldId": "field_6735",
         "name": "dueDate",
         "shapeDescriptor": Object {
           "FieldShapeFromShape": Object {
-            "fieldId": "field_6707",
-            "shapeId": "shape_6708",
+            "fieldId": "field_6735",
+            "shapeId": "shape_6736",
           },
         },
-        "shapeId": "shape_6712",
+        "shapeId": "shape_6740",
       },
     },
     Object {
       "AddField": Object {
-        "fieldId": "field_6709",
+        "fieldId": "field_6737",
         "name": "id",
         "shapeDescriptor": Object {
           "FieldShapeFromShape": Object {
-            "fieldId": "field_6709",
-            "shapeId": "shape_6705",
+            "fieldId": "field_6737",
+            "shapeId": "shape_6733",
           },
         },
-        "shapeId": "shape_6712",
+        "shapeId": "shape_6740",
       },
     },
     Object {
       "AddField": Object {
-        "fieldId": "field_6710",
+        "fieldId": "field_6738",
         "name": "isDone",
         "shapeDescriptor": Object {
           "FieldShapeFromShape": Object {
-            "fieldId": "field_6710",
-            "shapeId": "shape_6704",
+            "fieldId": "field_6738",
+            "shapeId": "shape_6732",
           },
         },
-        "shapeId": "shape_6712",
+        "shapeId": "shape_6740",
       },
     },
     Object {
       "AddField": Object {
-        "fieldId": "field_6711",
+        "fieldId": "field_6739",
         "name": "task",
         "shapeDescriptor": Object {
           "FieldShapeFromShape": Object {
-            "fieldId": "field_6711",
-            "shapeId": "shape_6703",
+            "fieldId": "field_6739",
+            "shapeId": "shape_6731",
           },
         },
-        "shapeId": "shape_6712",
+        "shapeId": "shape_6740",
       },
     },
     Object {
       "AddShape": Object {
         "baseShapeId": "$list",
         "name": "",
-        "shapeId": "shape_6713",
+        "shapeId": "shape_6741",
       },
     },
     Object {
@@ -357,10 +357,10 @@ Object {
             "consumingParameterId": "$listItem",
             "providerDescriptor": Object {
               "ShapeProvider": Object {
-                "shapeId": "shape_6712",
+                "shapeId": "shape_6740",
               },
             },
-            "shapeId": "shape_6713",
+            "shapeId": "shape_6741",
           },
         },
       },
@@ -370,7 +370,7 @@ Object {
         "httpMethod": "GET",
         "httpStatusCode": 200,
         "pathId": "path_it2OyjUysW",
-        "responseId": "response_6714",
+        "responseId": "response_6742",
       },
     },
     Object {
@@ -378,9 +378,9 @@ Object {
         "bodyDescriptor": Object {
           "httpContentType": "application/json",
           "isRemoved": false,
-          "shapeId": "shape_6713",
+          "shapeId": "shape_6741",
         },
-        "responseId": "response_6714",
+        "responseId": "response_6742",
       },
     },
   ],

--- a/workspaces/ui-v2/src/lib/__tests/diff-helpers/__snapshots__/shape-interpretations.test.ts.snap
+++ b/workspaces/ui-v2/src/lib/__tests/diff-helpers/__snapshots__/shape-interpretations.test.ts.snap
@@ -4825,7 +4825,7 @@ Object {
                 },
                 Object {
                   "JsonArrayItem": Object {
-                    "index": 0,
+                    "index": 16,
                   },
                 },
                 Object {
@@ -4864,7 +4864,7 @@ Object {
                 },
                 Object {
                   "JsonArrayItem": Object {
-                    "index": 16,
+                    "index": 0,
                   },
                 },
                 Object {
@@ -5518,7 +5518,7 @@ Object {
               },
               Object {
                 "JsonArrayItem": Object {
-                  "index": 0,
+                  "index": 16,
                 },
               },
               Object {
@@ -5557,7 +5557,7 @@ Object {
               },
               Object {
                 "JsonArrayItem": Object {
-                  "index": 16,
+                  "index": 0,
                 },
               },
               Object {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5162,7 +5162,7 @@ chokidar@^2.1.8:
   optionalDependencies:
     fsevents "^1.2.7"
 
-chokidar@^3.3.0, chokidar@^3.4.1:
+chokidar@^3.3.0, chokidar@^3.4.1, chokidar@^3.5.1:
   version "3.5.1"
   resolved "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
   integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==


### PR DESCRIPTION
## Why
In #822 a first version of a mechanism got introduced that lets Spectacle respond to the spec changes on disk, due to things like Git operations, manual edits, etc. While it unblocked us for Optic v10, it included a couple of data races and a relied on the not to be trusted `fs.watch`. This had the potential for some really funky bugs (as data races always tend to produce), for the system to get overwhelmed in the case of many concurrent file changes, high CPU usage during watching, etc.

## What
This re-implements the mechanism for detecting changes to the Spec from the file system by using an `AsyncGenerator` instead of event emitters, as well as `chokidar` instead of straight up `fs.watch`. 

By using an `AsyncGenerator` the reload mechanism can exert back-pressure and prevent being overwhelmed. It also makes sure there is strict control over the consumption of these change events, allowing strict control over timing, concurrency, etc.  With the use of `chokidar` we don't only get more performant and reliable file watching (especially cross platform), but also an initial layer of debouncing of change events (which can come in quick successions in certain scenarios, like Git rebases for example). Projections are not reloaded until the spec has been stable for 2 seconds, a reasonable amount of latency in an eventually consistent system.

## Validation
* [ ] CI passes
* [x] Manual changes to `specification.json` show up in the Docs UI without daemon restart.
* [x] Projections aren't rebuilt constantly during rapid sequences of changes like a Git rebase, but when stable again.
