### PR TITLE
Fix windows / linux scroll

### DIFF
--- a/workspaces/ui-v2/src/optic-components/pages/diffs/AddEndpointsPage/AddEndpointsPage.tsx
+++ b/workspaces/ui-v2/src/optic-components/pages/diffs/AddEndpointsPage/AddEndpointsPage.tsx
@@ -296,7 +296,7 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   endpointNameContainer: {
-    overflowX: 'scroll',
+    overflowX: 'auto',
     flexGrow: 1,
   },
   endpointContributionContainer: {


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Fix scrollbar showing up on endpoint names in windows/linux when unnecessary - will show up when the endpoint name is really long.

![optic-snip](https://user-images.githubusercontent.com/18374483/119906095-66c5a200-bf02-11eb-8398-2e6d00591310.JPG)


## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
