### PR TITLE
fix: Use prod base domain when in prod, not the other way around

### DIFF
--- a/.github/workflows/release-side-channel.yml
+++ b/.github/workflows/release-side-channel.yml
@@ -51,6 +51,10 @@ jobs:
         env:
           FLAGS_FILE: ${{ github.event.inputs.flags_file }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          REACT_APP_PROD_API_BASE: https://api.useoptic.com
+          REACT_APP_STAGING_API_BASE: https://api.o3c.info
+          REACT_APP_PROD_SPEC_VIEWER_BASE: https://spec.useoptic.com
+          REACT_APP_STAGING_SPEC_VIEWER_BASE: https://spec.o3c.info
         run: task utility:create-docker-network verdaccio:up release:side-channel:npm_packages
       - uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571 # v2.2.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,6 +242,10 @@ jobs:
     - name: Install Dependencies and Build Optic
       env:
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        REACT_APP_PROD_API_BASE: https://api.useoptic.com
+        REACT_APP_STAGING_API_BASE: https://api.o3c.info
+        REACT_APP_PROD_SPEC_VIEWER_BASE: https://spec.useoptic.com
+        REACT_APP_STAGING_SPEC_VIEWER_BASE: https://spec.o3c.info
       run: |
         if [ "${{ needs.release_logic.outputs.is_prerelease }}" == "true" ] && [ -n "${{ needs.release_logic.outputs.prerelease_tag }}" ]; then
           echo "Prelease with a tag detected. Staging any feature flags for '${{ needs.release_logic.outputs.prerelease_tag }}'."

--- a/workspaces/ui-v2/src/entry-points/local/local-cli.tsx
+++ b/workspaces/ui-v2/src/entry-points/local/local-cli.tsx
@@ -53,9 +53,9 @@ const appConfig: OpticAppConfig = {
     },
     backendApi: {
       domain:
-        (window.location.hostname.indexOf('useoptic.com') >= 0
-          ? process.env.REACT_APP_PROD_API_BASE
-          : process.env.REACT_APP_STAGING_API_BASE) || 'https://api.o3c.info',
+        (process.env.NODE_ENV === 'development'
+          ? process.env.REACT_APP_STAGING_API_BASE
+          : process.env.REACT_APP_PROD_API_BASE) || 'https://api.o3c.info',
     },
     sharing: {
       enabled: true,

--- a/workspaces/ui-v2/src/entry-points/local/local-cli.tsx
+++ b/workspaces/ui-v2/src/entry-points/local/local-cli.tsx
@@ -61,8 +61,8 @@ const appConfig: OpticAppConfig = {
       enabled: true,
       specViewerDomain:
         (process.env.NODE_ENV === 'development'
-          ? process.env.REACT_APP_PROD_SPEC_VIEWER_BASE
-          : process.env.REACT_APP_STAGING_SPEC_VIEWER_BASE) ||
+          ? process.env.REACT_APP_STAGING_SPEC_VIEWER_BASE
+          : process.env.REACT_APP_PROD_SPEC_VIEWER_BASE) ||
         'https://spec.o3c.info',
     },
   },


### PR DESCRIPTION
Looks like the condition to determine which backend base domain to use got reversed.. thanks @ukmadlz for finding this!