### PR TITLE
Connect query parameter id and contributions to query parameter compo…

### DIFF
--- a/workspaces/spectacle/src/graphql/schema.ts
+++ b/workspaces/spectacle/src/graphql/schema.ts
@@ -110,11 +110,17 @@ type HttpBody {
 Query Parameters, 1:1 mapping to a HttpRequest
 """
 type QueryParameters {
+  # Id for the query parameter
+  id: String!
+
   # Root shape ID for the QueryParameter. Look at the shapeChoices query getting more information about the root shape
   rootShapeId: String!
 
   # Is the body removed
   isRemoved: Boolean!
+
+  # Contributions for the query parameter
+  contributions: JSON
 }
 
 """

--- a/workspaces/spectacle/src/spectacle.ts
+++ b/workspaces/spectacle/src/spectacle.ts
@@ -353,11 +353,26 @@ export async function makeSpectacle(opticContext: IOpticContext) {
       },
     },
     QueryParameters: {
+      id: () => {
+        // TODO QPB - connect this to the correct value
+        // return parent.value.id
+        return `query_${uuidv4()}`;
+      },
       rootShapeId: (parent: endpoints.QueryParametersNodeWrapper) => {
         return parent.value.rootShapeId;
       },
       isRemoved: (parent: endpoints.QueryParametersNodeWrapper) => {
         return parent.value.isRemoved;
+      },
+      contributions: (
+        parent: endpoints.QueryParametersNodeWrapper,
+        _: {},
+        context: GraphQLContext
+      ) => {
+        // TODO QPB - connect this to the correct value
+        // const id = parent.value.id;
+        const id = `query_${uuidv4()}`;
+        return context.spectacleContext().contributionsProjection[id] || {};
       },
     },
     Path: {

--- a/workspaces/ui-v2/src/pages/changelog/ChangelogEndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/changelog/ChangelogEndpointRootPage.tsx
@@ -167,11 +167,16 @@ const ChangelogRootComponent: FC<
         />
 
         {thisEndpoint.query && (
-          <div className={classes.bodyContainer} id="query-parameters">
+          <div
+            className={classes.bodyContainer}
+            id={thisEndpoint.query.queryParametersId}
+          >
             <div className={classes.bodyHeaderContainer}>
               <h6 className={classes.bodyHeader}>Query Parameters</h6>
-              {/* TODO QPB - change id from this to query id from spectacle */}
-              <ReactMarkdown className={classes.contents} source={'TODO'} />
+              <ReactMarkdown
+                className={classes.contents}
+                source={thisEndpoint.query.description}
+              />
             </div>
             <div className={classes.bodyDetails}>
               <div>

--- a/workspaces/ui-v2/src/pages/diffs/EndpointDocumentationPane.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/EndpointDocumentationPane.tsx
@@ -117,8 +117,7 @@ export const EndpointDocumentationPane: FC<
           targetLocation={highlightedLocation}
           expectedLocation={Location.Query}
         >
-          {/* TODO QPB - change id from this to query id from spectacle */}
-          <div id="query-parameters">
+          <div id={thisEndpoint.query.queryParametersId}>
             <h6 className={classes.bodyHeader}>Query Parameters</h6>
             <div className={classes.bodyDetails}>
               <ShapeFetcher

--- a/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
@@ -243,15 +243,17 @@ export const EndpointRootPage: FC<
           }
         />
         {thisEndpoint.query && (
-          <div className={classes.bodyContainer} id="query-parameters">
+          <div
+            className={classes.bodyContainer}
+            id={thisEndpoint.query.queryParametersId}
+          >
             <div className={classes.bodyHeaderContainer}>
               <h6 className={classes.bodyHeader}>Query Parameters</h6>
-              {/* TODO QPB - change id from this to query id from spectacle */}
               <MarkdownBodyContribution
-                id={'QUERY TODO'}
+                id={thisEndpoint.query.queryParametersId}
                 contributionKey={'description'}
                 defaultText={'Add a description'}
-                initialValue={'TODO'}
+                initialValue={thisEndpoint.query.description}
                 endpoint={thisEndpoint}
               />
             </div>

--- a/workspaces/ui-v2/src/store/endpoints/thunks.ts
+++ b/workspaces/ui-v2/src/store/endpoints/thunks.ts
@@ -23,8 +23,10 @@ export const AllEndpointsQuery = `{
     requestContributions
     isRemoved
     query {
+      id
       rootShapeId
       isRemoved
+      contributions
     }
     bodies {
       contentType
@@ -66,8 +68,10 @@ export type EndpointQueryResults = {
     isRemoved: boolean;
     bodies: HttpBody[];
     query?: {
+      id: string;
       rootShapeId: string;
       isRemoved: boolean;
+      contributions: Record<string, string>;
     };
     responses: {
       id: string;
@@ -95,7 +99,14 @@ export const endpointQueryResultsToJson = ({
     description: request.pathContributions.description || '',
     purpose: request.pathContributions.purpose || '',
     isRemoved: request.isRemoved,
-    query: request.query || null,
+    query: request.query
+      ? {
+          queryParametersId: request.query.id,
+          rootShapeId: request.query.rootShapeId,
+          isRemoved: request.query.isRemoved,
+          description: request.query.contributions.description || '',
+        }
+      : null,
     requestBodies: request.bodies.map((body) => ({
       requestId: request.id,
       contentType: body.contentType,

--- a/workspaces/ui-v2/src/types/endpoints.ts
+++ b/workspaces/ui-v2/src/types/endpoints.ts
@@ -27,8 +27,10 @@ export interface IEndpointWithChanges extends IEndpoint {
 }
 
 export interface IQueryParameters {
+  queryParametersId: string;
   rootShapeId: string;
   isRemoved: boolean;
+  description: string;
 }
 
 export interface IRequestBody {


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Moving the mocked part of the query parameter id into the spectacle layer - the query parameter id can properly be connected when https://github.com/opticdev/optic/pull/950 lands.

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
