### PR TITLE
Implement Commands Generator for deleting of Endpoint

### DIFF
--- a/workspaces/optic-engine-wasm/src/lib.rs
+++ b/workspaces/optic-engine-wasm/src/lib.rs
@@ -11,7 +11,7 @@ use optic_engine::{
 };
 use std::collections::HashMap;
 use uuid::Uuid;
-use wasm_bindgen::prelude::*;
+use wasm_bindgen::{__rt::WasmRefCell, prelude::*};
 
 #[wasm_bindgen(start)]
 pub fn init() {
@@ -378,6 +378,28 @@ pub fn spec_resolve_response(
 
   serde_json::to_string(&response)
     .map_err(|err| JsValue::from(format!("responses could not be serialized: {:?}", err)))
+}
+
+#[wasm_bindgen]
+pub fn spec_endpoint_delete_commands(
+  spec: &WasmSpecProjection,
+  path_id: String,
+  method: String,
+) -> Result<String, JsValue> {
+  let endpoint_queries = spec.endpoint_queries();
+
+  let commands = endpoint_queries
+    .delete_endpoint_commands(&path_id, &method)
+    .ok_or_else(|| {
+      JsValue::from("delete endpoint commands could not be generated for unexisting endpoint")
+    })?;
+
+  serde_json::to_string(&commands).map_err(|err| {
+    JsValue::from(format!(
+      "delete enpoints commands could not be serialized: {:?}",
+      err
+    ))
+  })
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////

--- a/workspaces/optic-engine/src/commands/endpoint.rs
+++ b/workspaces/optic-engine/src/commands/endpoint.rs
@@ -225,7 +225,7 @@ pub struct UnsetRequestBodyShape {
 #[derive(Deserialize, Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RemoveRequest {
-  request_id: RequestId,
+  pub request_id: RequestId,
 }
 
 // Responses
@@ -282,7 +282,7 @@ pub struct UnsetResponseBodyShape {
 #[derive(Deserialize, Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RemoveResponse {
-  response_id: ResponseId,
+  pub response_id: ResponseId,
 }
 
 // Headers
@@ -473,6 +473,17 @@ impl AggregateCommand<EndpointProjection> for EndpointCommand {
         ))]
       }
 
+      EndpointCommand::RemoveRequest(command) => {
+        validation.require(
+          validation.request_exists(&command.request_id),
+          "request id must be in use to be removed",
+        )?;
+
+        vec![EndpointEvent::from(endpoint_events::RequestRemoved::from(
+          command,
+        ))]
+      }
+
       // Responses
       // ---------
       EndpointCommand::AddResponseByPathAndMethod(command) => {
@@ -497,6 +508,17 @@ impl AggregateCommand<EndpointProjection> for EndpointCommand {
         )?;
 
         vec![EndpointEvent::from(endpoint_events::ResponseBodySet::from(
+          command,
+        ))]
+      }
+
+      EndpointCommand::RemoveResponse(command) => {
+        validation.require(
+          validation.response_exists(&command.response_id),
+          "response id must be in use to be removed",
+        )?;
+
+        vec![EndpointEvent::from(endpoint_events::ResponseRemoved::from(
           command,
         ))]
       }
@@ -1008,6 +1030,46 @@ mod test {
   }
 
   #[test]
