### PR TITLE
Update spectacle projection to handle query parameter events

### DIFF
--- a/workspaces/graph-lib/src/endpoints-graph/index.ts
+++ b/workspaces/graph-lib/src/endpoints-graph/index.ts
@@ -247,15 +247,7 @@ export class RequestNodeWrapper implements NodeWrapper {
   }
 
   query(): QueryParametersNodeWrapper | null {
-    const neighbors = this.queries.listIncomingNeighborsByType(
-      this.result.id,
-      NodeType.QueryParameters
-    );
-    if (neighbors.results.length === 0) {
-      return null;
-    }
-
-    return neighbors.results[0] as QueryParametersNodeWrapper;
+    return this.path().query();
   }
 }
 
@@ -324,6 +316,18 @@ export class PathNodeWrapper implements NodeWrapper {
       this.result.id,
       NodeType.Response
     );
+  }
+
+  query(): QueryParametersNodeWrapper | null {
+    const neighbors = this.queries.listIncomingNeighborsByType(
+      this.result.id,
+      NodeType.QueryParameters
+    );
+    if (neighbors.results.length === 0) {
+      return null;
+    }
+
+    return neighbors.results[0] as QueryParametersNodeWrapper;
   }
 
   components(): PathNodeWrapper[] {

--- a/workspaces/graph-lib/src/endpoints-graph/index.ts
+++ b/workspaces/graph-lib/src/endpoints-graph/index.ts
@@ -59,7 +59,9 @@ export type ResponseNode = {
   isRemoved: boolean;
 };
 export type QueryParametersNode = {
-  rootShapeId: string;
+  queryParameterId: string;
+  rootShapeId: string | null;
+  httpMethod: string;
   isRemoved: boolean;
 };
 export type BodyNode = {
@@ -247,7 +249,7 @@ export class RequestNodeWrapper implements NodeWrapper {
   }
 
   query(): QueryParametersNodeWrapper | null {
-    return this.path().query();
+    return this.path().query(this.value.httpMethod);
   }
 }
 
@@ -318,16 +320,19 @@ export class PathNodeWrapper implements NodeWrapper {
     );
   }
 
-  query(): QueryParametersNodeWrapper | null {
+  query(httpMethod: string): QueryParametersNodeWrapper | null {
     const neighbors = this.queries.listIncomingNeighborsByType(
       this.result.id,
       NodeType.QueryParameters
     );
-    if (neighbors.results.length === 0) {
+    const queryWithHttpMethod = (neighbors.results as QueryParametersNodeWrapper[]).filter(
+      (queryNode) => queryNode.value.httpMethod === httpMethod
+    );
+    if (queryWithHttpMethod.length === 0) {
       return null;
     }
 
-    return neighbors.results[0] as QueryParametersNodeWrapper;
+    return queryWithHttpMethod[0] as QueryParametersNodeWrapper;
   }
 
   components(): PathNodeWrapper[] {

--- a/workspaces/ui-v2/public/example-sessions/todos-partial.json
+++ b/workspaces/ui-v2/public/example-sessions/todos-partial.json
@@ -1924,11 +1924,30 @@
       }
     },
     {
-      "RequestQueryParametersShapeSet": {
-        "requestId": "request_SqY61Qc9Mi",
+      "QueryParametersAdded": {
+        "queryParametersId": "query_LqY12Qc9Mi",
+        "httpMethod": "GET",
+        "pathId": "path_xhUZ8irdJO",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "ec3dd58b-bdf3-42b0-88a8-7e8f85f49e74",
+          "clientCommandBatchId": "2cc302d2-c660-4362-9601-dc14fe69542c",
+          "createdAt": "2020-11-20T20:52:31.789Z"
+        }
+      }
+    },
+    {
+      "QueryParametersShapeSet": {
+        "queryParametersId": "query_LqY12Qc9Mi",
         "shapeDescriptor": {
           "shapeId": "shape_tNRgroSwLj",
           "isRemoved": false
+        },
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "ec3dd58b-bdf3-42b0-88a8-7e8f85f49e74",
+          "clientCommandBatchId": "2cc302d2-c660-4362-9601-dc14fe69542c",
+          "createdAt": "2020-11-20T20:52:31.789Z"
         }
       }
     },
@@ -1945,7 +1964,7 @@
         "eventContext": {
           "clientId": "anonymous",
           "clientSessionId": "ec3dd58b-bdf3-42b0-88a8-7e8f85f49e74",
-          "clientCommandBatchId": "b8aa13c5-a333-4cb2-90d0-ef1c6ba79865",
+          "clientCommandBatchId": "2cc302d2-c660-4362-9601-dc14fe69542c",
           "createdAt": "2020-11-20T20:52:31.789Z"
         }
       }
@@ -1963,7 +1982,7 @@
         "eventContext": {
           "clientId": "anonymous",
           "clientSessionId": "ec3dd58b-bdf3-42b0-88a8-7e8f85f49e74",
-          "clientCommandBatchId": "b8aa13c5-a333-4cb2-90d0-ef1c6ba79865",
+          "clientCommandBatchId": "2cc302d2-c660-4362-9601-dc14fe69542c",
           "createdAt": "2020-11-20T20:52:31.789Z"
         }
       }
@@ -1982,7 +2001,7 @@
         "eventContext": {
           "clientId": "anonymous",
           "clientSessionId": "ec3dd58b-bdf3-42b0-88a8-7e8f85f49e74",
-          "clientCommandBatchId": "b8aa13c5-a333-4cb2-90d0-ef1c6ba79865",
+          "clientCommandBatchId": "2cc302d2-c660-4362-9601-dc14fe69542c",
           "createdAt": "2020-11-20T20:52:31.789Z"
         }
       }
@@ -1993,7 +2012,7 @@
         "eventContext": {
           "clientId": "anonymous",
           "clientSessionId": "ec3dd58b-bdf3-42b0-88a8-7e8f85f49e74",
-          "clientCommandBatchId": "b8aa13c5-a333-4cb2-90d0-ef1c6ba79865",
+          "clientCommandBatchId": "2cc302d2-c660-4362-9601-dc14fe69542c",
           "createdAt": "2020-11-20T20:52:31.789Z"
         }
       }


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Updated to handle the new query parameter events. This feels a little odd to me and it feels like we should have an endpoint node (I don't think we need a new event, but we can add this into the spectacle projection). This should work though

## What
What's changing? Anything of note to call out?

Feel free to merge this if it makes sense @JaapRood 

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
