### PR TITLE
Implement a basic History page UI

### DIFF
--- a/workspaces/ui-v2/src/components/navigation/NavButton.tsx
+++ b/workspaces/ui-v2/src/components/navigation/NavButton.tsx
@@ -3,7 +3,6 @@ import { makeStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import Link from '@material-ui/core/Link';
 import { LightBlueBackground, OpticBlueReadable } from '<src>/styles';
-import { useHistory } from 'react-router-dom';
 
 export type NavButtonProps = {
   Icon: React.ElementType;
@@ -14,8 +13,6 @@ export type NavButtonProps = {
 export function NavButton(props: NavButtonProps) {
   const classes = useStyles();
   const { Icon, title, to } = props;
-
-  const history = useHistory();
 
   return (
     <Link className={classes.root} href={to}>

--- a/workspaces/ui-v2/src/components/navigation/NavButton.tsx
+++ b/workspaces/ui-v2/src/components/navigation/NavButton.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
+import Link from '@material-ui/core/Link';
 import { LightBlueBackground, OpticBlueReadable } from '<src>/styles';
 import { useHistory } from 'react-router-dom';
 
@@ -17,19 +18,14 @@ export function NavButton(props: NavButtonProps) {
   const history = useHistory();
 
   return (
-    <div
-      className={classes.root}
-      onClick={() => {
-        history.push(to);
-      }}
-    >
+    <Link className={classes.root} href={to}>
       <div className={classes.box}>
         <Icon className={classes.iconStyles} />
       </div>
       <Typography variant="subtitle2" className={classes.font}>
         {title}
       </Typography>
-    </div>
+    </Link>
   );
 }
 
@@ -61,6 +57,7 @@ const useStyles = makeStyles((theme) => ({
     cursor: 'pointer',
     '&:hover': {
       backgroundColor: LightBlueBackground,
+      textDecoration: 'none',
     },
   },
   iconStyles: {

--- a/workspaces/ui-v2/src/components/navigation/Routes.ts
+++ b/workspaces/ui-v2/src/components/navigation/Routes.ts
@@ -158,7 +158,7 @@ export const useChangelogHistoryPage: () => {
   linkTo: () => string;
 } = () => {
   const baseUrl = useBaseUrl();
-  const path = `${baseUrl}/changelog`;
+  const path = `${baseUrl}/history`;
   return {
     path,
     linkTo: () => path,

--- a/workspaces/ui-v2/src/components/navigation/TopNavigation.tsx
+++ b/workspaces/ui-v2/src/components/navigation/TopNavigation.tsx
@@ -9,7 +9,7 @@ import { NavButton } from './NavButton';
 import {
   ChangeHistory as ChangeHistoryIcon,
   Subject as SubjectIcon,
-  List as ListIcon,
+  Schedule as ScheduleIcon,
 } from '@material-ui/icons';
 import {
   useDiffReviewPageLink,
@@ -53,13 +53,6 @@ export function TopNavigation(props: { AccessoryNavigation?: any }) {
                   to={documentationPage.linkTo()}
                   Icon={SubjectIcon}
                 />
-                {shouldRenderChangelogHistory && (
-                  <NavButton
-                    title="Changelog"
-                    to={changelogHistoryPage.linkTo()}
-                    Icon={ListIcon}
-                  />
-                )}
 
                 {/*@aidan: this needs to change*/}
                 {appConfig.navigation.showDiff && (
@@ -67,6 +60,14 @@ export function TopNavigation(props: { AccessoryNavigation?: any }) {
                     title="Diffs"
                     to={diffsPage.linkTo()}
                     Icon={ChangeHistoryIcon}
+                  />
+                )}
+
+                {shouldRenderChangelogHistory && (
+                  <NavButton
+                    title="History"
+                    to={changelogHistoryPage.linkTo()}
+                    Icon={ScheduleIcon}
                   />
                 )}
               </div>

--- a/workspaces/ui-v2/src/entry-points/cloud/cloud-viewer.tsx
+++ b/workspaces/ui-v2/src/entry-points/cloud/cloud-viewer.tsx
@@ -141,7 +141,7 @@ export default function CloudViewer() {
                       <Switch>
                         {shouldRenderChangelogHistory && (
                           <Route
-                            path={`${match.path}/changelog`}
+                            path={`${match.path}/history`}
                             component={ChangelogHistory}
                           />
                         )}

--- a/workspaces/ui-v2/src/entry-points/demo/demo-examples.tsx
+++ b/workspaces/ui-v2/src/entry-points/demo/demo-examples.tsx
@@ -114,7 +114,7 @@ export default function DemoExamples(props: { lookupDir: string }) {
                       <Switch>
                         {shouldRenderChangelogHistory && (
                           <Route
-                            path={`${match.path}/changelog`}
+                            path={`${match.path}/history`}
                             component={ChangelogHistory}
                           />
                         )}

--- a/workspaces/ui-v2/src/entry-points/local/local-cli.tsx
+++ b/workspaces/ui-v2/src/entry-points/local/local-cli.tsx
@@ -119,7 +119,7 @@ export default function LocalCli() {
                         <Switch>
                           {shouldRenderChangelogHistory && (
                             <Route
-                              path={`${match.path}/changelog`}
+                              path={`${match.path}/history`}
                               component={ChangelogHistory}
                             />
                           )}

--- a/workspaces/ui-v2/src/entry-points/local/public-examples.tsx
+++ b/workspaces/ui-v2/src/entry-points/local/public-examples.tsx
@@ -113,7 +113,7 @@ export default function PublicExamples(props: { lookupDir: string }) {
                       <Switch>
                         {shouldRenderChangelogHistory && (
                           <Route
-                            path={`${match.path}/changelog`}
+                            path={`${match.path}/history`}
                             component={ChangelogHistory}
                           />
                         )}

--- a/workspaces/ui-v2/src/pages/changelogHistory/ChangelogHistory.tsx
+++ b/workspaces/ui-v2/src/pages/changelogHistory/ChangelogHistory.tsx
@@ -1,7 +1,9 @@
 import React, { FC } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
+import { Schedule as ScheduleIcon } from '@material-ui/icons';
 
 import {
+  Button,
   Link, // this should probably be one of our own global components
 } from '@material-ui/core';
 
@@ -25,25 +27,45 @@ export const ChangelogHistory: FC = () => {
       <Page.Navbar />
       <Page.Body padded className={classes.pageBody} loading={loading}>
         <section className={classes.changelogSection}>
-          <h1>Changelog</h1>
+          <div className={classes.changelogTimeline}>
+            <ScheduleIcon className={classes.changelogIcon} />
+          </div>
+
           <ol className={classes.commitsList}>
             {batchCommits.map((batchCommit, i) => (
               <li className={classes.commitsListItem} key={batchCommit.batchId}>
-                <Link
-                  className={classes.commitLink}
-                  href={
-                    i === 0
-                      ? documentationPage.linkTo()
-                      : changelogPage.linkTo(batchCommit.batchId)
-                  }
-                >
+                <div className={classes.commitDetails}>
                   <h4 className={classes.commitMessage}>
                     {batchCommit.commitMessage}
                   </h4>
                   <span className={classes.commitTime}>
                     {formatTimeAgo(new Date(batchCommit.createdAt))}
                   </span>
-                </Link>
+                </div>
+
+                <div className={classes.commitControls}>
+                  <Button
+                    className={classes.commitCompareButton}
+                    href={
+                      i === 0
+                        ? documentationPage.linkTo()
+                        : changelogPage.linkTo(batchCommit.batchId)
+                    }
+                  >
+                    Compare
+                  </Button>
+
+                  {i !== 0 && (
+                    <Button
+                      className={classes.commitResetButton}
+                      onClick={() => {
+                        console.log(`resetting to ${batchCommit.batchId}`);
+                      }}
+                    >
+                      Reset
+                    </Button>
+                  )}
+                </div>
               </li>
             ))}
           </ol>
@@ -64,8 +86,22 @@ const useStyles = makeStyles((theme) => ({
   changelogSection: {
     display: 'flex',
     maxWidth: theme.breakpoints.values.md,
-    flexDirection: 'column',
+    marginTop: theme.spacing(4),
     flexGrow: 1,
+  },
+
+  changelogTimeline: {
+    borderLeft: `2px solid ${theme.palette.grey[200]}`,
+    paddingRight: theme.spacing(1),
+    flexShrink: 0,
+  },
+  changelogIcon: {
+    marginLeft: theme.spacing(-1.5) - 1,
+    paddingBottom: theme.spacing(1),
+    background: theme.palette.background.default,
+    boxSizing: 'content-box',
+    fontSize: theme.spacing(3),
+    color: theme.palette.grey[400],
   },
 
   commitsList: {
@@ -73,19 +109,44 @@ const useStyles = makeStyles((theme) => ({
     // worth extracting into a mixin
     listStyleType: 'none',
     paddingLeft: 0,
+    marginTop: theme.spacing(3) + theme.spacing(1), // clock height + it's bottom spacing
+    maxWidth: '100%',
 
     display: 'flex',
     flexDirection: 'column',
     flexGrow: 1,
   },
-  commitsListItem: {},
-
-  commitLink: {
+  commitsListItem: {
     display: 'flex',
     justifyContent: 'space-between',
-    alignItems: 'center',
+    alignItems: 'flex-start',
+    background: '#fff',
+    padding: theme.spacing(2),
+    marginBottom: theme.spacing(3),
+    borderRadius: theme.shape.borderRadius,
+    border: `1px solid ${theme.palette.grey[200]}`,
   },
 
-  commitMessage: {},
-  commitTime: {},
+  commitDetails: {
+    display: 'flex',
+    flexDirection: 'column',
+    margin: 0,
+
+    '& h4': {},
+  },
+
+  commitMessage: {
+    margin: 0,
+  },
+  commitTime: {
+    fontSize: theme.typography.pxToRem(theme.typography.fontSize - 2),
+  },
+
+  commitControls: {
+    display: 'flex',
+    flexShrink: 0,
+    flexGrow: 0,
+  },
+  commitCompareButton: {},
+  commitResetButton: {},
 }));

--- a/workspaces/ui-v2/src/pages/changelogHistory/ChangelogHistory.tsx
+++ b/workspaces/ui-v2/src/pages/changelogHistory/ChangelogHistory.tsx
@@ -2,10 +2,7 @@ import React, { FC } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import { Schedule as ScheduleIcon } from '@material-ui/icons';
 
-import {
-  Button,
-  Link, // this should probably be one of our own global components
-} from '@material-ui/core';
+import { Button } from '@material-ui/core';
 
 import {
   Page,


### PR DESCRIPTION
## Why
We had a very basic page rendering a list of batch commits, but it didn't look too much like a history view yet.

## What
A short pass to:

- establish the History page name and route (instead of changelog)
- design the History page to look somewhat like a timeline

![Screenshot 2021-06-23 at 18 09 01](https://user-images.githubusercontent.com/857549/123132039-92c73b00-d44e-11eb-9fb1-9277e0fb48ea.png)


## Validation
* [ ] CI passes

