### PR TITLE
New fields, within objects, inside of lists [BREAK] -> Do not break

### DIFF
--- a/workspaces/shape-hash/src/json-to-shape-hash.ts
+++ b/workspaces/shape-hash/src/json-to-shape-hash.ts
@@ -76,14 +76,18 @@ function toJson(item: any) {
   switch (item.type) {
     case types.OBJECT:
       const newObj: Record<string, any> = {};
-      if (item.hasOwnProperty('fields')) { 
+      if (item.hasOwnProperty('fields')) {
         item.fields.forEach(({ key, hash }: any) => {
           newObj[key] = toJson(hash);
         });
       }
       return newObj;
     case types.ARRAY:
-      return [...item.items.map(toJson)];
+      if (item.hasOwnProperty('items')) {
+        return [...item.items.map(toJson)];
+      } else {
+        return [];
+      }
     case types.STRING:
       return 'string';
     case types.NUMBER:

--- a/workspaces/ui-v2/src/lib/__tests/diff-helpers/__snapshots__/shape-interpretations.test.ts.snap
+++ b/workspaces/ui-v2/src/lib/__tests/diff-helpers/__snapshots__/shape-interpretations.test.ts.snap
@@ -2100,6 +2100,7 @@ Object {
     ],
     "lastList": "shape_7",
     "lastListItem": "shape_6",
+    "lastObject": undefined,
   },
   "preview": Object {
     "diffDescription": Object {
@@ -3859,6 +3860,7 @@ Object {
     ],
     "lastList": "shape_13",
     "lastListItem": "shape_12",
+    "lastObject": "shape_12",
   },
   "preview": Object {
     "diffDescription": Object {
@@ -4129,6 +4131,7 @@ Object {
     ],
     "lastList": "shape_13",
     "lastListItem": "shape_12",
+    "lastObject": "shape_12",
   },
   "preview": Object {
     "diffDescription": Object {
@@ -4387,6 +4390,7 @@ Object {
     ],
     "lastList": "shape_13",
     "lastListItem": "shape_12",
+    "lastObject": "shape_12",
   },
   "preview": Object {
     "diffDescription": Object {
@@ -5672,6 +5676,7 @@ Object {
     ],
     "lastList": "baseline-shape_5",
     "lastListItem": "baseline-shape_4",
+    "lastObject": undefined,
   },
   "preview": Object {
     "diffDescription": Object {
@@ -6009,6 +6014,7 @@ Object {
     ],
     "lastList": "baseline-shape_5",
     "lastListItem": "baseline-shape_4",
+    "lastObject": undefined,
   },
   "preview": Object {
     "diffDescription": Object {

--- a/workspaces/ui-v2/src/lib/shape-trail-parser.ts
+++ b/workspaces/ui-v2/src/lib/shape-trail-parser.ts
@@ -89,7 +89,13 @@ export async function shapeTrailParserLastId(
     if (lastTrail.hasOwnProperty('ListItemTrail')) {
       const listItemTrail = (lastTrail as IListItemTrail).ListItemTrail;
       const choices = await getChoices(listItemTrail.itemShapeId, spectacle);
+
+      const lastObjectOption = Object.entries(
+        choices.allowedCoreShapeKindsByShapeId
+      ).find(([key, value]) => value === ICoreShapeKinds.ObjectKind);
+
       return {
+        lastObject: lastObjectOption ? lastObjectOption[0] : undefined,
         lastList: listItemTrail.listShapeId,
         lastListItem: listItemTrail.itemShapeId,
         ...choices,


### PR DESCRIPTION
## Why
We tracked down a bunch of the Optic 10 diff issues folks have been having and they seem to have a small/common cause. The new shape trail parser did not include the object ID when the last shape trail was `ListItemTrail`, and the list shape could be an object. 

This meant that the diff would be interpreted as a new field, but when it tried to lookup the object it had to attach itself to, it would hit an invariant we coded. 

## What
The shape trail parser has been updated. Interestingly, we do have snapshot tests for this scenerio, but we didn't make a strong assertion that the lastObject should be defined in these cases. Lots of JSON to approve, it was simply missed. I've updated the cases and manually reviewed them. 

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
