### PR TITLE
Revive debugOptic and update error page

### DIFF
--- a/workspaces/spectacle-shared/src/local-cli/client.ts
+++ b/workspaces/spectacle-shared/src/local-cli/client.ts
@@ -7,6 +7,7 @@ import {
   IOpticConfigRepository,
   IOpticDiffService,
   IOpticEngine,
+  IOpticSpecRepository,
   SpectacleInput,
   StartDiffResult,
 } from '@useoptic/spectacle';
@@ -69,6 +70,7 @@ export interface LocalCliServices {
   capturesService: IOpticCapturesService;
   opticEngine: IOpticEngine;
   configRepository: IOpticConfigRepository;
+  specRepository: IOpticSpecRepository;
 }
 export interface LocalCliCapturesServiceDependencies {
   baseUrl: string;
@@ -199,5 +201,13 @@ export class LocalCliConfigRepository implements IOpticConfigRepository {
     );
     const config: IApiCliConfig = result.config;
     return config.name;
+  }
+}
+
+export class LocalCliSpecRepository implements IOpticSpecRepository {
+  constructor(private dependencies: { baseUrl: string }) {}
+
+  async listEvents(): Promise<any> {
+    return JsonHttpClient.getJson(`${this.dependencies.baseUrl}/events`);
   }
 }

