### PR TITLE
docs: use legacy peerDependency behavior when running NPM 7

### DIFF
--- a/website/docs/get-started/quickstart.mdx
+++ b/website/docs/get-started/quickstart.mdx
@@ -25,7 +25,7 @@ yarn global add @useoptic/cli
   <TabItem value="npm">
 
 ```bash
-npm install @useoptic/cli -g
+npm install @useoptic/cli -g --legacy-peer-deps
 ```
 
   </TabItem>

--- a/website/docs/integrations/cicd/circleci.mdx
+++ b/website/docs/integrations/cicd/circleci.mdx
@@ -47,7 +47,7 @@ commands:
     - run:
         name: Run Optic CI
         command: |-
-          npm install @useoptic/cli
+          npm install --legacy-peer-deps @useoptic/cli
           npx api run test-cci --exit-on-diff
           npx api status --print-coverage
 ```

--- a/website/docs/integrations/cicd/github-actions.mdx
+++ b/website/docs/integrations/cicd/github-actions.mdx
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4 (or choose the latest version)
 
       - name: Install Optic # Or add to your development/build dependencies in your package management
-        run: npm install @useoptic/cli
+        run: npm install --legacy-peer-deps @useoptic/cli
 
       - name: Run tests
         run: npx api run run-tests --exit-on-diff


### PR DESCRIPTION
## Why

Per discussions, NPM 7 changes peerDependency behavior. This is a good thing, but a change in behavior that can impact how Optic CLI installs via NPM (particularly with Node versions 15, 16, which ship with NPM 7). This forces the previous peerDependency behavior while we consider the future of Optic CLI delivery as a whole.

## Validation
* [ ] CI passes