### PR TITLE
Pass errors onto sentry for network calls

### DIFF
--- a/workspaces/ui-v2/src/store/documentationEdit/thunks.ts
+++ b/workspaces/ui-v2/src/store/documentationEdit/thunks.ts
@@ -1,5 +1,6 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import { v4 as uuidv4 } from 'uuid';
+import * as Sentry from '@sentry/react';
 import {
   AddContribution,
   CQRSCommand,
@@ -23,30 +24,36 @@ const fetchDeleteEndpointCommands = async (
   pathId: string,
   method: string
 ): Promise<CQRSCommand[]> => {
-  const results = await spectacle.query<
-    EndpointProjection,
-    {
-      pathId: string;
-      method: string;
-    }
-  >({
-    query: `
-    query X($pathId: ID, $method: String) {
-      endpoint(pathId: $pathId, method: $method) {
-        commands {
-          remove
-        }
+  try {
+    const results = await spectacle.query<
+      EndpointProjection,
+      {
+        pathId: string;
+        method: string;
       }
-    }`,
-    variables: {
-      pathId,
-      method,
-    },
-  });
-  if (results.errors) {
-    throw new Error();
+    >({
+      query: `
+      query X($pathId: ID, $method: String) {
+        endpoint(pathId: $pathId, method: $method) {
+          commands {
+            remove
+          }
+        }
+      }`,
+      variables: {
+        pathId,
+        method,
+      },
+    });
+    if (results.errors) {
+      throw new Error();
+    }
+    return results.data!.endpoint.commands.remove;
+  } catch (e) {
+    console.error(e);
+    Sentry.captureException(e);
+    throw e;
   }
-  return results.data!.endpoint.commands.remove;
 };
 
 export const saveDocumentationChanges = createAsyncThunk<
@@ -96,34 +103,40 @@ export const saveDocumentationChanges = createAsyncThunk<
     const commands = [...deleteCommands, ...contributionCommands];
 
     if (commands.length > 0) {
-      await spectacle.mutate({
-        query: `
-      mutation X(
-        $commands: [JSON],
-        $batchCommitId: ID,
-        $commitMessage: String,
-        $clientId: ID,
-        $clientSessionId: ID
-      ) {
-        applyCommands(
-          commands: $commands,
-          batchCommitId: $batchCommitId,
-          commitMessage: $commitMessage,
-          clientId: $clientId,
-          clientSessionId: $clientSessionId
-        ) {
-          batchCommitId
-        }
+      try {
+        await spectacle.mutate({
+          query: `
+          mutation X(
+            $commands: [JSON],
+            $batchCommitId: ID,
+            $commitMessage: String,
+            $clientId: ID,
+            $clientSessionId: ID
+          ) {
+            applyCommands(
+              commands: $commands,
+              batchCommitId: $batchCommitId,
+              commitMessage: $commitMessage,
+              clientId: $clientId,
+              clientSessionId: $clientSessionId
+            ) {
+              batchCommitId
+            }
+          }
+        `,
+          variables: {
+            commands,
+            commitMessage,
+            batchCommitId: uuidv4(),
+            clientId,
+            clientSessionId,
+          },
+        });
+      } catch (e) {
+        console.error(e);
+        Sentry.captureException(e);
+        throw e;
       }
-      `,
-        variables: {
-          commands,
-          commitMessage,
-          batchCommitId: uuidv4(),
-          clientId,
-          clientSessionId,
-        },
-      });
     }
   }
 );

--- a/workspaces/ui-v2/src/store/metadata.ts
+++ b/workspaces/ui-v2/src/store/metadata.ts
@@ -4,6 +4,7 @@ import {
   SerializedError,
 } from '@reduxjs/toolkit';
 import { v4 as uuidv4 } from 'uuid';
+import * as Sentry from '@sentry/react';
 
 import { Client } from '@useoptic/cli-client';
 import {
@@ -49,18 +50,23 @@ const fetchMetadata = createAsyncThunk(
         return result.data.metadata.id;
       });
 
-    const [apiName, clientAgent, specificationId] = await Promise.all([
-      apiNamePromise,
-      clientAgentPromise,
-      specMetadataPromise,
-    ]);
-
-    return {
-      apiName,
-      clientAgent,
-      specificationId,
-      sessionId: uuidv4(),
-    };
+    try {
+      const [apiName, clientAgent, specificationId] = await Promise.all([
+        apiNamePromise,
+        clientAgentPromise,
+        specMetadataPromise,
+      ]);
+      return {
+        apiName,
+        clientAgent,
+        specificationId,
+        sessionId: uuidv4(),
+      };
+    } catch (e) {
+      console.error(e);
+      Sentry.captureException(e);
+      throw e;
+    }
   }
 );
 


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Trying to add more visibility into sentry errors. The reason we need this is because redux does not cause our errors to bubble up, which means the sentry global onerror handler doesn't catch on certain things.

I also did notice during testing this, the elusive `Network Error` is because the daemon crashes (probably from rust code panicing)

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
