### PR TITLE
ingest: fixed exception on empty responses

### DIFF
--- a/workspaces/cli-shared/src/ingest/ecs-to-sample.ts
+++ b/workspaces/cli-shared/src/ingest/ecs-to-sample.ts
@@ -10,7 +10,8 @@ export function ecsToHttpInteraction(
   const { path, domain } = ecs.url;
 
   function extractBody(message: any) {
-    const content = message.body.content;
+    const content =
+      message.body && message.body.content ? message.body.content : '';
     if (typeof content === 'string') {
       return {
         asJsonString: tryParseJson(content),
@@ -43,7 +44,10 @@ export function ecsToHttpInteraction(
         shapeHashV1Base64: null,
       },
       body: {
-        contentType: request.headers['content-type'] || null,
+        contentType:
+          request.headers && request.headers['content-type']
+            ? request.headers['content-type']
+            : null,
         value: extractBody(request),
       },
     },
@@ -55,7 +59,10 @@ export function ecsToHttpInteraction(
         shapeHashV1Base64: null,
       },
       body: {
-        contentType: response.headers['content-type'] || null,
+        contentType:
+          response.headers && response.headers['content-type']
+            ? response.headers['content-type']
+            : null,
         value: extractBody(response),
       },
     },


### PR DESCRIPTION
## Why

When attempting to write documentation, I noticed that if the server provides an empty response, Optic throws an exception. This is an exceptional circumstance, though I still want Optic to handle it gracefully.

## What

Minimal assumptions on responses - we do still expect a status code if we get a response, I didn't wrap that up. I also added more protection around request header `content-type`, which would always be present from clients like browsers...I just wanted to make sure we covered our bases for any homegrown clients.

## Validation
* [ ] CI passes
* [ ] Verified in staging

