### PR TITLE
Handle content type null crashing diff flow

### DIFF
--- a/workspaces/ui-v2/src/lib/new-regions-interpreter.ts
+++ b/workspaces/ui-v2/src/lib/new-regions-interpreter.ts
@@ -65,7 +65,7 @@ function newContentType(
         shapes: [],
         copy: [
           plain('Document'),
-          code(location.inRequest!.contentType!.toString()),
+          code(location.inRequest!.contentType || 'null'),
           plain('Request'),
         ],
       },


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

@jshearer and I paired on this. It's possible to have content type null captured here - updating the UI to allow for this.

While working on this - the specific capture is interesting (from here https://github.com/opticdev/optic/issues/929) because:
- A GET request was made with a request body `{}` + learnt
- A subsequent GET request with no request body was sent (with null) - learning this causes two endpoints to show up (with the same id, i.e. same pathId and method
<img width="981" alt="Screen Shot 2021-06-25 at 11 18 31 AM" src="https://user-images.githubusercontent.com/18374483/123468778-1ac05880-d5a7-11eb-8949-06fc33246eb9.png">

Technically this should result in the request body being removed as a diff instead of creating a new AddRequest command. This could also be part of the manual edit work (depending on how we want to specify edits, if we go through the diff flow + with edits, or use similar components). Something like...
<img width="1059" alt="Screen Shot 2021-06-25 at 11 23 46 AM" src="https://user-images.githubusercontent.com/18374483/123469522-0466cc80-d5a8-11eb-813b-e3cc457f1cb2.png">


## What
What's changing? Anything of note to call out?

Don't crash the page if the diff has a null content type

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
