### PR TITLE
fix: Allow minor versions of tokio to be compatible. 

### DIFF
--- a/workspaces/optic-engine/Cargo.toml
+++ b/workspaces/optic-engine/Cargo.toml
@@ -30,7 +30,7 @@ serde = { version = "1.0.106", features = ["derive"] }
 serde_json = "1.0.57"
 thiserror = "1.0.24"
 # all of tokio for now, until we figure out what we need exactly
-tokio = { version = "~1.1.1", features = ["full"], optional = true }
+tokio = { version = "^1.1.1", features = ["full"], optional = true }
 tokio-util = { version = "0.6.3", features = ["codec"], optional = true }
 tokio-stream = { version= "0.1.2", features = ["fs", "io-util"], optional = true }
 uuid = { version = "0.8.2", features = ["v4", "wasm-bindgen"] }


### PR DESCRIPTION
See: https://github.com/rust-lang/cargo/issues/6584#issuecomment-457245362

## Why
> The `~` requirement is indeed more strict than `^`, but Cargo strongly discourages usage of any version requirement other than `^` unless you're really sure you know what you're doing


## What
Change the dependency qualifier to `~`, to allow dependents using other `1.x.x` tokio versions to build. 
