### PR TITLE
Add query parameter parsing strategy info tooltip

### DIFF
--- a/workspaces/ui-v2/src/components/QueryParametersPanel.tsx
+++ b/workspaces/ui-v2/src/components/QueryParametersPanel.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
-import { makeStyles } from '@material-ui/core';
+import { makeStyles, Tooltip } from '@material-ui/core';
+import { Help as HelpIcon } from '@material-ui/icons';
 import classnames from 'classnames';
 
 import {
@@ -42,8 +43,16 @@ export const QueryParametersPanel: FC<QueryParametersPanelProps> = ({
 }) => {
   const classes = useStyles();
   return (
-    // TODO QPB add in query parsing strategy here?
-    <Panel header={''}>
+    <Panel
+      header={
+        <Tooltip title="?key=value1&key=value2 is treated as an array of key=[value1, value2]">
+          <div className={classes.queryTooltipContainer}>
+            Query string parsing strategy
+            <HelpIcon fontSize="small" className={classes.queryTooltipIcon} />
+          </div>
+        </Tooltip>
+      }
+    >
       {Object.entries(parameters).map(([key, field]) => (
         <div
           className={classnames(classes.queryComponentContainer, [
@@ -63,6 +72,13 @@ export const QueryParametersPanel: FC<QueryParametersPanelProps> = ({
 };
 
 const useStyles = makeStyles((theme) => ({
+  queryTooltipContainer: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+  queryTooltipIcon: {
+    margin: theme.spacing(0, 1),
+  },
   queryComponentContainer: {
     marginBottom: theme.spacing(1),
     padding: theme.spacing(1, 0),


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

<img width="690" alt="Screen Shot 2021-07-06 at 3 59 17 PM" src="https://user-images.githubusercontent.com/18374483/124676297-1fbcbc00-de73-11eb-80a4-7ba822a68166.png">

## What
What's changing? Anything of note to call out?

In the future, a tooltip might not be the best component for complex query pattern parsing, but for now I think this is sufficient.

Also I am not a huge fan of the current copy, so any suggestions are appreciated

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
