### PR TITLE
Remove shell script and replace with command

### DIFF
--- a/workspaces/optic-engine-native/package.json
+++ b/workspaces/optic-engine-native/package.json
@@ -4,9 +4,9 @@
   "scripts": {
     "postinstall": "node scripts/install",
     "preuninstall": "node scripts/uninstall",
-    "ws:build": "scripts/build-binaries.sh",
+    "ws:build": "node scripts/uninstall && cargo build",
     "ws:clean": "rm -rf build target",
-    "ws:test": "scripts/test.sh"
+    "ws:test": "cargo test"
   },
   "repository": {
     "type": "git",

--- a/workspaces/optic-engine-native/scripts/build-binaries.sh
+++ b/workspaces/optic-engine-native/scripts/build-binaries.sh
@@ -1,4 +1,0 @@
-#!/bin/bash -e
-
-node scripts/uninstall
-cargo build

--- a/workspaces/optic-engine-native/scripts/test.sh
+++ b/workspaces/optic-engine-native/scripts/test.sh
@@ -1,3 +1,0 @@
-#!/bin/bash -e
-
-cargo test


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

After much fighting (see this PR https://github.com/opticdev/optic/pull/974), I figured out what was happening with our regression run.

- Windows builds local binaries
- In the `optic-engine-native` package, a shell script is specified in package.json
- Shell scripts on windows didn't get run - see https://github.com/opticdev/optic/runs/3008312479?check_suite_focus=true#step:7:218 compared to the mac os run https://github.com/opticdev/optic/runs/3008312539?check_suite_focus=true#step:7:231 (this is a little hard to read since several `yarn ws:build` commands run in parallel, but windows does nothing)
- Moving the shell scripts -> package.json commands fixes this

One oddity that I can't explain is we actually specify `shell: bash` for the `task workspaces:build:ci` command https://github.com/opticdev/optic/blob/develop/.github/workflows/regression-suites.yml#L49 but the shell script still isn't run. Perhaps this is a quirk with the github actions bash shell?

## What
What's changing? Anything of note to call out?

## Validation
This CI run (the commit targets release which triggers the regression suite runs https://github.com/opticdev/optic/actions/runs/1009198013) passes