+  pub fn can_handle_remove_request_command() {
+    let initial_events: Vec<EndpointEvent> = serde_json::from_value(json!([
+      {"PathComponentAdded": {"pathId": "path_1","parentPathId": "root","name": "todos"}},
+      {"RequestAdded": {"requestId": "request_1", "pathId": "path_1", "httpMethod": "GET"}},
+      {"RequestAdded": {"requestId": "request_2", "pathId": "path_1", "httpMethod": "POST"}},
+      {"RequestRemoved": {"requestId": "request_2" }},
+    ]))
+    .expect("initial events should be valid endpoint events");
+
+    let mut projection = EndpointProjection::from(initial_events);
+
+    let valid_command: EndpointCommand = serde_json::from_value(json!(
+      {"RemoveRequest": {"requestId": "request_1" }}
+    ))
+    .expect("example command should be a valid command");
+
+    let new_events = projection
+      .execute(valid_command)
+      .expect("valid command should yield new events");
+    assert_eq!(new_events.len(), 1);
+    assert_debug_snapshot!("can_handle_remove_request_command__new_events", new_events);
+
+    // TODO: enable this usecase once EndpointProjection handles new removing of requests
+    // let unexisting_request: EndpointCommand = serde_json::from_value(json!(
+    //   {"RemoveRequest": {"requestId": "request_2" }}
+    // ))
+    // .unwrap();
+    // let unexisting_request_result = projection.execute(unexisting_request);
+    // assert!(unexisting_request_result.is_err());
+    // assert_debug_snapshot!(
+    //   "can_handle_remove_request_command__unexisting_request_result",
+    //   unexisting_request_result.unwrap_err()
+    // );
+
+    for event in new_events {
+      projection.apply(event); // verify this doesn't panic goes a long way to verifying the events
+    }
+  }
+
+  #[test]
   pub fn can_handle_add_response_by_path_and_method_command() {
     let initial_events: Vec<EndpointEvent> = serde_json::from_value(json!([
       {"PathComponentAdded": {"pathId": "path_1","parentPathId": "root","name": "todos"}},
@@ -1094,6 +1156,49 @@ mod test {
       "can_handle_set_response_body_shape_command__unexisting_response_result",
       unexisting_response_result.unwrap_err()
     );
+
+    for event in new_events {
+      projection.apply(event); // verify this doesn't panic goes a long way to verifying the events
+    }
+  }
+
+  #[test]
+  pub fn can_handle_remove_response_command() {
+    let initial_events: Vec<EndpointEvent> = serde_json::from_value(json!([
+        {"PathComponentAdded": {"pathId": "path_1","parentPathId": "root","name": "todos"}},
+        {"RequestAdded": {"requestId": "request_1", "pathId": "path_1", "httpMethod": "GET"}},
+        {"RequestAdded": {"requestId": "request_2", "pathId": "path_1", "httpMethod": "POST"}},
+
+        {"ResponseAddedByPathAndMethod": {"responseId": "response_1", "pathId": "path_1", "httpMethod": "GET", "httpStatusCode": 200}},
+        {"ResponseAddedByPathAndMethod": {"responseId": "response_2", "pathId": "path_1", "httpMethod": "POST", "httpStatusCode": 201}},
+        {"ResponseRemoved": {"responseId": "response_2" }},
+      ]))
+      .expect("initial events should be valid endpoint events");
+
+    let mut projection = EndpointProjection::from(initial_events);
+
+    let valid_command: EndpointCommand = serde_json::from_value(json!(
+      {"RemoveResponse": {"responseId": "response_1" }}
+    ))
+    .expect("example command should be a valid command");
+
+    let new_events = projection
+      .execute(valid_command)
+      .expect("valid command should yield new events");
+    assert_eq!(new_events.len(), 1);
+    assert_debug_snapshot!("can_handle_remove_response_command__new_events", new_events);
+
+    // TODO: enable this usecase once EndpointProjection handles new removing of responses
+    // let unexisting_response: EndpointCommand = serde_json::from_value(json!(
+    //   {"RemoveRequest": {"requestId": "request_2" }}
+    // ))
+    // .unwrap();
+    // let unexisting_response_result = projection.execute(unexisting_response);
+    // assert!(unexisting_response_result.is_err());
+    // assert_debug_snapshot!(
+    //   "can_handle_remove_response_command__unexisting_response_result",
+    //   unexisting_response_result.unwrap_err()
+    // );
 
     for event in new_events {
       projection.apply(event); // verify this doesn't panic goes a long way to verifying the events

--- a/workspaces/optic-engine/src/commands/endpoint.rs
+++ b/workspaces/optic-engine/src/commands/endpoint.rs
@@ -91,6 +91,10 @@ impl EndpointCommand {
     })
   }
 
+  pub fn remove_request(request_id: RequestId) -> EndpointCommand {
+    EndpointCommand::RemoveRequest(RemoveRequest { request_id })
+  }
+
   // Responses
   // ---------
 
@@ -122,6 +126,10 @@ impl EndpointCommand {
         is_removed,
       },
     })
+  }
+
+  pub fn remove_response(response_id: ResponseId) -> EndpointCommand {
+    EndpointCommand::RemoveResponse(RemoveResponse { response_id })
   }
 }
 

