### PR TITLE
Prevent root node from being learnt multiple times

### DIFF
--- a/workspaces/optic-engine/src/queries/endpoint.rs
+++ b/workspaces/optic-engine/src/queries/endpoint.rs
@@ -41,9 +41,6 @@ impl<'a> EndpointQueries<'a> {
   }
 
   pub fn resolve_path(&self, path: &str) -> Option<PathComponentIdRef> {
-    // If the path is a root path, we need to check it separately
-    // There is always going to be a node for the root path, so we need to check
-    // If it has been learnt, there will be an associated HTTP method
     if path.eq("/") {
       return Some(ROOT_PATH_ID);
     }
@@ -541,6 +538,19 @@ mod test {
       {"ResponseAddedByPathAndMethod": {"responseId": "response_1", "pathId": "root", "httpMethod": "GET", "httpStatusCode": 200 }},
     ]))
     .expect("should be able to deserialize test events");
+
+    let spec_projection = SpecProjection::from(events);
+    // dbg!(Dot::with_config(&spec_projection.endpoint().graph, &[]));
+
+    let endpoint_queries = EndpointQueries::new(spec_projection.endpoint());
+
+    assert_eq!(endpoint_queries.resolve_path("/").unwrap(), "root");
+  }
+
+  #[test]
+  pub fn resolve_path_should_resolve_against_an_empty_spec() {
+    let events: Vec<SpecEvent> =
+      serde_json::from_value(json!([])).expect("should be able to deserialize test events");
 
     let spec_projection = SpecProjection::from(events);
     // dbg!(Dot::with_config(&spec_projection.endpoint().graph, &[]));

--- a/workspaces/optic-engine/src/queries/endpoint.rs
+++ b/workspaces/optic-engine/src/queries/endpoint.rs
@@ -45,26 +45,7 @@ impl<'a> EndpointQueries<'a> {
     // There is always going to be a node for the root path, so we need to check
     // If it has been learnt, there will be an associated HTTP method
     if path.eq("/") {
-      let root_path_node_index = self
-        .graph_get_index(ROOT_PATH_ID)
-        .expect("expected a node with node_id to exist");
-
-      let mut has_root_requests = false;
-      for child in self.graph_get_children(root_path_node_index) {
-        let child_node = self.endpoint_projection.graph.node_weight(child).unwrap();
-        match child_node {
-          Node::HttpMethod(..) => {
-            has_root_requests = true;
-            break;
-          }
-          _ => {}
-        }
-      }
-      return if has_root_requests {
-        Some(ROOT_PATH_ID)
-      } else {
-        None
-      };
+      return Some(ROOT_PATH_ID);
     }
 
     let path = Self::extract_normalized_path(path);
@@ -567,24 +548,6 @@ mod test {
     let endpoint_queries = EndpointQueries::new(spec_projection.endpoint());
 
     assert_eq!(endpoint_queries.resolve_path("/").unwrap(), "root");
-  }
-
-  #[test]
-  pub fn resolve_path_does_not_include_root_when_no_methods_attached() {
-    let events: Vec<SpecEvent> = serde_json::from_value(json!([
-      {"PathComponentAdded": { "pathId": "path_1", "parentPathId": "root", "name": "posts" }},
-      {"PathComponentAdded": { "pathId": "path_2", "parentPathId": "path_1", "name": "favourites" }},
-      {"PathComponentAdded": { "pathId": "path_3", "parentPathId": "root", "name": "authors" }},
-      {"PathComponentAdded": { "pathId": "path_4", "parentPathId": "path_3", "name": "dutch" }},
-    ]))
-    .expect("should be able to deserialize test events");
-
-    let spec_projection = SpecProjection::from(events);
-    // dbg!(Dot::with_config(&spec_projection.endpoint().graph, &[]));
-
-    let endpoint_queries = EndpointQueries::new(spec_projection.endpoint());
-
-    assert_eq!(endpoint_queries.resolve_path("/"), None);
   }
 
   #[test]

--- a/workspaces/ui-v2/src/hooks/useGroupedEndpoints.ts
+++ b/workspaces/ui-v2/src/hooks/useGroupedEndpoints.ts
@@ -1,0 +1,21 @@
+import { useMemo } from 'react';
+import groupBy from 'lodash.groupby';
+
+import { IEndpoint } from '<src>/types';
+import { findLongestCommonPath } from '<src>/utils';
+
+export const useGroupedEndpoints = <T extends IEndpoint>(endpoints: T[]) => {
+  return useMemo(() => {
+    const commonStart = findLongestCommonPath(
+      endpoints.map((endpoint) => endpoint.fullPath)
+    );
+    const endpointsWithGroups = endpoints.map((endpoint) => ({
+      ...endpoint,
+      // If there is only one endpoint, split['/'][1] returns undefined since
+      // commonStart.length === endpoint.fullPath.length
+      group: endpoint.fullPath.slice(commonStart.length).split('/')[1] || '',
+    }));
+
+    return groupBy(endpointsWithGroups, 'group');
+  }, [endpoints]);
+};

--- a/workspaces/ui-v2/src/pages/changelog/ChangelogListPage.tsx
+++ b/workspaces/ui-v2/src/pages/changelog/ChangelogListPage.tsx
@@ -1,10 +1,9 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC } from 'react';
 import {
   RouteComponentProps,
   useHistory,
   useRouteMatch,
 } from 'react-router-dom';
-import groupBy from 'lodash.groupby';
 import classNames from 'classnames';
 
 import {
@@ -19,12 +18,12 @@ import { useChangelogStyles } from '<src>/pages/changelog/components/ChangelogBa
 import { useEndpointsChangelog } from '<src>/hooks/useEndpointsChangelog';
 import { selectors, useAppSelector } from '<src>/store';
 import { IEndpointWithChanges } from '<src>/types';
-import { findLongestCommonPath } from '<src>/utils';
 
 import {
   ChangelogPageAccessoryNavigation,
   ValidateBatchId,
 } from './components';
+import { useGroupedEndpoints } from '<src>/hooks/useGroupedEndpoints';
 
 export const ChangelogListPage: FC<
   RouteComponentProps<{
@@ -53,19 +52,7 @@ export function ChangelogRootPage(props: { changelogBatchId: string }) {
   const history = useHistory();
   const match = useRouteMatch();
 
-  const groupedEndpoints = useMemo(() => {
-    const commonStart = findLongestCommonPath(
-      filteredAndMappedEndpoints.map((endpoint) => endpoint.fullPath)
-    );
-    const endpointsWithGroups = filteredAndMappedEndpoints.map((endpoint) => ({
-      ...endpoint,
-      // If there is only one endpoint, split['/'][1] returns undefined since
-      // commonStart.length === endpoint.fullPath.length
-      group: endpoint.fullPath.slice(commonStart.length).split('/')[1] || '',
-    }));
-
-    return groupBy(endpointsWithGroups, 'group');
-  }, [filteredAndMappedEndpoints]);
+  const groupedEndpoints = useGroupedEndpoints(filteredAndMappedEndpoints);
 
   const tocKeys = Object.keys(groupedEndpoints).sort();
   const changelogStyles = useChangelogStyles();

--- a/workspaces/ui-v2/src/pages/diffs/AddEndpointsPage/AddEndpointsPage.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/AddEndpointsPage/AddEndpointsPage.tsx
@@ -1,6 +1,5 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import groupBy from 'lodash.groupby';
 import classNames from 'classnames';
 import { makeStyles } from '@material-ui/styles';
 import { Check } from '@material-ui/icons';
@@ -26,6 +25,7 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 import { IPendingEndpoint } from '<src>/pages/diffs/contexts/SharedDiffState';
 import { useChangelogStyles } from '<src>/pages/changelog/components/ChangelogBackground';
 import { useRunOnKeypress } from '<src>/hooks/util';
+import { useGroupedEndpoints } from '<src>/hooks/useGroupedEndpoints';
 import { DiffAccessoryNavigation } from '<src>/pages/diffs/components/DiffAccessoryNavigation';
 import { selectors, useAppSelector } from '<src>/store';
 import { IEndpoint } from '<src>/types';
@@ -170,8 +170,9 @@ export function DocumentationRootPageWithPendingEndpoints() {
   const classes = useStyles();
 
   const diffReviewPagePendingEndpoint = useDiffReviewPagePendingEndpoint();
-  const grouped = useMemo(() => groupBy(endpoints, 'group'), [endpoints]);
-  const tocKeys = Object.keys(grouped).sort();
+  const groupedEndpoints = useGroupedEndpoints(endpoints);
+
+  const tocKeys = Object.keys(groupedEndpoints).sort();
   const changelogStyles = useChangelogStyles();
 
   const history = useHistory();
@@ -247,40 +248,42 @@ export function DocumentationRootPageWithPendingEndpoints() {
               >
                 {tocKey}
               </Typography>
-              {grouped[tocKey].map((endpoint: IEndpoint, index: number) => {
-                return (
-                  <ListItem
-                    key={index}
-                    button
-                    disableRipple
-                    disableGutters
-                    style={{ display: 'flex' }}
-                    onClick={() =>
-                      history.push(
-                        endpointPageLink.linkTo(
-                          endpoint.pathId,
-                          endpoint.method
+              {groupedEndpoints[tocKey].map(
+                (endpoint: IEndpoint, index: number) => {
+                  return (
+                    <ListItem
+                      key={index}
+                      button
+                      disableRipple
+                      disableGutters
+                      style={{ display: 'flex' }}
+                      onClick={() =>
+                        history.push(
+                          endpointPageLink.linkTo(
+                            endpoint.pathId,
+                            endpoint.method
+                          )
                         )
-                      )
-                    }
-                    className={classes.endpointRow}
-                  >
-                    <div className={classes.endpointNameContainer}>
-                      <EndpointName
-                        method={endpoint.method}
-                        fullPath={endpoint.fullPath}
-                        leftPad={6}
-                      />
-                    </div>
-                    <div
-                      className={classes.endpointContributionContainer}
-                      onClick={(e) => e.stopPropagation()}
+                      }
+                      className={classes.endpointRow}
                     >
-                      <ExistingEndpointNameField endpoint={endpoint} />
-                    </div>
-                  </ListItem>
-                );
-              })}
+                      <div className={classes.endpointNameContainer}>
+                        <EndpointName
+                          method={endpoint.method}
+                          fullPath={endpoint.fullPath}
+                          leftPad={6}
+                        />
+                      </div>
+                      <div
+                        className={classes.endpointContributionContainer}
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <ExistingEndpointNameField endpoint={endpoint} />
+                      </div>
+                    </ListItem>
+                  );
+                }
+              )}
             </div>
           );
         })}

--- a/workspaces/ui-v2/src/pages/diffs/ReviewDiffPages.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/ReviewDiffPages.tsx
@@ -59,7 +59,6 @@ export function DiffReviewPages(props: any) {
       </LoadingPage>
     );
   }
-  console.log(diff.data);
 
   return (
     <SharedDiffStore

--- a/workspaces/ui-v2/src/pages/docs/DocumentationRootPage/DocumentationRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/docs/DocumentationRootPage/DocumentationRootPage.tsx
@@ -1,5 +1,4 @@
-import React, { FC, useMemo } from 'react';
-import groupBy from 'lodash.groupby';
+import React, { FC } from 'react';
 import { Box, List, Typography } from '@material-ui/core';
 
 import { CenteredColumn, Loading, PageLayout } from '<src>/components';
@@ -10,8 +9,8 @@ import {
   selectors,
 } from '<src>/store';
 import { useRunOnKeypress } from '<src>/hooks/util';
+import { useGroupedEndpoints } from '<src>/hooks/useGroupedEndpoints';
 import { IEndpoint } from '<src>/types';
-import { findLongestCommonPath } from '<src>/utils';
 
 import { DocsPageAccessoryNavigation } from '../components';
 import { EndpointRow } from './EndpointRow';
@@ -44,19 +43,7 @@ export function DocumentationRootPage() {
     endpointsState.data || []
   );
 
-  const groupedEndpoints = useMemo(() => {
-    const commonStart = findLongestCommonPath(
-      filteredEndpoints.map((endpoint) => endpoint.fullPath)
-    );
-    const endpointsWithGroups = filteredEndpoints.map((endpoint) => ({
-      ...endpoint,
-      // If there is only one endpoint, split['/'][1] returns undefined since
-      // commonStart.length === endpoint.fullPath.length
-      group: endpoint.fullPath.slice(commonStart.length).split('/')[1] || '',
-    }));
-
-    return groupBy(endpointsWithGroups, 'group');
-  }, [filteredEndpoints]);
+  const groupedEndpoints = useGroupedEndpoints(filteredEndpoints);
 
   const tocKeys = Object.keys(groupedEndpoints).sort();
   const onKeyPress = useRunOnKeypress(


### PR DESCRIPTION
## Why
Describe the motivation for the changes.
Fixes:
- The root path node from being learnt multiple times
- Grouped endpoints showing up as `undefined`

The root path node can be learnt multiple times as when the interaction diff traverser gets a root path node, the `endpoint_queries.resolve_interaction_path(&interaction);` always returns `None` - https://github.com/opticdev/optic/blob/develop/workspaces/optic-engine/src/interactions/traverser.rs#L25

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
