### PR TITLE
Use spectacle path parameters for path grouping

### DIFF
--- a/workspaces/ui-v2/src/pages/changelog/ChangelogListPage.tsx
+++ b/workspaces/ui-v2/src/pages/changelog/ChangelogListPage.tsx
@@ -55,7 +55,9 @@ export function ChangelogRootPage(props: { changelogBatchId: string }) {
 
   const groupedEndpoints = useMemo(() => {
     const commonStart = findLongestCommonPath(
-      filteredAndMappedEndpoints.map((endpoint) => endpoint.fullPath)
+      filteredAndMappedEndpoints.map((endpoint) =>
+        endpoint.pathParameters.map((pathParameter) => pathParameter.name)
+      )
     );
     const endpointsWithGroups = filteredAndMappedEndpoints.map((endpoint) => ({
       ...endpoint,

--- a/workspaces/ui-v2/src/pages/docs/DocumentationRootPage/DocumentationRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/docs/DocumentationRootPage/DocumentationRootPage.tsx
@@ -46,8 +46,11 @@ export function DocumentationRootPage() {
 
   const groupedEndpoints = useMemo(() => {
     const commonStart = findLongestCommonPath(
-      filteredEndpoints.map((endpoint) => endpoint.fullPath)
+      filteredEndpoints.map((endpoint) =>
+        endpoint.pathParameters.map((pathParameter) => pathParameter.name)
+      )
     );
+
     const endpointsWithGroups = filteredEndpoints.map((endpoint) => ({
       ...endpoint,
       // If there is only one endpoint, split['/'][1] returns undefined since

--- a/workspaces/ui-v2/src/utils/__tests__/findLongestCommonPath.ts
+++ b/workspaces/ui-v2/src/utils/__tests__/findLongestCommonPath.ts
@@ -2,17 +2,21 @@ import { findLongestCommonPath } from '../findLongestCommonPath';
 
 describe('findLongestCommonPath', () => {
   test('returns the shared start for a list of items', () => {
-    const endpointNames = ['/api/list', '/api/:apiId', '/api/todos'];
+    const endpointNames = ['/api/list', '/api/:apiId', '/api/todos'].map((s) =>
+      s.split('/')
+    );
     expect(findLongestCommonPath(endpointNames)).toBe('/api');
   });
 
   test('returns the shared start with same letters following slash', () => {
-    const endpointNames = ['/api/list', '/api/liststs'];
+    const endpointNames = ['/api/list', '/api/liststs'].map((s) =>
+      s.split('/')
+    );
     expect(findLongestCommonPath(endpointNames)).toBe('/api');
   });
 
   test('returns the shared start for a single item', () => {
-    const endpointNames = ['/api/list'];
+    const endpointNames = ['/api/list'].map((s) => s.split('/'));
     expect(findLongestCommonPath(endpointNames)).toBe('/api/list');
   });
 

--- a/workspaces/ui-v2/src/utils/findLongestCommonPath.ts
+++ b/workspaces/ui-v2/src/utils/findLongestCommonPath.ts
@@ -1,9 +1,8 @@
-export function findLongestCommonPath(paths: string[]): string {
+export function findLongestCommonPath(paths: string[][]): string {
   if (paths.length === 0) return '/';
   let match: string[] = [];
-  const splitPaths = paths.map((path) => path.split('/'));
   // sorted paths by lengths ascending
-  const sortedPaths = splitPaths
+  const sortedPaths = paths
     .concat()
     .sort((a, b) => (a.length - b.length > 0 ? 1 : -1));
   const shortestPath = sortedPaths[0];


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

As promised - following this Pr comment https://github.com/opticdev/optic/pull/893/files#r653776706 - updating the path grouping to use the spectacle provided paths

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
