### PR TITLE
Add specId to user saved doc changes event

### DIFF
--- a/workspaces/analytics/src/uiEvents.ts
+++ b/workspaces/analytics/src/uiEvents.ts
@@ -59,11 +59,12 @@ export class OpticUIEvents {
 
   userSavedDocChanges(
     deletedEndpointCount: number,
-    contributionChangesCount: number
+    contributionChangesCount: number,
+    specId: string
   ) {
     this.dispatch({
       type: 'user_saved_documentation_changes',
-      data: { deletedEndpointCount, contributionChangesCount },
+      data: { deletedEndpointCount, contributionChangesCount, specId },
     });
   }
 

--- a/workspaces/ui-v2/src/pages/docs/components/EditContributionsButton.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/EditContributionsButton.tsx
@@ -26,6 +26,9 @@ export function EditContributionsButton() {
   const isEditing = useAppSelector(
     (state) => state.documentationEdits.isEditing
   );
+  const specId = useAppSelector(
+    (state) => state.metadata.data?.specificationId!
+  );
   const commitModalOpen = useAppSelector(
     (state) => state.documentationEdits.commitModalOpen
   );
@@ -66,7 +69,8 @@ export function EditContributionsButton() {
       .then(() => {
         analytics.userSavedDocChanges(
           deletedEndpointCount,
-          pendingCount - deletedEndpointCount
+          pendingCount - deletedEndpointCount,
+          specId
         );
         if (shouldRedirect) {
           history.push(documentationPageRoute.linkTo());


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

This is on the diff save flow, adding to the documentation save flow

An easier way to do this in the future is run this through the redux store and add a middleware layer that acts as context

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
