### PR TITLE
Fix cannot read commands of undefined

### DIFF
--- a/workspaces/ui-v2/src/lib/new-regions-interpreter.ts
+++ b/workspaces/ui-v2/src/lib/new-regions-interpreter.ts
@@ -1,3 +1,5 @@
+import * as Sentry from '@sentry/react';
+
 import {
   CurrentSpecContext,
   IInterpretation,
@@ -39,9 +41,25 @@ function newContentType(
   learnedBodies: ILearnedBodies
 ): IInterpretation {
   if (udiff.isA(DiffTypes.UnmatchedRequestBodyContentType)) {
-    const { commands } = learnedBodies.requests.find(
+    const learnedRequestBody = learnedBodies.requests.find(
       (i) => i.contentType === location.inRequest?.contentType
-    )!;
+    );
+
+    if (!learnedRequestBody) {
+      console.error(
+        `Could not learn body for request with content type ${location.inRequest?.contentType}`
+      );
+      Sentry.captureEvent({
+        message: 'No learned request body was found',
+        extra: {
+          learnedBodies,
+          location,
+          udiff,
+        },
+      });
+    }
+
+    const commands = learnedRequestBody ? learnedRequestBody.commands : [];
 
     return {
       previewTabs: [
@@ -77,11 +95,27 @@ function newContentType(
     };
   } else if (udiff.isA(DiffTypes.UnmatchedResponseBodyContentType)) {
     //learn status code too.... currently missing
-    const { commands } = learnedBodies.responses.find(
+    const learnedResponseBody = learnedBodies.responses.find(
       (i) =>
         i.contentType === location.inResponse?.contentType &&
         i.statusCode === location.inResponse?.statusCode
-    )!;
+    );
+
+    if (!learnedResponseBody) {
+      console.error(
+        `Could not learn body for response with status code ${location.inResponse?.statusCode} content type ${location.inResponse?.contentType}`
+      );
+      Sentry.captureEvent({
+        message: 'No learned response body was found',
+        extra: {
+          learnedBodies,
+          location,
+          udiff,
+        },
+      });
+    }
+
+    const commands = learnedResponseBody ? learnedResponseBody.commands : [];
 
     return {
       previewTabs: [


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

If there is an unmatched request or response body, and the learner does not find anything to learn, the UI crashes here. Adding this to be resilient to that (it's still not correct, and we'll still get sentry errors). The root cause is that there's a mismatch between the diff intepretation and the body learner (something I'm not too sure how that'd be an issue and what information would be useful to debug).

This will cause the UI to render _something_ but no commands will be generated (which I believe is better than crashing)

## What
What's changing? Anything of note to call out?

This also sends learnedbody information and the diff information to sentry - do we want to sanitize any of this information? 

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
