### PR TITLE
Fix endpoint removal when endpoint is the last endpoint in the spec

### DIFF
--- a/workspaces/optic-engine/src/queries/endpoint.rs
+++ b/workspaces/optic-engine/src/queries/endpoint.rs
@@ -170,6 +170,7 @@ impl<'a> EndpointQueries<'a> {
           }
         }
         DfsEvent::Finish(finished_node_index, time) => {
+          let is_root_node = *root_path_node_index == finished_node_index;
           let path_id = path_ids_by_index
             .get(&finished_node_index)
             .expect("finished path node should already have been discovered");
@@ -180,12 +181,12 @@ impl<'a> EndpointQueries<'a> {
             .iter()
             .any(|child_path_id| !unused_path_ids.contains(*child_path_id));
 
-          if !path_ids_with_endpoints.contains(path_id) && !has_used_child {
+          if !path_ids_with_endpoints.contains(path_id) && !has_used_child && !is_root_node {
             unused_path_ids.insert(path_id.clone());
             unused_path_ids_sorted.push(path_id.clone());
           }
 
-          if *root_path_node_index == finished_node_index {
+          if is_root_node {
             Control::Break(())
           } else {
             Control::Continue

--- a/workspaces/ui-v2/src/store/documentationEdit/thunks.ts
+++ b/workspaces/ui-v2/src/store/documentationEdit/thunks.ts
@@ -71,12 +71,16 @@ export const saveDocumentationChanges = createAsyncThunk<
     const deleteCommands: CQRSCommand[] = (
       await Promise.all(
         deletedEndpoints.map(({ pathId, method }) =>
-          fetchDeleteEndpointCommands(spectacle, pathId, method)
+          fetchDeleteEndpointCommands(
+            spectacle,
+            pathId,
+            method
+          ).then((deleteCommands) =>
+            deleteCommands.concat([PrunePathComponents()])
+          )
         )
       )
-    )
-      .flatMap((x) => x)
-      .concat([PrunePathComponents()]);
+    ).flatMap((x) => x);
 
     const validContributions = getValidContributions(state);
 


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

When removing an endpoint and that endpoint is the last one in the node graph - PrunePathsCommand removes all nodes, and also marks the root node for removal - which cannot be done and rust panics!

## What
What's changing? Anything of note to call out?
We need to preserve the root node (since we can only have 1 unique id in the graph, and root is always a deterministic id and we are orphaning nodes). We also "can't" remove the root node since remove == orphan

Also updated the PrunePathsCommand to be appended to after every endpoint deletion (this is more "correct" and also does not add a PrunePathsCommand every time we create a contribution.

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
