### PR TITLE
Fix bug where initial learning of query parameters could not result into optional bodies

### DIFF
--- a/workspaces/optic-engine/src/interactions/mod.rs
+++ b/workspaces/optic-engine/src/interactions/mod.rs
@@ -139,7 +139,9 @@ pub fn analyze_undocumented_bodies<'a>(
   results.into_iter().flat_map(move |result| match result {
     InteractionDiffResult::UnmatchedQueryParameters(diff) => {
       if include_query_params {
-        let query_params = &interaction.request.query;
+        let maybe_query_params: Option<BodyDescriptor> = (&interaction.request.query).into();
+        let query_params = maybe_query_params.or_else(|| Some(BodyDescriptor::empty_object()));
+
         let query_trail_observations = observe_body_trails(query_params);
 
         vec![BodyAnalysisResult {

--- a/workspaces/optic-engine/src/interactions/mod.rs
+++ b/workspaces/optic-engine/src/interactions/mod.rs
@@ -12,7 +12,9 @@ mod traverser;
 mod visitors;
 
 use result::InteractionTrail;
-pub use result::{BodyAnalysisLocation, BodyAnalysisResult, InteractionDiffResult};
+pub use result::{
+  BodyAnalysisLocation, BodyAnalysisResult, InteractionDiffResult, UnmatchedQueryParameters,
+};
 use visitors::{InteractionVisitors, PathVisitor};
 
 /// Compute diffs based on a spec and an interaction.
@@ -89,6 +91,13 @@ pub fn diff(
           .collect()
       }
       _ => vec![result],
+    })
+    .filter(|result| {
+      // filter out any left-over results that aren't for outside consumoption
+      !matches!(
+        result,
+        InteractionDiffResult::UnmatchedQueryParameters(UnmatchedQueryParameters::Unobserved(_)),
+      )
     })
     .collect()
 }

--- a/workspaces/optic-engine/src/interactions/visitors/diff.rs
+++ b/workspaces/optic-engine/src/interactions/visitors/diff.rs
@@ -124,7 +124,6 @@ impl QueryParametersVisitor<InteractionDiffResult> for DiffQueryParametersVisito
       query_parameters_id,
       query_shape_id,
     ) {
-      (None, None, None) => {}
       (_, Some(query_parameters_id), Some(shape_descriptor)) => {
         let requests_trail = RequestSpecTrail::SpecQueryParameters(SpecQueryParameters {
           query_parameters_id: query_parameters_id.clone(),
@@ -143,7 +142,7 @@ impl QueryParametersVisitor<InteractionDiffResult> for DiffQueryParametersVisito
           ),
         ))
       }
-      _ => {
+      (maybe_query_params, _, _) => {
         let requests_trail = RequestSpecTrail::SpecPath(SpecPath {
           path_id: String::from(context.path),
         });
@@ -156,10 +155,11 @@ impl QueryParametersVisitor<InteractionDiffResult> for DiffQueryParametersVisito
         };
 
         self.push(InteractionDiffResult::UnmatchedQueryParameters(
-          UnmatchedQueryParameters {
-            requests_trail,
+          UnmatchedQueryParameters::new(
             interaction_trail,
-          },
+            requests_trail,
+            maybe_query_params.is_some(),
+          ),
         ))
       }
     }

--- a/workspaces/optic-engine/tests/fixtures/undocumented-bodies-learner/requests-with-and-without-query-params.json
+++ b/workspaces/optic-engine/tests/fixtures/undocumented-bodies-learner/requests-with-and-without-query-params.json
@@ -1,0 +1,107 @@
+{
+  "events": [
+    {
+      "PathComponentAdded": {
+        "pathId": "path_jNlbaVZ0Ar",
+        "parentPathId": "root",
+        "name": "todos",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "bcfad727-81fd-4552-b0fb-82828f7b05f2",
+          "clientCommandBatchId": "ad4c2dd3-feb9-443a-b506-a64603d8185a",
+          "createdAt": "2020-04-02T18:52:25.989Z"
+        }
+      }
+    }
+  ],
+  "session": {
+    "samples": [
+      {
+        "uuid": "id1",
+        "request": {
+          "host": "example.com",
+          "method": "GET",
+          "path": "/todos",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": "status=open&label=feature"
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "asShapeHashBytes": null,
+              "asJsonString": "[]",
+              "asText": null
+            }
+          }
+        },
+        "tags": []
+      },
+      {
+        "uuid": "id2",
+        "request": {
+          "host": "example.com",
+          "method": "GET",
+          "path": "/todos",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "asShapeHashBytes": null,
+              "asJsonString": "[]",
+              "asText": null
+            }
+          }
+        },
+        "tags": []
+      }
+    ]
+  }
+}

