### PR TITLE
Fix intercept mode not being able to diff

### DIFF
--- a/workspaces/cli-server/src/server.ts
+++ b/workspaces/cli-server/src/server.ts
@@ -159,7 +159,7 @@ class CliServer {
       bodyParser.json({ limit: '5kb' }),
       async (req, res: express.Response) => {
         const { path, taskConfig, captureId } = req.body;
-        if (captureId && taskConfig) {
+        if (captureId) {
           const paths = await getPathsRelativeToCwd(path);
           const { capturesPath } = paths;
           const capturesHelpers = new CapturesHelpers(capturesPath);

--- a/workspaces/local-cli/src/commands/intercept.ts
+++ b/workspaces/local-cli/src/commands/intercept.ts
@@ -155,6 +155,8 @@ export default class Intercept extends Command {
     );
 
     await sessionManager.run(persistenceManager);
+    await cliClient.markCaptureAsCompleted(cliSession.session.id, captureId);
+
     if (browsers) {
       browsers!.cleanup();
     }


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

`api --intercept` doesn't work as it doesn't save the `optic-capture-state`. This is captured in two places:
- findSession - which makes a post to `/api/sessions`. If the captureId is not null and there is task config, we save the optic capture state. I can't think of why we wouldn't want to save optic-capture-state when there is a captureId but no taskConfig. The places where captureId is not null is:
  - intercept https://github.com/opticdev/optic/blob/develop/workspaces/local-cli/src/commands/intercept.ts
  - local-cli-task-runner https://github.com/opticdev/optic/blob/develop/workspaces/local-cli/src/shared/local-cli-task-runner.ts
  - ingest-only-task-runner https://github.com/opticdev/optic/blob/develop/workspaces/local-cli/src/shared/ingest-only-task-runner.ts
- `cliClient.markCaptureAsCompleted` - this doesn't include the `metadata` field which means we should create the file through findSession

I don't know what `ingest-only-task-runner` is used for and if it is safe to create an `optic-capture-state` file, but this PR will create an optic-capture-state file for this

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
