### PR TITLE
feat: run website in k8s

### DIFF
--- a/.github/workflows/docs-website.yml
+++ b/.github/workflows/docs-website.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set env vars
         run: |
           echo "TAG=${BRANCH}-b${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
-          if [ "$BRANCH" =~ ^(develop|release)$ ]
+          if [[ "$BRANCH" =~ ^(develop|release)$ ]]
           then
             echo "APP_ENV=production" >> $GITHUB_ENV
           else

--- a/.github/workflows/docs-website.yml
+++ b/.github/workflows/docs-website.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Set env vars
         run: |
           echo "TAG=${BRANCH}-b${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
-          echo "USER=${GITHUB_ACTOR}" >> $GITHUB_ENV
           if [[ "$BRANCH" =~ ^(develop|release)$ ]]
           then
             echo "APP_ENV=production" >> $GITHUB_ENV
@@ -56,6 +55,7 @@ jobs:
       - env:
           REPO: 513974440343.dkr.ecr.us-east-1.amazonaws.com/docs
           SLACK_WEBHOOK: ${{ secrets.BUILD_BOT_SLACK_WEBHOOK_URL }}
+          USER: ${{ github.actor }}
           MSG: "was deployed to ${{ env.APP_ENV }}."
         run: |
           aws eks update-kubeconfig --name default --alias "$APP_ENV"

--- a/.github/workflows/docs-website.yml
+++ b/.github/workflows/docs-website.yml
@@ -1,0 +1,70 @@
+---
+name: Docs Website
+
+on:
+  push:
+    paths:
+      - .github/works/docs-website.yml
+      - website/**/*
+      - "!website/README.md"
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
+      - name: Install Task
+        run: curl -sL https://taskfile.dev/install.sh | sudo bash -s -- -b /usr/local/bin/
+      - name: Install Skaffold
+        run: |
+          curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-amd64
+          sudo install skaffold /usr/local/bin/
+      - name: Set branch name
+        run: echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
+      - name: Set env vars
+        run: |
+          echo "TAG=${BRANCH}-b${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
+          if [ "$BRANCH" =~ ^(develop|release)$" ]
+          then
+            echo "APP_ENV=production" >> $GITHUB_ENV
+          else
+            echo "APP_ENV=staging" >> $GITHUB_ENV
+          fi
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@32d908adfb55576ba0c59f3c557058e80b5194c3 # v1.5.3
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: "us-east-1"
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@060516122e7b4cc1cc3d4614a998adbb93d3fbf2 # v1.2.2
+      - env:
+          REPO: 513974440343.dkr.ecr.us-east-1.amazonaws.com/docs
+          SLACK_WEBHOOK: ${{ secrets.BUILD_BOT_SLACK_WEBHOOK_URL }}
+          USER: ${{ env.GITHUB_ACTOR }}
+        run: >
+          task
+            website:docker:build
+            website:docker:push
+            docker:slack-notifier
+      - name: Configure staging AWS credentials
+        uses: aws-actions/configure-aws-credentials@32d908adfb55576ba0c59f3c557058e80b5194c3 # v1.5.3
+        if: env.APP_ENV == 'staging'
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_STAGING_CI_ROLE_ARN }}
+          role-duration-seconds: 900 # 15m, minimum
+          role-session-name: GithubActionStagingDeploy
+      - env:
+          REPO: 513974440343.dkr.ecr.us-east-1.amazonaws.com/docs
+          SLACK_WEBHOOK: ${{ secrets.BUILD_BOT_SLACK_WEBHOOK_URL }}
+          USER: ${{ env.GITHUB_ACTOR }}
+          MSG: "was deployed to ${{ env.APP_ENV }}."
+        run: >
+          task
+            website:docker:deploy
+            docker:slack-notifier

--- a/.github/workflows/docs-website.yml
+++ b/.github/workflows/docs-website.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set env vars
         run: |
           echo "TAG=${BRANCH}-b${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
