### PR TITLE
Fix rust snapshots post rust release

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -72,6 +72,12 @@ jobs:
       uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d # v1.4.4
       with:
         node-version: "14.x"
+    - name: 'Rust toolchain'
+      uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # https://github.com/actions-rs/toolchain/commits/v1
+      with:
+        toolchain: stable
+        profile: minimal
+        override: true
     - name: Install Task
       run: curl -sL https://taskfile.dev/install.sh | sudo bash -s -- -b /usr/local/bin/
     - name: "install dependencies, build, and test"

--- a/workspaces/optic-engine/tests/snapshots/events__spec_should_deserialize.snap
+++ b/workspaces/optic-engine/tests/snapshots/events__spec_should_deserialize.snap
@@ -1,5 +1,5 @@
 ---
-source: workspaces/optic-engine-native/tests/events.rs
+source: workspaces/optic-engine/tests/events.rs
 expression: events
 ---
 [
@@ -9238,7 +9238,7 @@ expression: events
         BatchCommitStarted(
             BatchCommitStarted {
                 batch_id: "2c11ed2c-d28a-4711-ad6d-dae57a072d81",
-                commit_message: "\n\nChanges:\n- Added \'400\' Response with \'application/json\' Content-Type ",
+                commit_message: "\n\nChanges:\n- Added '400' Response with 'application/json' Content-Type ",
                 event_context: Some(
                     EventContext {
                         client_id: "anonymous",
@@ -9465,7 +9465,7 @@ expression: events
         BatchCommitStarted(
             BatchCommitStarted {
                 batch_id: "ef3911d5-a55e-4542-bcd5-df906451df39",
-                commit_message: "\n\nChanges:\n- Added \'200\' Response with \'application/json\' Content-Type ",
+                commit_message: "\n\nChanges:\n- Added '200' Response with 'application/json' Content-Type ",
                 event_context: Some(
                     EventContext {
                         client_id: "anonymous",
@@ -10459,7 +10459,7 @@ expression: events
         BatchCommitStarted(
             BatchCommitStarted {
                 batch_id: "84008f7c-c965-469d-a71e-e4f61fe8939a",
-                commit_message: "\n\nChanges:\n- Added \'200\' Response with \'application/json\' Content-Type ",
+                commit_message: "\n\nChanges:\n- Added '200' Response with 'application/json' Content-Type ",
                 event_context: Some(
                     EventContext {
                         client_id: "anonymous",


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

It looks like the latest rust version that got released today changed snapshot behavior https://blog.rust-lang.org/2021/06/17/Rust-1.53.0.html - see failing run here https://github.com/opticdev/optic/runs/2851483321

Specifically escaping `'` - I don't see this in the patch notes, but I imagine that this would not be a user facing change?

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
