### PR TITLE
Fix links to `Monitor Live APIs with Optic` link

### DIFF
--- a/website/docs/get-started/config.mdx
+++ b/website/docs/get-started/config.mdx
@@ -10,7 +10,7 @@ Before configuring a task, you'll need to [install and initialize Optic](/docs) 
 
 - **Recommended for remote API projects** [Have Optic intercept your API traffic seamlessly](/docs/get-started/config/intercept)
 - **Recommended for local development** [Have Optic start your API for you and intercept traffic](/docs/get-started/config/run-with-optic)
-- **To see your API as it behaves today** [Monitor your Live API with Optic](http://localhost:4000/docs/deploy/live)
+- **To see your API as it behaves today** [Monitor your Live API with Optic](/docs/deploy/live)
 - [Set up Optic as a proxy for your environment](/docs/get-started/config/proxy)
 
 You may also explore our docs to learn more about [running your tests with Optic](/docs/get-started/testing), [getting API changelogs in your pull requests](/docs/apiops/pull-requests), and [sharing Optic with your team](docs/using/share-with-team).
@@ -52,7 +52,7 @@ Only use a [proxy task](/docs/get-started/config/proxy) for new projects if thes
   </TabItem>
   <TabItem value="monitor-live">
 
-[Monitor your Live API with Optic](http://localhost:4000/docs/deploy/live)
+[Monitor your Live API with Optic](/docs/deploy/live)
 
 **When would I monitor my live API?** Monitoring live traffic helps establish the baseline behavior of your API today by sampling existing traffic (such as from tests or users). This traffic establishes how your API is working today, as deployed.
 


### PR DESCRIPTION
## Why
I'm working on [OpenAPI spec for Backstrage's Catalog plugin](https://github.com/backstage/backstage/issues/2566). I wanted to find a way to validate the spec that I created against the real API. In the process, I found Optic which I'm going to try today. While reading the docs, I realized that the link to "Monitor Live APIs with Optic" was broken.

## What

Since "Monitor Live APIs with Optic" page exists at the specified path, I'm assuming that `http://locahost:4000` was a mistake. I removed the host so the link will work.

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