-          if [ "$BRANCH" =~ ^(develop|release)$" ]
+          if [ "$BRANCH" =~ ^(develop|release)$ ]
           then
             echo "APP_ENV=production" >> $GITHUB_ENV
           else

--- a/.github/workflows/docs-website.yml
+++ b/.github/workflows/docs-website.yml
@@ -4,7 +4,7 @@ name: Docs Website
 on:
   push:
     paths:
-      - .github/works/docs-website.yml
+      - .github/workflows/docs-website.yml
       - website/**/*
       - "!website/README.md"
   workflow_dispatch:

--- a/.github/workflows/docs-website.yml
+++ b/.github/workflows/docs-website.yml
@@ -40,15 +40,10 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@060516122e7b4cc1cc3d4614a998adbb93d3fbf2 # v1.2.2
-      - env:
-          REPO: 513974440343.dkr.ecr.us-east-1.amazonaws.com/docs
-          SLACK_WEBHOOK: ${{ secrets.BUILD_BOT_SLACK_WEBHOOK_URL }}
-          USER: ${{ env.GITHUB_ACTOR }}
-        run: >
+      - run: >
           task
             website:docker:build
             website:docker:push
-            docker:slack-notifier
       - name: Configure staging AWS credentials
         uses: aws-actions/configure-aws-credentials@32d908adfb55576ba0c59f3c557058e80b5194c3 # v1.5.3
         if: env.APP_ENV == 'staging'

--- a/.github/workflows/docs-website.yml
+++ b/.github/workflows/docs-website.yml
@@ -57,4 +57,6 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.BUILD_BOT_SLACK_WEBHOOK_URL }}
           USER: ${{ env.GITHUB_ACTOR }}
           MSG: "was deployed to ${{ env.APP_ENV }}."
-        run: task website:docker:deploy docker:slack-notifier
+        run: |
+          aws eks update-kubeconfig --name default --alias "$APP_ENV"
+          task website:docker:deploy docker:slack-notifier

--- a/.github/workflows/docs-website.yml
+++ b/.github/workflows/docs-website.yml
@@ -7,6 +7,7 @@ on:
       - .github/works/docs-website.yml
       - website/**/*
       - "!website/README.md"
+  workflow_dispatch:
 
 jobs:
   run:

--- a/.github/workflows/docs-website.yml
+++ b/.github/workflows/docs-website.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Set env vars
         run: |
           echo "TAG=${BRANCH}-b${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
+          echo "USER=${GITHUB_ACTOR}" >> $GITHUB_ENV
           if [[ "$BRANCH" =~ ^(develop|release)$ ]]
           then
             echo "APP_ENV=production" >> $GITHUB_ENV
@@ -55,7 +56,6 @@ jobs:
       - env:
           REPO: 513974440343.dkr.ecr.us-east-1.amazonaws.com/docs
           SLACK_WEBHOOK: ${{ secrets.BUILD_BOT_SLACK_WEBHOOK_URL }}
-          USER: ${{ env.GITHUB_ACTOR }}
           MSG: "was deployed to ${{ env.APP_ENV }}."
         run: |
           aws eks update-kubeconfig --name default --alias "$APP_ENV"

--- a/.github/workflows/docs-website.yml
+++ b/.github/workflows/docs-website.yml
@@ -41,10 +41,7 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@060516122e7b4cc1cc3d4614a998adbb93d3fbf2 # v1.2.2
-      - run: >
-          task
-            website:docker:build
-            website:docker:push
+      - run: task website:docker:build website:docker:push
       - name: Configure staging AWS credentials
         uses: aws-actions/configure-aws-credentials@32d908adfb55576ba0c59f3c557058e80b5194c3 # v1.5.3
         if: env.APP_ENV == 'staging'
@@ -60,7 +57,4 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.BUILD_BOT_SLACK_WEBHOOK_URL }}
           USER: ${{ env.GITHUB_ACTOR }}
           MSG: "was deployed to ${{ env.APP_ENV }}."
