### PR TITLE
Fix UI gql queries

### DIFF
--- a/workspaces/spectacle-shared/src/local-cli/client.ts
+++ b/workspaces/spectacle-shared/src/local-cli/client.ts
@@ -150,7 +150,7 @@ export class LocalCliDiffService implements IOpticDiffService {
 
   async listDiffs(): Promise<IListDiffsResponse> {
     const result = await this.dependencies.spectacle.query<any, any>({
-      query: `query X($diffId: ID) {
+      query: `query X($diffId: ID!) {
         diff(diffId: $diffId) {
           diffs
         }
@@ -164,7 +164,7 @@ export class LocalCliDiffService implements IOpticDiffService {
 
   async listUnrecognizedUrls(): Promise<IListUnrecognizedUrlsResponse> {
     const result = await this.dependencies.spectacle.query<any, any>({
-      query: `query X($diffId: ID) {
+      query: `query X($diffId: ID!) {
         diff(diffId: $diffId) {
           unrecognizedUrls
         }

--- a/workspaces/ui-v2/src/store/documentationEdit/thunks.ts
+++ b/workspaces/ui-v2/src/store/documentationEdit/thunks.ts
@@ -33,7 +33,7 @@ const fetchDeleteEndpointCommands = async (
       }
     >({
       query: `
-      query X($pathId: ID, $method: String) {
+      query X($pathId: ID!, $method: String!) {
         endpoint(pathId: $pathId, method: $method) {
           commands {
             remove


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

When I added this - https://github.com/opticdev/optic/pull/912/files#diff-9d0ba504d2645e362388f01514b44ae2c69158d09f52ca3aab7c722ec5cd26cfR8-R46 I missed a couple of usage points here. Graphql queries + mutations need to match the underlying schemas (which is somewhat annoying, and we need to be careful about changing these queries in the future to be stronger typed (for any arguments)) - the biggest one will be making sure when we update the query, we need to update gitbot (and if / when we expose spectacle as a first class thing, treat these as breaking changes).

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
