### PR TITLE
style: Uniformly style the share button

### DIFF
--- a/workspaces/ui-v2/src/components/sharing/ShareButton.tsx
+++ b/workspaces/ui-v2/src/components/sharing/ShareButton.tsx
@@ -118,7 +118,14 @@ export const ShareButton: React.FC<{}> = (props) => {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <div style={{ paddingRight: 10, display: 'flex', flexDirection: 'row' }}>
+    <div
+      style={{
+        marginRight: 5,
+        opacity: 0.45,
+        display: 'flex',
+        flexDirection: 'row',
+      }}
+    >
       <Button
         variant="outlined"
         className={styles.root}


### PR DESCRIPTION
Makes the share button look the same as all the other buttons.

<img width="356" alt="Screen Shot 2021-06-24 at 4 57 16 PM" src="https://user-images.githubusercontent.com/4368270/123331499-5c9cc080-d50d-11eb-8e25-be323ec9d18e.png">

