### PR TITLE
Install rust toolchain for npm package release and side channel

### DIFF
--- a/.github/workflows/release-side-channel.yml
+++ b/.github/workflows/release-side-channel.yml
@@ -21,6 +21,12 @@ jobs:
         uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d # https://github.com/actions/setup-node/releases/tag/v1.4.4
         with:
           node-version: 14
+      - name: 'Rust toolchain'
+        uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # https://github.com/actions-rs/toolchain/commits/v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
       - name: Install Task
         uses: Arduino/actions/setup-taskfile@9d04a51fc17daddb0eb127933aaa950af1e3ff97 # they dont give us any tags :\
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,6 +227,12 @@ jobs:
     - uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d # https://github.com/actions/setup-node/releases/tag/v1.4.4
       with:
         node-version: 12
+    - name: 'Rust toolchain'
+      uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # https://github.com/actions-rs/toolchain/commits/v1
+      with:
+        toolchain: stable
+        profile: minimal
+        override: true
     - name: 'Caching node modules'
       uses: actions/cache@d1255ad9362389eac595a9ae406b8e8cb3331f16 # https://github.com/actions/cache/releases/tag/v2.1.2
       with:


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

https://github.com/opticdev/optic/pull/896#discussion_r653877736
> my guess is that the base container comes with a 1.52.0 version of rust, and when you run the rust-toolchain action, it upgrades it to 1.53.0

As a result, we should apply these to the release branches where we run the tests otherwise the tests fail and run a different verison of the build (I also noticed the side channel and the release workflow specify different versions of node - sidechannel == 14, release ==12) is there a better way to standardize this so we have the same env for our builds? @notnmeyer ?

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
