### PR TITLE
optic-engine-native workspace needs .env

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -56,6 +56,7 @@ tasks:
           cp $FLAGS_FILE workspaces/cli-server/.env
           cp $FLAGS_FILE workspaces/cli-scripts/.env
           cp $FLAGS_FILE workspaces/optic-engine/.env
+          cp $FLAGS_FILE workspaces/optic-engine-native/.env
           cp $FLAGS_FILE workspaces/ui-v2/.env.production.local
         else
           echo "Please specify the FLAGS_FILE environment variable"


### PR DESCRIPTION

## Why
When we reorganized the optic-engine folder structure we did not preserve the invariant where the workspace that is responsible for installing the prebuilt binaries needs the .env to tell it where to get them from. 

## What
optic-engine-native workspace needs .env  in the published npm artifact so it knows where to install binaries from. However, this should not affect production, which is set by default when the .env is not present

## Validation
* [ ] CI passes
* [ ] Verified in side-channel build
