### PR TITLE
Implement query parameter panel component

### DIFF
--- a/workspaces/ui-v2/src/components/ContributionsList/ContributionList.tsx
+++ b/workspaces/ui-v2/src/components/ContributionsList/ContributionList.tsx
@@ -1,0 +1,33 @@
+import React, { FC } from 'react';
+import { IShapeRenderer } from '<src>/components';
+
+type Contribution = {
+  id: string;
+  contributionKey: string;
+  value: string;
+  endpointId: string;
+  depth: number;
+  shapes: IShapeRenderer[];
+  name: string;
+};
+
+type ContributionsListProps = {
+  contributions: Contribution[];
+  ContributionComponent: FC<Contribution>;
+};
+
+export const ContributionsList: FC<ContributionsListProps> = ({
+  contributions,
+  ContributionComponent,
+}) => {
+  return (
+    <>
+      {contributions.map((contribution) => (
+        <ContributionComponent
+          key={contribution.id + contribution.value}
+          {...contribution}
+        />
+      ))}
+    </>
+  );
+};

--- a/workspaces/ui-v2/src/components/ContributionsList/index.ts
+++ b/workspaces/ui-v2/src/components/ContributionsList/index.ts
@@ -1,0 +1,1 @@
+export * from './ContributionList';

--- a/workspaces/ui-v2/src/components/Panel.tsx
+++ b/workspaces/ui-v2/src/components/Panel.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 import { makeStyles } from '@material-ui/core';
+import { FontFamilyMono } from '<src>/styles';
 
 type PanelProps = {
   header: React.ReactNode;
@@ -23,26 +24,22 @@ const useStyles = makeStyles((theme) => ({
     width: '100%',
   },
   header: {
+    display: 'flex',
     backgroundColor: '#e4e8ed',
     color: '#4f566b',
-    flex: 1,
-    fontSize: 13,
-    height: 35,
-    display: 'flex',
-    fontWeight: 400,
-    paddingLeft: 13,
-    fontFamily: 'Roboto',
+    fontSize: theme.typography.fontSize - 1,
+    height: theme.spacing(4),
+    paddingLeft: theme.spacing(2),
+    fontFamily: FontFamilyMono,
     alignItems: 'center',
+    overflow: 'hidden',
     borderTopLeftRadius: 8,
     borderTopRightRadius: 8,
-    overflow: 'hidden',
     borderBottom: '1px solid #e2e2e2',
   },
   content: {
     backgroundColor: '#f8fafc',
-    paddingTop: 8,
-    paddingBottom: 8,
-    borderTop: 'none',
+    padding: theme.spacing(1),
     maxHeight: '80vh',
     overflowY: 'auto',
     borderLeft: '1px solid #e4e8ed',

--- a/workspaces/ui-v2/src/components/Panel.tsx
+++ b/workspaces/ui-v2/src/components/Panel.tsx
@@ -1,0 +1,54 @@
+import React, { FC } from 'react';
+import { makeStyles } from '@material-ui/core';
+
+type PanelProps = {
+  header: React.ReactNode;
+};
+
+export const Panel: FC<PanelProps> = ({ children, header }) => {
+  const classes = useStyles();
+  return (
+    <div className={classes.wrapper}>
+      <div className={classes.header}>
+        <div>{header}</div>
+      </div>
+      <div className={classes.content}>{children}</div>
+    </div>
+  );
+};
+
+const useStyles = makeStyles((theme) => ({
+  wrapper: {
+    overflow: 'hidden',
+    width: '100%',
+  },
+  header: {
+    backgroundColor: '#e4e8ed',
+    color: '#4f566b',
+    flex: 1,
+    fontSize: 13,
+    height: 35,
+    display: 'flex',
+    fontWeight: 400,
+    paddingLeft: 13,
+    fontFamily: 'Roboto',
+    alignItems: 'center',
+    borderTopLeftRadius: 8,
+    borderTopRightRadius: 8,
+    overflow: 'hidden',
+    borderBottom: '1px solid #e2e2e2',
+  },
+  content: {
+    backgroundColor: '#f8fafc',
+    paddingTop: 8,
+    paddingBottom: 8,
+    borderTop: 'none',
+    maxHeight: '80vh',
+    overflowY: 'auto',
+    borderLeft: '1px solid #e4e8ed',
+    borderRight: '1px solid #e4e8ed',
+    borderBottom: '1px solid #e4e8ed',
+    borderBottomRightRadius: 4,
+    borderBottomLeftRadius: 4,
+  },
+}));

--- a/workspaces/ui-v2/src/components/Panel.tsx
+++ b/workspaces/ui-v2/src/components/Panel.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+import classNames from 'classnames';
 import { makeStyles } from '@material-ui/core';
 import { FontFamilyMono } from '<src>/styles';
 
@@ -6,10 +7,12 @@ type PanelProps = {
   header: React.ReactNode;
 };
 
-export const Panel: FC<PanelProps> = ({ children, header }) => {
+export const Panel: FC<
+  PanelProps & React.HtmlHTMLAttributes<HTMLDivElement>
+> = ({ children, header, className, ...props }) => {
   const classes = useStyles();
   return (
-    <div className={classes.wrapper}>
+    <div {...props} className={classNames(classes.wrapper, className)}>
       <div className={classes.header}>
         <div>{header}</div>
       </div>
@@ -33,8 +36,8 @@ const useStyles = makeStyles((theme) => ({
     fontFamily: FontFamilyMono,
     alignItems: 'center',
     overflow: 'hidden',
-    borderTopLeftRadius: 8,
-    borderTopRightRadius: 8,
+    borderTopLeftRadius: theme.shape.borderRadius * 2,
+    borderTopRightRadius: theme.shape.borderRadius * 2,
     borderBottom: '1px solid #e2e2e2',
   },
   content: {
@@ -45,7 +48,7 @@ const useStyles = makeStyles((theme) => ({
     borderLeft: '1px solid #e4e8ed',
     borderRight: '1px solid #e4e8ed',
     borderBottom: '1px solid #e4e8ed',
-    borderBottomRightRadius: 4,
-    borderBottomLeftRadius: 4,
+    borderBottomRightRadius: theme.shape.borderRadius,
+    borderBottomLeftRadius: theme.shape.borderRadius,
   },
 }));

--- a/workspaces/ui-v2/src/components/QueryParametersPanel.tsx
+++ b/workspaces/ui-v2/src/components/QueryParametersPanel.tsx
@@ -49,7 +49,7 @@ export const QueryParametersPanel: FC<QueryParametersPanelProps> = ({
 const useStyles = makeStyles((theme) => ({
   queryComponentContainer: {
     marginBottom: theme.spacing(1),
-    padding: `${theme.spacing(1)}px 0`,
+    padding: theme.spacing(1, 0),
     display: 'flex',
     '&:not(:first-child)': {
       borderTop: '1px solid #e4e8ed',

--- a/workspaces/ui-v2/src/components/QueryParametersPanel.tsx
+++ b/workspaces/ui-v2/src/components/QueryParametersPanel.tsx
@@ -1,0 +1,58 @@
+import React, { FC } from 'react';
+import { makeStyles } from '@material-ui/core';
+import { IFieldRenderer, IShapeRenderer, ShapeRenderer } from './ShapeRenderer';
+import { Panel } from './Panel';
+
+type QueryParameters = Record<string, IFieldRenderer>;
+
+type QueryParametersPanelProps = {
+  parameters: QueryParameters;
+};
+
+// TODO this should move into redux
+export const convertShapeToQueryParameters = (
+  shapes: IShapeRenderer[]
+): QueryParameters => {
+  const queryParameters: QueryParameters = {};
+  if (shapes.length !== 1 || !shapes[0].asObject) {
+    console.error('unexpected format for query parameters');
+    return {};
+  }
+
+  for (const field of shapes[0].asObject.fields) {
+    queryParameters[field.name] = field;
+  }
+
+  return queryParameters;
+};
+
+export const QueryParametersPanel: FC<QueryParametersPanelProps> = ({
+  parameters,
+}) => {
+  const classes = useStyles();
+  return (
+    // TODO add in query parsing strategy here?
+    <Panel header={''}>
+      {Object.entries(parameters).map(([key, field]) => (
+        // TODO style this better
+        <div className={classes.queryComponentContainer}>
+          <div>{key}</div>
+          <div>
+            <ShapeRenderer showExamples={false} shape={field.shapeChoices} />
+          </div>
+        </div>
+      ))}
+    </Panel>
+  );
+};
+
+const useStyles = makeStyles((theme) => ({
+  queryComponentContainer: {
+    marginBottom: theme.spacing(2),
+    paddingLeft: theme.spacing(1),
+    display: 'flex',
+    '&:not(:first-child)': {
+      borderTop: '1px solid #e4e8ed',
+    },
+  },
+}));

--- a/workspaces/ui-v2/src/components/QueryParametersPanel.tsx
+++ b/workspaces/ui-v2/src/components/QueryParametersPanel.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react';
 import { makeStyles } from '@material-ui/core';
 import { IFieldRenderer, IShapeRenderer, ShapeRenderer } from './ShapeRenderer';
 import { Panel } from './Panel';
+import { FontFamily } from '<src>/styles';
 
 type QueryParameters = Record<string, IFieldRenderer>;
 
@@ -9,7 +10,7 @@ type QueryParametersPanelProps = {
   parameters: QueryParameters;
 };
 
-// TODO this should move into redux
+// TODO QPB this should move into redux
 export const convertShapeToQueryParameters = (
   shapes: IShapeRenderer[]
 ): QueryParameters => {
@@ -31,12 +32,11 @@ export const QueryParametersPanel: FC<QueryParametersPanelProps> = ({
 }) => {
   const classes = useStyles();
   return (
-    // TODO add in query parsing strategy here?
+    // TODO QPB add in query parsing strategy here?
     <Panel header={''}>
       {Object.entries(parameters).map(([key, field]) => (
-        // TODO style this better
         <div className={classes.queryComponentContainer}>
-          <div>{key}</div>
+          <div className={classes.queryKey}>{key}</div>
           <div>
             <ShapeRenderer showExamples={false} shape={field.shapeChoices} />
           </div>
@@ -48,11 +48,16 @@ export const QueryParametersPanel: FC<QueryParametersPanelProps> = ({
 
 const useStyles = makeStyles((theme) => ({
   queryComponentContainer: {
-    marginBottom: theme.spacing(2),
-    paddingLeft: theme.spacing(1),
+    marginBottom: theme.spacing(1),
+    padding: `${theme.spacing(1)}px 0`,
     display: 'flex',
     '&:not(:first-child)': {
       borderTop: '1px solid #e4e8ed',
     },
+  },
+  queryKey: {
+    fontFamily: FontFamily,
+    fontWeight: 600,
+    fontSize: theme.typography.fontSize - 1,
   },
 }));

--- a/workspaces/ui-v2/src/components/index.ts
+++ b/workspaces/ui-v2/src/components/index.ts
@@ -1,5 +1,6 @@
 export * from './Button';
 export * from './CommitMessageModal';
+export * from './ContributionsList';
 export * from './DebugOpticComponent';
 export * from './EditableTextField';
 export * from './EndpointName';
@@ -12,3 +13,5 @@ export * from './navigation';
 export * from './ShapeRenderer';
 export * from './Page';
 export * from './LightToolTip';
+export * from './Panel';
+export * from './QueryParametersPanel';

--- a/workspaces/ui-v2/src/pages/changelog/ChangelogEndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/changelog/ChangelogEndpointRootPage.tsx
@@ -160,7 +160,7 @@ const ChangelogRootComponent: FC<
           }
         />
 
-        {/* TODO PR implement query renderer */}
+        {/* TODO QPB implement query renderer */}
 
         {thisEndpoint.requestBodies.map((requestBody) => (
           <TwoColumnBodyChangelog

--- a/workspaces/ui-v2/src/pages/changelog/ChangelogEndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/changelog/ChangelogEndpointRootPage.tsx
@@ -151,6 +151,7 @@ const ChangelogRootComponent: FC<
                 }}
               >
                 <EndpointTOC
+                  query={thisEndpoint.query}
                   requests={thisEndpoint.requestBodies}
                   responses={thisEndpoint.responseBodies}
                 />
@@ -158,6 +159,8 @@ const ChangelogRootComponent: FC<
             </CodeBlock>
           }
         />
+
+        {/* TODO PR implement query renderer */}
 
         {thisEndpoint.requestBodies.map((requestBody) => (
           <TwoColumnBodyChangelog

--- a/workspaces/ui-v2/src/pages/diffs/EndpointDocumentationPane.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/EndpointDocumentationPane.tsx
@@ -100,7 +100,7 @@ export const EndpointDocumentationPane: FC<
         </div>
       </CodeBlock>
       <div style={{ height: 50 }} />
-      {/* TODO PR implement query renderer */}
+      {/* TODO QPB implement query renderer */}
 
       {thisEndpoint.requestBodies.map((requestBody) => (
         <React.Fragment key={requestBody.requestId}>

--- a/workspaces/ui-v2/src/pages/diffs/EndpointDocumentationPane.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/EndpointDocumentationPane.tsx
@@ -93,12 +93,15 @@ export const EndpointDocumentationPane: FC<
           }}
         >
           <EndpointTOC
+            query={thisEndpoint.query}
             requests={thisEndpoint.requestBodies}
             responses={thisEndpoint.responseBodies}
           />
         </div>
       </CodeBlock>
       <div style={{ height: 50 }} />
+      {/* TODO PR implement query renderer */}
+
       {thisEndpoint.requestBodies.map((requestBody) => (
         <React.Fragment key={requestBody.requestId}>
           <HighlightedLocation

--- a/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
@@ -16,7 +16,7 @@ import {
   convertShapeToQueryParameters,
 } from '<src>/components';
 import { useDocumentationPageLink } from '<src>/components/navigation/Routes';
-import { SubtleBlueBackground } from '<src>/styles';
+import { FontFamily, SubtleBlueBackground } from '<src>/styles';
 import {
   useAppSelector,
   useAppDispatch,
@@ -244,48 +244,51 @@ export const EndpointRootPage: FC<
         />
         {thisEndpoint.query && (
           <div className={classes.bodyContainer} id="query-parameters">
-            <div>
-              <h6>Query Parameters</h6>
-              <MarkdownBodyContribution
-                id={'QUERY TODO'}
-                contributionKey={'description'}
-                defaultText={'Add a description'}
-                initialValue={'TODO'}
-                endpoint={thisEndpoint}
-              />
-              <ContributionFetcher
-                rootShapeId={thisEndpoint.query.rootShapeId}
-                endpointId={endpointId}
-              >
-                {(contributions) => (
-                  <ContributionsList
-                    ContributionComponent={(contribution) => (
-                      <DocsFieldOrParameterContribution
-                        key={contribution.id}
-                        endpoint={{
-                          pathId,
-                          method,
-                        }}
-                        id={contribution.id}
-                        name={contribution.name}
-                        shapes={contribution.shapes}
-                        depth={contribution.depth}
-                        initialValue={contribution.value}
-                      />
-                    )}
-                    contributions={contributions}
-                  />
-                )}
-              </ContributionFetcher>
-            </div>
-            <div>
-              <ShapeFetcher rootShapeId={thisEndpoint.query.rootShapeId}>
-                {(shapes) => (
-                  <QueryParametersPanel
-                    parameters={convertShapeToQueryParameters(shapes)}
-                  />
-                )}
-              </ShapeFetcher>
+            <h6 className={classes.bodyHeader}>Query Parameters</h6>
+            <div className={classes.bodyDetails}>
+              <div>
+                {/* TODO QPB - change id from this to query id from spectacle */}
+                <MarkdownBodyContribution
+                  id={'QUERY TODO'}
+                  contributionKey={'description'}
+                  defaultText={'Add a description'}
+                  initialValue={'TODO'}
+                  endpoint={thisEndpoint}
+                />
+                <ContributionFetcher
+                  rootShapeId={thisEndpoint.query.rootShapeId}
+                  endpointId={endpointId}
+                >
+                  {(contributions) => (
+                    <ContributionsList
+                      ContributionComponent={(contribution) => (
+                        <DocsFieldOrParameterContribution
+                          key={contribution.id}
+                          endpoint={{
+                            pathId,
+                            method,
+                          }}
+                          id={contribution.id}
+                          name={contribution.name}
+                          shapes={contribution.shapes}
+                          depth={contribution.depth}
+                          initialValue={contribution.value}
+                        />
+                      )}
+                      contributions={contributions}
+                    />
+                  )}
+                </ContributionFetcher>
+              </div>
+              <div>
+                <ShapeFetcher rootShapeId={thisEndpoint.query.rootShapeId}>
+                  {(shapes) => (
+                    <QueryParametersPanel
+                      parameters={convertShapeToQueryParameters(shapes)}
+                    />
+                  )}
+                </ShapeFetcher>
+              </div>
             </div>
           </div>
         )}
@@ -340,11 +343,22 @@ const useStyles = makeStyles((theme) => ({
     display: 'fixed',
   },
   bodyContainer: {
+    marginTop: theme.spacing(6),
+    width: '100%',
+  },
+  bodyHeader: {
+    fontSize: '1.25rem',
+    fontFamily: FontFamily,
+    fontWeight: 500,
+    lineHeight: 1.6,
+    letterSpacing: '0.0075em',
+  },
+  bodyDetails: {
     display: 'flex',
     width: '100%',
-    marginTop: theme.spacing(6),
     '& > div': {
       width: '50%',
+      padding: `0 ${theme.spacing(1)}px`,
     },
   },
 }));

--- a/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
@@ -11,6 +11,9 @@ import {
   JsonLike,
   PageLayout,
   FullWidth,
+  ContributionsList,
+  QueryParametersPanel,
+  convertShapeToQueryParameters,
 } from '<src>/components';
 import { useDocumentationPageLink } from '<src>/components/navigation/Routes';
 import { SubtleBlueBackground } from '<src>/styles';
@@ -32,6 +35,8 @@ import {
   MarkdownBodyContribution,
   TwoColumn,
   DeleteEndpointConfirmationModal,
+  ContributionFetcher,
+  ShapeFetcher,
 } from '<src>/pages/docs/components';
 
 export const EndpointRootPageWithDocsNav: FC<
@@ -229,6 +234,7 @@ export const EndpointRootPage: FC<
                 }}
               >
                 <EndpointTOC
+                  query={thisEndpoint.query}
                   requests={thisEndpoint.requestBodies}
                   responses={thisEndpoint.responseBodies}
                 />
@@ -236,6 +242,53 @@ export const EndpointRootPage: FC<
             </CodeBlock>
           }
         />
+        {thisEndpoint.query && (
+          <div className={classes.bodyContainer} id="query-parameters">
+            <div>
+              <h6>Query Parameters</h6>
+              <MarkdownBodyContribution
+                id={'QUERY TODO'}
+                contributionKey={'description'}
+                defaultText={'Add a description'}
+                initialValue={'TODO'}
+                endpoint={thisEndpoint}
+              />
+              <ContributionFetcher
+                rootShapeId={thisEndpoint.query.rootShapeId}
+                endpointId={endpointId}
+              >
+                {(contributions) => (
+                  <ContributionsList
+                    ContributionComponent={(contribution) => (
+                      <DocsFieldOrParameterContribution
+                        key={contribution.id}
+                        endpoint={{
+                          pathId,
+                          method,
+                        }}
+                        id={contribution.id}
+                        name={contribution.name}
+                        shapes={contribution.shapes}
+                        depth={contribution.depth}
+                        initialValue={contribution.value}
+                      />
+                    )}
+                    contributions={contributions}
+                  />
+                )}
+              </ContributionFetcher>
+            </div>
+            <div>
+              <ShapeFetcher rootShapeId={thisEndpoint.query.rootShapeId}>
+                {(shapes) => (
+                  <QueryParametersPanel
+                    parameters={convertShapeToQueryParameters(shapes)}
+                  />
+                )}
+              </ShapeFetcher>
+            </div>
+          </div>
+        )}
         {thisEndpoint.requestBodies.map((requestBody) => (
           <TwoColumnBodyEditable
             key={requestBody.rootShapeId}
@@ -285,5 +338,13 @@ const useStyles = makeStyles((theme) => ({
   deleteInfoHeader: {
     justifyContent: 'center',
     display: 'fixed',
+  },
+  bodyContainer: {
+    display: 'flex',
+    width: '100%',
+    marginTop: theme.spacing(6),
+    '& > div': {
+      width: '50%',
+    },
   },
 }));

--- a/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
@@ -244,17 +244,19 @@ export const EndpointRootPage: FC<
         />
         {thisEndpoint.query && (
           <div className={classes.bodyContainer} id="query-parameters">
-            <h6 className={classes.bodyHeader}>Query Parameters</h6>
+            <div className={classes.bodyHeaderContainer}>
+              <h6 className={classes.bodyHeader}>Query Parameters</h6>
+              {/* TODO QPB - change id from this to query id from spectacle */}
+              <MarkdownBodyContribution
+                id={'QUERY TODO'}
+                contributionKey={'description'}
+                defaultText={'Add a description'}
+                initialValue={'TODO'}
+                endpoint={thisEndpoint}
+              />
+            </div>
             <div className={classes.bodyDetails}>
               <div>
-                {/* TODO QPB - change id from this to query id from spectacle */}
-                <MarkdownBodyContribution
-                  id={'QUERY TODO'}
-                  contributionKey={'description'}
-                  defaultText={'Add a description'}
-                  initialValue={'TODO'}
-                  endpoint={thisEndpoint}
-                />
                 <ContributionFetcher
                   rootShapeId={thisEndpoint.query.rootShapeId}
                   endpointId={endpointId}
@@ -346,12 +348,16 @@ const useStyles = makeStyles((theme) => ({
     marginTop: theme.spacing(6),
     width: '100%',
   },
+  bodyHeaderContainer: {
+    marginBottom: theme.spacing(2),
+  },
   bodyHeader: {
     fontSize: '1.25rem',
     fontFamily: FontFamily,
     fontWeight: 500,
     lineHeight: 1.6,
     letterSpacing: '0.0075em',
+    margin: `${theme.spacing(3)}px 0`,
   },
   bodyDetails: {
     display: 'flex',

--- a/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
@@ -338,7 +338,7 @@ const useStyles = makeStyles((theme) => ({
     padding: '16px 0',
   },
   icon: {
-    paddingLeft: 8,
+    paddingLeft: theme.spacing(1),
   },
   deleteInfoHeader: {
     justifyContent: 'center',
@@ -357,14 +357,14 @@ const useStyles = makeStyles((theme) => ({
     fontWeight: 500,
     lineHeight: 1.6,
     letterSpacing: '0.0075em',
-    margin: `${theme.spacing(3)}px 0`,
+    margin: theme.spacing(3, 0),
   },
   bodyDetails: {
     display: 'flex',
     width: '100%',
     '& > div': {
       width: '50%',
-      padding: `0 ${theme.spacing(1)}px`,
+      padding: theme.spacing(0, 1),
     },
   },
 }));

--- a/workspaces/ui-v2/src/pages/docs/components/DataFetchers.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/DataFetchers.tsx
@@ -6,7 +6,7 @@ import { IShapeRenderer } from '<src>/components';
 type ContributionFetcherProps = {
   rootShapeId: string;
   endpointId: string;
-  // TODO change this typing
+  // TODO QPB change this typing - currently this holds contributions, and the data for rendering the shape
   children: (
     contributions: {
       id: string;

--- a/workspaces/ui-v2/src/pages/docs/components/DataFetchers.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/DataFetchers.tsx
@@ -20,7 +20,7 @@ type ContributionFetcherProps = {
   ) => React.ReactNode;
 };
 
-// TODO replace this by fetching the contributions in redux
+// TODO QPB replace this by fetching the contributions in redux
 export const ContributionFetcher: FC<ContributionFetcherProps> = ({
   rootShapeId,
   endpointId,
@@ -46,7 +46,7 @@ type ShapeFetcherProps = {
   children: (shapes: ReturnType<typeof useShapeDescriptor>) => React.ReactNode;
 };
 
-// TODO replace this by fetching the shapes in redux
+// TODO QPB replace this by fetching the shapes in redux
 export const ShapeFetcher: FC<ShapeFetcherProps> = ({
   rootShapeId,
   children,

--- a/workspaces/ui-v2/src/pages/docs/components/DataFetchers.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/DataFetchers.tsx
@@ -1,0 +1,56 @@
+import React, { FC } from 'react';
+import { createFlatList } from '<src>/components/FieldOrParameter';
+import { useShapeDescriptor } from '<src>/hooks/useShapeDescriptor';
+import { IShapeRenderer } from '<src>/components';
+
+type ContributionFetcherProps = {
+  rootShapeId: string;
+  endpointId: string;
+  // TODO change this typing
+  children: (
+    contributions: {
+      id: string;
+      contributionKey: string;
+      value: string;
+      endpointId: string;
+      depth: number;
+      name: string;
+      shapes: IShapeRenderer[];
+    }[]
+  ) => React.ReactNode;
+};
+
+// TODO replace this by fetching the contributions in redux
+export const ContributionFetcher: FC<ContributionFetcherProps> = ({
+  rootShapeId,
+  endpointId,
+  children,
+}) => {
+  const shapes = useShapeDescriptor(rootShapeId, undefined);
+  const contributions = createFlatList(shapes);
+  const contributionsMapped = contributions.map((contribution) => ({
+    id: contribution.contributionId,
+    contributionKey: 'description',
+    value: contribution.description,
+    endpointId: endpointId,
+    depth: contribution.depth,
+    name: contribution.name,
+    shapes: contribution.shapes,
+  }));
+
+  return <>{children(contributionsMapped)}</>;
+};
+
+type ShapeFetcherProps = {
+  rootShapeId: string;
+  children: (shapes: ReturnType<typeof useShapeDescriptor>) => React.ReactNode;
+};
+
+// TODO replace this by fetching the shapes in redux
+export const ShapeFetcher: FC<ShapeFetcherProps> = ({
+  rootShapeId,
+  children,
+}) => {
+  const shapes = useShapeDescriptor(rootShapeId, undefined);
+  return <>{children(shapes)}</>;
+};

--- a/workspaces/ui-v2/src/pages/docs/components/EndpointTOC.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/EndpointTOC.tsx
@@ -3,10 +3,11 @@ import makeStyles from '@material-ui/styles/makeStyles';
 import { getReasonPhrase } from 'http-status-codes';
 import { List, ListItem, Typography } from '@material-ui/core';
 import { SubtleGreyBackground } from '<src>/styles';
-import { IRequestBody, IResponseBody } from '<src>/types';
+import { IQueryParameters, IRequestBody, IResponseBody } from '<src>/types';
 import { goToAnchor } from '<src>/utils';
 
 export type EndpointTOCProps = {
+  query: IQueryParameters | null;
   requests: IRequestBody[];
   responses: IResponseBody[];
 };
@@ -30,9 +31,19 @@ export function EndpointTOC(props: EndpointTOCProps) {
 
   return (
     <List dense>
-      {props.requests.length === 0 && props.responses.length === 0 ? (
+      {props.query === null &&
+      props.requests.length === 0 &&
+      props.responses.length === 0 ? (
         <Typography className={classes.none}>No bodies documented.</Typography>
       ) : null}
+
+      {props.query && (
+        <EndpointTOCRow
+          label={'Query Parameters'}
+          anchorLink="query-parameters"
+          detail={<>consumes query string</>}
+        />
+      )}
 
       {props.requests.map((request) => (
         <EndpointTOCRow

--- a/workspaces/ui-v2/src/pages/docs/components/index.ts
+++ b/workspaces/ui-v2/src/pages/docs/components/index.ts
@@ -8,3 +8,4 @@ export * from './EndpointTOC';
 export * from './MarkdownBodyContribution';
 export * from './RenderBody';
 export * from './TwoColumn';
+export * from './DataFetchers';

--- a/workspaces/ui-v2/src/types/contributions.ts
+++ b/workspaces/ui-v2/src/types/contributions.ts
@@ -1,3 +1,4 @@
+// TODO clean up usages of IContribution and IContributions
 export interface IContribution {
   id: string;
   contributionKey: string;

--- a/workspaces/ui-v2/src/types/contributions.ts
+++ b/workspaces/ui-v2/src/types/contributions.ts
@@ -1,4 +1,4 @@
-// TODO clean up usages of IContribution and IContributions
+// TODO QPB clean up usages of IContribution and IContributions
 export interface IContribution {
   id: string;
   contributionKey: string;


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Targets https://github.com/opticdev/optic/pull/948

This creates the UI component for a query parameter panel. This is used in 3 locations - changelog page, documentation page and diff review flow. There are other components (request / response body renderers, path parameters) that are used in these contexts and also have their own specialized version. This PR also attempts to build a more composable solution to these.

## What
What's changing? Anything of note to call out?

Creates a QueryParameterPanel component with data fetcher / adaptor components (that can be removed if we move the data fetching into redux). 

This should all be gated by the `REACT_APP_FF_LEARN_UNDOCUMENTED_QUERY_PARAMETERS` FF - as no query parameters will be learnt or returned by spectacle.

Note the styling is currently inconsistent with the other request / response body panels (moved out header + description out of the two columns and different font families). What we'll want to do is migrate the other components to use these panels (rather than trying to emulate hard coded styles here) - ignore the `age1` field, was just testing the styling for multi row. We'll also want to adjust the styling when we render shapes (i.e. arrays, etc)

<img width="1199" alt="Screen Shot 2021-06-30 at 2 05 36 PM" src="https://user-images.githubusercontent.com/18374483/124031528-47f87680-d9ac-11eb-9cd9-eeaaf0b529f9.png">

There's a lot to follow this up. Here's an attempt to capture everything that should follow this (annotations in code related to this bet will be label `// TODO QPB` - i.e. query parameter bet

TODOS (stack ranked based on importance / sequence - might not get to everything as part of this bet):
- [ ] Update QueryParameterPanel to handle changelog renderering
- [ ] Implement QueryParameterPanel on the diff and changelog parts and handle relevant UI diff components
- [ ] Move BodyRender to components and make it use the `Panel` component
- [ ] Update PathParameters to be a PathParameterPanel and use the `Panel` component
- [ ] Move contributions into redux (split from main data models, i.e. endpoints / requests / shapes)
- [ ] Provide way to query changes per field / shape / body, etc
- [ ] Move shape accumulation into redux (requires changing the way we query for changes)
- [ ] Migrate + reduce number of usages of docs field params specializations
- [ ] Migrate current UI components to use the panel components created above (e.g. BodyPanel, PathParametersPanel, QueryParameterPanel)
- [ ] Consolidate color scheme (right now these are copy pasted from current usage)
- [ ] Reorganize `<src>/components` - we probably want a distinction between things like a `Button` and more specialized components like `QueryParameterPanel` - similar to the [atomic design](https://bradfrost.com/blog/post/atomic-web-design/) (naming tbd if we want to follow atoms / molecudes)


## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
