### PR TITLE
Use node-version 14 for releases

### DIFF
--- a/.github/workflows/build-ui-v2.yml
+++ b/.github/workflows/build-ui-v2.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Configure Node
         uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d # v1.4.4
         with:
-          node-version: 12
+          node-version: 14
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@1417e62aeacec5e7fbe447bb7712d50847507342 # v1.5.4
         with:

--- a/.github/workflows/regression-suites.yml
+++ b/.github/workflows/regression-suites.yml
@@ -34,7 +34,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@c46424eee26de4078d34105d3de3cc4992202b1e  # v2.1.4
         with:
-          node-version: 12
+          node-version: 14
       - name: Restore cached node_modules
         id: workspace-node-modules
         uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6  # v2.1.4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # https://github.com/actions/checkout/releases/tag/v2.3.3
       - uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d # https://github.com/actions/setup-node/releases/tag/v1.4.4
         with:
-          node-version: 12
+          node-version: 14
       - name: Install Task
         run: curl -sL https://taskfile.dev/install.sh | sudo bash -s -- -b /usr/local/bin/
       - name: Set version output
@@ -111,7 +111,7 @@ jobs:
         uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # https://github.com/actions/checkout/releases/tag/v2.3.3
       - uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d # https://github.com/actions/setup-node/releases/tag/v1.4.4
         with:
-          node-version: 12
+          node-version: 14
       - name: 'Determine version and archive name'
         shell: bash
         run: |
@@ -176,7 +176,7 @@ jobs:
       - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # https://github.com/actions/checkout/releases/tag/v2.3.3
       - uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d # https://github.com/actions/setup-node/releases/tag/v1.4.4
         with:
-          node-version: 12
+          node-version: 14
       - name: 'Determine version and archive name'
         run: |
           OPTIC_VERSION=${{ needs.release_logic.outputs.version }}
@@ -226,7 +226,7 @@ jobs:
       #   ref: release
     - uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d # https://github.com/actions/setup-node/releases/tag/v1.4.4
       with:
-        node-version: 12
+        node-version: 14
     - name: 'Caching node modules'
       uses: actions/cache@d1255ad9362389eac595a9ae406b8e8cb3331f16 # https://github.com/actions/cache/releases/tag/v2.1.2
       with:


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Re: https://github.com/opticdev/optic/pull/910#issuecomment-865312849 - specifying node version 14 - which is the latest LTS node version - keeping this separate and we can decide if we want to include this in the next release, or include this into the next release (the sidechannel build is on node version 14, everything else is on version 12)

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