--- a/workspaces/optic-engine/tests/fixtures/undocumented-bodies-learner/requests-with-and-without-query-params.json
+++ b/workspaces/optic-engine/tests/fixtures/undocumented-bodies-learner/requests-with-and-without-query-params.json
@@ -101,6 +101,49 @@
           }
         },
         "tags": []
+      },
+      {
+        "uuid": "id3",
+        "request": {
+          "host": "example.com",
+          "method": "GET",
+          "path": "/todos",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": "status=closed"
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "asShapeHashBytes": null,
+              "asJsonString": "[]",
+              "asText": null
+            }
+          }
+        },
+        "tags": []
       }
     ]
   }

--- a/workspaces/optic-engine/tests/undocumented_bodies_learner.rs
+++ b/workspaces/optic-engine/tests/undocumented_bodies_learner.rs
@@ -91,6 +91,42 @@ async fn get_request_with_object_query_params() {
   // dbg!(Dot::with_config(&_updated_spec.shape().graph, &[]));
 }
 
+#[tokio::main]
+#[test]
+async fn requests_with_and_without_query_params() {
+  let capture = DebugCapture::from_name("requests-with-and-without-query-params.json").await;
+  let spec = SpecProjection::from(capture.events);
+
+  let mut learned_undocumented_bodies = LearnedUndocumentedBodiesProjection::default();
+
+  let learner_config = AnalyzeUndocumentedBodiesConfig::default().with_query_params(true);
+
+  for interaction in capture.session.samples {
+    let results = analyze_undocumented_bodies(&spec, interaction, &learner_config);
+
+    for result in results {
+      learned_undocumented_bodies.apply(result)
+    }
+  }
+
+  let mut id_generator = SequentialIdGenerator { next_id: 1093 }; // <3 primes
+
+  let endpoint_bodies = learned_undocumented_bodies
+    .into_endpoint_bodies(&mut id_generator)
+    .next()
+    .expect("an endpoint should have been learned for");
+
+  let commands = endpoint_bodies.into_commands().collect::<Vec<_>>();
+
+  dbg!(&commands);
+
+  let _updated_spec = assert_valid_commands(spec, commands);
+
+  // TODO: assert snapshots on these once we figure out how to get stable ids to be generated
+  // dbg!(Dot::with_config(&_updated_spec.endpoint().graph, &[]));
+  // dbg!(Dot::with_config(&_updated_spec.shape().graph, &[]));
+}
+
 #[derive(Deserialize, Debug)]
 struct DebugCapture {
   events: Vec<SpecEvent>,

--- a/workspaces/optic-engine/tests/undocumented_bodies_learner.rs
+++ b/workspaces/optic-engine/tests/undocumented_bodies_learner.rs
@@ -118,7 +118,7 @@ async fn requests_with_and_without_query_params() {
 
   let commands = endpoint_bodies.into_commands().collect::<Vec<_>>();
 
-  dbg!(&commands);
+  // dbg!(&commands);
 
   let _updated_spec = assert_valid_commands(spec, commands);
 


### PR DESCRIPTION
## Why
We uncovered a bug where query parameters for newly added endpoints would never be learned as optional, despite there being a mix of interactions for endpoints with and without query parameters.

## What
The query parameters diff visitor is updated to allow results to be generated in the case where an interaction doesn't have any interactions captured, and there isn't an existing spec yet. Before, that case was completely ignored, which is fine for the main diffing flow, but not enough for the learning of new query parameters, where we need to track whether query parameters were omitted in requests. With these changes, an internal variant of `UnmatchedQueryParameters` is added, used for the undocumented body learner and filtered out of output diff results.

## Validation
* [ ] CI passes
* [x] Query parameters can be learned as optional
* [x] No "undocumented query parameters" diffs for existing documented endpoints without any query parameters captured.
