### PR TITLE
feature: Show request method in coverage report

### DIFF
--- a/workspaces/local-cli/src/shared/coverage.ts
+++ b/workspaces/local-cli/src/shared/coverage.ts
@@ -180,16 +180,18 @@ export async function printCoverage(
 
     const pathIds = new Map<string, string>(
       response.data.requests.map((r) => [
-        r.pathId,
+        `${r.method} ${r.pathId}`,
         r.absolutePathPatternWithParameterNames,
       ])
     );
 
-    for (const [pathId, pathString] of pathIds.entries()) {
+    for (const [_pathId, pathString] of pathIds.entries()) {
+      const [method, pathId] = _pathId.split(' ');
       const total_count =
         map_without_diffs[
-          TotalForPath({
+          TotalForPathAndMethod({
             path_id: pathId,
+            http_method: method,
           })
         ];
 
@@ -198,7 +200,7 @@ export async function printCoverage(
       }
 
       const requests = response.data.requests.filter(
-        (r) => r.pathId === pathId
+        (r) => r.pathId === pathId && r.method === method
       );
 
       let total_endpoint_requests = 0;
@@ -299,7 +301,9 @@ export async function printCoverage(
           : colors.red;
 
       const endpoint_contents = color_func(
-        `${colors.bold(pathString)} -> ${pct_coverage.toFixed(1)}% covered`
+        `${method} ${colors.bold(pathString)} -> ${pct_coverage.toFixed(
+          1
+        )}% covered`
       );
 
       table.push([


### PR DESCRIPTION
## Why
A "request" in Optic is qualified by HTTP method, as well as path. This change updates the coverage report to show requests method, as well as path.

Ex:

<img width="1035" alt="Screen Shot 2021-06-24 at 3 24 42 PM" src="https://user-images.githubusercontent.com/4368270/123321240-b64abe00-d500-11eb-8034-bd34bcbc70e7.png">
