### PR TITLE
Fix spectacle typings from IBaseSpectacle -> IForkedSpectacle

### DIFF
--- a/workspaces/spectacle-shared/src/local-cli/client.ts
+++ b/workspaces/spectacle-shared/src/local-cli/client.ts
@@ -1,5 +1,4 @@
 import {
-  IBaseSpectacle,
   ICapture,
   IForkableSpectacle,
   IListDiffsResponse,
@@ -24,7 +23,7 @@ import { IApiCliConfig } from '@useoptic/cli-config';
 
 export class LocalCliSpectacle implements IForkableSpectacle {
   constructor(private baseUrl: string, private opticEngine: IOpticEngine) {}
-  async fork(): Promise<IBaseSpectacle> {
+  async fork(): Promise<IForkableSpectacle> {
     const events = await JsonHttpClient.getJson(`${this.baseUrl}/events`);
     const opticContext = await InMemoryOpticContextBuilder.fromEvents(
       this.opticEngine,
@@ -49,18 +48,18 @@ export class LocalCliSpectacle implements IForkableSpectacle {
 }
 
 export interface LocalCliServices {
-  spectacle: IBaseSpectacle;
+  spectacle: IForkableSpectacle;
   capturesService: IOpticCapturesService;
   opticEngine: IOpticEngine;
   configRepository: IOpticConfigRepository;
 }
 export interface LocalCliCapturesServiceDependencies {
   baseUrl: string;
-  spectacle: IBaseSpectacle;
+  spectacle: IForkableSpectacle;
 }
 export interface LocalCliDiffServiceDependencies {
   baseUrl: string;
-  spectacle: IBaseSpectacle;
+  spectacle: IForkableSpectacle;
   diffId: string;
   captureId: string;
 }
@@ -161,7 +160,7 @@ export class LocalCliDiffService implements IOpticDiffService {
 
 export interface LocalCliConfigRepositoryDependencies {
   baseUrl: string;
-  spectacle: IBaseSpectacle;
+  spectacle: IForkableSpectacle;
 }
 
 export class LocalCliConfigRepository implements IOpticConfigRepository {

--- a/workspaces/spectacle/src/in-memory/index.ts
+++ b/workspaces/spectacle/src/in-memory/index.ts
@@ -509,7 +509,7 @@ export class InMemorySpectacle
     this.spectaclePromise = makeSpectacle(opticContext);
   }
 
-  async fork(): Promise<IBaseSpectacle> {
+  async fork(): Promise<IForkableSpectacle> {
     const opticContext = await InMemoryOpticContextBuilder.fromEventsAndInteractions(
       this.opticContext.opticEngine,
       [...(await this.opticContext.specRepository.listEvents())],

--- a/workspaces/ui-v2/src/contexts/spectacle-provider.tsx
+++ b/workspaces/ui-v2/src/contexts/spectacle-provider.tsx
@@ -1,14 +1,14 @@
 import React, { useCallback, useContext, useEffect, useState } from 'react';
-import { SpectacleInput, IBaseSpectacle } from '@useoptic/spectacle';
+import { SpectacleInput, IForkableSpectacle } from '@useoptic/spectacle';
 
 import { AsyncStatus } from '<src>/types';
 
-export const SpectacleContext = React.createContext<IBaseSpectacle | null>(
+export const SpectacleContext = React.createContext<IForkableSpectacle | null>(
   null
 );
 
 export const SpectacleStore = (props: {
-  spectacle: IBaseSpectacle;
+  spectacle: IForkableSpectacle;
   children: React.ReactNode;
 }) => {
   return (

--- a/workspaces/ui-v2/src/entry-points/cloud/cloud-viewer.tsx
+++ b/workspaces/ui-v2/src/entry-points/cloud/cloud-viewer.tsx
@@ -163,7 +163,7 @@ class CloudInMemorySpectacle
     this.spectaclePromise = makeSpectacle(opticContext);
   }
 
-  async fork(): Promise<IBaseSpectacle> {
+  async fork(): Promise<IForkableSpectacle> {
     const opticContext = await InMemoryOpticContextBuilder.fromEvents(
       this.opticContext.opticEngine,
       [...(await this.opticContext.specRepository.listEvents())]
@@ -197,9 +197,9 @@ export type CloudInMemorySpectacleDependenciesLoader = () => Promise<CloudInMemo
 //@SYNC: useInMemorySpectacle useCloudInMemorySpectacle
 export function useCloudInMemorySpectacle(
   loadDependencies: CloudInMemorySpectacleDependenciesLoader
-): AsyncStatus<CloudInMemoryBaseSpectacle> {
+): AsyncStatus<CloudInMemorySpectacle> {
   const opticEngine = useOpticEngine();
-  const [spectacle, setSpectacle] = useState<CloudInMemoryBaseSpectacle>();
+  const [spectacle, setSpectacle] = useState<CloudInMemorySpectacle>();
   const [inputs, setInputs] = useState<{
     events: any[];
     samples: any[];

--- a/workspaces/ui-v2/src/entry-points/demo/demo-examples.tsx
+++ b/workspaces/ui-v2/src/entry-points/demo/demo-examples.tsx
@@ -14,7 +14,6 @@ import { DiffReviewEnvironments } from '<src>/pages/diffs/ReviewDiffPages';
 import {
   InMemoryOpticContextBuilder,
   InMemorySpectacle,
-  InMemoryBaseSpectacle,
 } from '@useoptic/spectacle/build/in-memory';
 import { CapturesServiceStore } from '<src>/hooks/useCapturesHook';
 import { ChangelogPages } from '<src>/pages/changelog/ChangelogPages';

--- a/workspaces/ui-v2/src/entry-points/demo/demo-examples.tsx
+++ b/workspaces/ui-v2/src/entry-points/demo/demo-examples.tsx
@@ -138,9 +138,9 @@ export type InMemorySpectacleDependenciesLoader = () => Promise<InMemorySpectacl
 //@SYNC: useInMemorySpectacle
 export function useInMemorySpectacle(
   loadDependencies: InMemorySpectacleDependenciesLoader
-): AsyncStatus<InMemoryBaseSpectacle> {
+): AsyncStatus<InMemorySpectacle> {
   const opticEngine = useOpticEngine();
-  const [spectacle, setSpectacle] = useState<InMemoryBaseSpectacle>();
+  const [spectacle, setSpectacle] = useState<InMemorySpectacle>();
   const [inputs, setInputs] = useState<{
     events: any[];
     samples: any[];

--- a/workspaces/ui-v2/src/entry-points/local/public-examples.tsx
+++ b/workspaces/ui-v2/src/entry-points/local/public-examples.tsx
@@ -14,7 +14,6 @@ import { DiffReviewEnvironments } from '<src>/pages/diffs/ReviewDiffPages';
 import {
   InMemoryOpticContextBuilder,
   InMemorySpectacle,
-  InMemoryBaseSpectacle,
 } from '@useoptic/spectacle/build/in-memory';
 import { CapturesServiceStore } from '<src>/hooks/useCapturesHook';
 import { ChangelogPages } from '<src>/pages/changelog/ChangelogPages';
@@ -138,9 +137,9 @@ export type InMemorySpectacleDependenciesLoader = () => Promise<InMemorySpectacl
 //@SYNC: useInMemorySpectacle
 export function useInMemorySpectacle(
   loadDependencies: InMemorySpectacleDependenciesLoader
-): AsyncStatus<InMemoryBaseSpectacle> {
+): AsyncStatus<InMemorySpectacle> {
   const opticEngine = useOpticEngine();
-  const [spectacle, setSpectacle] = useState<InMemoryBaseSpectacle>();
+  const [spectacle, setSpectacle] = useState<InMemorySpectacle>();
   const [inputs, setInputs] = useState<{
     events: any[];
     samples: any[];


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

We are always creating a forkable version of spectacle, which means we can "upgrade" the typing to be spectacle. Noticed this while working on the redux stuff (which I want to keep in isolation and relies on having a forkable spectacle type)

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
