### PR TITLE
Fix rust snapshot tests

### DIFF
--- a/workspaces/optic-engine/tests/snapshots/events__spec_should_deserialize.snap
+++ b/workspaces/optic-engine/tests/snapshots/events__spec_should_deserialize.snap
@@ -9238,7 +9238,7 @@ expression: events
         BatchCommitStarted(
             BatchCommitStarted {
                 batch_id: "2c11ed2c-d28a-4711-ad6d-dae57a072d81",
-                commit_message: "\n\nChanges:\n- Added \'400\' Response with \'application/json\' Content-Type ",
+                commit_message: "\n\nChanges:\n- Added '400' Response with 'application/json' Content-Type ",
                 event_context: Some(
                     EventContext {
                         client_id: "anonymous",
@@ -9465,7 +9465,7 @@ expression: events
         BatchCommitStarted(
             BatchCommitStarted {
                 batch_id: "ef3911d5-a55e-4542-bcd5-df906451df39",
-                commit_message: "\n\nChanges:\n- Added \'200\' Response with \'application/json\' Content-Type ",
+                commit_message: "\n\nChanges:\n- Added '200' Response with 'application/json' Content-Type ",
                 event_context: Some(
                     EventContext {
                         client_id: "anonymous",
@@ -10459,7 +10459,7 @@ expression: events
         BatchCommitStarted(
             BatchCommitStarted {
                 batch_id: "84008f7c-c965-469d-a71e-e4f61fe8939a",
-                commit_message: "\n\nChanges:\n- Added \'200\' Response with \'application/json\' Content-Type ",
+                commit_message: "\n\nChanges:\n- Added '200' Response with 'application/json' Content-Type ",
                 event_context: Some(
                     EventContext {
                         client_id: "anonymous",


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Snapshot tests were updated in this commit https://github.com/opticdev/optic/commit/dc2011b586bd3869b378ef0ee40cc0b2b0271d6a  - a similar fix to this PR was applied in https://github.com/opticdev/optic/pull/896

## What
What's changing? Anything of note to call out?

FYI @acunniffe - I think you might be running an older version of rust on your machine (which is why those snapshots would have failed) - the behavior changed from `1.52.1` -> `1.53.0`

```
➜  rustc --version
rustc 1.53.0 (53cb7b09b 2021-06-17)
```

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
