### PR TITLE
Hide reset to commit button for cloud viewer

### DIFF
--- a/workspaces/ui-v2/src/components/navigation/TopNavigation.tsx
+++ b/workspaces/ui-v2/src/components/navigation/TopNavigation.tsx
@@ -51,8 +51,7 @@ export function TopNavigation(props: { AccessoryNavigation?: any }) {
                   Icon={SubjectIcon}
                 />
 
-                {/*@aidan: this needs to change*/}
-                {appConfig.navigation.showDiff && (
+                {appConfig.features.allowEditing && (
                   <NavButton
                     title="Diffs"
                     to={diffsPage.linkTo()}

--- a/workspaces/ui-v2/src/components/navigation/TopNavigation.tsx
+++ b/workspaces/ui-v2/src/components/navigation/TopNavigation.tsx
@@ -51,7 +51,7 @@ export function TopNavigation(props: { AccessoryNavigation?: any }) {
                   Icon={SubjectIcon}
                 />
 
-                {appConfig.features.allowEditing && (
+                {appConfig.allowEditing && (
                   <NavButton
                     title="Diffs"
                     to={diffsPage.linkTo()}

--- a/workspaces/ui-v2/src/contexts/config/AppConfiguration.tsx
+++ b/workspaces/ui-v2/src/contexts/config/AppConfiguration.tsx
@@ -2,8 +2,8 @@ import React, { ReactNode, useContext } from 'react';
 import invariant from 'invariant';
 
 interface IAppConfigurations {
-  navigation: {
-    showDiff: boolean;
+  features: {
+    allowEditing: boolean;
   };
   analytics:
     | { enabled: false }
@@ -13,9 +13,6 @@ interface IAppConfigurations {
         sentryUrl?: string;
         fullStoryOrgId?: string;
       };
-  documentation: {
-    allowDescriptionEditing: boolean;
-  };
   backendApi: {
     domain?: string;
   };

--- a/workspaces/ui-v2/src/contexts/config/AppConfiguration.tsx
+++ b/workspaces/ui-v2/src/contexts/config/AppConfiguration.tsx
@@ -2,9 +2,7 @@ import React, { ReactNode, useContext } from 'react';
 import invariant from 'invariant';
 
 interface IAppConfigurations {
-  features: {
-    allowEditing: boolean;
-  };
+  allowEditing: boolean;
   analytics:
     | { enabled: false }
     | {

--- a/workspaces/ui-v2/src/entry-points/cloud/cloud-viewer.tsx
+++ b/workspaces/ui-v2/src/entry-points/cloud/cloud-viewer.tsx
@@ -41,17 +41,14 @@ import { SpecRepositoryStore } from '<src>/contexts/SpecRepositoryContext';
 
 const appConfig: OpticAppConfig = {
   config: {
-    navigation: {
-      showDiff: false,
+    features: {
+      allowEditing: false,
     },
     analytics: {
       enabled: Boolean(process.env.REACT_APP_ENABLE_ANALYTICS === 'yes'),
       segmentToken: process.env.REACT_APP_SEGMENT_CLOUD_UI,
       fullStoryOrgId: process.env.REACT_APP_FULLSTORY_ORG,
       sentryUrl: process.env.REACT_APP_SENTRY_URL,
-    },
-    documentation: {
-      allowDescriptionEditing: false,
     },
     backendApi: {
       domain:

--- a/workspaces/ui-v2/src/entry-points/cloud/cloud-viewer.tsx
+++ b/workspaces/ui-v2/src/entry-points/cloud/cloud-viewer.tsx
@@ -41,9 +41,7 @@ import { SpecRepositoryStore } from '<src>/contexts/SpecRepositoryContext';
 
 const appConfig: OpticAppConfig = {
   config: {
-    features: {
-      allowEditing: false,
-    },
+    allowEditing: false,
     analytics: {
       enabled: Boolean(process.env.REACT_APP_ENABLE_ANALYTICS === 'yes'),
       segmentToken: process.env.REACT_APP_SEGMENT_CLOUD_UI,

--- a/workspaces/ui-v2/src/entry-points/demo/demo-examples.tsx
+++ b/workspaces/ui-v2/src/entry-points/demo/demo-examples.tsx
@@ -39,9 +39,7 @@ import { SpecRepositoryStore } from '<src>/contexts/SpecRepositoryContext';
 
 const appConfig: OpticAppConfig = {
   config: {
-    features: {
-      allowEditing: true,
-    },
+    allowEditing: true,
     analytics: {
       enabled: false,
     },

--- a/workspaces/ui-v2/src/entry-points/demo/demo-examples.tsx
+++ b/workspaces/ui-v2/src/entry-points/demo/demo-examples.tsx
@@ -39,14 +39,11 @@ import { SpecRepositoryStore } from '<src>/contexts/SpecRepositoryContext';
 
 const appConfig: OpticAppConfig = {
   config: {
-    navigation: {
-      showDiff: true,
+    features: {
+      allowEditing: true,
     },
     analytics: {
       enabled: false,
-    },
-    documentation: {
-      allowDescriptionEditing: true,
     },
     backendApi: {},
     sharing: { enabled: false },

--- a/workspaces/ui-v2/src/entry-points/local/local-cli.tsx
+++ b/workspaces/ui-v2/src/entry-points/local/local-cli.tsx
@@ -44,17 +44,14 @@ import { SpecRepositoryStore } from '<src>/contexts/SpecRepositoryContext';
 
 const appConfig: OpticAppConfig = {
   config: {
-    navigation: {
-      showDiff: true,
+    features: {
+      allowEditing: true,
     },
     analytics: {
       enabled: Boolean(process.env.REACT_APP_ENABLE_ANALYTICS === 'yes'),
       segmentToken: process.env.REACT_APP_SEGMENT_LOCAL_UI,
       fullStoryOrgId: process.env.REACT_APP_FULLSTORY_ORG,
       sentryUrl: process.env.REACT_APP_SENTRY_URL,
-    },
-    documentation: {
-      allowDescriptionEditing: true,
     },
     backendApi: {
       domain:

--- a/workspaces/ui-v2/src/entry-points/local/local-cli.tsx
+++ b/workspaces/ui-v2/src/entry-points/local/local-cli.tsx
@@ -44,9 +44,7 @@ import { SpecRepositoryStore } from '<src>/contexts/SpecRepositoryContext';
 
 const appConfig: OpticAppConfig = {
   config: {
-    features: {
-      allowEditing: true,
-    },
+    allowEditing: true,
     analytics: {
       enabled: Boolean(process.env.REACT_APP_ENABLE_ANALYTICS === 'yes'),
       segmentToken: process.env.REACT_APP_SEGMENT_LOCAL_UI,

--- a/workspaces/ui-v2/src/entry-points/local/public-examples.tsx
+++ b/workspaces/ui-v2/src/entry-points/local/public-examples.tsx
@@ -39,9 +39,7 @@ import { SpecRepositoryStore } from '<src>/contexts/SpecRepositoryContext';
 
 const appConfig: OpticAppConfig = {
   config: {
-    features: {
-      allowEditing: true,
-    },
+    allowEditing: true,
     analytics: {
       enabled: false,
     },

--- a/workspaces/ui-v2/src/entry-points/local/public-examples.tsx
+++ b/workspaces/ui-v2/src/entry-points/local/public-examples.tsx
@@ -39,14 +39,11 @@ import { SpecRepositoryStore } from '<src>/contexts/SpecRepositoryContext';
 
 const appConfig: OpticAppConfig = {
   config: {
-    navigation: {
-      showDiff: true,
+    features: {
+      allowEditing: true,
     },
     analytics: {
       enabled: false,
-    },
-    documentation: {
-      allowDescriptionEditing: true,
     },
     backendApi: {},
     sharing: { enabled: false },

--- a/workspaces/ui-v2/src/pages/changelogHistory/ChangelogHistory.tsx
+++ b/workspaces/ui-v2/src/pages/changelogHistory/ChangelogHistory.tsx
@@ -91,7 +91,7 @@ export const ChangelogHistory: FC = () => {
                       </Button>
                     )}
 
-                    {!isCurrent && appConfig.features.allowEditing && (
+                    {!isCurrent && appConfig.allowEditing && (
                       <Button
                         className={classes.commitResetButton}
                         variant="outlined"

--- a/workspaces/ui-v2/src/pages/changelogHistory/ChangelogHistory.tsx
+++ b/workspaces/ui-v2/src/pages/changelogHistory/ChangelogHistory.tsx
@@ -15,6 +15,7 @@ import {
   useDocumentationPageLink,
 } from '<src>/components';
 import { useAnalytics } from '<src>/contexts/analytics';
+import { useAppConfig } from '<src>/contexts/config/AppConfiguration';
 import { BatchCommit, useBatchCommits } from '<src>/hooks/useBatchCommits';
 import { formatTimeAgo } from '<src>/utils';
 import {
@@ -26,6 +27,7 @@ import {
 import { ConfirmResetModal } from './components';
 
 export const ChangelogHistory: FC = () => {
+  const appConfig = useAppConfig();
   const { loading, batchCommits } = useBatchCommits();
   const changelogPage = useChangelogPages();
   const documentationPage = useDocumentationPageLink();
@@ -89,7 +91,7 @@ export const ChangelogHistory: FC = () => {
                       </Button>
                     )}
 
-                    {!isCurrent && (
+                    {!isCurrent && appConfig.features.allowEditing && (
                       <Button
                         className={classes.commitResetButton}
                         variant="outlined"

--- a/workspaces/ui-v2/src/pages/docs/components/DocPageNavigation.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/DocPageNavigation.tsx
@@ -21,7 +21,7 @@ export const DocsPageAccessoryNavigation: FC = () => {
       {appConfig.sharing.enabled && <ShareButton />}
       <PromptNavigateAway shouldPrompt={isEditing && pendingCount > 0} />
       <ChangesSinceDropdown />
-      {appConfig.features.allowEditing && <EditContributionsButton />}
+      {appConfig.allowEditing && <EditContributionsButton />}
     </div>
   );
 };

--- a/workspaces/ui-v2/src/pages/docs/components/DocPageNavigation.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/DocPageNavigation.tsx
@@ -21,9 +21,7 @@ export const DocsPageAccessoryNavigation: FC = () => {
       {appConfig.sharing.enabled && <ShareButton />}
       <PromptNavigateAway shouldPrompt={isEditing && pendingCount > 0} />
       <ChangesSinceDropdown />
-      {appConfig.documentation.allowDescriptionEditing && (
-        <EditContributionsButton />
-      )}
+      {appConfig.features.allowEditing && <EditContributionsButton />}
     </div>
   );
 };


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Cloud viewer should not be able to edit specs - as cloud viewer loads an inmemory instance. Updating the config to be more generally "edit" since that's more how we use these features (and we can make them more granular later if required).

<img width="1058" alt="Screen Shot 2021-07-07 at 8 19 03 AM" src="https://user-images.githubusercontent.com/18374483/124785795-04e25a00-defc-11eb-8502-228958cbe3d6.png">


## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
