### PR TITLE
Pass exit status through from script

### DIFF
--- a/workspaces/local-cli/src/commands/scripts.ts
+++ b/workspaces/local-cli/src/commands/scripts.ts
@@ -19,7 +19,10 @@ import {
   userDebugLogger,
 } from '@useoptic/cli-shared';
 import { generateOas } from './generate/oas';
-import { spawnProcess } from '../shared/spawn-process';
+import {
+  spawnProcess,
+  spawnProcessReturnExitCode,
+} from '../shared/spawn-process';
 import { ensureDaemonStarted } from '@useoptic/cli-server';
 import { lockFilePath } from '../shared/paths';
 import { Config } from '../config';
@@ -131,7 +134,8 @@ export default class Scripts extends Command {
     };
 
     console.log(`Running command: ${colors.grey(script.command)} `);
-    await spawnProcess(script.command, env);
+    const exitStatus = await spawnProcessReturnExitCode(script.command, env);
+    process.exit(exitStatus);
   }
 
   // TODO: this is copy/pasted from commands/status.ts

--- a/workspaces/local-cli/src/commands/scripts.ts
+++ b/workspaces/local-cli/src/commands/scripts.ts
@@ -134,8 +134,8 @@ export default class Scripts extends Command {
     };
 
     console.log(`Running command: ${colors.grey(script.command)} `);
-    const exitStatus = await spawnProcessReturnExitCode(script.command, env);
-    process.exit(exitStatus);
+    const exitCode = await spawnProcessReturnExitCode(script.command, env);
+    process.exit(exitCode);
   }
 
   // TODO: this is copy/pasted from commands/status.ts


### PR DESCRIPTION
## Why

When running a script through the CLI, the CLI does not pass the exit code from the spawned process. This prevented me from using scripts for doing API checks that could fail a build.

It also prevented me from accessing the environment variables provided to the scripts, specifically `SPECTACLE_URL`.

## What

This passes through the exit code from the spawned process.