-        run: >
-          task
-            website:docker:deploy
-            docker:slack-notifier
+        run: task website:docker:deploy docker:slack-notifier

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -9,12 +9,14 @@ on:
       - website/**
       - .github/**
       - "**.md"
+      - Taskfile.yml
   pull_request:
     branches: [ 'develop' ]
     paths-ignore:
       - website/**
       - .github/**
       - "**.md"
+      - Taskfile.yml
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -130,7 +130,7 @@ tasks:
         * TAG — the Docker image tag
         * USER — the user to direct the message at
     vars:
-      MESSAGE: '{{.USER}}: `{{.REPO}}:{{.TAG}}` was pushed to our Docker registry.'
+      MESSAGE: '{{.USER}}: `{{.REPO}}:{{.TAG}}` {{default "was pushed to our Docker registry." .MSG}}'
     env:
       DATA: '{"text":"{{.MESSAGE}}"}'
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -24,6 +24,9 @@ includes:
   verdaccio:
     taskfile: docker/private-npm-registry/Taskfile.yml
     dir: docker/private-npm-registry
+  website:
+    taskfile: website/Taskfile.yml
+    dir: website
 
 tasks:
   postpull:

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -9,6 +9,6 @@ RUN yarn build
 
 FROM library/nginx:alpine
 
-COPY --from=build --chown=nginx:nginx /tmp/docs/build/ /usr/share/nginx/html/
+COPY --from=build /tmp/docs/build/ /usr/share/nginx/html/
 COPY etc/nginx/conf.d/ /etc/nginx/conf.d/
 EXPOSE 80

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -3,16 +3,12 @@ FROM 513974440343.dkr.ecr.us-east-1.amazonaws.com/nodejs-base:latest as build
 ARG APP_NAME=docs
 RUN mkdir -p /tmp/$APP_NAME
 WORKDIR /tmp/$APP_NAME
-
 COPY . .
-
-# the build script depends on dev dependencies, and the default from the upstream image is
-# set to "production". so set this to "dev" to install all deps
-RUN NODE_ENV=dev yarn install
-
+RUN yarn install
 RUN yarn build
 
 FROM library/nginx:alpine
+
 COPY --from=build /tmp/docs/build/ /usr/share/nginx/html/
 COPY etc/nginx/conf.d/ /etc/nginx/conf.d/
 EXPOSE 80

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -1,0 +1,18 @@
+FROM 513974440343.dkr.ecr.us-east-1.amazonaws.com/nodejs-base:latest as build
+
+ARG APP_NAME=docs
+RUN mkdir -p /tmp/$APP_NAME
+WORKDIR /tmp/$APP_NAME
+
+COPY . .
+
+# the build script depends on dev dependencies, and the default from the upstream image is
+# set to "production". so set this to "dev" to install all deps
+RUN NODE_ENV=dev yarn install
+
+RUN yarn build
+
+FROM library/nginx:alpine
+COPY --from=build /tmp/docs/build/ /usr/share/nginx/html/
+COPY etc/nginx/conf.d/ /etc/nginx/conf.d/
+EXPOSE 80

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -9,6 +9,6 @@ RUN yarn build
 
 FROM library/nginx:alpine
 
-COPY --from=build /tmp/docs/build/ /usr/share/nginx/html/
+COPY --from=build --chown=nginx:nginx /tmp/docs/build/ /usr/share/nginx/html/
 COPY etc/nginx/conf.d/ /etc/nginx/conf.d/
 EXPOSE 80

--- a/website/Taskfile.yml
+++ b/website/Taskfile.yml
@@ -84,3 +84,15 @@ tasks:
     desc: Stop Docs
     cmds:
       - docker-compose down
+
+  docker:deploy:
+    desc: Deploy Docs to K8s
+    env:
+      TAG: '{{default "local" .TAG}}'
+    cmds:
+      - skaffold deploy -i 513974440343.dkr.ecr.us-east-1.amazonaws.com/docs:$TAG
+
+  docker:ci:
+    - docker:build
+    - docker:push
+    - docker:deploy

--- a/website/Taskfile.yml
+++ b/website/Taskfile.yml
@@ -30,7 +30,7 @@ tasks:
 
   deploy:staging:
     desc: Dry run of a deploy to staging
-    cmds: 
+    cmds:
       - task: deploy
         vars:
           AWS_PROFILE: staging
@@ -38,15 +38,15 @@ tasks:
 
   deploy:staging:doit:
     desc: Deploy to staging
-    cmds: 
+    cmds:
       - task: deploy
         vars:
           AWS_PROFILE: staging
-          DRY_RUN: false  
+          DRY_RUN: false
 
   deploy:prod:
     desc: Dry run of a deploy to production
-    cmds: 
+    cmds:
       - task: deploy
         vars:
           AWS_PROFILE: production
@@ -58,4 +58,9 @@ tasks:
       - task: deploy
         vars:
           AWS_PROFILE: production
-          DRY_RUN: false  
+          DRY_RUN: false
+
+  docker:build:
+    desc: Build a Docker image
+    cmds:
+      - docker build . -t testing/docs

--- a/website/Taskfile.yml
+++ b/website/Taskfile.yml
@@ -54,7 +54,7 @@ tasks:
 
   deploy:prod:doit:
     desc: Deploy to production
-    cmds: 
+    cmds:
       - task: deploy
         vars:
           AWS_PROFILE: production
@@ -73,6 +73,12 @@ tasks:
       TAG: '{{default "local" .TAG}}'
     cmds:
       - docker push 513974440343.dkr.ecr.us-east-1.amazonaws.com/docs:$TAG
+      - |
+        if [[ "$BRANCH" =~ ^(develop|release) ]]
+        then
+          docker tag 513974440343.dkr.ecr.us-east-1.amazonaws.com/docs:$TAG 513974440343.dkr.ecr.us-east-1.amazonaws.com/docs:latest
+          docker push 513974440343.dkr.ecr.us-east-1.amazonaws.com/docs:latest
+        fi
 
   docker:up:
     desc: Start Docs

--- a/website/Taskfile.yml
+++ b/website/Taskfile.yml
@@ -63,7 +63,7 @@ tasks:
   docker:build:
     desc: Build a Docker image
     cmds:
-      - docker build . -t testing/docs
+      - docker build . -t 513974440343.dkr.ecr.us-east-1.amazonaws.com/docs
 
   docker:up:
     desc: Start the docs webserver locally

--- a/website/Taskfile.yml
+++ b/website/Taskfile.yml
@@ -63,12 +63,16 @@ tasks:
   docker:build:
     desc: Build a Docker image
     cmds:
+      # built with docker to avoid a docker-compose dependency in CI
       - docker build . -t 513974440343.dkr.ecr.us-east-1.amazonaws.com/docs
 
   docker:up:
-    desc: Start the docs webserver locally
+    desc: Start Docs
     cmds:
       - docker-compose up -d
+      - echo "Listening on localhost:34999"
 
   docker:down:
-    - docker-compose down
+    desc: Stop Docs
+    cmds:
+      - docker-compose down

--- a/website/Taskfile.yml
+++ b/website/Taskfile.yml
@@ -62,9 +62,17 @@ tasks:
 
   docker:build:
     desc: Build a Docker image
+    env:
+      TAG: '{{default "local" .TAG}}'
     cmds:
       # built with docker to avoid a docker-compose dependency in CI
-      - docker build . -t 513974440343.dkr.ecr.us-east-1.amazonaws.com/docs
+      - docker build . -t 513974440343.dkr.ecr.us-east-1.amazonaws.com/docs:$TAG
+
+  docker:push:
+    env:
+      TAG: '{{default "local" .TAG}}'
+    cmds:
+      - docker push 513974440343.dkr.ecr.us-east-1.amazonaws.com/docs:$TAG
 
   docker:up:
     desc: Start Docs

--- a/website/Taskfile.yml
+++ b/website/Taskfile.yml
@@ -64,3 +64,11 @@ tasks:
     desc: Build a Docker image
     cmds:
       - docker build . -t testing/docs
+
+  docker:up:
+    desc: Start the docs webserver locally
+    cmds:
+      - docker-compose up -d
+
+  docker:down:
+    - docker-compose down

--- a/website/Taskfile.yml
+++ b/website/Taskfile.yml
@@ -96,7 +96,7 @@ tasks:
     env:
       TAG: '{{default "local" .TAG}}'
     cmds:
-      - skaffold deploy -i 513974440343.dkr.ecr.us-east-1.amazonaws.com/docs:$TAG
+      - skaffold deploy -i 513974440343.dkr.ecr.us-east-1.amazonaws.com/docs:$TAG --namespace docs
 
   docker:ci:
     - docker:build

--- a/website/Taskfile.yml
+++ b/website/Taskfile.yml
@@ -74,7 +74,7 @@ tasks:
     cmds:
       - docker push 513974440343.dkr.ecr.us-east-1.amazonaws.com/docs:$TAG
       - |
-        if [[ "$BRANCH" =~ ^(develop|release) ]]
+        if [[ "$BRANCH" =~ ^(develop|release)$ ]]
         then
           docker tag 513974440343.dkr.ecr.us-east-1.amazonaws.com/docs:$TAG 513974440343.dkr.ecr.us-east-1.amazonaws.com/docs:latest
           docker push 513974440343.dkr.ecr.us-east-1.amazonaws.com/docs:latest

--- a/website/docker-compose.yml
+++ b/website/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3"
+
+services:
+  docs:
+    image: 513974440343.dkr.ecr.us-east-1.amazonaws.com/docs
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - 34999:80
+    networks: [optic]
+
+networks:
+  optic:
+    name: optic
+    external: true

--- a/website/etc/nginx/conf.d/security-headers.conf
+++ b/website/etc/nginx/conf.d/security-headers.conf
@@ -1,0 +1,6 @@
+add_header strict-transport-security "max-age=63072000; includeSubdomains; preload";
+add_header x-content-type-options nosniff;
+add_header x-frame-options DENY;
+add_header x-xss-protection "1; mode=block";
+add_header referrer-policy same-origin;
+add_header content-security-policy "default-src 'self' 'unsafe-inline' wss: data: https:; connect-src 'self' 'unsafe-inline' wss: data: https: http://localhost:6782 http://localhost:34444; script-src 'self' 'unsafe-inline' https:; style-src 'self' 'unsafe-inline' 'unsafe-eval' https://fonts.googleapis.com; object-src 'none'; font-src 'self' https://fonts.gstatic.com";

--- a/website/etc/nginx/conf.d/security-headers.conf
+++ b/website/etc/nginx/conf.d/security-headers.conf
@@ -3,4 +3,4 @@ add_header x-content-type-options nosniff;
 add_header x-frame-options DENY;
 add_header x-xss-protection "1; mode=block";
 add_header referrer-policy same-origin;
-add_header content-security-policy "default-src 'self' 'unsafe-inline' wss: data: https:; connect-src 'self' 'unsafe-inline' wss: data: https: http://localhost:6782 http://localhost:34444; script-src 'self' 'unsafe-inline' https:; style-src 'self' 'unsafe-inline' 'unsafe-eval' https://fonts.googleapis.com; object-src 'none'; font-src 'self' https://fonts.gstatic.com";
+add_header content-security-policy "default-src 'self' 'unsafe-inline' wss: data: https:; connect-src 'self' 'unsafe-inline' wss: data: https:; script-src 'self' 'unsafe-inline' https:; style-src 'self' 'unsafe-inline' 'unsafe-eval' https://fonts.googleapis.com; object-src 'none'; font-src 'self' https://fonts.gstatic.com";

--- a/website/k8s/.helmignore
+++ b/website/k8s/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/website/k8s/Chart.yaml
+++ b/website/k8s/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: nginx
+description: an nginx chart focused on host our static react sites
+type: application
+version: 0.1.0
+appVersion: 0.0.0

--- a/website/k8s/templates/autoscaling.yaml
+++ b/website/k8s/templates/autoscaling.yaml
@@ -1,0 +1,20 @@
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Values.name }}
+  labels:
+    app: {{ .Values.name }}
+spec:
+  maxReplicas: {{ .Values.hpa_max_replicas }}
+  minReplicas: {{ .Values.hpa_min_replicas }}
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Values.name }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.hpa_cpu_util }}

--- a/website/k8s/templates/deployment.yaml
+++ b/website/k8s/templates/deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.name }}
+  labels:
+    app: {{ .Values.name }}
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: {{ .Values.replicas }}
+  revisionHistoryLimit: {{ .Values.revision_history_limit }}
+  selector:
+    matchLabels:
+      app: {{ .Values.name }}
+  minReadySeconds: {{ .Values.min_ready_seconds }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.name }}
+    spec:
+      nodeSelector:
+        node-group: {{ .Values.node_group | default "default" }}
+      containers:
+        - name: {{ .Values.name }}
+          image: {{ .Values.image }}
+          {{- if .Values.tty_enabled }}
+          stdin: true
+          tty: true
+          {{- end }}
+          resources:
+            requests:
+              cpu: {{ .Values.resources.requests.cpu }}
+              memory: {{ .Values.resources.requests.memory }}

--- a/website/k8s/templates/netpol.yaml
+++ b/website/k8s/templates/netpol.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Values.name }}
+  labels:
+    app: {{ .Values.name }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ .Values.name }}
+  ingress:
+     - from: []
+       ports:
+        - protocol: TCP
+          port: {{ .Values.port }}

--- a/website/k8s/templates/service.yaml
+++ b/website/k8s/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.name }}
+  labels:
+    app: {{ .Values.name }}
+spec:
+  type: NodePort
+  selector:
+    app: {{ .Values.name }}
+  ports:
+    - name: http
+      protocol: TCP
+      port: {{ .Values.port }}
+      targetPort: {{ .Values.port }}

--- a/website/k8s/values.development.yaml
+++ b/website/k8s/values.development.yaml
@@ -1,0 +1,14 @@
+name: docs
+hpa_cpu_util: 75
+hpa_max_replicas: 2
+hpa_min_replicas: 1
+image: docs
+replicas: 1
+resources:
+  requests:
+    cpu: 64m
+    memory: 64M
+revision_history: 3
+min_ready_seconds: 5
+tty_enabled: false
+port: 80

--- a/website/k8s/values.production.yaml
+++ b/website/k8s/values.production.yaml
@@ -1,0 +1,14 @@
+name: docs
+hpa_cpu_util: 75
+hpa_max_replicas: 10
+hpa_min_replicas: 3
+image: docs
+replicas: 3
+resources:
+  requests:
+    cpu: 64m
+    memory: 64M
+revision_history: 5
+min_ready_seconds: 5
+tty_enabled: false
+port: 80

--- a/website/k8s/values.staging.yaml
+++ b/website/k8s/values.staging.yaml
@@ -1,0 +1,14 @@
+name: docs
+hpa_cpu_util: 75
+hpa_max_replicas: 2
+hpa_min_replicas: 1
+image: docs
+replicas: 1
+resources:
+  requests:
+    cpu: 64m
+    memory: 64M
+revision_history: 3
+min_ready_seconds: 5
+tty_enabled: false
+port: 80

--- a/website/skaffold.yml
+++ b/website/skaffold.yml
@@ -1,7 +1,7 @@
 apiVersion: skaffold/v2beta14
 kind: Config
 metadata:
-  name: optichub
+  name: docs
 build:
   artifacts:
     - image: 513974440343.dkr.ecr.us-east-1.amazonaws.com/docs
@@ -10,7 +10,7 @@ build:
 deploy:
   helm:
     releases:
-      - name: optichub
+      - name: docs
         chartPath: chart/
         valuesFiles:
           - values.development.yaml

--- a/website/skaffold.yml
+++ b/website/skaffold.yml
@@ -1,0 +1,33 @@
+apiVersion: skaffold/v2beta14
+kind: Config
+metadata:
+  name: optichub
+build:
+  artifacts:
+    - image: 513974440343.dkr.ecr.us-east-1.amazonaws.com/docs
+      docker:
+        dockerfile: Dockerfile
+deploy:
+  helm:
+    releases:
+      - name: optichub
+        chartPath: chart/
+        valuesFiles:
+          - values.development.yaml
+        artifactOverrides:
+          image: 513974440343.dkr.ecr.us-east-1.amazonaws.com/docs
+profiles:
+  - name: staging
+    activation:
+      - kubeContext: staging
+    patches:
+      - op: replace
+        path: /deploy/helm/releases/0/valuesFiles/0
+        value: values.staging.yaml
+  - name: production
+    activation:
+      - kubeContext: production
+    patches:
+      - op: replace
+        path: /deploy/helm/releases/0/valuesFiles/0
+        value: values.production.yaml

--- a/website/skaffold.yml
+++ b/website/skaffold.yml
@@ -11,9 +11,11 @@ deploy:
   helm:
     releases:
       - name: docs
-        chartPath: chart/
+        namespace: docs
+        createNamespace: true
+        chartPath: k8s/
         valuesFiles:
-          - values.development.yaml
+          - k8s/values.development.yaml
         artifactOverrides:
           image: 513974440343.dkr.ecr.us-east-1.amazonaws.com/docs
 profiles:
@@ -23,11 +25,11 @@ profiles:
     patches:
       - op: replace
         path: /deploy/helm/releases/0/valuesFiles/0
-        value: values.staging.yaml
+        value: k8s/values.staging.yaml
   - name: production
     activation:
       - kubeContext: production
     patches:
       - op: replace
         path: /deploy/helm/releases/0/valuesFiles/0
-        value: values.production.yaml
+        value: k8s/values.production.yaml


### PR DESCRIPTION
there's upcoming changes to our marketing and docs sites. this does some prep work by getting the current website building and deploying to k8s. this PR,

* docker-izes the existing website
* adds a helm chart and deployment bits
    * k8s objects live in the "docs" namespace
* adds a CI workflow to build/push/deploy
    * pushes to website/* will build and deploy to staging, unless...
    * the branch is "release" or "develop" in which case we deploy to prod

## Validation
* [ ] CI passes
* [ ] Verified in staging
