### PR TITLE
Fix sourcemap upload

### DIFF
--- a/workspaces/ui-v2/config/webpack.config.js
+++ b/workspaces/ui-v2/config/webpack.config.js
@@ -603,15 +603,8 @@ module.exports = function (webpackEnv) {
           project: 'local-ui',
           release: `local_cli_${appPackageJson.version}`,
           // webpack specific configuration
-          include: '.',
-          ignore: [
-            'node_modules',
-            'webpack.config.js',
-            'config',
-            'scripts',
-            'jest.config.js',
-            'setupTests.js',
-          ],
+          include: './build/',
+          ignore: [],
         }),
       // Inlines the webpack runtime script. This script is too small to warrant
       // a network request.


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Our sourcemaps were being uploaded under `~/build/static/js/chunkname.js` where they were being served via `~/static/js/chunkname.js` - specifying the `./build` directory is more correct here

Output of sourcemap build with debug command:
```bash
> Found 11 release files
> Analyzing 11 sources
> Rewriting sources
> Adding source map references
> Bundling files for upload... ~/static/js/2.4fbd248d> Bundling files for upload... ~/static/js/2.4fbd248d> Bundled 11 files for upload
> Uploaded release files to Sentry
> File upload complete (processing pending on server)

Source Map Upload Report
  Minified Scripts
    ~/static/js/2.4fbd248d.chunk.js (sourcemap at 2.4fbd248d.chunk.js.map)
    ~/static/js/3.1a933fa5.chunk.js (sourcemap at 3.1a933fa5.chunk.js.map)
    ~/static/js/4.bc8a9d6c.chunk.js (sourcemap at 4.bc8a9d6c.chunk.js.map)
    ~/static/js/main.bb272a4f.chunk.js (sourcemap at main.bb272a4f.chunk.js.map)
    ~/static/js/runtime-main.121f9a98.js (sourcemap at runtime-main.121f9a98.js.map)
  Source Maps
    ~/static/css/main.1ffa1dce.chunk.css.map
    ~/static/js/2.4fbd248d.chunk.js.map
    ~/static/js/3.1a933fa5.chunk.js.map
    ~/static/js/4.bc8a9d6c.chunk.js.map
    ~/static/js/main.bb272a4f.chunk.js.map
    ~/static/js/runtime-main.121f9a98.js.map
Compiled successfully.

File sizes after gzip:

  564.25 KB  build/static/js/2.4fbd248d.chunk.js
  76.44 KB   build/static/js/main.bb272a4f.chunk.js
  3.12 KB    build/static/js/3.1a933fa5.chunk.js
  2.12 KB    build/static/js/runtime-main.121f9a98.js
  1.57 KB    build/static/js/4.bc8a9d6c.chunk.js
  297 B      build/static/css/main.1ffa1dce.chunk.css
```

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
