### PR TITLE
docs: add verbose flag in favor of check notes

### DIFF
--- a/website/docs/integrations/frameworks/actix.mdx
+++ b/website/docs/integrations/frameworks/actix.mdx
@@ -45,9 +45,9 @@ HttpServer::new(...)
     .await
 ```
 
-## Verifying with `api check start`
+## Verifying with `api run start --verbose`
 
-The setup tool will guide you through running checks to assure Optic is running successfully with your API project. You should see everything pass at this point. If you don't, it's most likely that you're not starting the API on the `$PORT` Optic provides. The Optic check will also report any other common issues it detects and give you steps and suggestions to resolve them.
+Which will give you advanced debugging logs on the console, and report common errors. Run some traffic through your application: we recommend at least 5 requests. You should seee Optic report the requests on the console. When you're confident that everything is ready, you can run the command without the `--verbose` flag.
 
 Should you need any more help, or want to chat about the process, please reach out to us. You can schedule a [quick chat with the maintainers](https://calendly.com/opticlabs/maintainer-office-hours) or [open an issue on GitHub](https://github.com/opticdev/optic/issues/new?title=API%20Init:%20).
 

--- a/website/docs/integrations/frameworks/c-sharp.mdx
+++ b/website/docs/integrations/frameworks/c-sharp.mdx
@@ -53,9 +53,9 @@ public static IHostBuilder CreateHostBuilder(string[] args) {
 
 ```
 
-## Verifying with `api check start`
+## Verifying with `api run start --verbose`
 
