### PR TITLE
Fix crash on the bulk learn modal

### DIFF
--- a/workspaces/ui-v2/src/pages/diffs/AddEndpointsPage/components/BulkLearnModal.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/AddEndpointsPage/components/BulkLearnModal.tsx
@@ -13,7 +13,7 @@ import {
 import { EndpointName, SpinningOpticLogo } from '<src>/components';
 import { useSharedDiffContext } from '<src>/pages/diffs/contexts/SharedDiffContext';
 import { IUndocumentedUrl } from '<src>/pages/diffs/contexts/SharedDiffState';
-import { makePattern } from '<src>/utils';
+import { makePattern, urlStringToPathComponents } from '<src>/utils';
 
 type BulkLearnModalProps = {
   undocumentedEndpointsToLearn: IUndocumentedUrl[];
@@ -80,14 +80,19 @@ export const BulkLearnModal: FC<BulkLearnModalProps> = ({
     ({ path, method }) => {
       // For selectedUrls, unspecified selected urls will not be
       // in wipPatterns
-      const pattern = wipPatterns[path + method]
-        ? makePattern(wipPatterns[path + method].components)
-        : path;
-      return {
-        pattern,
-        method,
-        pathComponents: wipPatterns[path + method].components,
-      };
+      if (wipPatterns[path + method]) {
+        return {
+          pattern: makePattern(wipPatterns[path + method].components),
+          method,
+          pathComponents: wipPatterns[path + method].components,
+        };
+      } else {
+        return {
+          pattern: path,
+          method,
+          pathComponents: urlStringToPathComponents(path),
+        };
+      }
     }
   );
   const [learningInfo, setLearningInfo] = useState<{


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

In this PR https://github.com/opticdev/optic/pull/942/files I added `pathComponents: wipPatterns[path + method].components` - which crashes when no path parameters are specified on the diff flow. This PR fixes that

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
