### PR TITLE
Only show share button when on docs page

### DIFF
--- a/workspaces/ui-v2/src/components/navigation/TopNavigation.tsx
+++ b/workspaces/ui-v2/src/components/navigation/TopNavigation.tsx
@@ -18,7 +18,6 @@ import {
 } from './Routes';
 import { useAppConfig } from '<src>/contexts/config/AppConfiguration';
 import { useAppSelector } from '<src>/store';
-import { ShareButton } from '../sharing/ShareButton';
 
 export function TopNavigation(props: { AccessoryNavigation?: any }) {
   const classes = useStyles();
@@ -73,7 +72,6 @@ export function TopNavigation(props: { AccessoryNavigation?: any }) {
               </div>
               <div className={classes.spacer} />
               <div>{AccessoryNavigation && <AccessoryNavigation />}</div>
-              {appConfig.sharing.enabled && <ShareButton />}
             </Toolbar>
           </AppBar>
         </Container>

--- a/workspaces/ui-v2/src/pages/docs/components/DocPageNavigation.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/DocPageNavigation.tsx
@@ -5,6 +5,7 @@ import { useAppConfig } from '<src>/contexts/config/AppConfiguration';
 import { useAppSelector, selectors } from '<src>/store';
 
 import { EditContributionsButton } from './EditContributionsButton';
+import { ShareButton } from '<src>/components/sharing/ShareButton';
 
 export const DocsPageAccessoryNavigation: FC = () => {
   const appConfig = useAppConfig();
@@ -22,6 +23,7 @@ export const DocsPageAccessoryNavigation: FC = () => {
       {appConfig.documentation.allowDescriptionEditing && (
         <EditContributionsButton />
       )}
+      {appConfig.sharing.enabled && <ShareButton />}
     </div>
   );
 };

--- a/workspaces/ui-v2/src/pages/docs/components/DocPageNavigation.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/DocPageNavigation.tsx
@@ -18,12 +18,12 @@ export const DocsPageAccessoryNavigation: FC = () => {
 
   return (
     <div style={{ paddingRight: 10, display: 'flex', flexDirection: 'row' }}>
+      {appConfig.sharing.enabled && <ShareButton />}
       <PromptNavigateAway shouldPrompt={isEditing && pendingCount > 0} />
       <ChangesSinceDropdown />
       {appConfig.documentation.allowDescriptionEditing && (
         <EditContributionsButton />
       )}
-      {appConfig.sharing.enabled && <ShareButton />}
     </div>
   );
 };


### PR DESCRIPTION
@niclim pointed out that the share button only really makes sense on the docs page, so I moved it into the `DocsPageAccessoryNavigation` component.