### PR TITLE
intercept: log the diff URI to the console (as well as open the browser)

### DIFF
--- a/workspaces/local-cli/src/commands/intercept.ts
+++ b/workspaces/local-cli/src/commands/intercept.ts
@@ -163,6 +163,7 @@ export default class Intercept extends Command {
     const uiBaseUrl = makeUiBaseUrl(daemonState);
 
     const uiUrl = linkToCapture(uiBaseUrl, cliSession.session.id, captureId);
+    console.log(fromOptic(`Opening your API Diff at ${uiUrl}`));
     openBrowser(uiUrl);
 
     cleanupAndExit(0);


### PR DESCRIPTION
## Why

On Windows, Optic does not reliably open the browser with the diff capture after ending a capture session. The console log shows no UI URIs, and there's no "next step" context when the browser launch fails. This is the quick fix to provide that context while we dig into the issue of launching the browser reliably on Windows.

## What

A single console.log from Optic to provide context.

## Validation
* [ ] CI passes
* [ ] Verified in staging

