### PR TITLE
Add test command as alias

### DIFF
--- a/workspaces/cli-config/src/helpers/initial-task.ts
+++ b/workspaces/cli-config/src/helpers/initial-task.ts
@@ -29,16 +29,23 @@ export const defaultCommandInit =
 function buildInitialTask(flags: any, taskName: string) {
   //default config and valid for start injected
   let commandConfig = `  ${taskName}:
-     command: ${escapeIt(flags.command || defaultCommandInit)}
-     inboundUrl: ${flags.inboundUrl || 'http://localhost:4000'}
+    command: ${escapeIt(flags.command || defaultCommandInit)}
+    inboundUrl: ${flags.inboundUrl || 'http://localhost:4000'}
 `.trimRight();
 
   if (flags.inboundUrl && flags.targetUrl) {
     commandConfig = `  ${taskName}:
-     inboundUrl: ${flags.inboundUrl}
-     targetUrl: ${flags.targetUrl}
+    inboundUrl: ${flags.inboundUrl}
+    targetUrl: ${flags.targetUrl}
 `.trimRight();
   }
+
+  commandConfig = `${commandConfig}
+  # Use the test command to test your API in your CI build pipeline 
+  test:
+    command: ${escapeIt('echo "Error: no test command specified" && exit 1')}
+    useTask: start
+`.trimRight();
 
   return commandConfig;
 }

--- a/workspaces/local-cli/src/commands/test.ts
+++ b/workspaces/local-cli/src/commands/test.ts
@@ -1,0 +1,16 @@
+import { Command, flags } from '@oclif/command';
+import {
+  LocalTaskSessionWrapper,
+  runCommandFlags,
+} from '../shared/local-cli-task-runner';
+
+export default class Test extends Command {
+  static description = 'alias for "api run test --ci"';
+  static flags = runCommandFlags;
+
+  async run() {
+    const { flags } = this.parse(Test);
+    flags['ci'] = true;
+    await LocalTaskSessionWrapper(this, 'test', flags);
+  }
+}

--- a/workspaces/local-cli/src/shared/local-cli-task-runner.ts
+++ b/workspaces/local-cli/src/shared/local-cli-task-runner.ts
@@ -102,6 +102,7 @@ export async function LocalTaskSessionWrapper(
     flags['print-coverage'] = true;
     flags['pass-exit-code'] = true;
     flags['collect-diffs'] = true;
+    flags['exit-on-diff'] = true;
   }
 
   const usesTaskSpecificBoundary = flags['ci'] || flags['exit-on-diff'];


### PR DESCRIPTION
## Why

Running tests is one of the most important steps while using Optic, especially in the build pipeline. We want to make it easy to set up testing for people.

## What

This adds a special `test` command that will allow people to start up Optic, their API, run their tests, and handle any non-0 exit codes in CI to stop the build. The specifics are:

* Adds a test command `api test` which is an alias for `api run test --ci`
* Modifies the `--ci` flag to include `--exit-on-diff`
* Fixes some of the spacing in the `optic.yml` init output
* Adds a test task to the `optic.yml` on `api init`

Once the docs are updated, I think a link from `opitc.yml` to the docs about testing would be great!
