### PR TITLE
refactor: Change paths to include `personId`

### DIFF
--- a/workspaces/ui-v2/src/entry-points/cloud/TopLevelRoutes.tsx
+++ b/workspaces/ui-v2/src/entry-points/cloud/TopLevelRoutes.tsx
@@ -11,7 +11,7 @@ export default function TopLevelRoutes() {
         <Route
           strict
           //@TODO: centralize this path pattern
-          path="/public-specs/:personId/:specId"
+          path="/person/:personId/public-specs/:specId"
           component={CloudViewer}
         />
 

--- a/workspaces/ui-v2/src/entry-points/cloud/TopLevelRoutes.tsx
+++ b/workspaces/ui-v2/src/entry-points/cloud/TopLevelRoutes.tsx
@@ -11,7 +11,7 @@ export default function TopLevelRoutes() {
         <Route
           strict
           //@TODO: centralize this path pattern
-          path="/public-specs/:specId"
+          path="/public-specs/:personId/:specId"
           component={CloudViewer}
         />
 

--- a/workspaces/ui-v2/src/entry-points/cloud/TopLevelRoutes.tsx
+++ b/workspaces/ui-v2/src/entry-points/cloud/TopLevelRoutes.tsx
@@ -11,7 +11,7 @@ export default function TopLevelRoutes() {
         <Route
           strict
           //@TODO: centralize this path pattern
-          path="/person/:personId/public-specs/:specId"
+          path="/people/:personId/public-specs/:specId"
           component={CloudViewer}
         />
 

--- a/workspaces/ui-v2/src/entry-points/cloud/cloud-viewer.tsx
+++ b/workspaces/ui-v2/src/entry-points/cloud/cloud-viewer.tsx
@@ -74,7 +74,7 @@ export default function CloudViewer() {
         }
       })();
       const response = await fetch(
-        `${apiBase}/api/people/${personId}/specs/${specId}`,
+        `${apiBase}/api/people/${personId}/public-specs/${specId}`,
         {
           headers: { accept: 'application/json' },
         }

--- a/workspaces/ui-v2/src/entry-points/cloud/cloud-viewer.tsx
+++ b/workspaces/ui-v2/src/entry-points/cloud/cloud-viewer.tsx
@@ -67,7 +67,7 @@ export default function CloudViewer() {
         return body;
       }
       const apiBase = (function () {
-        if (window.location.hostname.indexOf('useoptic.com')) {
+        if (window.location.hostname.indexOf('useoptic.com') >= 0) {
           return process.env.REACT_APP_PROD_API_BASE;
         } else {
           return process.env.REACT_APP_STAGING_API_BASE;

--- a/workspaces/ui-v2/src/entry-points/cloud/cloud-viewer.tsx
+++ b/workspaces/ui-v2/src/entry-points/cloud/cloud-viewer.tsx
@@ -74,7 +74,7 @@ export default function CloudViewer() {
         }
       })();
       const response = await fetch(
-        `${apiBase}/api/specs/${personId}/${specId}`,
+        `${apiBase}/api/person/${personId}/specs/${specId}`,
         {
           headers: { accept: 'application/json' },
         }

--- a/workspaces/ui-v2/src/entry-points/cloud/cloud-viewer.tsx
+++ b/workspaces/ui-v2/src/entry-points/cloud/cloud-viewer.tsx
@@ -57,8 +57,8 @@ const appConfig: OpticAppConfig = {
 
 export default function CloudViewer() {
   const match = useRouteMatch();
-  const params = useParams<{ specId: string }>();
-  const { specId } = params;
+  const params = useParams<{ specId: string; personId: string }>();
+  const { personId, specId } = params;
   const task: CloudInMemorySpectacleDependenciesLoader = useCallback(async () => {
     const loadUploadedSpec = async () => {
       if (process.env.NODE_ENV === 'development') {
@@ -73,11 +73,14 @@ export default function CloudViewer() {
           return process.env.REACT_APP_STAGING_API_BASE;
         }
       })();
-      const response = await fetch(`${apiBase}/api/specs/${specId}`, {
-        headers: { accept: 'application/json' },
-      });
+      const response = await fetch(
+        `${apiBase}/api/specs/${personId}/${specId}`,
+        {
+          headers: { accept: 'application/json' },
+        }
+      );
       if (!response.ok) {
-        throw new Error(`could not find spec ${specId}`);
+        throw new Error(`could not find spec ${personId}/${specId}`);
       }
       const responseJson = await response.json();
       let signedUrl = responseJson.read_url;
@@ -88,7 +91,7 @@ export default function CloudViewer() {
 
       let contentReq = await fetch(signedUrl);
       if (!contentReq.ok) {
-        throw new Error(`Unable to fetch spec ${specId}`);
+        throw new Error(`Unable to fetch spec ${personId}/${specId}`);
       }
 
       let spec = await contentReq.json();
@@ -99,7 +102,7 @@ export default function CloudViewer() {
       events,
       samples: [],
     };
-  }, [specId]);
+  }, [specId, personId]);
   const { loading, error, data } = useCloudInMemorySpectacle(task);
   if (loading) {
     return <Loading />;

--- a/workspaces/ui-v2/src/entry-points/cloud/cloud-viewer.tsx
+++ b/workspaces/ui-v2/src/entry-points/cloud/cloud-viewer.tsx
@@ -74,7 +74,7 @@ export default function CloudViewer() {
         }
       })();
       const response = await fetch(
-        `${apiBase}/api/person/${personId}/specs/${specId}`,
+        `${apiBase}/api/people/${personId}/specs/${specId}`,
         {
           headers: { accept: 'application/json' },
         }


### PR DESCRIPTION
Part of https://github.com/opticdev/monorail/pull/307

## Why
Individual specs (as opposed to specs as part of a larger project, which will come as a later feature) live on the `Person` aggregate in `backend-web`. Since we aren't using snapshots yet, and the cost is minimal to include the extra piece of data, we now also include the `personId` that a particular spec lives on when fetching it.

## What
Paths change to `/public-specs/{personId}/{specId}`.
GitBot learns about this here: https://github.com/opticdev/optic-changelog/pull/45
