### PR TITLE
Fix pending endpoint documentation display

### DIFF
--- a/workspaces/ui-v2/src/pages/diffs/contexts/SimulatedCommandContext.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/contexts/SimulatedCommandContext.tsx
@@ -4,12 +4,10 @@ import { v4 as uuidv4 } from 'uuid';
 import { IForkableSpectacle } from '@useoptic/spectacle';
 
 import { Loading } from '<src>/components';
-import {
-  SpectacleStore,
-  useSpectacleContext,
-} from '<src>/contexts/spectacle-provider';
+import { SpectacleStore } from '<src>/contexts/spectacle-provider';
 import { useSessionId } from '<src>/hooks/useSessionId';
-import { createReduxStore, useAppDispatch, endpointActions } from '<src>/store';
+import { createReduxStore } from '<src>/store';
+import { useFetchEndpoints } from '<src>/hooks/useFetchEndpoints';
 
 type SimulatedCommandStoreProps = {
   spectacle: IForkableSpectacle;
@@ -82,15 +80,7 @@ mutation X($commands: [JSON], $batchCommitId: ID, $commitMessage: String, $clien
 }
 
 const DataFetcherComponent: FC = ({ children }) => {
-  const spectacle = useSpectacleContext();
-  const dispatch = useAppDispatch();
-  useEffect(() => {
-    dispatch(
-      endpointActions.fetchEndpoints({
-        spectacle,
-      })
-    );
-  }, [spectacle, dispatch]);
+  useFetchEndpoints();
   return <>{children}</>;
 };
 

--- a/workspaces/ui-v2/src/store/root.ts
+++ b/workspaces/ui-v2/src/store/root.ts
@@ -3,15 +3,18 @@ import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 
 import { reducer as endpointsReducer } from './endpoints';
 
-export const store = configureStore({
-  reducer: {
-    endpoints: endpointsReducer,
-  },
-  middleware: (getDefaultMiddleware) =>
-    getDefaultMiddleware({
-      serializableCheck: false,
-    }),
-});
+export const createReduxStore = () =>
+  configureStore({
+    reducer: {
+      endpoints: endpointsReducer,
+    },
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware({
+        serializableCheck: false,
+      }),
+  });
+
+export const store = createReduxStore();
 
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Turns out I did need to implement the simulated store with redux (the endpoint documentation pane) - The pending endpoint page should now load - instead of saying there is no endpoint here

<img width="1748" alt="Screen Shot 2021-06-07 at 11 08 06 AM" src="https://user-images.githubusercontent.com/18374483/121068072-a7ce7980-c780-11eb-9218-b4c2a03c90e0.png">


## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
