### PR TITLE
Remove reset button on the last commit

### DIFF
--- a/workspaces/ui-v2/src/pages/changelogHistory/ChangelogHistory.tsx
+++ b/workspaces/ui-v2/src/pages/changelogHistory/ChangelogHistory.tsx
@@ -25,11 +25,6 @@ import {
 
 import { ConfirmResetModal } from './components';
 
-const SPECIFICATION_METADATA_COMMIT_MESSAGE =
-  'Initialize specification attributes';
-const canShowResetButton = (commitMessage: string, index: number) =>
-  commitMessage !== SPECIFICATION_METADATA_COMMIT_MESSAGE && index !== 0;
-
 export const ChangelogHistory: FC = () => {
   const { loading, batchCommits } = useBatchCommits();
   const changelogPage = useChangelogPages();
@@ -94,7 +89,7 @@ export const ChangelogHistory: FC = () => {
                       </Button>
                     )}
 
-                    {canShowResetButton(batchCommit.commitMessage, i) && (
+                    {!isCurrent && (
                       <Button
                         className={classes.commitResetButton}
                         variant="outlined"


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

I missed this message when reviewing https://github.com/opticdev/optic/pull/919#discussion_r657821610 - we can rely on the assumption the first commit is the specification initialization commit. Also with the changes to how the reset works, we are resetting + including the commit, rather than removing the commit

<img width="1011" alt="Screen Shot 2021-06-24 at 10 58 48 AM" src="https://user-images.githubusercontent.com/18374483/123310678-30684c00-d4db-11eb-9e88-cbd27b2879b1.png">

Going to merge this in as for testing + retroactive review

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