-The setup tool will guide you through running checks to assure Optic is running successfully with your API project. You should see everything pass at this point. If you don't, it's most likely that you're not starting the API on the `$PORT` Optic provides. The Optic check will also report any other common issues it detects and give you steps and suggestions to resolve them.
+Which will give you advanced debugging logs on the console, and report common errors. Run some traffic through your application: we recommend at least 5 requests. You should seee Optic report the requests on the console. When you're confident that everything is ready, you can run the command without the `--verbose` flag.
 
 Should you need any more help, or want to chat about the process, please reach out to us. You can schedule a [quick chat with the maintainers](https://calendly.com/opticlabs/maintainer-office-hours) or [open an issue on GitHub](https://github.com/opticdev/optic/issues/new?title=API%20Init:%20).
 

--- a/website/docs/integrations/frameworks/django.mdx
+++ b/website/docs/integrations/frameworks/django.mdx
@@ -48,9 +48,9 @@ def main():
 ... # other code
 ```
 
-## Verifying with `api check start`
+## Verifying with `api run start --verbose`
 
-The setup tool will guide you through running checks to assure Optic is running successfully with your API project. You should see everything pass at this point. If you don't, it's most likely that you're not starting the API on the `$PORT` Optic provides. The Optic check will also report any other common issues it detects and give you steps and suggestions to resolve them.
+Which will give you advanced debugging logs on the console, and report common errors. Run some traffic through your application: we recommend at least 5 requests. You should seee Optic report the requests on the console. When you're confident that everything is ready, you can run the command without the `--verbose` flag.
 
 Should you need any more help, or want to chat about the process, please reach out to us. You can schedule a [quick chat with the maintainers](https://calendly.com/opticlabs/maintainer-office-hours) or [open an issue on GitHub](https://github.com/opticdev/optic/issues/new?title=API%20Init:%20).
 

--- a/website/docs/integrations/frameworks/elixir.mdx
+++ b/website/docs/integrations/frameworks/elixir.mdx
@@ -62,9 +62,9 @@ watchers: [
 ]
 ```
 
-## Verifying with `api check start`
+## Verifying with `api run start --verbose`
 
-The setup tool will guide you through running checks to assure Optic is running successfully with your API project. You should see everything pass at this point. If you don't, it's most likely that you're not starting the API on the `$PORT` Optic provides. The Optic check will also report any other common issues it detects and give you steps and suggestions to resolve them.
+Which will give you advanced debugging logs on the console, and report common errors. Run some traffic through your application: we recommend at least 5 requests. You should seee Optic report the requests on the console. When you're confident that everything is ready, you can run the command without the `--verbose` flag.
 
 Should you need any more help, or want to chat about the process, please reach out to us. You can schedule a [quick chat with the maintainers](https://calendly.com/opticlabs/maintainer-office-hours) or [open an issue on GitHub](https://github.com/opticdev/optic/issues/new?title=API%20Init:%20).
 

--- a/website/docs/integrations/frameworks/express.mdx
+++ b/website/docs/integrations/frameworks/express.mdx
@@ -39,9 +39,9 @@ app.listen(3000)
 app.listen(port || 3000)
 ```
 
-## Verifying with `api check start`
+## Verifying with `api run start --verbose`
 
-The setup tool will guide you through running checks to assure Optic is running successfully with your API project. You should see everything pass at this point. If you don't, it's most likely that you're not starting the API on the `$PORT` Optic provides. The Optic check will also report any other common issues it detects and give you steps and suggestions to resolve them.
+Which will give you advanced debugging logs on the console, and report common errors. Run some traffic through your application: we recommend at least 5 requests. You should seee Optic report the requests on the console. When you're confident that everything is ready, you can run the command without the `--verbose` flag.
 
 Should you need any more help, or want to chat about the process, please reach out to us. You can schedule a [quick chat with the maintainers](https://calendly.com/opticlabs/maintainer-office-hours) or [open an issue on GitHub](https://github.com/opticdev/optic/issues/new?title=API%20Init:%20).
 

--- a/website/docs/integrations/frameworks/fastapi.mdx
+++ b/website/docs/integrations/frameworks/fastapi.mdx
@@ -21,9 +21,9 @@ tasks:
     inboundUrl: https://localhost:3005
 ```
 
-## Verifying with `api check start`
+## Verifying with `api run start --verbose`
 
-The setup tool will guide you through running checks to assure Optic is running successfully with your API project. You should see everything pass at this point. If you don't, it's most likely that you're not starting the API on the `$PORT` Optic provides. The Optic check will also report any other common issues it detects and give you steps and suggestions to resolve them.
+Which will give you advanced debugging logs on the console, and report common errors. Run some traffic through your application: we recommend at least 5 requests. You should seee Optic report the requests on the console. When you're confident that everything is ready, you can run the command without the `--verbose` flag.
 
 Should you need any more help, or want to chat about the process, please reach out to us. You can schedule a [quick chat with the maintainers](https://calendly.com/opticlabs/maintainer-office-hours) or [open an issue on GitHub](https://github.com/opticdev/optic/issues/new?title=API%20Init:%20).
 

--- a/website/docs/integrations/frameworks/flask.mdx
+++ b/website/docs/integrations/frameworks/flask.mdx
@@ -27,9 +27,9 @@ Suppose your flask application typically runs on port 3005 (as above). Running `
 
 *Make sure these are different ports* - your requests should still be sent to the `inboundUrl`, but now optic will capture them and look for diffs.
 
-## Verifying with `api check start`
+## Verifying with `api run start --verbose`
 
-The setup tool will guide you through running checks to assure Optic is running successfully with your API project. You should see everything pass at this point. If you don't, it's most likely that you're not starting the API on the `$PORT` Optic provides. The Optic check will also report any other common issues it detects and give you steps and suggestions to resolve them.
+Which will give you advanced debugging logs on the console, and report common errors. Run some traffic through your application: we recommend at least 5 requests. You should seee Optic report the requests on the console. When you're confident that everything is ready, you can run the command without the `--verbose` flag.
 
 Should you need any more help, or want to chat about the process, please reach out to us. You can schedule a [quick chat with the maintainers](https://calendly.com/opticlabs/maintainer-office-hours) or [open an issue on GitHub](https://github.com/opticdev/optic/issues/new?title=API%20Init:%20).
 

--- a/website/docs/integrations/frameworks/gorilla.mdx
+++ b/website/docs/integrations/frameworks/gorilla.mdx
@@ -41,9 +41,9 @@ if os.Getenv("PORT") != "" {
 http.ListenAndServe(port, r)
 ```
 
-## Verifying with `api check start`
+## Verifying with `api run start --verbose`
 
-The setup tool will guide you through running checks to assure Optic is running successfully with your API project. You should see everything pass at this point. If you don't, it's most likely that you're not starting the API on the `$PORT` Optic provides. The Optic check will also report any other common issues it detects and give you steps and suggestions to resolve them.
+Which will give you advanced debugging logs on the console, and report common errors. Run some traffic through your application: we recommend at least 5 requests. You should seee Optic report the requests on the console. When you're confident that everything is ready, you can run the command without the `--verbose` flag.
 
 Should you need any more help, or want to chat about the process, please reach out to us. You can schedule a [quick chat with the maintainers](https://calendly.com/opticlabs/maintainer-office-hours) or [open an issue on GitHub](https://github.com/opticdev/optic/issues/new?title=API%20Init:%20).
 

--- a/website/docs/integrations/frameworks/hapi.mdx
+++ b/website/docs/integrations/frameworks/hapi.mdx
@@ -45,9 +45,9 @@ const server = Hapi.server({
 });
 ```
 
-## Verifying with `api check start`
+## Verifying with `api run start --verbose`
 
-The setup tool will guide you through running checks to assure Optic is running successfully with your API project. You should see everything pass at this point. If you don't, it's most likely that you're not starting the API on the `$PORT` Optic provides. The Optic check will also report any other common issues it detects and give you steps and suggestions to resolve them.
+Which will give you advanced debugging logs on the console, and report common errors. Run some traffic through your application: we recommend at least 5 requests. You should seee Optic report the requests on the console. When you're confident that everything is ready, you can run the command without the `--verbose` flag.
 
 Should you need any more help, or want to chat about the process, please reach out to us. You can schedule a [quick chat with the maintainers](https://calendly.com/opticlabs/maintainer-office-hours) or [open an issue on GitHub](https://github.com/opticdev/optic/issues/new?title=API%20Init:%20).
 

--- a/website/docs/integrations/frameworks/laravel.mdx
+++ b/website/docs/integrations/frameworks/laravel.mdx
@@ -21,9 +21,9 @@ tasks:
     inboundUrl: https://localhost:3005
 ```
 
-## Verifying with `api check start`
+## Verifying with `api run start --verbose`
 
-The setup tool will guide you through running checks to assure Optic is running successfully with your API project. You should see everything pass at this point. If you don't, it's most likely that you're not starting the API on the `$PORT` Optic provides. The Optic check will also report any other common issues it detects and give you steps and suggestions to resolve them.
+Which will give you advanced debugging logs on the console, and report common errors. Run some traffic through your application: we recommend at least 5 requests. You should seee Optic report the requests on the console. When you're confident that everything is ready, you can run the command without the `--verbose` flag.
 
 Should you need any more help, or want to chat about the process, please reach out to us. You can schedule a [quick chat with the maintainers](https://calendly.com/opticlabs/maintainer-office-hours) or [open an issue on GitHub](https://github.com/opticdev/optic/issues/new?title=API%20Init:%20).
 

--- a/website/docs/integrations/frameworks/lithium.mdx
+++ b/website/docs/integrations/frameworks/lithium.mdx
@@ -52,9 +52,9 @@ int main() {
 }
 ```
 
-## Verifying with `api check start`
+## Verifying with `api run start --verbose`
 
-The setup tool will guide you through running checks to assure Optic is running successfully with your API project. You should see everything pass at this point. If you don't, it's most likely that you're not starting the API on the `$PORT` Optic provides. The Optic check will also report any other common issues it detects and give you steps and suggestions to resolve them.
+Which will give you advanced debugging logs on the console, and report common errors. Run some traffic through your application: we recommend at least 5 requests. You should seee Optic report the requests on the console. When you're confident that everything is ready, you can run the command without the `--verbose` flag.
 
 Should you need any more help, or want to chat about the process, please reach out to us. You can schedule a [quick chat with the maintainers](https://calendly.com/opticlabs/maintainer-office-hours) or [open an issue on GitHub](https://github.com/opticdev/optic/issues/new?title=API%20Init:%20).
 

--- a/website/docs/integrations/frameworks/pistache.mdx
+++ b/website/docs/integrations/frameworks/pistache.mdx
@@ -62,9 +62,9 @@ int main() {
 }
 ```
 
-## Verifying with `api check start`
+## Verifying with `api run start --verbose`
 
-The setup tool will guide you through running checks to assure Optic is running successfully with your API project. You should see everything pass at this point. If you don't, it's most likely that you're not starting the API on the `$PORT` Optic provides. The Optic check will also report any other common issues it detects and give you steps and suggestions to resolve them.
+Which will give you advanced debugging logs on the console, and report common errors. Run some traffic through your application: we recommend at least 5 requests. You should seee Optic report the requests on the console. When you're confident that everything is ready, you can run the command without the `--verbose` flag.
 
 Should you need any more help, or want to chat about the process, please reach out to us. You can schedule a [quick chat with the maintainers](https://calendly.com/opticlabs/maintainer-office-hours) or [open an issue on GitHub](https://github.com/opticdev/optic/issues/new?title=API%20Init:%20).
 

--- a/website/docs/integrations/frameworks/puma.mdx
+++ b/website/docs/integrations/frameworks/puma.mdx
@@ -21,9 +21,9 @@ tasks:
     inboundUrl: https://localhost:3005
 ```
 
-## Verifying with `api check start`
+## Verifying with `api run start --verbose`
 
-The setup tool will guide you through running checks to assure Optic is running successfully with your API project. You should see everything pass at this point. If you don't, it's most likely that you're not starting the API on the `$PORT` Optic provides. The Optic check will also report any other common issues it detects and give you steps and suggestions to resolve them.
+Which will give you advanced debugging logs on the console, and report common errors. Run some traffic through your application: we recommend at least 5 requests. You should seee Optic report the requests on the console. When you're confident that everything is ready, you can run the command without the `--verbose` flag.
 
 Should you need any more help, or want to chat about the process, please reach out to us. You can schedule a [quick chat with the maintainers](https://calendly.com/opticlabs/maintainer-office-hours) or [open an issue on GitHub](https://github.com/opticdev/optic/issues/new?title=API%20Init:%20).
 

--- a/website/docs/integrations/frameworks/rocket-ignite.mdx
+++ b/website/docs/integrations/frameworks/rocket-ignite.mdx
@@ -21,9 +21,9 @@ tasks:
     inboundUrl: https://localhost:3005
 ```
 
-## Verifying with `api check start`
+## Verifying with `api run start --verbose`
 
-The setup tool will guide you through running checks to assure Optic is running successfully with your API project. You should see everything pass at this point. If you don't, it's most likely that you're not starting the API on the `$PORT` Optic provides. The Optic check will also report any other common issues it detects and give you steps and suggestions to resolve them.
+Which will give you advanced debugging logs on the console, and report common errors. Run some traffic through your application: we recommend at least 5 requests. You should seee Optic report the requests on the console. When you're confident that everything is ready, you can run the command without the `--verbose` flag.
 
 Should you need any more help, or want to chat about the process, please reach out to us. You can schedule a [quick chat with the maintainers](https://calendly.com/opticlabs/maintainer-office-hours) or [open an issue on GitHub](https://github.com/opticdev/optic/issues/new?title=API%20Init:%20).
 

--- a/website/docs/integrations/frameworks/rocket.mdx
+++ b/website/docs/integrations/frameworks/rocket.mdx
@@ -60,9 +60,9 @@ rocket::custom(config)
 
 ```
 
-## Verifying with `api check start`
+## Verifying with `api run start --verbose`
 
-The setup tool will guide you through running checks to assure Optic is running successfully with your API project. You should see everything pass at this point. If you don't, it's most likely that you're not starting the API on the `$PORT` Optic provides. The Optic check will also report any other common issues it detects and give you steps and suggestions to resolve them.
+Which will give you advanced debugging logs on the console, and report common errors. Run some traffic through your application: we recommend at least 5 requests. You should seee Optic report the requests on the console. When you're confident that everything is ready, you can run the command without the `--verbose` flag.
 
 Should you need any more help, or want to chat about the process, please reach out to us. You can schedule a [quick chat with the maintainers](https://calendly.com/opticlabs/maintainer-office-hours) or [open an issue on GitHub](https://github.com/opticdev/optic/issues/new?title=API%20Init:%20).
 

--- a/website/docs/integrations/frameworks/ruby-on-rails.mdx
+++ b/website/docs/integrations/frameworks/ruby-on-rails.mdx
@@ -21,9 +21,9 @@ tasks:
     inboundUrl: https://localhost:3005
 ```
 
-## Verifying with `api check start`
+## Verifying with `api run start --verbose`
 
-The setup tool will guide you through running checks to assure Optic is running successfully with your API project. You should see everything pass at this point. If you don't, it's most likely that you're not starting the API on the `$PORT` Optic provides. The Optic check will also report any other common issues it detects and give you steps and suggestions to resolve them.
+Which will give you advanced debugging logs on the console, and report common errors. Run some traffic through your application: we recommend at least 5 requests. You should seee Optic report the requests on the console. When you're confident that everything is ready, you can run the command without the `--verbose` flag.
 
 Should you need any more help, or want to chat about the process, please reach out to us. You can schedule a [quick chat with the maintainers](https://calendly.com/opticlabs/maintainer-office-hours) or [open an issue on GitHub](https://github.com/opticdev/optic/issues/new?title=API%20Init:%20).
 

--- a/website/docs/integrations/frameworks/sails.mdx
+++ b/website/docs/integrations/frameworks/sails.mdx
@@ -21,9 +21,9 @@ tasks:
     inboundUrl: https://localhost:3005
 ```
 
-## Verifying with `api check start`
+## Verifying with `api run start --verbose`
 
-The setup tool will guide you through running checks to assure Optic is running successfully with your API project. You should see everything pass at this point. If you don't, it's most likely that you're not starting the API on the `$PORT` Optic provides. The Optic check will also report any other common issues it detects and give you steps and suggestions to resolve them.
+Which will give you advanced debugging logs on the console, and report common errors. Run some traffic through your application: we recommend at least 5 requests. You should seee Optic report the requests on the console. When you're confident that everything is ready, you can run the command without the `--verbose` flag.
 
 Should you need any more help, or want to chat about the process, please reach out to us. You can schedule a [quick chat with the maintainers](https://calendly.com/opticlabs/maintainer-office-hours) or [open an issue on GitHub](https://github.com/opticdev/optic/issues/new?title=API%20Init:%20).
 

--- a/website/docs/integrations/frameworks/spring.mdx
+++ b/website/docs/integrations/frameworks/spring.mdx
@@ -21,9 +21,9 @@ tasks:
     inboundUrl: https://localhost:3005
 ```
 
-## Verifying with `api check start`
+## Verifying with `api run start --verbose`
 
-The setup tool will guide you through running checks to assure Optic is running successfully with your API project. You should see everything pass at this point. If you don't, it's most likely that you're not starting the API on the `$PORT` Optic provides. The Optic check will also report any other common issues it detects and give you steps and suggestions to resolve them.
+Which will give you advanced debugging logs on the console, and report common errors. Run some traffic through your application: we recommend at least 5 requests. You should seee Optic report the requests on the console. When you're confident that everything is ready, you can run the command without the `--verbose` flag.
 
 Should you need any more help, or want to chat about the process, please reach out to us. You can schedule a [quick chat with the maintainers](https://calendly.com/opticlabs/maintainer-office-hours) or [open an issue on GitHub](https://github.com/opticdev/optic/issues/new?title=API%20Init:%20).
 

--- a/website/docs/integrations/ides/intellij.md
+++ b/website/docs/integrations/ides/intellij.md
@@ -22,11 +22,7 @@ Just like Git, Cargo, or many other coding tools, the first step for integrating
 
 ![Running api init](/img/blog-content/intellij-api-init.png)
 
-Here we've selected the Proxy integration. This allows us to set the port on which our application runs with the IntelliJ run configurations, and gives us a place to pass traffic through Optic. Our API project runs on port 8080, so the targetUrl is `http://localhost:8080`. Optic will observe and forward traffic sent to `http://locaalhost:4000`, which is how we'll test our work as we develop. 
-
-Optic guides us to check our configuration. Go ahead and start your project with the Green Play button next to the Run Configurations in IntelliJ, and wait for it to start up. Then, run `api check` from the terminal. Optic will run some tests and make sure the configuration is right. If there are any issues, it will enumerate them and provide some suggested remedies. When all is set up properly, you'll get a check passed message.
-
-![API Check passed](/img/blog-content/intellij-api-start.png)
+Here we've selected the Proxy integration. This allows us to set the port on which our application runs with the IntelliJ run configurations, and gives us a place to pass traffic through Optic. Our API project runs on port 8080, so the targetUrl is `http://localhost:8080`. Optic will observe and forward traffic sent to `http://locaalhost:4000`, which is how we'll test our work as we develop.
 
 The Optic installer tells you to run `api start`, which will work. However, we can integrate this command with the IntelliJ Run Configurations so Optic will run with your existing configurations and even with your existing debugger.
 

--- a/website/docs/using/advanced-configuration.mdx
+++ b/website/docs/using/advanced-configuration.mdx
@@ -84,10 +84,10 @@ tasks:
 Next, run:
 
 ``` bash
-api check start-proxy
+api run start-proxy --verbose
 ```` 
 
-This will validate that the configuration is correct. Once the configuration check passes, you can [document your API](/docs/using/baseline) with:
+which will give you advanced debugging logs on the console, and report common errors. When you're confident that everything is ready, you can run the command without the `--verbose` flag.
 
 ``` bash
 api run start-proxy

--- a/website/docs/using/cli-commands.mdx
+++ b/website/docs/using/cli-commands.mdx
@@ -7,15 +7,9 @@ The Optic CLI installs the `api` command, which is used to manage integration, o
 
 ## Documenting your API
 
-### `check`
-
-Verifies that Optic can run your tasks and monitor traffic. When initializing Optic with your repository, the guided setup will have you run this command to validate the configuration. If there are any issues, they will be reported on the command line and in the Optic setup UI with recommendations on how to proceed. It takes the name of the task you wish to check, usually `start`:
-
-`api check start`
-
 ### `help`
 
-Provides usage information for `api` and subcommands. For subcommands that take parameters, such as `run` and `check` which take a task name, `--help` will provide the same information.
+Provides usage information for `api` and subcommands. For subcommands that take parameters, such as `run` which takes a task name, `--help` will provide the same information.
 
 For example, to learn more about the `init` command, run:
 
@@ -50,6 +44,7 @@ Run has a few flags that can modify the default behavior:
 - `--exit-on-diff` returns an exit code of `1` if unexpected API behavior is returned, such as an undocumented route or a change in behavior on a documented route. Normally, Optic returns `0` on successful termination regardless of the behavior observed. This is primarily used in CI/CD scenarios, such as in [GitHub Actions](/docs/github-actions), to fail builds when undocumented behavior is detected.
 - `--pass-exit-code` returns the exit code of your task. If you are using a [dependent task](/docs/get-started/testing), the exit code of the dependent command (not the base command) will be passed through. This flag is overridden by `--exit-on-diff` which will always exit a capture session with exit code 1 when a diff was detected. 
 - `--transparent-proxy` configures Optic to [transparently forward](/docs/using/advanced-configuration#transparent-proxy-mode) all traffic, which may be necessary for certain application configurations.
+- `--verbose` provides additional logging to the console, including data on problems starting the API application or the Optic proxy.
 
 ### `spec`
 


### PR DESCRIPTION
## Why

Adding a quick blurb on `--verbose` in favor of `check` language while we finish up new docs

## What

o3c.info/docs

## Validation
* [x] CI passes
* [x] Visual review in staging