--- a/workspaces/optic-engine/src/commands/snapshots/optic_engine__commands__endpoint__test__can_handle_remove_request_command__new_events.snap
+++ b/workspaces/optic-engine/src/commands/snapshots/optic_engine__commands__endpoint__test__can_handle_remove_request_command__new_events.snap
@@ -1,0 +1,12 @@
+---
+source: workspaces/optic-engine/src/commands/endpoint.rs
+expression: new_events
+---
+[
+    RequestRemoved(
+        RequestRemoved {
+            request_id: "request_1",
+            event_context: None,
+        },
+    ),
+]

--- a/workspaces/optic-engine/src/commands/snapshots/optic_engine__commands__endpoint__test__can_handle_remove_response_command__new_events.snap
+++ b/workspaces/optic-engine/src/commands/snapshots/optic_engine__commands__endpoint__test__can_handle_remove_response_command__new_events.snap
@@ -1,0 +1,12 @@
+---
+source: workspaces/optic-engine/src/commands/endpoint.rs
+expression: new_events
+---
+[
+    ResponseRemoved(
+        ResponseRemoved {
+            response_id: "response_1",
+            event_context: None,
+        },
+    ),
+]

--- a/workspaces/optic-engine/src/interactions/traverser.rs
+++ b/workspaces/optic-engine/src/interactions/traverser.rs
@@ -56,7 +56,11 @@ impl<'a> Traverser<'a> {
       Some(path_id) => {
         let responses = self
           .endpoint_queries
-          .resolve_responses(interaction, path_id);
+          .resolve_responses_by_method_and_status_code(
+            &interaction.request.method,
+            interaction.response.status_code,
+            path_id,
+          );
         for response in responses {
           // eprintln!("visiting response body");
           response_body_visitor.visit(

--- a/workspaces/optic-engine/src/projections/conflicts.rs
+++ b/workspaces/optic-engine/src/projections/conflicts.rs
@@ -9,7 +9,7 @@ use petgraph::Direction::Incoming;
 use petgraph::Graph;
 use std::collections::HashMap;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ConflictsProjection {
   pub graph: Graph<Node, Edge>,
 
@@ -328,7 +328,7 @@ impl ConflictsProjection {
 pub type AbsolutePathPattern = String;
 pub type ConflictingIds = Vec<String>;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Node {
   Path(AbsolutePathPattern, ConflictingIds),
   HttpMethod(HttpMethod, ConflictingIds),
@@ -336,7 +336,7 @@ pub enum Node {
   HttpContentType(HttpContentType, ConflictingIds),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Edge {
   IsChildOf,
 }

--- a/workspaces/optic-engine/src/projections/endpoint.rs
+++ b/workspaces/optic-engine/src/projections/endpoint.rs
@@ -288,11 +288,11 @@ impl EndpointProjection {
     }
   }
 
-  pub fn get_response_node_indexes<'a>(
+  pub fn get_response_nodes<'a>(
     &'a self,
     path_id: &'a PathComponentId,
     method: &'a HttpMethod,
-  ) -> Option<impl Iterator<Item = NodeIndex> + 'a> {
+  ) -> Option<impl Iterator<Item = &Node> + 'a> {
     let path_node_index = self.get_path_component_node_index(path_id)?;
 
     let children = self
@@ -315,7 +315,7 @@ impl EndpointProjection {
         let operations = children.filter_map(move |i| {
           let node = self.graph.node_weight(i).unwrap();
           match node {
-            Node::Response(_, _) => Some(i),
+            Node::Response(response_id, body_descriptor) => Some(node),
             _ => None,
           }
         });

--- a/workspaces/optic-engine/src/projections/endpoint.rs
+++ b/workspaces/optic-engine/src/projections/endpoint.rs
@@ -1,6 +1,5 @@
 use crate::events::endpoint as endpoint_events;
 use crate::events::{EndpointEvent, SpecEvent};
-use serde::Serialize;
 use crate::state::endpoint::*;
 use crate::{
   commands::{endpoint, EndpointCommand, SpecCommand, SpecCommandError},
@@ -8,6 +7,7 @@ use crate::{
 };
 use cqrs_core::{Aggregate, AggregateCommand, AggregateEvent, Event};
 use petgraph::graph::{Graph, NodeIndex};
+use serde::Serialize;
 use std::collections::HashMap;
 
 pub const ROOT_PATH_ID: &str = "root";
@@ -287,6 +287,44 @@ impl EndpointProjection {
       None
     }
   }
+
+  // TODO: figure out why this isn't allowed (#rustlang head scratcher that I can't seem to figure out: shouldn't this trait bound syntax vs impl syntax be identical? https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=372d707441227b01c2b8d1c55bef5954)
+  // pub fn get_response_node_indexes<'a, I: 'a + Iterator<Item = NodeIndex>>(
+  //   &'a self,
+  //   path_id: &'a PathComponentId,
+  //   method: &'a HttpMethod,
+  // ) -> Option<I> {
+  //   let path_node_index = self.get_path_component_node_index(path_id)?;
+
+  //   let children = self
+  //     .graph
+  //     .neighbors_directed(*path_node_index, petgraph::Direction::Incoming);
+
+  //   let matching_method = children
+  //     .filter(move |i| {
+  //       let node = self.graph.node_weight(*i).unwrap();
+  //       match node {
+  //         Node::HttpMethod(http_method) => method == http_method,
+  //         _ => false,
+  //       }
+  //     })
+  //     .flat_map(move |i| {
+  //       let children = self
+  //         .graph
+  //         .neighbors_directed(i, petgraph::Direction::Incoming);
+
+  //       let operations = children.filter_map(move |i| {
+  //         let node = self.graph.node_weight(i).unwrap();
+  //         match node {
+  //           Node::Response(_, _) => Some(i),
+  //           _ => None,
+  //         }
+  //       });
+  //       operations
+  //     });
+
+  //   Some(matching_method)
+  // }
 }
 
 impl Default for EndpointProjection {

--- a/workspaces/optic-engine/src/projections/endpoint.rs
+++ b/workspaces/optic-engine/src/projections/endpoint.rs
@@ -288,43 +288,42 @@ impl EndpointProjection {
     }
   }
 
-  // TODO: figure out why this isn't allowed (#rustlang head scratcher that I can't seem to figure out: shouldn't this trait bound syntax vs impl syntax be identical? https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=372d707441227b01c2b8d1c55bef5954)
-  // pub fn get_response_node_indexes<'a, I: 'a + Iterator<Item = NodeIndex>>(
-  //   &'a self,
-  //   path_id: &'a PathComponentId,
-  //   method: &'a HttpMethod,
-  // ) -> Option<I> {
-  //   let path_node_index = self.get_path_component_node_index(path_id)?;
+  pub fn get_response_node_indexes<'a>(
+    &'a self,
+    path_id: &'a PathComponentId,
+    method: &'a HttpMethod,
+  ) -> Option<impl Iterator<Item = NodeIndex> + 'a> {
+    let path_node_index = self.get_path_component_node_index(path_id)?;
 
-  //   let children = self
-  //     .graph
-  //     .neighbors_directed(*path_node_index, petgraph::Direction::Incoming);
+    let children = self
+      .graph
+      .neighbors_directed(*path_node_index, petgraph::Direction::Incoming);
 
-  //   let matching_method = children
-  //     .filter(move |i| {
-  //       let node = self.graph.node_weight(*i).unwrap();
-  //       match node {
-  //         Node::HttpMethod(http_method) => method == http_method,
-  //         _ => false,
-  //       }
-  //     })
-  //     .flat_map(move |i| {
-  //       let children = self
-  //         .graph
-  //         .neighbors_directed(i, petgraph::Direction::Incoming);
+    let matching_method = children
+      .filter(move |i| {
+        let node = self.graph.node_weight(*i).unwrap();
+        match node {
+          Node::HttpMethod(http_method) => method == http_method,
+          _ => false,
+        }
+      })
+      .flat_map(move |i| {
+        let children = self
+          .graph
+          .neighbors_directed(i, petgraph::Direction::Incoming);
 
-  //       let operations = children.filter_map(move |i| {
-  //         let node = self.graph.node_weight(i).unwrap();
-  //         match node {
-  //           Node::Response(_, _) => Some(i),
-  //           _ => None,
-  //         }
-  //       });
-  //       operations
-  //     });
+        let operations = children.filter_map(move |i| {
+          let node = self.graph.node_weight(i).unwrap();
+          match node {
+            Node::Response(_, _) => Some(i),
+            _ => None,
+          }
+        });
+        operations
+      });
 
-  //   Some(matching_method)
-  // }
+    Some(matching_method)
+  }
 }
 
 impl Default for EndpointProjection {

--- a/workspaces/optic-engine/src/projections/endpoint.rs
+++ b/workspaces/optic-engine/src/projections/endpoint.rs
@@ -12,29 +12,29 @@ use std::collections::HashMap;
 
 pub const ROOT_PATH_ID: &str = "root";
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PathComponentDescriptor {
   pub is_parameter: bool,
   pub name: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 pub struct BodyDescriptor {
   pub http_content_type: HttpContentType,
   pub root_shape_id: ShapeId,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 pub struct RequestBodyDescriptor {
   pub body: Option<BodyDescriptor>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 pub struct ResponseBodyDescriptor {
   pub body: Option<BodyDescriptor>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Node {
   PathComponent(PathComponentId, PathComponentDescriptor),
   HttpMethod(HttpMethod),
@@ -43,12 +43,12 @@ pub enum Node {
   Response(ResponseId, ResponseBodyDescriptor),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Edge {
   IsChildOf,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct EndpointProjection {
   pub graph: Graph<Node, Edge>,
   // SAFETY: node indices are not stable upon removing of nodes from graph -> node indices might be referred to

--- a/workspaces/optic-engine/src/projections/endpoint.rs
+++ b/workspaces/optic-engine/src/projections/endpoint.rs
@@ -308,11 +308,17 @@ impl EndpointProjection {
         }
       })
       .flat_map(move |i| {
-        let children = self
+        let status_code_nodes = self
           .graph
           .neighbors_directed(i, petgraph::Direction::Incoming);
 
-        let operations = children.filter_map(move |i| {
+        status_code_nodes
+      })
+      .flat_map(move |i| {
+        let response_nodes = self
+          .graph
+          .neighbors_directed(i, petgraph::Direction::Incoming);
+        let operations = response_nodes.filter_map(move |i| {
           let node = self.graph.node_weight(i).unwrap();
           match node {
             Node::Response(response_id, body_descriptor) => Some(node),

--- a/workspaces/optic-engine/src/projections/history.rs
+++ b/workspaces/optic-engine/src/projections/history.rs
@@ -13,26 +13,26 @@ pub const ROOT_COMMIT_ID: &str = "root";
 pub type NodeId = String;
 pub type CommitId = String;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Node {
   BatchCommit(BatchCommitNode),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BatchCommitNode(CommitId, BatchCommitDescriptor);
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BatchCommitDescriptor {
   commit_message: String,
   pub is_complete: bool,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Edge {
   IsParentOf,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct HistoryProjection {
   pub graph: Graph<Node, Edge>,
   pub node_id_to_index: HashMap<NodeId, NodeIndex>,

--- a/workspaces/optic-engine/src/projections/mod.rs
+++ b/workspaces/optic-engine/src/projections/mod.rs
@@ -23,7 +23,7 @@ use crate::events::{EndpointEvent, RfcEvent, ShapeEvent, SpecEvent};
 use cqrs_core::{Aggregate, AggregateCommand, AggregateEvent, CommandError};
 use std::error::Error;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SpecProjection {
   endpoint: endpoint::EndpointProjection,
   history: history::HistoryProjection,

--- a/workspaces/optic-engine/src/queries/endpoint.rs
+++ b/workspaces/optic-engine/src/queries/endpoint.rs
@@ -445,8 +445,10 @@ mod test {
       .unwrap()
       .collect::<Vec<_>>();
 
+    // dbg!(Dot::with_config(&updated_spec.endpoint().graph, &[]));
+
     // TODO: enable these assertions as the EndpointProjection handles the resulting events
-    // assert_eq!(remaining_requests.len(), 0);
+    assert_eq!(remaining_requests.len(), 0);
     // assert_eq!(remaining_responses.len(), 0);
   }
 

--- a/workspaces/optic-engine/src/queries/endpoint.rs
+++ b/workspaces/optic-engine/src/queries/endpoint.rs
@@ -449,7 +449,7 @@ mod test {
 
     // TODO: enable these assertions as the EndpointProjection handles the resulting events
     assert_eq!(remaining_requests.len(), 0);
-    // assert_eq!(remaining_responses.len(), 0);
+    assert_eq!(remaining_responses.len(), 0);
   }
 
   fn assert_valid_commands(

--- a/workspaces/optic-engine/src/queries/endpoint.rs
+++ b/workspaces/optic-engine/src/queries/endpoint.rs
@@ -1,11 +1,13 @@
+use crate::commands::SpecCommand;
+use crate::events::HttpInteraction;
 use crate::projections::endpoint::{Edge, EndpointProjection, Node, ROOT_PATH_ID};
 use crate::projections::endpoint::{RequestBodyDescriptor, ResponseBodyDescriptor};
 use crate::state::endpoint::{
   HttpMethod, HttpStatusCode, PathComponentId, PathComponentIdRef, RequestId, ResponseId,
 };
-use crate::HttpInteraction;
 use petgraph::graph::Graph;
 use petgraph::visit::EdgeFilteredNeighborsDirected;
+use serde::Serialize;
 
 pub struct EndpointQueries<'a> {
   pub endpoint_projection: &'a EndpointProjection,
@@ -262,6 +264,14 @@ impl<'a> EndpointQueries<'a> {
     matching_status_code
   }
 
+  pub fn delete_endpoint_commands(
+    &self,
+    path_id: PathComponentIdRef,
+    method: &'a HttpMethod,
+  ) -> Option<DeleteEndpointCommands> {
+    todo!("implement generation of delete endpoint commands");
+  }
+
   fn graph_get_index(&self, node_id: &str) -> Option<&petgraph::graph::NodeIndex> {
     self.endpoint_projection.node_id_to_index.get(node_id)
   }
@@ -288,6 +298,13 @@ impl<'a> EndpointQueries<'a> {
       .neighbors_directed(*node_index, petgraph::Direction::Incoming);
     return neighbors;
   }
+}
+
+#[derive(Debug, Serialize)]
+pub struct DeleteEndpointCommands {
+  path_id: PathComponentId,
+  method: HttpMethod,
+  commands: Vec<SpecCommand>,
 }
 
 #[cfg(test)]

--- a/workspaces/optic-engine/src/queries/endpoint.rs
+++ b/workspaces/optic-engine/src/queries/endpoint.rs
@@ -405,7 +405,6 @@ mod test {
   }
 
   #[test]
-  #[ignore]
   pub fn can_generate_delete_commands() {
     let events: Vec<SpecEvent> = serde_json::from_value(json!([
       {"PathComponentAdded": { "pathId": "path_1", "parentPathId": "root", "name": "posts" }},
@@ -424,7 +423,7 @@ mod test {
     .expect("should be able to deserialize test events");
 
     let spec_projection = SpecProjection::from(events);
-    dbg!(Dot::with_config(&spec_projection.endpoint().graph, &[]));
+    // dbg!(Dot::with_config(&spec_projection.endpoint().graph, &[]));
 
     let endpoint_queries = EndpointQueries::new(spec_projection.endpoint());
 
@@ -434,8 +433,8 @@ mod test {
       .delete_endpoint_commands(&subject_path, &subject_method)
       .expect("delete commands are generated for existing path and method");
 
-    // TODO: test ignored because remove commands aren't handled yet
-    let updated_spec = assert_valid_commands(deleted_endpoint_commmands.commands);
+    let updated_spec =
+      assert_valid_commands(spec_projection.clone(), deleted_endpoint_commmands.commands);
     let updated_queries = EndpointQueries::new(&updated_spec.endpoint());
     let remaining_requests = updated_queries
       .resolve_requests(&subject_path, &subject_method)
@@ -445,12 +444,17 @@ mod test {
       .resolve_responses(&subject_path, &subject_method)
       .unwrap()
       .collect::<Vec<_>>();
-    assert_eq!(remaining_requests.len(), 0);
-    assert_eq!(remaining_responses.len(), 0);
+
+    // TODO: enable these assertions as the EndpointProjection handles the resulting events
+    // assert_eq!(remaining_requests.len(), 0);
+    // assert_eq!(remaining_responses.len(), 0);
   }
 
-  fn assert_valid_commands(commands: impl IntoIterator<Item = SpecCommand>) -> SpecProjection {
-    let mut spec_projection = SpecProjection::default();
+  fn assert_valid_commands(
+    mut spec_projection: SpecProjection,
+    commands: impl IntoIterator<Item = SpecCommand>,
+  ) -> SpecProjection {
+    // let mut spec_projection = SpecProjection::default();
     for command in commands {
       let events = spec_projection
         .execute(command)


### PR DESCRIPTION
## Why
To let the user delete endpoints from a spec, the Optic Engine needs to be able to generate the commands that achieve this. The UI should be able to query these commands, so it can be in control of when the deletion is actually applied and in what context (simulated for previews, or to the persisted spec).

## What
The WASM interface now exposes a `spec_endpoint_delete_commands`, which uses the new `EndpointQueries.delete_endpoint_commands` to generate commands that result in the removal of all requests and responses for a given (path, http method) pair. Once the result events are applied to the internal `SpecProjection` (used for the diffing, but _not_ the Spectacle queries), the affected requests or responses are no longer considered part of the spec.

A couple of things will be tackled separately, which is possible with the feature still being hidden behind an opt-in feature flag:

- **Updating the Spectacle's spec projection**. The Optic Engine exposes a graph representation to Spectacle which it uses to resolve the queries it receives. Excellent existing snapshot coverage will help us handle the new events.
- **Pruning of path components**. To allow a deleted endpoint to be rediscovered as an "undocumented url" from the Optic UI, any path components without requests + responses should be pruned from the spec. This should either happen through the generation of additional "garbage collection" commands after applying a match, or through performing the pruning on a projection / query level.

## Validation
* [x] CI passes
* [x] Deletion commands can be generated
* [x] Deletion commands are valid and converted into events.
* [x] Events, when applied, removed all responses and requests from the spec.
