### PR TITLE
Query connect spectacle to rust

### DIFF
--- a/workspaces/spectacle/src/graphql/schema.ts
+++ b/workspaces/spectacle/src/graphql/schema.ts
@@ -139,7 +139,7 @@ type HttpRequest {
   method: String
 
   # Query parameters associated with this HTTP request
-  query: QueryParameters!
+  query: QueryParameters
   
   # Request bodies associated with this HTTP request
   bodies: [HttpBody]

--- a/workspaces/spectacle/src/spectacle.ts
+++ b/workspaces/spectacle/src/spectacle.ts
@@ -312,12 +312,8 @@ export async function makeSpectacle(opticContext: IOpticContext) {
       method: (parent: endpoints.RequestNodeWrapper) => {
         return Promise.resolve(parent.value.httpMethod);
       },
-      query: async () => {
-        // TODO connect up to rust code
-        return {
-          rootShapeId: 'shape-1',
-          isRemoved: false,
-        };
+      query: async (parent: endpoints.RequestNodeWrapper) => {
+        return parent.query();
       },
       bodies: (parent: endpoints.RequestNodeWrapper) => {
         return Promise.resolve(parent.bodies().results);
@@ -354,12 +350,11 @@ export async function makeSpectacle(opticContext: IOpticContext) {
       },
     },
     QueryParameters: {
-      // TODO change typings when connected to graph lib + rust
-      rootShapeId: (parent: { rootShapeId: string; isRemoved: boolean }) => {
-        return parent.rootShapeId;
+      rootShapeId: (parent: endpoints.QueryParametersNodeWrapper) => {
+        return parent.value.rootShapeId;
       },
-      isRemoved: (parent: { rootShapeId: string; isRemoved: boolean }) => {
-        return parent.isRemoved;
+      isRemoved: (parent: endpoints.QueryParametersNodeWrapper) => {
+        return parent.value.isRemoved;
       },
     },
     Path: {

--- a/workspaces/spectacle/src/spectacle.ts
+++ b/workspaces/spectacle/src/spectacle.ts
@@ -313,7 +313,10 @@ export async function makeSpectacle(opticContext: IOpticContext) {
         return Promise.resolve(parent.value.httpMethod);
       },
       query: async (parent: endpoints.RequestNodeWrapper) => {
-        return parent.query();
+        return process.env.REACT_APP_FF_LEARN_UNDOCUMENTED_QUERY_PARAMETERS ===
+          'true'
+          ? parent.query()
+          : null;
       },
       bodies: (parent: endpoints.RequestNodeWrapper) => {
         return Promise.resolve(parent.bodies().results);

--- a/workspaces/ui-v2/public/example-sessions/todos-partial.json
+++ b/workspaces/ui-v2/public/example-sessions/todos-partial.json
@@ -1910,6 +1910,93 @@
           "createdAt": "2020-10-20T20:52:31.789Z"
         }
       }
+    },
+    {
+      "BatchCommitStarted": {
+        "batchId": "2cc302d2-c660-4362-9601-dc14fe69542c",
+        "commitMessage": "Learn query parameters",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "ec3dd58b-bdf3-42b0-88a8-7e8f85f49e74",
+          "clientCommandBatchId": "b8aa13c5-a333-4cb2-90d0-ef1c6ba79865",
+          "createdAt": "2020-11-20T20:52:31.789Z"
+        }
+      }
+    },
+    {
+      "RequestQueryParametersShapeSet": {
+        "requestId": "request_SqY61Qc9Mi",
+        "shapeDescriptor": {
+          "shapeId": "shape_tNRgroSwLj",
+          "isRemoved": false
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_tNRgroSwLj",
+        "baseShapeId": "$object",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "ec3dd58b-bdf3-42b0-88a8-7e8f85f49e74",
+          "clientCommandBatchId": "b8aa13c5-a333-4cb2-90d0-ef1c6ba79865",
+          "createdAt": "2020-11-20T20:52:31.789Z"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_qQT0krhOKn",
+        "baseShapeId": "$number",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "ec3dd58b-bdf3-42b0-88a8-7e8f85f49e74",
+          "clientCommandBatchId": "b8aa13c5-a333-4cb2-90d0-ef1c6ba79865",
+          "createdAt": "2020-11-20T20:52:31.789Z"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_hnI7P1UdbB",
+        "shapeId": "shape_tNRgroSwLj",
+        "name": "age",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_hnI7P1UdbB",
+            "shapeId": "shape_qQT0krhOKn"
+          }
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "ec3dd58b-bdf3-42b0-88a8-7e8f85f49e74",
+          "clientCommandBatchId": "b8aa13c5-a333-4cb2-90d0-ef1c6ba79865",
+          "createdAt": "2020-11-20T20:52:31.789Z"
+        }
+      }
+    },
+    {
+      "BatchCommitEnded": {
+        "batchId": "2cc302d2-c660-4362-9601-dc14fe69542c",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "ec3dd58b-bdf3-42b0-88a8-7e8f85f49e74",
+          "clientCommandBatchId": "b8aa13c5-a333-4cb2-90d0-ef1c6ba79865",
+          "createdAt": "2020-11-20T20:52:31.789Z"
+        }
+      }
     }
   ],
   "session": {

--- a/workspaces/ui-v2/src/hooks/useEndpointBodyHook.ts
+++ b/workspaces/ui-v2/src/hooks/useEndpointBodyHook.ts
@@ -94,7 +94,11 @@ export function useEndpointBody(
   pathId: string,
   method: string,
   renderChangesSince?: string
-): { requests: IRequestBody[]; responses: IResponseBody[] } {
+): {
+  query: IQueryParameters | null;
+  requests: IRequestBody[];
+  responses: IResponseBody[];
+} {
   const spectacleInput =
     typeof renderChangesSince === 'undefined'
       ? {
@@ -119,22 +123,19 @@ export function useEndpointBody(
     debugger;
   }
   if (!data) {
-    return { requests: [], responses: [] };
+    return { query: null, requests: [], responses: [] };
   } else {
     const request = data.requests.find(
       (i) => i.pathId === pathId && i.method === method
     );
     if (!request) {
-      return { requests: [], responses: [] };
+      return { query: null, requests: [], responses: [] };
     }
     const requests: IRequestBody[] = request.bodies.map((body: any) => {
       return {
         requestId: request.id,
         contentType: body.contentType,
         rootShapeId: body.rootShapeId,
-        query: {
-          rootShapeId: request.query?.rootShapeId || null,
-        },
         pathId: request.pathId,
         method: request.method,
         changes: request.changes,
@@ -161,16 +162,22 @@ export function useEndpointBody(
       (a, b) => a.statusCode - b.statusCode
     );
 
-    return { requests, responses: sortedResponses };
+    return {
+      query: request.query || null,
+      requests,
+      responses: sortedResponses,
+    };
   }
+}
+
+export interface IQueryParameters {
+  rootShapeId: string;
+  isRemoved: boolean;
 }
 
 export interface IRequestBody {
   requestId: string;
   contentType: string;
-  query: {
-    rootShapeId: string | null;
-  };
   rootShapeId: string;
   pathId: string;
   method: string;

--- a/workspaces/ui-v2/src/hooks/useEndpointBodyHook.ts
+++ b/workspaces/ui-v2/src/hooks/useEndpointBodyHook.ts
@@ -8,6 +8,10 @@ const EndpointBodyQueryWithoutChanges = `
     pathId
     method
     requestContributions
+    query {
+      rootShapeId
+      isRemoved
+    }
     bodies {
       contentType
       rootShapeId
@@ -34,6 +38,10 @@ query X($sinceBatchCommitId: String) {
     changes(sinceBatchCommitId: $sinceBatchCommitId) {
       added
       changed
+    }
+    query {
+      rootShapeId
+      isRemoved
     }
     bodies {
       contentType
@@ -67,6 +75,10 @@ type EndpointBodyQueryResponse = {
     method: string;
     requestContributions: Record<string, string>;
     bodies: Body[];
+    query?: {
+      rootShapeId: string;
+      isRemoved: boolean;
+    };
     changes?: IChanges;
     responses: {
       id: string;
@@ -120,6 +132,9 @@ export function useEndpointBody(
         requestId: request.id,
         contentType: body.contentType,
         rootShapeId: body.rootShapeId,
+        query: {
+          rootShapeId: request.query?.rootShapeId || null,
+        },
         pathId: request.pathId,
         method: request.method,
         changes: request.changes,
@@ -153,6 +168,9 @@ export function useEndpointBody(
 export interface IRequestBody {
   requestId: string;
   contentType: string;
+  query: {
+    rootShapeId: string | null;
+  };
   rootShapeId: string;
   pathId: string;
   method: string;


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Connects the Rust intepretation of query parameter events to spectacle - uses the `REACT_APP_FF_LEARN_UNDOCUMENTED_QUERY_PARAMETERS` FF to gate showing these events

## What
What's changing? Anything of note to call out?

- Handle with_query_parameters for the spectacle endpoint projection
- Exposes QueryParameterNode through graph-lib, spectacle
     
## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
