### PR TITLE
Fix capture for context type text/html with no text body

### DIFF
--- a/workspaces/cli-shared/src/httptoolkit-capturing-proxy.ts
+++ b/workspaces/cli-shared/src/httptoolkit-capturing-proxy.ts
@@ -292,7 +292,7 @@ export class HttpToolkitCapturingProxy {
           asText:
             this.config.flags.includeTextBody && json
               ? null
-              : req.body.text || null,
+              : req.body.text || '',
         },
       };
     }

--- a/workspaces/ui-v2/src/pages/diffs/ReviewEndpointDiffPage/ReviewEndpointDiffPageContainer.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/ReviewEndpointDiffPage/ReviewEndpointDiffPageContainer.tsx
@@ -44,7 +44,7 @@ export const ReviewEndpointDiffContainer: FC<
 
   return (
     <PageLayout AccessoryNavigation={DiffAccessoryNavigation}>
-      {!endpoint || shapeDiffs.loading ? (
+      {!endpoint || shapeDiffs.loading || newRegionDiffs.loading ? (
         <Loading />
       ) : (
         <ReviewEndpointDiffPage


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

When a non-json response is returned with a content length 0 - the proxy captures this as null - when it should be an empty string. 

TODO
- [ ] test this proxy out and send 0 length non-json responses

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
