### PR TITLE
Disallow editing contributions when endpoint is staged for deletion

### DIFF
--- a/workspaces/ui-v2/src/hooks/useEndpointsChangelog.tsx
+++ b/workspaces/ui-v2/src/hooks/useEndpointsChangelog.tsx
@@ -1,6 +1,5 @@
 import { useSpectacleQuery } from '<src>/contexts/spectacle-provider';
 
-//@todo not working as expected -- never any changes
 export const endpointChangeQuery = `query X($sinceBatchCommitId: String) {
     endpointChanges(sinceBatchCommitId: $sinceBatchCommitId) {
       endpoints {

--- a/workspaces/ui-v2/src/pages/docs/components/Contributions.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/Contributions.tsx
@@ -30,8 +30,10 @@ export function DocsFieldOrParameterContribution({
   endpointId,
 }: DocsFieldOrParameterContributionProps) {
   const contributionKey = 'description';
-  const isEditing = useAppSelector(
-    (state) => state.documentationEdits.isEditing
+  const isEditable = useAppSelector(
+    (state) =>
+      state.documentationEdits.isEditing &&
+      !state.documentationEdits.deletedEndpoints.includes(endpointId)
   );
   const contributionValue = useAppSelector(
     (state) =>
@@ -57,7 +59,7 @@ export function DocsFieldOrParameterContribution({
           })
         )
       }
-      isEditing={isEditing}
+      isEditing={isEditable}
     />
   );
 }
@@ -78,8 +80,10 @@ export function EndpointNameContribution({
   initialValue,
   endpointId,
 }: EndpointNameContributionProps) {
-  const isEditing = useAppSelector(
-    (state) => state.documentationEdits.isEditing
+  const isEditable = useAppSelector(
+    (state) =>
+      state.documentationEdits.isEditing &&
+      !state.documentationEdits.deletedEndpoints.includes(endpointId)
   );
   const contributionValue = useAppSelector(
     (state) =>
@@ -95,7 +99,7 @@ export function EndpointNameContribution({
         <title>{value || 'Unnamed Endpoint'}</title>
       </Helmet>
       <EditableTextField
-        isEditing={isEditing}
+        isEditing={isEditable}
         setEditing={(value) =>
           dispatch(
             documentationEditActions.updateEditState({
@@ -129,8 +133,10 @@ export function EndpointNameMiniContribution({
   initialValue,
   endpointId,
 }: EndpointNameContributionProps) {
-  const isEditing = useAppSelector(
-    (state) => state.documentationEdits.isEditing
+  const isEditable = useAppSelector(
+    (state) =>
+      state.documentationEdits.isEditing &&
+      !state.documentationEdits.deletedEndpoints.includes(endpointId)
   );
   const contributionValue = useAppSelector(
     (state) =>
@@ -142,7 +148,7 @@ export function EndpointNameMiniContribution({
 
   return (
     <EditableTextField
-      isEditing={isEditing}
+      isEditing={isEditable}
       setEditing={(value) =>
         dispatch(
           documentationEditActions.updateEditState({

--- a/workspaces/ui-v2/src/pages/docs/components/MarkdownBodyContribution.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/MarkdownBodyContribution.tsx
@@ -29,8 +29,10 @@ export function MarkdownBodyContribution({
 }: MarkdownBodyContributionProps) {
   const classes = useStyles();
 
-  const isEditing = useAppSelector(
-    (state) => state.documentationEdits.isEditing
+  const isEditable = useAppSelector(
+    (state) =>
+      state.documentationEdits.isEditing &&
+      !state.documentationEdits.deletedEndpoints.includes(endpointId)
   );
   const contributionValue = useAppSelector(
     (state) =>
@@ -40,7 +42,7 @@ export function MarkdownBodyContribution({
   const value =
     contributionValue !== undefined ? contributionValue : initialValue;
 
-  const inner = isEditing ? (
+  const inner = isEditable ? (
     <TextField
       inputProps={{ className: classNames(classes.contents, classes.editing) }}
       fullWidth


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

When a user stages an endpoint for deletion, contributions should not be editable (since the user action would be ignored). 

## What
What's changing? Anything of note to call out?
Endpoint list page (with not deleted and staged for deletion)
<img width="953" alt="Screen Shot 2021-06-08 at 4 38 03 PM" src="https://user-images.githubusercontent.com/18374483/121271217-0a567100-c878-11eb-9bc5-a4728180b62e.png">

Endpoint root page
Not deleted
<img width="1195" alt="Screen Shot 2021-06-08 at 4 38 09 PM" src="https://user-images.githubusercontent.com/18374483/121271223-0cb8cb00-c878-11eb-8760-d996bfbdea68.png">
Staged for deletion
<img width="1198" alt="Screen Shot 2021-06-08 at 4 38 14 PM" src="https://user-images.githubusercontent.com/18374483/121271225-0de9f800-c878-11eb-98f6-f829ce9c69ee.png">


## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
