### PR TITLE
Handle endpoint removal in changelog

### DIFF
--- a/workspaces/graph-lib/src/endpoints-graph/index.ts
+++ b/workspaces/graph-lib/src/endpoints-graph/index.ts
@@ -139,6 +139,10 @@ export interface NodeListWrapper {
 export class BodyNodeWrapper implements NodeWrapper {
   constructor(public result: Node, private queries: GraphQueries) {}
 
+  get value(): BodyNode {
+    return this.result.data as BodyNode;
+  }
+
   response(): ResponseNodeWrapper | null {
     const neighbors = this.queries.listOutgoingNeighborsByType(
       this.result.id,

--- a/workspaces/graph-lib/src/endpoints-graph/index.ts
+++ b/workspaces/graph-lib/src/endpoints-graph/index.ts
@@ -66,6 +66,27 @@ export type BatchCommitNode = {
   commitMessage: string;
 };
 
+export enum EdgeType {
+  IsChildOf = 'IsChildOf',
+  CreatedIn = 'CreatedIn',
+  UpdatedIn = 'UpdatedIn',
+  RemovedIn = 'RemovedIn',
+}
+
+export type Edge =
+  | {
+      type: EdgeType.IsChildOf;
+    }
+  | {
+      type: EdgeType.UpdatedIn;
+    }
+  | {
+      type: EdgeType.CreatedIn;
+    }
+  | {
+      type: EdgeType.UpdatedIn;
+    };
+
 ////////////////////////////////////////////////////////////////////////////////
 // A batch commit node can never be removed
 const isNodeRemoved = (node: Node): boolean =>
@@ -73,17 +94,21 @@ const isNodeRemoved = (node: Node): boolean =>
 
 ////////////////////////////////////////////////////////////////////////////////
 
-export class GraphIndexer implements GraphCommandHandler<Node, NodeId> {
+export class GraphIndexer implements GraphCommandHandler<Node, NodeId, Edge> {
   readonly nodesById: Map<NodeId, Node>;
   readonly nodesByType: Map<NodeType, Node[]>;
   readonly outboundNeighbors: Map<NodeId, Map<NodeType, Node[]>>;
   readonly inboundNeighbors: Map<NodeId, Map<NodeType, Node[]>>;
+  readonly outboundNeighborsByEdgeType: Map<NodeId, Map<EdgeType, Node[]>>;
+  readonly inboundNeighborsByEdgeType: Map<NodeId, Map<EdgeType, Node[]>>;
 
   constructor() {
     this.nodesByType = new Map();
     this.nodesById = new Map();
     this.outboundNeighbors = new Map();
     this.inboundNeighbors = new Map();
+    this.outboundNeighborsByEdgeType = new Map();
+    this.inboundNeighborsByEdgeType = new Map();
   }
 
   addNode(node: Node) {
@@ -95,7 +120,7 @@ export class GraphIndexer implements GraphCommandHandler<Node, NodeId> {
     this.unsafeAddNode(node);
   }
 
-  addEdge(edge: any, sourceNodeId: NodeId, targetNodeId: NodeId) {
+  addEdge(edge: Edge, sourceNodeId: NodeId, targetNodeId: NodeId) {
     const sourceNode = this.nodesById.get(sourceNodeId);
     if (!sourceNode) {
       throw new Error(`expected ${sourceNodeId} to exist`);
@@ -111,10 +136,26 @@ export class GraphIndexer implements GraphCommandHandler<Node, NodeId> {
     mapAppend(outboundNeighbors, targetNode.type, targetNode);
     this.outboundNeighbors.set(sourceNodeId, outboundNeighbors);
 
+    const outboundNeighborsByEdgeType =
+      this.outboundNeighborsByEdgeType.get(sourceNodeId) || new Map();
+    mapAppend(outboundNeighborsByEdgeType, edge.type, targetNode);
+    this.outboundNeighborsByEdgeType.set(
+      sourceNodeId,
+      outboundNeighborsByEdgeType
+    );
+
     const inboundNeighbors =
       this.inboundNeighbors.get(targetNodeId) || new Map();
     mapAppend(inboundNeighbors, sourceNode.type, sourceNode);
     this.inboundNeighbors.set(targetNodeId, inboundNeighbors);
+
+    const inboundNeighborsByEdgeType =
+      this.inboundNeighborsByEdgeType.get(targetNodeId) || new Map();
+    mapAppend(inboundNeighborsByEdgeType, edge.type, sourceNode);
+    this.inboundNeighborsByEdgeType.set(
+      targetNodeId,
+      inboundNeighborsByEdgeType
+    );
   }
 
   unsafeAddNode(node: Node) {
@@ -308,6 +349,27 @@ export class BatchCommitNodeWrapper implements NodeWrapper {
       NodeType.Response
     );
   }
+
+  createdInEdgeNodes(): NodeListWrapper {
+    return this.queries.listIncomingNeighborsByEdgeType(
+      this.result.id,
+      EdgeType.CreatedIn
+    );
+  }
+
+  updatedInEdgeNodes(): NodeListWrapper {
+    return this.queries.listIncomingNeighborsByEdgeType(
+      this.result.id,
+      EdgeType.UpdatedIn
+    );
+  }
+
+  removedInEdgeNodes(): NodeListWrapper {
+    return this.queries.listIncomingNeighborsByEdgeType(
+      this.result.id,
+      EdgeType.RemovedIn
+    );
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -382,6 +444,36 @@ export class GraphQueries {
     return this.wrapList(outgoingNeighborType, filteredNeighborsOfType);
   }
 
+  listIncomingNeighborsByEdgeType(
+    id: NodeId,
+    edgeType: EdgeType
+  ): NodeListWrapper {
+    const neighbors = this.index.inboundNeighborsByEdgeType.get(id);
+
+    if (!neighbors) {
+      return this.wrapList(null, []);
+    }
+
+    const neighborsOfType = neighbors.get(edgeType);
+
+    return this.wrapList(null, neighborsOfType || []);
+  }
+
+  listOutgoingNeighborsByEdgeType(
+    id: NodeId,
+    edgeType: EdgeType
+  ): NodeListWrapper {
+    const neighbors = this.index.outboundNeighborsByEdgeType.get(id);
+
+    if (!neighbors) {
+      return this.wrapList(null, []);
+    }
+
+    const neighborsOfType = neighbors.get(edgeType);
+
+    return this.wrapList(null, neighborsOfType || []);
+  }
+
   *descendantsIterator(
     nodeId: NodeId,
     seenSet: Set<NodeId> = new Set(),
@@ -425,7 +517,8 @@ export class GraphQueries {
     throw new Error(`unexpected node.type`);
   }
 
-  wrapList(type: NodeType, nodes: Node[]): NodeListWrapper {
+  //@TODO move away from null here
+  wrapList(type: NodeType | null, nodes: Node[]): NodeListWrapper {
     //@TODO add list helpers (map, etc.)
     return {
       results: nodes.map((node) => this.wrap(node)),

--- a/workspaces/graph-lib/src/index.ts
+++ b/workspaces/graph-lib/src/index.ts
@@ -1,14 +1,11 @@
 import * as endpoints from './endpoints-graph';
 import * as shapes from './shapes-graph';
 
-export {
-  endpoints,
-  shapes
-};
+export { endpoints, shapes };
 
 ////////////////////////////////////////////////////////////////////////////////
 
-export interface GraphCommandHandler<N, I, E = any> {
+export interface GraphCommandHandler<N, I, E> {
   addNode(node: N): void;
 
   addEdge(edge: E, sourceNodeId: I, targetNodeId: I): void;

--- a/workspaces/spectacle/src/graphql/schema.ts
+++ b/workspaces/spectacle/src/graphql/schema.ts
@@ -78,6 +78,9 @@ type Path {
   
   # Path ID
   pathId: String
+
+  # Is the path removed
+  isRemoved: Boolean
 }
 
 type Endpoint {
@@ -97,6 +100,9 @@ type HttpBody {
   
   # Root shape ID for the HTTP body. Look at the shapeChoices query getting more information about the root shape
   rootShapeId: String
+
+  # Is the body removed
+  isRemoved: Boolean
 }
 
 """
@@ -134,6 +140,9 @@ type HttpRequest {
   
   # Request contributions which define descriptions
   requestContributions: JSON
+
+  # Is the request removed
+  isRemoved: Boolean
 }
 
 """
@@ -170,6 +179,9 @@ type HttpResponse {
   
   # HTTP response contributions which define descriptions
   contributions: JSON
+
+  # Is the response removed
+  isRemoved: Boolean
 }
 
 """

--- a/workspaces/spectacle/src/helpers.ts
+++ b/workspaces/spectacle/src/helpers.ts
@@ -1,5 +1,4 @@
 import { shapes, endpoints } from '@useoptic/graph-lib';
-import { NodeType } from '../../graph-lib/build/shapes-graph';
 
 export function buildEndpointsGraph(spec: any, opticEngine: any) {
   const serializedGraph = JSON.parse(
@@ -84,13 +83,14 @@ export function buildEndpointChanges(
   shapeQueries: shapes.GraphQueries,
   sinceBatchCommitId?: string
 ): EndpointChanges {
+  // Sorted in reverse order - the latest change takes precedence
   const sortedBatchCommits = endpointQueries
     .listNodesByType(endpoints.NodeType.BatchCommit)
     .results.sort((a: any, b: any) => {
       return a.result.data.createdAt < b.result.data.createdAt ? 1 : -1;
-    });
+    }) as endpoints.BatchCommitNodeWrapper[];
 
-  let deltaBatchCommits;
+  let deltaBatchCommits: endpoints.BatchCommitNodeWrapper[];
 
   if (sinceBatchCommitId) {
     const sinceBatchCommit: any = endpointQueries.findNodeById(
@@ -107,14 +107,55 @@ export function buildEndpointChanges(
 
   const changes = new Changes();
 
-  deltaBatchCommits.forEach((batchCommit: any) => {
-    batchCommit.requests().results.forEach((request: any) => {
-      changes.captureChange('added', endpointFromRequest(request));
-    });
-
-    batchCommit.responses().results.forEach((response: any) => {
-      changes.captureChange('updated', endpointFromResponse(response));
-    });
+  deltaBatchCommits.forEach((batchCommit: endpoints.BatchCommitNodeWrapper) => {
+    // Only createdIn and removedIn edges pointing to a request is treated as
+    // an added or removed change, everything else is updated.
+    // Bodies, and shape changes are handled below
+    batchCommit
+      .createdInEdgeNodes()
+      .results.forEach((node: endpoints.NodeWrapper) => {
+        if (node.result.type === endpoints.NodeType.Request) {
+          changes.captureChange(
+            'added',
+            endpointFromRequest(node as endpoints.RequestNodeWrapper)
+          );
+        } else if (node.result.type === endpoints.NodeType.Response) {
+          changes.captureChange(
+            'updated',
+            endpointFromResponse(node as endpoints.ResponseNodeWrapper)
+          );
+        }
+      });
+    batchCommit
+      .removedInEdgeNodes()
+      .results.forEach((node: endpoints.NodeWrapper) => {
+        if (node.result.type === endpoints.NodeType.Request) {
+          changes.captureChange(
+            'removed',
+            endpointFromRequest(node as endpoints.RequestNodeWrapper)
+          );
+        } else if (node.result.type === endpoints.NodeType.Response) {
+          changes.captureChange(
+            'updated',
+            endpointFromResponse(node as endpoints.ResponseNodeWrapper)
+          );
+        }
+      });
+    batchCommit
+      .updatedInEdgeNodes()
+      .results.forEach((node: endpoints.NodeWrapper) => {
+        if (node.result.type === endpoints.NodeType.Request) {
+          changes.captureChange(
+            'updated',
+            endpointFromRequest(node as endpoints.RequestNodeWrapper)
+          );
+        } else if (node.result.type === endpoints.NodeType.Response) {
+          changes.captureChange(
+            'updated',
+            endpointFromResponse(node as endpoints.ResponseNodeWrapper)
+          );
+        }
+      });
   });
 
   // Gather batch commit neighbors
@@ -123,12 +164,12 @@ export function buildEndpointChanges(
     const batchCommitId = batchCommit.result.id;
     // TODO: create query for neighbors of all types
     shapeQueries
-      .listIncomingNeighborsByType(batchCommitId, NodeType.Shape)
+      .listIncomingNeighborsByType(batchCommitId, shapes.NodeType.Shape)
       .results.forEach((shape: any) => {
         batchCommitNeighborIds.set(shape.result.id, batchCommitId);
       });
     shapeQueries
-      .listIncomingNeighborsByType(batchCommitId, NodeType.Field)
+      .listIncomingNeighborsByType(batchCommitId, shapes.NodeType.Field)
       .results.forEach((field: any) => {
         batchCommitNeighborIds.set(field.result.id, batchCommitId);
       });
@@ -181,7 +222,10 @@ class Changes {
     this.changes = new Map();
   }
 
-  captureChange(category: string, endpoint: Endpoint): boolean {
+  captureChange(
+    category: 'added' | 'updated' | 'removed',
+    endpoint: Endpoint
+  ): boolean {
     if (this.changes.has(endpoint.endpointId)) return false;
     this.changes.set(endpoint.endpointId, {
       change: { category },
@@ -201,20 +245,22 @@ class Changes {
   }
 }
 
-function endpointFromRequest(request: any): Endpoint {
+function endpointFromRequest(request: endpoints.RequestNodeWrapper): Endpoint {
   let pathNode = request.path();
-  const pathId = pathNode.result.data.pathId;
+  const pathId = pathNode.value.pathId;
   const path = pathNode.absolutePathPatternWithParameterNames;
-  const method = request.result.data.httpMethod;
+  const method = request.value.httpMethod;
   const endpointId = JSON.stringify({ path, method });
   return { endpointId, pathId, path, method };
 }
 
-function endpointFromResponse(response: any): Endpoint {
+function endpointFromResponse(
+  response: endpoints.ResponseNodeWrapper
+): Endpoint {
   let pathNode = response.path();
-  const pathId = pathNode.result.data.pathId;
+  const pathId = pathNode.value.pathId;
   const path = pathNode.absolutePathPatternWithParameterNames;
-  const method = response.result.data.httpMethod;
+  const method = response.value.httpMethod;
   const endpointId = JSON.stringify({ path, method });
   return { endpointId, pathId, path, method };
 }

--- a/workspaces/spectacle/src/in-memory/index.ts
+++ b/workspaces/spectacle/src/in-memory/index.ts
@@ -84,7 +84,6 @@ export class InMemorySpecRepository implements IOpticSpecReadWriteRepository {
       commandContext.clientSessionId
     );
     const newEvents = JSON.parse(newEventsString);
-    console.log(newEventsString);
     this.events.push(...newEvents);
     this.notifications.emit('change');
   }

--- a/workspaces/spectacle/src/in-memory/index.ts
+++ b/workspaces/spectacle/src/in-memory/index.ts
@@ -84,6 +84,7 @@ export class InMemorySpecRepository implements IOpticSpecReadWriteRepository {
       commandContext.clientSessionId
     );
     const newEvents = JSON.parse(newEventsString);
+    console.log(newEventsString);
     this.events.push(...newEvents);
     this.notifications.emit('change');
   }

--- a/workspaces/spectacle/src/index.ts
+++ b/workspaces/spectacle/src/index.ts
@@ -320,18 +320,15 @@ export async function makeSpectacle(opticContext: IOpticContext) {
         return Promise.resolve(
           context
             .spectacleContext()
-            .endpointsQueries.listNodesByType(endpoints.NodeType.Path, {
-              includeRemoved: false,
-            }).results
+            .endpointsQueries.listNodesByType(endpoints.NodeType.Path).results
         );
       },
       requests: (parent: any, args: any, context: any, info: any) => {
         return Promise.resolve(
           context
             .spectacleContext()
-            .endpointsQueries.listNodesByType(endpoints.NodeType.Request, {
-              includeRemoved: false,
-            }).results
+            .endpointsQueries.listNodesByType(endpoints.NodeType.Request)
+            .results
         );
       },
       shapeChoices: async (parent: any, args: any, context: any, info: any) => {
@@ -447,7 +444,11 @@ export async function makeSpectacle(opticContext: IOpticContext) {
       responses: (parent: endpoints.RequestNodeWrapper) => {
         return Promise.resolve(parent.responses());
       },
-      pathContributions: (parent: any, args: any, context: any) => {
+      pathContributions: (
+        parent: endpoints.RequestNodeWrapper,
+        args: any,
+        context: any
+      ) => {
         const pathId = parent.path().value.pathId;
         const method = parent.value.httpMethod;
         return Promise.resolve(
@@ -456,28 +457,38 @@ export async function makeSpectacle(opticContext: IOpticContext) {
           ] || {}
         );
       },
-      requestContributions: (parent: any, args: any, context: any) => {
+      requestContributions: (
+        parent: endpoints.RequestNodeWrapper,
+        args: any,
+        context: any
+      ) => {
         return Promise.resolve(
           context.spectacleContext().contributionsProjection[
             parent.value.requestId
           ] || {}
         );
       },
+      isRemoved: (
+        parent: endpoints.RequestNodeWrapper,
+        args: any,
+        context: any
+      ) => {
+        return Promise.resolve(parent.value.isRemoved);
+      },
     },
     Path: {
-      absolutePathPattern: (parent: any) => {
-        return Promise.resolve(parent.result.data.absolutePathPattern);
+      absolutePathPattern: (parent: endpoints.PathNodeWrapper) => {
+        return Promise.resolve(parent.value.absolutePathPattern);
       },
-      isParameterized: (parent: any) => {
-        return Promise.resolve(parent.result.data.isParameterized);
+      isParameterized: (parent: endpoints.PathNodeWrapper) => {
+        return Promise.resolve(parent.value.isParameterized);
       },
-      name: (parent: any) => {
-        return Promise.resolve(parent.result.data.name);
+      name: (parent: endpoints.PathNodeWrapper) => {
+        return Promise.resolve(parent.value.name);
       },
-      pathId: (parent: any) => {
-        return Promise.resolve(parent.result.data.pathId);
+      pathId: (parent: endpoints.PathNodeWrapper) => {
+        return Promise.resolve(parent.value.pathId);
       },
-
       parentPathId: (parent: endpoints.PathNodeWrapper) => {
         const parentPath = parent.parentPath();
         if (parentPath) {
@@ -490,23 +501,41 @@ export async function makeSpectacle(opticContext: IOpticContext) {
       ) => {
         return Promise.resolve(parent.absolutePathPatternWithParameterNames);
       },
+      isRemoved: (
+        parent: endpoints.PathNodeWrapper,
+        args: any,
+        context: any
+      ) => {
+        return Promise.resolve(parent.value.isRemoved);
+      },
     },
     HttpResponse: {
-      id: (parent: any) => {
-        return Promise.resolve(parent.result.data.responseId);
+      id: (parent: endpoints.ResponseNodeWrapper) => {
+        return Promise.resolve(parent.value.responseId);
       },
-      statusCode: (parent: any) => {
-        return Promise.resolve(parent.result.data.httpStatusCode);
+      statusCode: (parent: endpoints.ResponseNodeWrapper) => {
+        return Promise.resolve(parent.value.httpStatusCode);
       },
-      bodies: (parent: any) => {
+      bodies: (parent: endpoints.ResponseNodeWrapper) => {
         return Promise.resolve(parent.bodies().results);
       },
-      contributions: (parent: any, args: any, context: any) => {
+      contributions: (
+        parent: endpoints.ResponseNodeWrapper,
+        args: any,
+        context: any
+      ) => {
         return Promise.resolve(
           context.spectacleContext().contributionsProjection[
-            parent.result.data.responseId
+            parent.value.responseId
           ] || {}
         );
+      },
+      isRemoved: (
+        parent: endpoints.ResponseNodeWrapper,
+        args: any,
+        context: any
+      ) => {
+        return Promise.resolve(parent.value.isRemoved);
       },
     },
     PathComponent: {
@@ -521,11 +550,18 @@ export async function makeSpectacle(opticContext: IOpticContext) {
       },
     },
     HttpBody: {
-      contentType: (parent: any) => {
-        return Promise.resolve(parent.result.data.httpContentType);
+      contentType: (parent: endpoints.BodyNodeWrapper) => {
+        return Promise.resolve(parent.value.httpContentType);
       },
-      rootShapeId: (parent: any) => {
-        return Promise.resolve(parent.result.data.rootShapeId);
+      rootShapeId: (parent: endpoints.BodyNodeWrapper) => {
+        return Promise.resolve(parent.value.rootShapeId);
+      },
+      isRemoved: (
+        parent: endpoints.BodyNodeWrapper,
+        args: any,
+        context: any
+      ) => {
+        return Promise.resolve(parent.value.isRemoved);
       },
     },
     OpticShape: {

--- a/workspaces/ui-v2/src/hooks/useEndpointsChangelog.tsx
+++ b/workspaces/ui-v2/src/hooks/useEndpointsChangelog.tsx
@@ -12,7 +12,7 @@ export const endpointChangeQuery = `query X($sinceBatchCommitId: String) {
     }
 }`;
 
-type ChangelogCategory = 'added' | 'updated' | 'removed';
+export type ChangelogCategory = 'added' | 'updated' | 'removed';
 
 export type EndpointChangelog = {
   change: {

--- a/workspaces/ui-v2/src/pages/changelog/ChangelogEndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/changelog/ChangelogEndpointRootPage.tsx
@@ -49,6 +49,7 @@ const ChangelogRootComponent: FC<
     batchId: string;
   }>
 > = ({ match }) => {
+  // TODO check if deleted + should render
   const endpointsState = useAppSelector((state) => state.endpoints.results);
 
   const { pathId, method, batchId } = match.params;

--- a/workspaces/ui-v2/src/pages/changelog/ChangelogEndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/changelog/ChangelogEndpointRootPage.tsx
@@ -100,8 +100,8 @@ const ChangelogRootComponent: FC<
   return (
     <>
       {isEndpointRemovedInThisBatch && (
-        <Alert severity="error" className={styles.deleteInfoHeader}>
-          This endpoint has been deleted
+        <Alert severity="error" className={styles.removedInfoHeader}>
+          This endpoint has been removed
         </Alert>
       )}
       <FullWidth style={{ paddingTop: 30, paddingBottom: 400 }}>
@@ -212,7 +212,7 @@ const useStyles = makeStyles((theme) => ({
     color: '#4f566b',
     paddingRight: 50,
   },
-  deleteInfoHeader: {
+  removedInfoHeader: {
     justifyContent: 'center',
     display: 'fixed',
   },

--- a/workspaces/ui-v2/src/pages/changelog/ChangelogListPage.tsx
+++ b/workspaces/ui-v2/src/pages/changelog/ChangelogListPage.tsx
@@ -16,12 +16,9 @@ import {
 import { Box, List, ListItem, Typography } from '@material-ui/core';
 import makeStyles from '@material-ui/styles/makeStyles';
 import { useChangelogStyles } from '<src>/pages/changelog/components/ChangelogBackground';
-import {
-  EndpointChangelog,
-  useEndpointsChangelog,
-} from '<src>/hooks/useEndpointsChangelog';
-import { useAppSelector } from '<src>/store';
-import { IEndpoint } from '<src>/types';
+import { useEndpointsChangelog } from '<src>/hooks/useEndpointsChangelog';
+import { selectors, useAppSelector } from '<src>/store';
+import { IEndpointWithChanges } from '<src>/types';
 
 import {
   ChangelogPageAccessoryNavigation,
@@ -48,18 +45,15 @@ export const ChangelogListPage: FC<
 export function ChangelogRootPage(props: { changelogBatchId: string }) {
   const endpointsState = useAppSelector((state) => state.endpoints.results);
   const changelog = useEndpointsChangelog(props.changelogBatchId);
-  const changelogByEndpointId = changelog.reduce(
-    (acc: Record<string, EndpointChangelog>, endpointChange) => {
-      acc[`${endpointChange.method}${endpointChange.pathId}`] = endpointChange;
-      return acc;
-    },
-    {}
+  const filteredAndMappedEndpoints = selectors.filterRemovedEndpointsForChangelogAndMapChanges(
+    endpointsState.data || [],
+    changelog
   );
   const history = useHistory();
   const match = useRouteMatch();
 
-  const grouped = useMemo(() => groupBy(endpointsState.data || [], 'group'), [
-    endpointsState,
+  const grouped = useMemo(() => groupBy(filteredAndMappedEndpoints, 'group'), [
+    filteredAndMappedEndpoints,
   ]);
   const tocKeys = Object.keys(grouped).sort();
   const changelogStyles = useChangelogStyles();
@@ -99,45 +93,44 @@ export function ChangelogRootPage(props: { changelogBatchId: string }) {
               >
                 {tocKey}
               </Typography>
-              {grouped[tocKey].map((endpoint: IEndpoint, index: number) => {
-                return (
-                  <ListItem
-                    key={index}
-                    button
-                    disableRipple
-                    disableGutters
-                    style={{ display: 'flex' }}
-                    onClick={() =>
-                      history.push(
-                        `${match.url}/paths/${endpoint.pathId}/methods/${endpoint.method}`
-                      )
-                    }
-                    className={classNames({
-                      [changelogStyles.added]:
-                        changelogByEndpointId[
-                          `${endpoint.method}${endpoint.pathId}`
-                        ]?.change.category === 'added',
-                      [changelogStyles.updated]:
-                        changelogByEndpointId[
-                          `${endpoint.method}${endpoint.pathId}`
-                        ]?.change.category === 'updated',
-                    })}
-                  >
-                    <div style={{ flex: 1 }}>
-                      <EndpointName
-                        method={endpoint.method}
-                        fullPath={endpoint.fullPath}
-                        leftPad={6}
-                      />
-                    </div>
-                    <div style={{ paddingRight: 15 }}>
-                      <Typography className={styles.smallField}>
-                        {endpoint.purpose || 'Unnamed Endpoint'}
-                      </Typography>
-                    </div>
-                  </ListItem>
-                );
-              })}
+              {grouped[tocKey].map(
+                (endpoint: IEndpointWithChanges, index: number) => {
+                  return (
+                    <ListItem
+                      key={index}
+                      button
+                      disableRipple
+                      disableGutters
+                      style={{ display: 'flex' }}
+                      onClick={() =>
+                        history.push(
+                          `${match.url}/paths/${endpoint.pathId}/methods/${endpoint.method}`
+                        )
+                      }
+                      className={classNames({
+                        [changelogStyles.added]: endpoint.changes === 'added',
+                        [changelogStyles.updated]:
+                          endpoint.changes === 'updated',
+                        [changelogStyles.removed]:
+                          endpoint.changes === 'removed',
+                      })}
+                    >
+                      <div style={{ flex: 1 }}>
+                        <EndpointName
+                          method={endpoint.method}
+                          fullPath={endpoint.fullPath}
+                          leftPad={6}
+                        />
+                      </div>
+                      <div style={{ paddingRight: 15 }}>
+                        <Typography className={styles.smallField}>
+                          {endpoint.purpose || 'Unnamed Endpoint'}
+                        </Typography>
+                      </div>
+                    </ListItem>
+                  );
+                }
+              )}
             </div>
           );
         })}

--- a/workspaces/ui-v2/src/pages/changelog/components/ChangelogBackground.tsx
+++ b/workspaces/ui-v2/src/pages/changelog/components/ChangelogBackground.tsx
@@ -3,6 +3,8 @@ import {
   AddedGreen,
   ChangedYellow,
   ChangedYellowBackground,
+  RemovedRed,
+  RemovedRedBackground,
 } from '<src>/constants/theme';
 
 export const useChangelogStyles = makeStyles(() => ({
@@ -13,5 +15,9 @@ export const useChangelogStyles = makeStyles(() => ({
   updated: {
     backgroundColor: ChangedYellowBackground,
     borderLeft: `2px solid ${ChangedYellow}`,
+  },
+  removed: {
+    backgroundColor: RemovedRedBackground,
+    borderLeft: `2px solid ${RemovedRed}`,
   },
 }));

--- a/workspaces/ui-v2/src/pages/diffs/AddEndpointsPage/AddEndpointsPage.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/AddEndpointsPage/AddEndpointsPage.tsx
@@ -27,7 +27,7 @@ import { IPendingEndpoint } from '<src>/pages/diffs/contexts/SharedDiffState';
 import { useChangelogStyles } from '<src>/pages/changelog/components/ChangelogBackground';
 import { useRunOnKeypress } from '<src>/hooks/util';
 import { DiffAccessoryNavigation } from '<src>/pages/diffs/components/DiffAccessoryNavigation';
-import { useAppSelector } from '<src>/store';
+import { selectors, useAppSelector } from '<src>/store';
 import { IEndpoint } from '<src>/types';
 
 import {
@@ -158,8 +158,8 @@ export function DiffUrlsPage() {
 }
 
 export function DocumentationRootPageWithPendingEndpoints() {
-  const endpoints = useAppSelector(
-    (state) => state.endpoints.results.data || []
+  const endpoints = selectors.filterRemovedEndpoints(
+    useAppSelector(selectors.getAssertedEndpoints)
   );
   const {
     pendingEndpoints,

--- a/workspaces/ui-v2/src/pages/diffs/AddEndpointsPage/AddEndpointsPage.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/AddEndpointsPage/AddEndpointsPage.tsx
@@ -159,7 +159,7 @@ export function DiffUrlsPage() {
 
 export function DocumentationRootPageWithPendingEndpoints() {
   const endpoints = selectors.filterRemovedEndpoints(
-    useAppSelector(selectors.getAssertedEndpoints)
+    useAppSelector((state) => state.endpoints.results.data || [])
   );
   const {
     pendingEndpoints,

--- a/workspaces/ui-v2/src/pages/diffs/EndpointDocumentationPane.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/EndpointDocumentationPane.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode } from 'react';
+import React, { FC, ReactNode, useMemo } from 'react';
 import { useEndpointBody } from '<src>/hooks/useEndpointBodyHook';
 import {
   EndpointName,
@@ -16,7 +16,7 @@ import { IParsedLocation } from '<src>/lib/Interfaces';
 import { HighlightedLocation } from '<src>/pages/diffs/components/HighlightedLocation';
 import { useSharedDiffContext } from '<src>/pages/diffs/contexts/SharedDiffContext';
 import { useDebouncedFn, useStateWithSideEffect } from '<src>/hooks/util';
-import { selectors, useAppSelector } from '<src>/store';
+import { useAppSelector } from '<src>/store';
 import { IPathParameter } from '<src>/types';
 import { getEndpointId } from '<src>/utils';
 
@@ -40,9 +40,15 @@ export const EndpointDocumentationPane: FC<
   renderHeader,
   ...props
 }) => {
-  const thisEndpoint = useAppSelector(
-    selectors.getAssertedEndpoint({ pathId, method })
+  const endpointsState = useAppSelector((state) => state.endpoints.results);
+  const thisEndpoint = useMemo(
+    () =>
+      endpointsState.data?.find(
+        (i) => i.pathId === pathId && i.method === method
+      ),
+    [endpointsState, method, pathId]
   );
+
   const bodies = useEndpointBody(pathId, method, lastBatchCommit);
 
   if (!thisEndpoint) {

--- a/workspaces/ui-v2/src/pages/diffs/EndpointDocumentationPane.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/EndpointDocumentationPane.tsx
@@ -16,7 +16,7 @@ import { IParsedLocation } from '<src>/lib/Interfaces';
 import { HighlightedLocation } from '<src>/pages/diffs/components/HighlightedLocation';
 import { useSharedDiffContext } from '<src>/pages/diffs/contexts/SharedDiffContext';
 import { useDebouncedFn, useStateWithSideEffect } from '<src>/hooks/util';
-import { useAppSelector } from '<src>/store';
+import { selectors, useAppSelector } from '<src>/store';
 import { IPathParameter } from '<src>/types';
 import { getEndpointId } from '<src>/utils';
 
@@ -40,10 +40,8 @@ export const EndpointDocumentationPane: FC<
   renderHeader,
   ...props
 }) => {
-  const thisEndpoint = useAppSelector((state) =>
-    state.endpoints.results.data?.find(
-      (endpoint) => endpoint.pathId === pathId && endpoint.method === method
-    )
+  const thisEndpoint = useAppSelector(
+    selectors.getAssertedEndpoint({ pathId, method })
   );
   const bodies = useEndpointBody(pathId, method, lastBatchCommit);
 

--- a/workspaces/ui-v2/src/pages/diffs/ReviewDiffPages.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/ReviewDiffPages.tsx
@@ -35,8 +35,9 @@ export function DiffReviewPages(props: any) {
   const allRequestsAndResponsesOfBaseSpec = useAllRequestsAndResponses();
   useFetchEndpoints();
   const endpointsState = useAppSelector((state) => state.endpoints.results);
-  const filteredEndpoints = selectors.filterRemovedEndpoints(
-    endpointsState.data || []
+  const filteredEndpoints = useMemo(
+    () => selectors.filterRemovedEndpoints(endpointsState.data || []),
+    [endpointsState.data]
   );
   const allPaths = usePaths();
 

--- a/workspaces/ui-v2/src/pages/diffs/ReviewDiffPages.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/ReviewDiffPages.tsx
@@ -15,7 +15,7 @@ import { ReviewEndpointDiffContainer } from './ReviewEndpointDiffPage';
 import { useDiffsForCapture } from '<src>/pages/diffs/hooks/useDiffForCapture';
 import { v4 as uuidv4 } from 'uuid';
 import { useAllRequestsAndResponses } from '<src>/pages/diffs/hooks/useAllRequestsAndResponses';
-import { useAppSelector } from '<src>/store';
+import { selectors, useAppSelector } from '<src>/store';
 import { useFetchEndpoints } from '<src>/hooks/useFetchEndpoints';
 import {
   CapturePageWithoutDiffOrRedirect,
@@ -35,6 +35,9 @@ export function DiffReviewPages(props: any) {
   const allRequestsAndResponsesOfBaseSpec = useAllRequestsAndResponses();
   useFetchEndpoints();
   const endpointsState = useAppSelector((state) => state.endpoints.results);
+  const filteredEndpoints = selectors.filterRemovedEndpoints(
+    endpointsState.data || []
+  );
   const allPaths = usePaths();
 
   const diffUndocumentedUrlsPageLink = useDiffUndocumentedUrlsPageLink();
@@ -63,7 +66,7 @@ export function DiffReviewPages(props: any) {
       diffTrails={diff.data!.trails}
       urls={diff.data!.urls}
       captureId={boundaryId}
-      endpoints={endpointsState.data!}
+      endpoints={filteredEndpoints}
       allPaths={allPaths.paths}
       requests={allRequestsAndResponsesOfBaseSpec.data?.requests!}
       responses={allRequestsAndResponsesOfBaseSpec.data?.responses!}

--- a/workspaces/ui-v2/src/pages/diffs/ReviewEndpointDiffPage/ReviewEndpointDiffPageContainer.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/ReviewEndpointDiffPage/ReviewEndpointDiffPageContainer.tsx
@@ -11,7 +11,7 @@ import { useSharedDiffContext } from '<src>/pages/diffs/contexts/SharedDiffConte
 import { SpectacleContext } from '<src>/contexts/spectacle-provider';
 import { Loading, PageLayout } from '<src>/components';
 import { DiffAccessoryNavigation } from '<src>/pages/diffs/components/DiffAccessoryNavigation';
-import { selectors, useAppSelector } from '<src>/store';
+import { useAppSelector } from '<src>/store';
 
 import { ReviewEndpointDiffPage } from './ReviewEndpointDiffPage';
 
@@ -26,8 +26,10 @@ export const ReviewEndpointDiffContainer: FC<
   const spectacle = useContext(SpectacleContext)!;
 
   const endpointDiffs = useEndpointDiffs(pathId, method);
-  const endpoint = useAppSelector(
-    selectors.getAssertedEndpoint({ pathId, method })
+  const endpoint = useAppSelector((state) =>
+    state.endpoints.results.data?.find(
+      (endpoint) => endpoint.pathId === pathId && endpoint.method === method
+    )
   );
   const { context } = useSharedDiffContext();
 

--- a/workspaces/ui-v2/src/pages/diffs/ReviewEndpointDiffPage/ReviewEndpointDiffPageContainer.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/ReviewEndpointDiffPage/ReviewEndpointDiffPageContainer.tsx
@@ -11,7 +11,7 @@ import { useSharedDiffContext } from '<src>/pages/diffs/contexts/SharedDiffConte
 import { SpectacleContext } from '<src>/contexts/spectacle-provider';
 import { Loading, PageLayout } from '<src>/components';
 import { DiffAccessoryNavigation } from '<src>/pages/diffs/components/DiffAccessoryNavigation';
-import { useAppSelector } from '<src>/store';
+import { selectors, useAppSelector } from '<src>/store';
 
 import { ReviewEndpointDiffPage } from './ReviewEndpointDiffPage';
 
@@ -26,10 +26,8 @@ export const ReviewEndpointDiffContainer: FC<
   const spectacle = useContext(SpectacleContext)!;
 
   const endpointDiffs = useEndpointDiffs(pathId, method);
-  const endpoint = useAppSelector((state) =>
-    state.endpoints.results.data?.find(
-      (endpoint) => endpoint.pathId === pathId && endpoint.method === method
-    )
+  const endpoint = useAppSelector(
+    selectors.getAssertedEndpoint({ pathId, method })
   );
   const { context } = useSharedDiffContext();
 

--- a/workspaces/ui-v2/src/pages/diffs/hooks/useDiffForCapture.ts
+++ b/workspaces/ui-v2/src/pages/diffs/hooks/useDiffForCapture.ts
@@ -25,7 +25,7 @@ export function useDiffsForCapture(
   const capturesService = useContext(CapturesServiceContext)!;
   const analytics = useAnalytics();
   const endpoints = selectors.filterRemovedEndpoints(
-    useAppSelector(selectors.getAssertedEndpoints)
+    useAppSelector((state) => state.endpoints.results.data || [])
   );
   const [diffState, setDiffState] = useState<DiffState>({
     loading: true,

--- a/workspaces/ui-v2/src/pages/diffs/hooks/useDiffForCapture.ts
+++ b/workspaces/ui-v2/src/pages/diffs/hooks/useDiffForCapture.ts
@@ -4,7 +4,7 @@ import { IOpticDiffService, IUnrecognizedUrl } from '@useoptic/spectacle';
 import { ParsedDiff } from '<src>/lib/parse-diff';
 import { IValueAffordanceSerializationWithCounterGroupedByDiffHash } from '@useoptic/cli-shared/build/diffs/initial-types';
 import { useAnalytics } from '<src>/contexts/analytics';
-import { useAppSelector } from '<src>/store';
+import { selectors, useAppSelector } from '<src>/store';
 
 interface DiffState {
   data?: {
@@ -24,8 +24,8 @@ export function useDiffsForCapture(
 ): DiffState {
   const capturesService = useContext(CapturesServiceContext)!;
   const analytics = useAnalytics();
-  const endpoints = useAppSelector(
-    (state) => state.endpoints.results.data || []
+  const endpoints = selectors.filterRemovedEndpoints(
+    useAppSelector(selectors.getAssertedEndpoints)
   );
   const [diffState, setDiffState] = useState<DiffState>({
     loading: true,

--- a/workspaces/ui-v2/src/pages/docs/DocumentationRootPage/DocumentationRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/docs/DocumentationRootPage/DocumentationRootPage.tsx
@@ -37,8 +37,12 @@ export function DocumentationRootPage() {
     );
   };
 
-  const grouped = useMemo(() => groupBy(endpointsState.data || [], 'group'), [
-    endpointsState,
+  const filteredEndpoints = selectors.filterRemovedEndpoints(
+    endpointsState.data || []
+  );
+
+  const grouped = useMemo(() => groupBy(filteredEndpoints, 'group'), [
+    filteredEndpoints,
   ]);
   const tocKeys = Object.keys(grouped).sort();
   const onKeyPress = useRunOnKeypress(

--- a/workspaces/ui-v2/src/pages/docs/DocumentationRootPage/DocumentationRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/docs/DocumentationRootPage/DocumentationRootPage.tsx
@@ -1,7 +1,8 @@
 import React, { FC, useMemo } from 'react';
 import groupBy from 'lodash.groupby';
-import { CenteredColumn, Loading, PageLayout } from '<src>/components';
 import { Box, List, Typography } from '@material-ui/core';
+
+import { CenteredColumn, Loading, PageLayout } from '<src>/components';
 import {
   useAppSelector,
   useAppDispatch,

--- a/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useMemo, useState } from 'react';
-import { RouteComponentProps } from 'react-router-dom';
+import { Redirect, RouteComponentProps } from 'react-router-dom';
 import { Button, makeStyles } from '@material-ui/core';
 import { Alert } from '@material-ui/lab';
 import { Delete as DeleteIcon, Undo as UndoIcon } from '@material-ui/icons';
@@ -11,8 +11,9 @@ import {
   IShapeRenderer,
   JsonLike,
   PageLayout,
+  FullWidth,
 } from '<src>/components';
-import { FullWidth } from '<src>/components';
+import { useDocumentationPageLink } from '<src>/components/navigation/Routes';
 import { useEndpointBody } from '<src>/hooks/useEndpointBodyHook';
 import { SubtleBlueBackground } from '<src>/constants/theme';
 import {
@@ -49,6 +50,7 @@ export const EndpointRootPage: FC<
     method: string;
   }>
 > = ({ match }) => {
+  const documentationPageLink = useDocumentationPageLink();
   const endpointsState = useAppSelector((state) => state.endpoints.results);
   const isEditing = useAppSelector(
     (state) => state.documentationEdits.isEditing
@@ -66,6 +68,8 @@ export const EndpointRootPage: FC<
       ),
     [endpointsState, method, pathId]
   );
+
+  const isEndpointRemoved = thisEndpoint ? thisEndpoint.isRemoved : false;
 
   const bodies = useEndpointBody(pathId, method);
 
@@ -108,6 +112,11 @@ export const EndpointRootPage: FC<
   if (!thisEndpoint) {
     return <>no endpoint here</>;
   }
+
+  if (isEndpointRemoved) {
+    return <Redirect to={documentationPageLink.linkTo()} />;
+  }
+
   const parameterizedPathParts = thisEndpoint.pathParameters.filter(
     (path) => path.isParameterized
   );

--- a/workspaces/ui-v2/src/store/endpoints.ts
+++ b/workspaces/ui-v2/src/store/endpoints.ts
@@ -21,6 +21,7 @@ export const AllEndpointsQuery = `{
     }
     method
     pathContributions
+    isRemoved
   }
 }`;
 
@@ -38,6 +39,7 @@ export type EndpointQueryResults = {
     }[];
     method: string;
     pathContributions: Record<string, string>;
+    isRemoved: boolean;
   }[];
 };
 
@@ -67,6 +69,7 @@ export const endpointQueryResultsToJson = ({
     })),
     description: request.pathContributions.description || '',
     purpose: request.pathContributions.purpose || '',
+    isRemoved: request.isRemoved,
   }));
 };
 

--- a/workspaces/ui-v2/src/store/selectors/endpointSelectors.ts
+++ b/workspaces/ui-v2/src/store/selectors/endpointSelectors.ts
@@ -1,0 +1,76 @@
+import { RootState } from '../root';
+import { IEndpoint, IEndpointWithChanges } from '<src>/types';
+import {
+  EndpointChangelog,
+  ChangelogCategory,
+} from '<src>/hooks/useEndpointsChangelog';
+import { getEndpointId } from '<src>/utils';
+
+export const getAssertedEndpoints = (state: RootState): IEndpoint[] => {
+  const endpointState = state.endpoints.results.data;
+
+  if (!endpointState) {
+    throw new Error(
+      'Endpoint results were nullable, loading and error states should be handled above this component'
+    );
+  }
+
+  return endpointState;
+};
+
+export const getAssertedEndpoint = ({
+  pathId,
+  method,
+}: {
+  pathId: string;
+  method: string;
+}) => (state: RootState): IEndpoint | undefined => {
+  const endpointState = getAssertedEndpoints(state);
+
+  return endpointState.find(
+    (endpoint) => endpoint.pathId === pathId && endpoint.method === method
+  );
+};
+
+export const filterRemovedEndpoints = (endpoints: IEndpoint[]): IEndpoint[] =>
+  endpoints.filter((endpoint) => !endpoint.isRemoved);
+
+/**
+ * Filters removed endpoints not removed in changes and joins changelog information
+ */
+export const filterRemovedEndpointsForChangelogAndMapChanges = (
+  endpoints: IEndpoint[],
+  endpointChanges: EndpointChangelog[]
+): IEndpointWithChanges[] => {
+  // key by endpointId
+  const endpointChangesByEndpointId = endpointChanges.reduce(
+    (acc: Record<string, ChangelogCategory>, endpointChange) => {
+      const endpointId = getEndpointId({
+        pathId: endpointChange.pathId,
+        method: endpointChange.method,
+      });
+      acc[endpointId] = endpointChange.change.category;
+      return acc;
+    },
+    {}
+  );
+
+  // Filter removed endpoints that have no changes to display
+  const filteredEndpoints = endpoints.filter((endpoint) => {
+    const endpointId = getEndpointId(endpoint);
+
+    // Assumption - if an endpoint is removed, but this batch of changes contains _any_ change for this endpoint
+    // we should show this endpoint - the last change you could make is a delete
+    // Two assumptions:
+    // - You cannot undelete a specific endpoint
+    // - You must always view changes compared to the latest version
+    return !(endpoint.isRemoved && !endpointChangesByEndpointId[endpointId]);
+  });
+
+  const endpointsWithChanges = filteredEndpoints.map((endpoint) => ({
+    ...endpoint,
+    changes: endpointChangesByEndpointId[getEndpointId(endpoint)] || null,
+  }));
+
+  return endpointsWithChanges;
+};

--- a/workspaces/ui-v2/src/store/selectors/endpointSelectors.ts
+++ b/workspaces/ui-v2/src/store/selectors/endpointSelectors.ts
@@ -1,36 +1,9 @@
-import { RootState } from '../root';
 import { IEndpoint, IEndpointWithChanges } from '<src>/types';
 import {
   EndpointChangelog,
   ChangelogCategory,
 } from '<src>/hooks/useEndpointsChangelog';
 import { getEndpointId } from '<src>/utils';
-
-export const getAssertedEndpoints = (state: RootState): IEndpoint[] => {
-  const endpointState = state.endpoints.results.data;
-
-  if (!endpointState) {
-    throw new Error(
-      'Endpoint results were nullable, loading and error states should be handled above this component'
-    );
-  }
-
-  return endpointState;
-};
-
-export const getAssertedEndpoint = ({
-  pathId,
-  method,
-}: {
-  pathId: string;
-  method: string;
-}) => (state: RootState): IEndpoint | undefined => {
-  const endpointState = getAssertedEndpoints(state);
-
-  return endpointState.find(
-    (endpoint) => endpoint.pathId === pathId && endpoint.method === method
-  );
-};
 
 export const filterRemovedEndpoints = (endpoints: IEndpoint[]): IEndpoint[] =>
   endpoints.filter((endpoint) => !endpoint.isRemoved);

--- a/workspaces/ui-v2/src/store/selectors/endpointSelectors.ts
+++ b/workspaces/ui-v2/src/store/selectors/endpointSelectors.ts
@@ -33,9 +33,9 @@ export const filterRemovedEndpointsForChangelogAndMapChanges = (
     const endpointId = getEndpointId(endpoint);
 
     // Assumption - if an endpoint is removed, but this batch of changes contains _any_ change for this endpoint
-    // we should show this endpoint - the last change you could make is a delete
+    // we should show this endpoint - the last change you could make is a removal
     // Two assumptions:
-    // - You cannot undelete a specific endpoint
+    // - You cannot un-remove a specific endpoint (with history, you can undo batches)
     // - You must always view changes compared to the latest version
     return !(endpoint.isRemoved && !endpointChangesByEndpointId[endpointId]);
   });

--- a/workspaces/ui-v2/src/store/selectors/index.ts
+++ b/workspaces/ui-v2/src/store/selectors/index.ts
@@ -1,1 +1,2 @@
 export * from './documentationEditSelectors';
+export * from './endpointSelectors';

--- a/workspaces/ui-v2/src/types/endpoints.ts
+++ b/workspaces/ui-v2/src/types/endpoints.ts
@@ -1,3 +1,5 @@
+import { ChangelogCategory } from '<src>/hooks/useEndpointsChangelog';
+
 export interface IPathParameter {
   id: string;
   name: string;
@@ -14,4 +16,9 @@ export interface IEndpoint {
   fullPath: string;
   pathParameters: IPathParameter[];
   group: string;
+  isRemoved: boolean;
+}
+
+export interface IEndpointWithChanges extends IEndpoint {
+  changes: ChangelogCategory | null;
 }


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

When removing an endpoint, we want to show these in the changelog history

Also, wherever I am saying delete, I really mean remove (old habits die hard)

## What
What's changing? Anything of note to call out?

Had to change a couple of things to get this to work
- Added in a RemovedIn edge when removing a request / response
- Moved the remove endpoint filtering logic (implemented in https://github.com/opticdev/optic/pull/876) to the UI (since we want to conditionally show deletions)
- Update the buildEndpointChanges function to handle a RemovedIn edge
- Update the changelog endpoint root page to handle a removed view
  - Show a banner if the endpoint was removed
  - If the endpoint should _not_ be visible in the changelog history view (i.e. would have been filtered) - redirect to the documentation root page (on the current changelog version)

I was also going to add in `getAssertedEndpoints` - but we need to consolidate our loading states further up the tree, and then we can use getAssertedEndpoints more effectively (this function would throw an error if state hasn't loaded and returns a non-nullable endpoint array) - there was only 2 places this would have been used so it wouldn't have been that useful.

To follow this PR:
- I am not sure if the gitbot will be able to handle deletion events. I'll have to follow up with this and see how the gitbot works (given that some of the required logic is on the UI side now) - although my guess is, yes it works

## Screenshots

Documentation page (current API spec)
<img width="1081" alt="Screen Shot 2021-06-11 at 3 12 09 PM" src="https://user-images.githubusercontent.com/18374483/121753550-737ff380-cac7-11eb-9eb6-3782540df931.png">

Changelog page with a deleted endpoint
<img width="1013" alt="Screen Shot 2021-06-11 at 3 12 13 PM" src="https://user-images.githubusercontent.com/18374483/121753561-7b3f9800-cac7-11eb-97b3-0139988a80e5.png">

Changelog endpoint page
<img width="1126" alt="Screen Shot 2021-06-11 at 4 02 13 PM" src="https://user-images.githubusercontent.com/18374483/121756285-69adbe80-cace-11eb-9e68-910c42d78b81.png">


## Validation
Before merging, we'll want to verify that the changelog still handles creation + update events correctly
- Creating a new endpoint
- Updating an endpoint (new response added, fields added, field changed)

Scenarios tested:
- Endpoints added (request added , resulting in an added endpoint, with requests, responses, bodies added)
- Responses added (results in an updated)
- Endpoint deleted (request deleted, resulting in a deleted endpoint)
-  Endpoint was deleted in batchCommit 3, but we are only viewing batchCommit 4 onwards - this should not show the deleted endpoint