### PR TITLE
Add stricter typing to diff flow

### DIFF
--- a/workspaces/ui-v2/src/lib/Interfaces.ts
+++ b/workspaces/ui-v2/src/lib/Interfaces.ts
@@ -7,9 +7,9 @@ import { IEndpoint, IRequestBody, IResponseBody } from '<src>/types';
 
 export interface IInterpretation {
   previewTabs: IInteractionPreviewTab[];
-  diffDescription?: IDiffDescription;
-  updateSpecChoices?: IPatchChoices;
-  toCommands: (choices?: IPatchChoices) => any[];
+  diffDescription: IDiffDescription;
+  updateSpecChoices: IPatchChoices;
+  toCommands: (choices: IPatchChoices) => any[];
 }
 
 export interface IShapeUpdateChoice {

--- a/workspaces/ui-v2/src/lib/parse-diff.ts
+++ b/workspaces/ui-v2/src/lib/parse-diff.ts
@@ -163,15 +163,6 @@ export class ParsedDiff {
   }
 }
 
-export function parseDiffsArray(
-  array: [IDiff, string[], string][]
-): ParsedDiff[] {
-  return array.map(
-    ([rawDiff, pointers, fingerprint]) =>
-      new ParsedDiff(rawDiff, pointers, fingerprint)
-  );
-}
-
 export class BodyShapeDiff {
   shapeTrail: IShapeTrail;
   normalizedShapeTrail: IShapeTrail;

--- a/workspaces/ui-v2/src/pages/diffs/ReviewEndpointDiffPage/DiffLinks.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/ReviewEndpointDiffPage/DiffLinks.tsx
@@ -16,26 +16,22 @@ export function DiffLinks({
   const classes = useStyles();
   return (
     <List>
-      {/* TODO figure out why diffDescription can be nullable */}
-      {allDiffs.map(
-        (diff, i) =>
-          diff.diffDescription && (
-            <React.Fragment key={diff.diffDescription.diffHash}>
-              <ListSubheader className={classes.locationHeader}>
-                {diff.diffDescription.location.inQuery
-                  ? 'Query Parameters'
-                  : diff.diffDescription.location.inRequest
-                  ? `Request Body ${diff.diffDescription.location.inRequest.contentType}`
-                  : diff.diffDescription.location.inResponse
-                  ? `${diff.diffDescription.location.inResponse.statusCode} Response ${diff.diffDescription.location.inResponse.contentType}`
-                  : 'Unknown location'}
-              </ListSubheader>
-              <ListItem button onClick={() => setSelectedDiff(i)}>
-                <ICopyRender variant="" copy={diff.diffDescription.title} />
-              </ListItem>
-            </React.Fragment>
-          )
-      )}
+      {allDiffs.map((diff, i) => (
+        <React.Fragment key={diff.diffDescription.diffHash}>
+          <ListSubheader className={classes.locationHeader}>
+            {diff.diffDescription.location.inQuery
+              ? 'Query Parameters'
+              : diff.diffDescription.location.inRequest
+              ? `Request Body ${diff.diffDescription.location.inRequest.contentType}`
+              : diff.diffDescription.location.inResponse
+              ? `${diff.diffDescription.location.inResponse.statusCode} Response ${diff.diffDescription.location.inResponse.contentType}`
+              : 'Unknown location'}
+          </ListSubheader>
+          <ListItem button onClick={() => setSelectedDiff(i)}>
+            <ICopyRender variant="" copy={diff.diffDescription.title} />
+          </ListItem>
+        </React.Fragment>
+      ))}
     </List>
   );
 }

--- a/workspaces/ui-v2/src/pages/diffs/ReviewEndpointDiffPage/ReviewEndpointDiffPage.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/ReviewEndpointDiffPage/ReviewEndpointDiffPage.tsx
@@ -33,7 +33,7 @@ const useRedirectForDiffCompleted = (allDiffs: IInterpretation[]) => {
   useEffect(() => {
     if (
       allDiffs.length > 0 &&
-      allDiffs.every((i) => isDiffHandled(i.diffDescription?.diffHash!))
+      allDiffs.every((i) => isDiffHandled(i.diffDescription.diffHash))
     ) {
       history.push(diffReviewPage.linkTo());
     }
@@ -123,7 +123,7 @@ export const ReviewEndpointDiffPage: FC<ReviewEndpointDiffPageProps> = ({
             setCurrentIndex={setCurrentIndex}
           />
           <DiffCard
-            key={renderedDiff.diffDescription?.diffHash}
+            key={renderedDiff.diffDescription.diffHash}
             updatedSpecChoices={(choices) => {
               setPreviewCommands(renderedDiff.toCommands(choices));
             }}
@@ -141,9 +141,9 @@ export const ReviewEndpointDiffPage: FC<ReviewEndpointDiffPageProps> = ({
               );
             }}
             ignore={() => {
-              addDiffHashIgnore(renderedDiff.diffDescription!.diffHash);
+              addDiffHashIgnore(renderedDiff.diffDescription.diffHash);
               setCurrentIndex(
-                getNextIncompleteDiff(renderedDiff.diffDescription!.diffHash)
+                getNextIncompleteDiff(renderedDiff.diffDescription.diffHash)
               );
             }}
           />
@@ -159,7 +159,7 @@ export const ReviewEndpointDiffPage: FC<ReviewEndpointDiffPageProps> = ({
             pathId={pathId}
             lastBatchCommit={batchCommit}
             highlightedLocation={
-              allDiffs[currentIndex].diffDescription?.location
+              allDiffs[currentIndex].diffDescription.location
             }
             renderHeader={() => (
               <>

--- a/workspaces/ui-v2/src/pages/diffs/components/ApproveAll.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/components/ApproveAll.tsx
@@ -41,7 +41,7 @@ export default function ApproveAll(props: { disabled?: boolean }) {
     analytics.userApprovedAll(shapeDiffs.results.length, 0);
     shapeDiffs.results.forEach((i) => {
       approveCommandsForDiff(
-        i.diffDescription?.diffHash!,
+        i.diffDescription.diffHash,
         i.toCommands(i.updateSpecChoices)
       );
     });

--- a/workspaces/ui-v2/src/pages/diffs/components/BuildSpecPatch.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/components/BuildSpecPatch.tsx
@@ -18,9 +18,9 @@ import { namerForOptions } from '<src>/lib/quick-namer';
 import { ArrowRight } from '@material-ui/icons';
 
 type IBuildSpecPatch = {
-  patchChoices?: IPatchChoices;
+  patchChoices: IPatchChoices;
   diffHash: string;
-  onPathChoicesUpdated: (pathChoices?: IPatchChoices) => void;
+  onPathChoicesUpdated: (pathChoices: IPatchChoices) => void;
   approved: () => void;
   ignore: () => void;
 };
@@ -63,7 +63,7 @@ export function BuildSpecPatch({
   const disabledWhenNoShapeSelected =
     patchChoices &&
     patchChoices.isField &&
-    selectedChoices?.shapes.every((i) => !i.isValid);
+    selectedChoices.shapes.every((i) => !i.isValid);
 
   return (
     <FormControl component="fieldset" style={{ width: '100%', paddingLeft: 5 }}>

--- a/workspaces/ui-v2/src/pages/diffs/components/DiffCard.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/components/DiffCard.tsx
@@ -31,8 +31,8 @@ type IDiffCardProps = {
   approve: () => void;
   ignore: () => void;
   handled: boolean;
-  specChoices?: IPatchChoices;
-  updatedSpecChoices: (choices?: IPatchChoices) => void;
+  specChoices: IPatchChoices;
+  updatedSpecChoices: (choices: IPatchChoices) => void;
 };
 
 export function DiffCard({


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

I was digging around the diff flow for implementing query parameters and I believe that there are typing we can make more strict. These were not possible before as there were paths that it was possible to get `diffDescription` and `updateSpecChoices` as undefined (but it appears these code paths have been removed)

I checked the pathways that we generate IInterpretations (new region intepretation and shape diff intepretation) and it looks like we are always guaranteed to have an interpretation with non-nullable diffDescriptions and updateSpecChoices

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
