### PR TITLE
Add query param panel to changelog page

### DIFF
--- a/workspaces/ui-v2/src/components/DataFetchers.tsx
+++ b/workspaces/ui-v2/src/components/DataFetchers.tsx
@@ -6,6 +6,7 @@ import { IShapeRenderer } from '<src>/components';
 type ContributionFetcherProps = {
   rootShapeId: string;
   endpointId: string;
+  changesSinceBatchCommit?: string;
   // TODO QPB change this typing - currently this holds contributions, and the data for rendering the shape
   children: (
     contributions: {
@@ -25,8 +26,9 @@ export const ContributionFetcher: FC<ContributionFetcherProps> = ({
   rootShapeId,
   endpointId,
   children,
+  changesSinceBatchCommit,
 }) => {
-  const shapes = useShapeDescriptor(rootShapeId, undefined);
+  const shapes = useShapeDescriptor(rootShapeId, changesSinceBatchCommit);
   const contributions = createFlatList(shapes);
   const contributionsMapped = contributions.map((contribution) => ({
     id: contribution.contributionId,
@@ -43,14 +45,16 @@ export const ContributionFetcher: FC<ContributionFetcherProps> = ({
 
 type ShapeFetcherProps = {
   rootShapeId: string;
+  changesSinceBatchCommit?: string;
   children: (shapes: ReturnType<typeof useShapeDescriptor>) => React.ReactNode;
 };
 
 // TODO QPB replace this by fetching the shapes in redux
 export const ShapeFetcher: FC<ShapeFetcherProps> = ({
   rootShapeId,
+  changesSinceBatchCommit,
   children,
 }) => {
-  const shapes = useShapeDescriptor(rootShapeId, undefined);
+  const shapes = useShapeDescriptor(rootShapeId, changesSinceBatchCommit);
   return <>{children(shapes)}</>;
 };

--- a/workspaces/ui-v2/src/components/QueryParametersPanel.tsx
+++ b/workspaces/ui-v2/src/components/QueryParametersPanel.tsx
@@ -1,8 +1,15 @@
 import React, { FC } from 'react';
 import { makeStyles } from '@material-ui/core';
+import classnames from 'classnames';
+
+import {
+  FontFamily,
+  AddedGreenBackground,
+  ChangedYellowBackground,
+  RemovedRedBackground,
+} from '<src>/styles';
 import { IFieldRenderer, IShapeRenderer, ShapeRenderer } from './ShapeRenderer';
 import { Panel } from './Panel';
-import { FontFamily } from '<src>/styles';
 
 type QueryParameters = Record<string, IFieldRenderer>;
 
@@ -16,7 +23,10 @@ export const convertShapeToQueryParameters = (
 ): QueryParameters => {
   const queryParameters: QueryParameters = {};
   if (shapes.length !== 1 || !shapes[0].asObject) {
-    console.error('unexpected format for query parameters');
+    if (shapes.length > 1) {
+      console.error('unexpected format for query parameters');
+    }
+    // otherwise loading
     return {};
   }
 
@@ -35,7 +45,13 @@ export const QueryParametersPanel: FC<QueryParametersPanelProps> = ({
     // TODO QPB add in query parsing strategy here?
     <Panel header={''}>
       {Object.entries(parameters).map(([key, field]) => (
-        <div className={classes.queryComponentContainer}>
+        <div
+          className={classnames(classes.queryComponentContainer, [
+            ...[field.changes?.added && classes.added],
+            ...[field.changes?.changed && classes.changed],
+          ])}
+          key={classes.queryKey}
+        >
           <div className={classes.queryKey}>{key}</div>
           <div>
             <ShapeRenderer showExamples={false} shape={field.shapeChoices} />
@@ -59,5 +75,14 @@ const useStyles = makeStyles((theme) => ({
     fontFamily: FontFamily,
     fontWeight: 600,
     fontSize: theme.typography.fontSize - 1,
+  },
+  added: {
+    backgroundColor: `${AddedGreenBackground}`,
+  },
+  changed: {
+    backgroundColor: `${ChangedYellowBackground}`,
+  },
+  removed: {
+    backgroundColor: `${RemovedRedBackground}`,
   },
 }));

--- a/workspaces/ui-v2/src/components/index.ts
+++ b/workspaces/ui-v2/src/components/index.ts
@@ -15,3 +15,4 @@ export * from './Page';
 export * from './LightToolTip';
 export * from './Panel';
 export * from './QueryParametersPanel';
+export * from './DataFetchers';

--- a/workspaces/ui-v2/src/pages/changelog/ChangelogEndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/changelog/ChangelogEndpointRootPage.tsx
@@ -270,14 +270,14 @@ const useStyles = makeStyles((theme) => ({
     fontWeight: 500,
     lineHeight: 1.6,
     letterSpacing: '0.0075em',
-    margin: `${theme.spacing(3)}px 0`,
+    margin: theme.spacing(3, 0),
   },
   bodyDetails: {
     display: 'flex',
     width: '100%',
     '& > div': {
       width: '50%',
-      padding: `0 ${theme.spacing(1)}px`,
+      padding: theme.spacing(1, 0),
     },
   },
 }));

--- a/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
@@ -14,6 +14,8 @@ import {
   ContributionsList,
   QueryParametersPanel,
   convertShapeToQueryParameters,
+  ContributionFetcher,
+  ShapeFetcher,
 } from '<src>/components';
 import { useDocumentationPageLink } from '<src>/components/navigation/Routes';
 import { FontFamily, SubtleBlueBackground } from '<src>/styles';
@@ -35,8 +37,6 @@ import {
   MarkdownBodyContribution,
   TwoColumn,
   DeleteEndpointConfirmationModal,
-  ContributionFetcher,
-  ShapeFetcher,
 } from '<src>/pages/docs/components';
 
 export const EndpointRootPageWithDocsNav: FC<

--- a/workspaces/ui-v2/src/pages/docs/components/index.ts
+++ b/workspaces/ui-v2/src/pages/docs/components/index.ts
@@ -8,4 +8,3 @@ export * from './EndpointTOC';
 export * from './MarkdownBodyContribution';
 export * from './RenderBody';
 export * from './TwoColumn';
-export * from './DataFetchers';


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

This targets https://github.com/opticdev/optic/pull/951

Adding in the query param component for the changelog flow. I'm not sure why the changelog doesn't work (the todo-partial example has weird events that don't generate a changelog and I haven't had a chance to dig into this) - we'll definitely want to verify this when we have a more e2e pass for generating events.

Here's what it _would_ look like with correct events - there's better styling we can add here (and a background for an overall field added might not make sense if the shape renderer doesnt have a green background as well)
<img width="1196" alt="Screen Shot 2021-06-30 at 4 07 29 PM" src="https://user-images.githubusercontent.com/18374483/124042253-48e5d400-d9bd-11eb-8d5a-1ed6053b1c97.png">

## What
What's changing? Anything of note to call out?

- Moved datafetchers (which should be temporary) from `<src>/pages/docs/components` -> `<src>/components`
- Fetch changelog information in useShapeDescriptor

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
