### PR TITLE
Fix safari path parameter editing

### DIFF
--- a/workspaces/ui-v2/src/pages/diffs/AddEndpointsPage/components/UndocumentedUrl.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/AddEndpointsPage/components/UndocumentedUrl.tsx
@@ -189,44 +189,22 @@ function PathComponentRender({
   const classes = useStyles();
   const [name, setName] = useState(pathComponent.name);
 
-  const [isEditing, setIsEditing] = useState(false);
-
   const onStartEdit = () => {
     const defaultValue = initialNameForComponent(pathComponent.index);
     if (defaultValue.length) {
       setName(defaultValue);
       onChange({ ...pathComponent, isParameter: true, name: defaultValue });
-      setIsEditing(true);
     } else {
       setName('');
       onChange({
         ...pathComponent,
         isParameter: true,
       });
-      setIsEditing(true);
     }
   };
 
-  if (pathComponent.isParameter && !isEditing) {
-    return (
-      <div
-        className={classNames(
-          classes.pathComponent,
-          classes.pathComponentButton
-        )}
-        onClick={() => {
-          if (pathComponent.isParameter) {
-            setIsEditing(true);
-          }
-        }}
-      >
-        <span className={classes.pathComponentInput}>{`{${name}}`}</span>
-      </div>
-    );
-  }
-
   const placeholder = 'name path parameter';
-  if (pathComponent.isParameter && isEditing) {
+  if (pathComponent.isParameter) {
     return (
       <div className={classes.pathComponent}>
         <span className={classes.pathComponentInput}>{'{'}</span>
@@ -234,13 +212,6 @@ function PathComponentRender({
           autoFocus
           value={name}
           placeholder={placeholder}
-          onBlur={(e) => {
-            //@ts-ignore
-            if (e.relatedTarget && e.relatedTarget.id === 'delete-button')
-              return;
-            setIsEditing(false);
-            onChange({ ...pathComponent, name });
-          }}
           onKeyDown={(e) => {
             // stop editing on enter, on escape or on backspace when empty
             if (
@@ -249,14 +220,15 @@ function PathComponentRender({
               (!name && e.keyCode === 8)
             ) {
               e.currentTarget.blur();
-              setIsEditing(false);
             }
           }}
           onChange={(e) => {
-            setName(e.target.value.replace(/\s/g, ''));
+            const name = e.target.value.replace(/\s/g, '');
+            setName(name);
             onChange({
               ...pathComponent,
               isParameter: true,
+              name,
             });
           }}
           style={{
@@ -279,7 +251,6 @@ function PathComponentRender({
               name: pathComponent.originalName,
               isParameter: false,
             });
-            setIsEditing(false);
           }}
         >
           <ClearIcon style={{ width: 10, height: 10 }} />
@@ -337,7 +308,6 @@ const useStyles = makeStyles((theme) => ({
   pathComponent: {
     fontFamily: 'Ubuntu Mono',
     marginLeft: 1,
-    userSelect: 'none',
     color: '#697386',
   },
   pathComponentButton: {


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

On safari, the named path parameter we could only edit one character at a time (before needing to unblur and reselect). Fixing this uncovered another error where the delete icon in safari could not be clicked.

## What
What's changing? Anything of note to call out?

- The issue was we had `userSelect: none` on the input component. The reason we could focus on it is because we programmatically focused on the input (using the `autoFocus` element)
- Removed the edit state (which is similar to isPathParameter). This is because `e.relatedTarget` for blur events is the target that _receives_ focus, which is different in safari. There's not a great way to sequence the onBlur to be after the onClick event. Instead, I removed the edit state such that we dont need the blur listener. This means the `x` shows up on all edited name fields (which I think might be better anyway, since it's easier to undo changes if you have named a bunch of parameters)

<img width="638" alt="Screen Shot 2021-06-01 at 10 36 20 AM" src="https://user-images.githubusercontent.com/18374483/120367487-c5ee3280-c2c5-11eb-9bfc-37d6add47d28.png">


## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
