### PR TITLE
Move discard endpoint on diff flow to recently added rows

### DIFF
--- a/workspaces/ui-v2/src/pages/diffs/AddEndpointsPage/AddEndpointsPage.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/AddEndpointsPage/AddEndpointsPage.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import classNames from 'classnames';
 import { makeStyles } from '@material-ui/styles';
-import { Check } from '@material-ui/icons';
+import { Check, Delete as DeleteIcon } from '@material-ui/icons';
 import { Divider, List, ListItem, Typography } from '@material-ui/core';
 
 import {
@@ -165,6 +165,7 @@ export function DocumentationRootPageWithPendingEndpoints() {
     pendingEndpoints,
     setCommitModalOpen,
     hasDiffChanges,
+    discardEndpoint,
   } = useSharedDiffContext();
   const pendingEndpointsToRender = pendingEndpoints.filter((i) => i.staged);
   const classes = useStyles();
@@ -231,6 +232,12 @@ export function DocumentationRootPageWithPendingEndpoints() {
                       onClick={(e) => e.stopPropagation()}
                     >
                       <PendingEndpointNameField endpoint={endpoint} />
+                      <DeleteIcon
+                        onClick={() => {
+                          discardEndpoint(endpoint.id);
+                        }}
+                        fontSize="small"
+                      />
                     </div>
                   </ListItem>
                 );
@@ -305,6 +312,8 @@ const useStyles = makeStyles((theme) => ({
     flexGrow: 1,
   },
   endpointContributionContainer: {
+    display: 'flex',
+    alignItems: 'center',
     paddingRight: 15,
     '@media (max-width: 1250px)': {
       paddingLeft: 20,

--- a/workspaces/ui-v2/src/pages/diffs/PendingEndpointPage.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/PendingEndpointPage.tsx
@@ -93,7 +93,6 @@ export function PendingEndpointPage(props: any) {
     ignoreBody,
     includeBody,
     stageEndpoint,
-    discardEndpoint,
     newEndpointCommands,
     endpointName,
     changeEndpointName,
@@ -231,13 +230,6 @@ export function PendingEndpointPage(props: any) {
                   </Button>
                 </div>
                 <div>
-                  <Button
-                    size="small"
-                    color="secondary"
-                    onClick={discardEndpoint}
-                  >
-                    Discard Endpoint
-                  </Button>
                   <Button
                     size="small"
                     variant="contained"


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Discard Endpoint is kind of misleading. The discard only does something if you've staged the endpoint. It also makes more sense to discard endpoints from the recently added view

## What
What's changing? Anything of note to call out?

### Before

<img width="637" alt="Screen Shot 2021-06-24 at 2 03 29 PM" src="https://user-images.githubusercontent.com/18374483/123332166-04f25b00-d4f5-11eb-88b0-43c05af3b357.png">

### After
<img width="634" alt="Screen Shot 2021-06-24 at 2 00 26 PM" src="https://user-images.githubusercontent.com/18374483/123332174-07ed4b80-d4f5-11eb-81c9-755feb958ab6.png">
<img width="958" alt="Screen Shot 2021-06-24 at 2 00 33 PM" src="https://user-images.githubusercontent.com/18374483/123332181-09b70f00-d4f5-11eb-8151-e1d5c68caabd.png">


## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
