### PR TITLE
Fix undelete from unstaging all endpoints

### DIFF
--- a/workspaces/ui-v2/src/store/documentationEdit/slice.ts
+++ b/workspaces/ui-v2/src/store/documentationEdit/slice.ts
@@ -80,7 +80,8 @@ const documentationEditSlice = createSlice({
     ) => {
       const { pathId, method } = action.payload;
       const newDeletedEndpoints = state.deletedEndpoints.filter(
-        (endpoint) => pathId !== endpoint.pathId && method !== endpoint.method
+        (endpoint) =>
+          !(pathId === endpoint.pathId && method === endpoint.method)
       );
       state.deletedEndpoints = newDeletedEndpoints;
     },


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

When a user undelete one endpoint, they expect only one endpoint to be undeleted.

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
