### PR TITLE
docs: updated install instructions

### DIFF
--- a/website/blog/how-to-discuss-api-changes-during-code-review.md
+++ b/website/blog/how-to-discuss-api-changes-during-code-review.md
@@ -41,7 +41,7 @@ For this tutorial, I'm using a fork of the [sample-node-api](https://github.com/
 The Optic command-line interface (CLI) requires Node version 12+. Assuming you have a recent version of Node installed, run the following to install the CLI:
 
 ```shell
-npm install @useoptic/cli -g --legacy-peer-deps
+npm install @useoptic/cli -g
 ```
 
 The [Optic Quick Start guide](https://useoptic.com/docs/) also includes instructions for setting up Optic using [Yarn](https://yarnpkg.com/) or [Homebrew](https://brew.sh/) if you prefer.

--- a/website/docs/get-started/config.mdx
+++ b/website/docs/get-started/config.mdx
@@ -34,7 +34,7 @@ import TabItem from '@theme/TabItem';
 
 **When would I use intercept mode?** Intercept mode is ideal when the project lifecycle is not easily managed with a single command, or the project is located on a remote system (such as behind an Amazon API Gateway). Intercept mode will assist in launching your tools with the proper proxy configurations to make the process as seamless as possible. 
 
-**When the intercept mode may be counter-indicated:** If your application runs locally and you'd like to test against it, we'd recommend [running your API with Optic]](/docs/get-started/config/run-with-optic) as it helps manage your project lifecycle and sets up the proxy to be friendly to local tests and workflows.
+**When the intercept mode may be counter-indicated:** If your application runs locally and you'd like to test against it, we'd recommend [running your API with Optic](/docs/get-started/config/run-with-optic) as it helps manage your project lifecycle and sets up the proxy to be friendly to local tests and workflows.
 
 Only use a [proxy task](/docs/get-started/config/proxy) for new projects if these other options are not feasible.
 

--- a/website/docs/get-started/quickstart.mdx
+++ b/website/docs/get-started/quickstart.mdx
@@ -25,7 +25,7 @@ yarn global add @useoptic/cli
   <TabItem value="npm">
 
 ```bash
-npm install @useoptic/cli -g --legacy-peer-deps
+npm install @useoptic/cli -g
 ```
 
   </TabItem>

--- a/website/docs/integrations/cicd/circleci.mdx
+++ b/website/docs/integrations/cicd/circleci.mdx
@@ -47,7 +47,7 @@ commands:
     - run:
         name: Run Optic CI
         command: |-
-          npm install --legacy-peer-deps @useoptic/cli
+          npm install @useoptic/cli
           npx api run test-cci --exit-on-diff
           npx api status --print-coverage
 ```

--- a/website/docs/integrations/cicd/github-actions.mdx
+++ b/website/docs/integrations/cicd/github-actions.mdx
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4 (or choose the latest version)
 
       - name: Install Optic # Or add to your development/build dependencies in your package management
-        run: npm install --legacy-peer-deps @useoptic/cli
+        run: npm install @useoptic/cli
 
       - name: Run tests
         run: npx api run run-tests --exit-on-diff


### PR DESCRIPTION
## Why

Just cleaning up the install instructions, is all.

## What

We no longer need the `--legacy-peer-deps` flag. Yay!
