### PR TITLE
Add in query parameter renderer in diff preview

### DIFF
--- a/workspaces/ui-v2/src/lib/Interfaces.ts
+++ b/workspaces/ui-v2/src/lib/Interfaces.ts
@@ -186,6 +186,7 @@ export interface IResponseBodyLocation {
 export interface IParsedLocation {
   pathId: string;
   method: string;
+  inQuery?: boolean;
   inRequest?: IRequestBodyLocation;
   inResponse?: IResponseBodyLocation;
 }

--- a/workspaces/ui-v2/src/pages/diffs/components/HighlightedLocation.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/components/HighlightedLocation.tsx
@@ -1,40 +1,59 @@
-import React from 'react';
+import React, { FC } from 'react';
 import { IParsedLocation } from '../../../lib/Interfaces';
 import { OpticBlueReadable, SubtleBlueBackground } from '<src>/styles';
 //@ts-ignore
 import ScrollIntoViewIfNeeded from 'react-scroll-into-view-if-needed';
 
-type IHighlightedLocation = {
-  targetLocation?: IParsedLocation;
-  statusCode?: number | undefined;
-  contentType?: string | undefined;
-  inRequest?: boolean | undefined;
-  inResponse?: boolean | undefined;
-  children: any;
-};
+type IHighlightedLocation =
+  | {
+      targetLocation?: IParsedLocation;
+      statusCode?: undefined;
+      contentType?: undefined;
+      expectedLocation: Location.Query;
+    }
+  | {
+      targetLocation?: IParsedLocation;
+      statusCode?: undefined;
+      contentType: string;
+      expectedLocation: Location.Request;
+    }
+  | {
+      targetLocation?: IParsedLocation;
+      statusCode: number;
+      contentType: string;
+      expectedLocation: Location.Response;
+    };
 
-export function HighlightedLocation({
-  targetLocation,
-  contentType,
-  statusCode,
-  inResponse,
-  inRequest,
-  children,
-}: IHighlightedLocation) {
+export enum Location {
+  Request,
+  Response,
+  Query,
+}
+
+export const HighlightedLocation: FC<IHighlightedLocation> = (props) => {
+  const { targetLocation, children } = props;
   const matches: boolean = (() => {
-    if (targetLocation && targetLocation.inRequest && inRequest) {
-      return (
-        targetLocation.inRequest.contentType === contentType &&
-        Boolean(contentType)
-      );
+    if (!targetLocation) {
+      return false;
     }
-    if (targetLocation && targetLocation.inResponse && inResponse) {
-      return (
-        targetLocation.inResponse.contentType === contentType &&
-        targetLocation.inResponse.statusCode === statusCode
-      );
+
+    switch (props.expectedLocation) {
+      case Location.Request:
+        return !!(
+          targetLocation.inRequest &&
+          targetLocation.inRequest.contentType === props.contentType
+        );
+      case Location.Response:
+        return !!(
+          targetLocation.inResponse &&
+          targetLocation.inResponse.contentType === props.contentType &&
+          targetLocation.inResponse.statusCode === props.statusCode
+        );
+      case Location.Query:
+        return !!targetLocation.inQuery;
+      default:
+        return false;
     }
-    return false;
   })();
 
   if (targetLocation && matches) {
@@ -57,4 +76,4 @@ export function HighlightedLocation({
   }
 
   return <>{children}</>;
-}
+};


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Targets https://github.com/opticdev/optic/pull/952

Add in query param panel to diff preview flow.

Here's where it is - the styling needs work (there's a large amount of white space which is because the other components already include margins in different spots), but I am going to see if i can convert some code / components to use the shared components I just built. Again this is behind a FF so we shouldn't get any query params coming through right now
<img width="586" alt="Screen Shot 2021-06-30 at 4 38 02 PM" src="https://user-images.githubusercontent.com/18374483/124044348-19859600-d9c2-11eb-9256-f7d5807eb42d.png">


## What
What's changing? Anything of note to call out?

- Minor refactor of the `HighlightLocation` component - now supports highlighting query parameter changes
- Add to review diff endpoint preview

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
