### PR TITLE
Fix double enter press when confirming change

### DIFF
--- a/workspaces/ui-v2/src/components/CommitMessageModal.tsx
+++ b/workspaces/ui-v2/src/components/CommitMessageModal.tsx
@@ -26,7 +26,7 @@ export const CommitMessageModal: FC<CommitMessageModalProps> = ({
   const [commitMessage, setCommitMessage] = useState('');
   const [isSaving, setIsSaving] = useState(false);
   const classes = useStyles();
-  const canSubmit = commitMessage.length > 0;
+  const canSubmit = commitMessage.length > 0 && !isSaving;
   const onKeyPress = useRunOnKeypress(
     () => {
       if (canSubmit) {
@@ -71,7 +71,7 @@ export const CommitMessageModal: FC<CommitMessageModalProps> = ({
           Cancel
         </Button>
         <Button
-          disabled={!canSubmit || isSaving}
+          disabled={!canSubmit}
           onClick={async () => {
             setIsSaving(true);
             await onSave(commitMessage);


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

During playing around with the UI - I noticed that on the commit modal - if you press enter twice quickly, you can send multiple spectacle mutations (the subsequent commands usually fail, or cause weird states) - updating the code so this is not possible (at least through the UI)

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
