### PR TITLE
Add cloud viewer tag on release instead of master

### DIFF
--- a/.github/workflows/build-ui-v2.yml
+++ b/.github/workflows/build-ui-v2.yml
@@ -51,7 +51,7 @@ jobs:
           echo "USER=${GITHUB_ACTOR}" >> $GITHUB_ENV
       - run: |
           task ui-v2:ci
-          if [ "$BRANCH" = "develop" ] || [ "$BRANCH" = "master" ]
+          if [ "$BRANCH" = "develop" ] || [ "$BRANCH" = "release" ]
           then
             docker tag \
               "513974440343.dkr.ecr.us-east-1.amazonaws.com/cloud-spec-viewer:${TAG}" \


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

It doesn't look like cloudviewer is getting deployed. I'm not 100% sure i follow the deployment pipeline - but I think that this fix should deploy the latest version of cloud viewer

This targets release (and I'll merge this back into develop)

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