--- a/workspaces/ui-v2/src/App.js
+++ b/workspaces/ui-v2/src/App.js
@@ -36,7 +36,7 @@ class App extends React.Component {
 
 function AppError() {
   return (
-    <div>
+    <div style={{ padding: '12px 24px' }}>
       <div>
         <h1>There was a problem in displaying the Optic app.</h1>
 

--- a/workspaces/ui-v2/src/App.js
+++ b/workspaces/ui-v2/src/App.js
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import { appTheme } from './constants/theme';
 import { BrowserRouter, Route } from 'react-router-dom';
@@ -34,16 +34,10 @@ class App extends React.Component {
   }
 }
 
-function AppError(props) {
-  const onClickRefresh = useCallback((e) => {
-    e.preventDefault();
-    window && window.location && window.location.reload(true);
-  }, []);
-
-  // we have to be as conservative as possible here and only use styles from App.css, as we're not sure what subsystems this error has touched
+function AppError() {
   return (
-    <div className="app-error-container">
-      <div className="app-error">
+    <div>
+      <div>
         <h1>There was a problem in displaying the Optic app.</h1>
 
         <h4>
@@ -51,39 +45,28 @@ function AppError(props) {
           from it automatically.
         </h4>
 
-        <h5>
-          Please feel free to{' '}
-          <a href={SupportLinks.Contact('Optic App crash report')}>
-            contact us about it.
-          </a>
-        </h5>
-
-        <p>Meanwhile, you could try the following:</p>
-
-        <ul>
-          <li>
-            Create a debug file and{' '}
-            <a href={SupportLinks.Contact('Optic App crash report')}>
-              {' '}
-              email it to our team
-            </a>{' '}
-            or <a href={SupportLinks.GithubIssues}> open a GitHub issue</a>
-            {': '}
-            <ul>
-              <li>
-                share a debug capture <code>api debug:capture</code>
-              </li>
-            </ul>
-          </li>
-          <li>
-            <button onClick={onClickRefresh}>Refresh the page</button> in your
-            browser.
-          </li>
-          <li>
-            Try <a href="https://browsehappy.com/">a different browser</a>, if
-            you can.
-          </li>
-        </ul>
+        <div>
+          You can help us debug this error:
+          <ul>
+            <li>
+              {/* eslint-disable-next-line */}
+              <a href="#" onClick={window.debugOptic}>
+                Click here
+              </a>{' '}
+              to generate a debug file
+            </li>
+            <li>
+              Send the debug file to{' '}
+              <a href={SupportLinks.Contact('Optic App crash report')}>
+                our team
+              </a>
+            </li>
+          </ul>
+          <p>
+            This debug file includes information about your specification,
+            current UI state and captured traffic Optic has seen.
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/workspaces/ui-v2/src/components/DebugOpticComponent.tsx
+++ b/workspaces/ui-v2/src/components/DebugOpticComponent.tsx
@@ -1,0 +1,58 @@
+import { FC, useEffect } from 'react';
+
+import { IOpticSpecRepository } from '@useoptic/spectacle/build';
+
+declare global {
+  interface Window {
+    __GLOBAL_DIFF_DEBUG_FUNCTION__?: () => any;
+    debugOptic?: () => void;
+  }
+}
+
+const GLOBAL_DIFF_DEBUG_FUNCTION = '__GLOBAL_DIFF_DEBUG_FUNCTION__';
+
+// In the future, we could directly dump the redux store
+export const useGlobalDiffDebug = (fn: () => any) => {
+  useEffect(() => {
+    window[GLOBAL_DIFF_DEBUG_FUNCTION] = fn;
+    return () => {
+      delete window[GLOBAL_DIFF_DEBUG_FUNCTION];
+    };
+  }, [fn]);
+};
+
+const debugDump = (specService: IOpticSpecRepository) => {
+  return async function () {
+    const events = await specService.listEvents();
+    const diffDebugFunction = window[GLOBAL_DIFF_DEBUG_FUNCTION];
+    const diffState = diffDebugFunction ? diffDebugFunction() : false;
+    const diffStateCleaned = JSON.parse(JSON.stringify(diffState));
+
+    const output = JSON.stringify(
+      {
+        events,
+        diffState: diffStateCleaned,
+      },
+      null,
+      2
+    );
+
+    const blob = new Blob([output], { type: 'application/json' });
+    const url = window.URL.createObjectURL(blob);
+
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `debug-optic-state-${Math.floor(Date.now() / 1000)}.json`;
+    console.log(link);
+    link.click();
+  };
+};
+
+export const DebugOpticComponent: FC<{
+  specService: IOpticSpecRepository;
+}> = ({ specService }) => {
+  useEffect(() => {
+    window.debugOptic = debugDump(specService);
+  }, [specService]);
+  return null;
+};

--- a/workspaces/ui-v2/src/components/index.ts
+++ b/workspaces/ui-v2/src/components/index.ts
@@ -1,4 +1,5 @@
 export * from './CommitMessageModal';
+export * from './DebugOpticComponent';
 export * from './EditableTextField';
 export * from './EndpointName';
 export * from './FieldOrParameter';

--- a/workspaces/ui-v2/src/contexts/MetadataLoader.tsx
+++ b/workspaces/ui-v2/src/contexts/MetadataLoader.tsx
@@ -24,7 +24,7 @@ export const MetadataLoader: FC = ({ children }) => {
   }
   if (result.error) {
     console.error(result.error);
-    return <>error</>;
+    return <>error loading app metadata</>;
   }
 
   return <>{children}</>;

--- a/workspaces/ui-v2/src/entry-points/cloud/cloud-viewer.tsx
+++ b/workspaces/ui-v2/src/entry-points/cloud/cloud-viewer.tsx
@@ -11,7 +11,7 @@ import { Provider as BaseUrlProvider } from '<src>/hooks/useBaseUrl';
 import { makeSpectacle, SpectacleInput } from '@useoptic/spectacle';
 import { DocumentationPages } from '<src>/pages/docs';
 import { SpectacleStore } from '<src>/contexts/spectacle-provider';
-import { Loading } from '<src>/components';
+import { Loading, DebugOpticComponent } from '<src>/components';
 import { DiffReviewEnvironments } from '<src>/pages/diffs/ReviewDiffPages';
 import { IBaseSpectacle } from '@useoptic/spectacle';
 import { IForkableSpectacle } from '@useoptic/spectacle';
@@ -128,6 +128,9 @@ export default function CloudViewer() {
                   initialize={initialize}
                   track={track}
                 >
+                  <DebugOpticComponent
+                    specService={data.opticContext.specRepository}
+                  />
                   <MetadataLoader>
                     <Switch>
                       <Route

--- a/workspaces/ui-v2/src/entry-points/demo/demo-examples.tsx
+++ b/workspaces/ui-v2/src/entry-points/demo/demo-examples.tsx
@@ -10,7 +10,7 @@ import { Provider as ReduxProvider } from 'react-redux';
 import { Provider as BaseUrlProvider } from '<src>/hooks/useBaseUrl';
 import { DocumentationPages } from '<src>/pages/docs';
 import { SpectacleStore } from '<src>/contexts/spectacle-provider';
-import { Loading } from '<src>/components';
+import { Loading, DebugOpticComponent } from '<src>/components';
 import { DiffReviewEnvironments } from '<src>/pages/diffs/ReviewDiffPages';
 import {
   InMemoryOpticContextBuilder,
@@ -102,6 +102,9 @@ export default function DemoExamples(props: { lookupDir: string }) {
                   initialize={initialize}
                   track={track}
                 >
+                  <DebugOpticComponent
+                    specService={data.opticContext.specRepository}
+                  />
                   <MetadataLoader>
                     <Switch>
                       <Route

--- a/workspaces/ui-v2/src/entry-points/local/local-cli.tsx
+++ b/workspaces/ui-v2/src/entry-points/local/local-cli.tsx
@@ -15,7 +15,7 @@ import { SpectacleStore } from '<src>/contexts/spectacle-provider';
 import { DiffReviewEnvironments } from '<src>/pages/diffs/ReviewDiffPages';
 import { CapturesServiceStore } from '<src>/hooks/useCapturesHook';
 import { ChangelogPages } from '<src>/pages/changelog/ChangelogPages';
-import { Loading } from '<src>/components';
+import { Loading, DebugOpticComponent } from '<src>/components';
 import {
   AppConfigurationStore,
   OpticAppConfig,
@@ -27,6 +27,7 @@ import {
   LocalCliConfigRepository,
   LocalCliServices,
   LocalCliSpectacle,
+  LocalCliSpecRepository,
 } from '@useoptic/spectacle-shared';
 import { AnalyticsStore } from '<src>/contexts/analytics';
 import {
@@ -55,6 +56,7 @@ const appConfig: OpticAppConfig = {
     },
   },
 };
+
 export default function LocalCli() {
   const match = useRouteMatch();
   const params = useParams<{ specId: string }>();
@@ -84,6 +86,7 @@ export default function LocalCli() {
                   initialize={initialize}
                   track={track}
                 >
+                  <DebugOpticComponent specService={data.specRepository} />
                   <MetadataLoader>
                     <Switch>
                       <Route
@@ -140,8 +143,15 @@ export function useLocalCliServices(
     baseUrl: apiBaseUrl,
     spectacle,
   });
+  const specRepository = new LocalCliSpecRepository({ baseUrl: apiBaseUrl });
   return {
     loading: false,
-    data: { spectacle, capturesService, opticEngine, configRepository },
+    data: {
+      spectacle,
+      capturesService,
+      opticEngine,
+      configRepository,
+      specRepository,
+    },
   };
 }

--- a/workspaces/ui-v2/src/entry-points/local/public-examples.tsx
+++ b/workspaces/ui-v2/src/entry-points/local/public-examples.tsx
@@ -10,7 +10,7 @@ import { Provider as ReduxProvider } from 'react-redux';
 import { Provider as BaseUrlProvider } from '<src>/hooks/useBaseUrl';
 import { DocumentationPages } from '<src>/pages/docs';
 import { SpectacleStore } from '<src>/contexts/spectacle-provider';
-import { Loading } from '<src>/components';
+import { Loading, DebugOpticComponent } from '<src>/components';
 import { DiffReviewEnvironments } from '<src>/pages/diffs/ReviewDiffPages';
 import {
   InMemoryOpticContextBuilder,
@@ -102,6 +102,9 @@ export default function PublicExamples(props: { lookupDir: string }) {
                   initialize={initialize}
                   track={track}
                 >
+                  <DebugOpticComponent
+                    specService={data.opticContext.specRepository}
+                  />
                   <MetadataLoader>
                     <Switch>
                       <Route

--- a/workspaces/ui-v2/src/pages/changelog/ChangelogEndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/changelog/ChangelogEndpointRootPage.tsx
@@ -82,7 +82,7 @@ const ChangelogRootComponent: FC<
     return <Loading />;
   }
   if (endpointsState.error) {
-    return <>error</>;
+    return <>error loading endpoint changelog information</>;
   }
 
   if (!thisEndpoint) {

--- a/workspaces/ui-v2/src/pages/diffs/contexts/SharedDiffContext.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/contexts/SharedDiffContext.tsx
@@ -1,4 +1,11 @@
-import React, { FC, useContext, useEffect, useMemo, useState } from 'react';
+import React, {
+  FC,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import {
   IPendingEndpoint,
   IUndocumentedUrl,
@@ -26,6 +33,7 @@ import { useAnalytics } from '<src>/contexts/analytics';
 import { makePattern } from '<src>/pages/diffs/AddEndpointsPage/utils';
 import { IPath } from '<src>/hooks/usePathsHook';
 import { pathToRegexpEscaped } from '<src>/utils';
+import { useGlobalDiffDebug } from '<src>/components';
 
 export const SharedDiffReactContext = React.createContext<ISharedDiffContext | null>(
   null
@@ -173,6 +181,17 @@ export const SharedDiffStore: FC<SharedDiffStoreProps> = (props) => {
       method: string;
     };
   }>({});
+
+  useGlobalDiffDebug(
+    useCallback(
+      () => ({
+        context,
+        wipPatterns,
+        currentSpecContext,
+      }),
+      [context, wipPatterns, currentSpecContext]
+    )
+  );
 
   const wipPatternMatchers = Object.entries(wipPatterns)
     .filter(([, { isParameterized }]) => isParameterized)


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Revived debugOptic so it dumps relevant debugging information. Also updated the error page to be simpler and more streamlined (sending debug state is the most effective way for us to track errors if we've missed handling cases anywhere in the app).

## What
What's changing? Anything of note to call out?

The debugOptic function now:
- Returns the spec events
- Dumps the SharedDiffContext state - this is effectively everything that has passed through the diffing process. Any errors in the rust process perhaps should be dumped out into a debug dump log? Although we have sentry errors sent (it would be nice to get captures / dump logs of interactions that caused the rust engine to die.

The updated error UI looks like
<img width="1749" alt="Screen Shot 2021-06-15 at 10 34 33 AM" src="https://user-images.githubusercontent.com/18374483/122098906-46348d80-cdc6-11eb-9396-75e0f1b99cb1.png">


## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
