### PR TITLE
Refactor IParsedLocation to use typescript type narrowing

### DIFF
--- a/workspaces/ui-v2/src/lib/Interfaces.ts
+++ b/workspaces/ui-v2/src/lib/Interfaces.ts
@@ -210,33 +210,25 @@ export interface IResponseBodyLocation {
   responseId?: string;
 }
 
-// TODO QPB - refactor this type such that
-/**
- * 
 export interface IParsedLocation {
   pathId: string;
   method: string;
-  location: {
-    type: 'query'
-  } | {
-    type: 'request'
-    requestId: string
-    contentType: string
-  } | {
-    type: 'response'
-    statusCode: number
-    contentType: string
-    responseId: string
-  }}
- */
-export interface IParsedLocation {
-  pathId: string;
-  method: string;
-  inQuery?: {
-    queryParametersId: string;
-  };
-  inRequest?: IRequestBodyLocation;
-  inResponse?: IResponseBodyLocation;
+  data:
+    | {
+        type: 'query';
+        queryParametersId: string;
+      }
+    | {
+        type: 'request';
+        requestId: string;
+        contentType: string;
+      }
+    | {
+        type: 'response';
+        statusCode: number;
+        contentType: string;
+        responseId: string;
+      };
 }
 
 ///////////////////////////////////////

--- a/workspaces/ui-v2/src/lib/Interfaces.ts
+++ b/workspaces/ui-v2/src/lib/Interfaces.ts
@@ -201,7 +201,7 @@ export const DiffInResponse = (key: string): boolean =>
 export interface IParsedLocation {
   pathId: string;
   method: string;
-  data:
+  descriptor:
     | {
         type: 'query';
         queryParametersId: string;

--- a/workspaces/ui-v2/src/lib/Interfaces.ts
+++ b/workspaces/ui-v2/src/lib/Interfaces.ts
@@ -198,18 +198,6 @@ export const DiffInResponse = (key: string): boolean =>
 
 // The ones we like to work with in the UI
 
-// TODO QPB remove these external exports
-export interface IRequestBodyLocation {
-  contentType?: string;
-  requestId?: string;
-}
-
-export interface IResponseBodyLocation {
-  statusCode: number;
-  contentType?: string;
-  responseId?: string;
-}
-
 export interface IParsedLocation {
   pathId: string;
   method: string;

--- a/workspaces/ui-v2/src/lib/__tests/diff-helpers/__snapshots__/new-regions-interpretations.test.ts.snap
+++ b/workspaces/ui-v2/src/lib/__tests/diff-helpers/__snapshots__/new-regions-interpretations.test.ts.snap
@@ -164,12 +164,11 @@ Object {
       "diffHash": "8de10f26b6ef26ca",
       "getJsonBodyToPreview": [Function],
       "location": Object {
-        "inQuery": undefined,
-        "inRequest": Object {
+        "descriptor": Object {
           "contentType": "application/json",
           "requestId": undefined,
+          "type": "request",
         },
-        "inResponse": undefined,
         "method": "GET",
         "pathId": "path_it2OyjUysW",
       },
@@ -389,12 +388,11 @@ Object {
       "diffHash": "e958234709591c5f",
       "getJsonBodyToPreview": [Function],
       "location": Object {
-        "inQuery": undefined,
-        "inRequest": undefined,
-        "inResponse": Object {
+        "descriptor": Object {
           "contentType": "application/json",
           "responseId": undefined,
           "statusCode": 200,
+          "type": "response",
         },
         "method": "GET",
         "pathId": "path_it2OyjUysW",

--- a/workspaces/ui-v2/src/lib/__tests/diff-helpers/__snapshots__/shape-interpretations.test.ts.snap
+++ b/workspaces/ui-v2/src/lib/__tests/diff-helpers/__snapshots__/shape-interpretations.test.ts.snap
@@ -64,12 +64,11 @@ Object {
       "diffHash": "84167c0c7595d4d6",
       "getJsonBodyToPreview": [Function],
       "location": Object {
-        "inQuery": undefined,
-        "inRequest": undefined,
-        "inResponse": Object {
+        "descriptor": Object {
           "contentType": "application/json",
           "responseId": "baseline-response_1",
           "statusCode": 200,
+          "type": "response",
         },
         "method": "GET",
         "pathId": "baseline-path_3",
@@ -305,12 +304,11 @@ Object {
       "diffHash": "d9a9a649152793af",
       "getJsonBodyToPreview": [Function],
       "location": Object {
-        "inQuery": undefined,
-        "inRequest": undefined,
-        "inResponse": Object {
+        "descriptor": Object {
           "contentType": "application/json",
           "responseId": "baseline-response_1",
           "statusCode": 200,
+          "type": "response",
         },
         "method": "GET",
         "pathId": "baseline-path_3",
@@ -520,12 +518,11 @@ Object {
       "diffHash": "c1c137f409e885dc",
       "getJsonBodyToPreview": [Function],
       "location": Object {
-        "inQuery": undefined,
-        "inRequest": undefined,
-        "inResponse": Object {
+        "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_1",
           "statusCode": 200,
+          "type": "response",
         },
         "method": "GET",
         "pathId": "path_2",
@@ -782,12 +779,11 @@ Object {
       "diffHash": "c1c137f409e885dc",
       "getJsonBodyToPreview": [Function],
       "location": Object {
-        "inQuery": undefined,
-        "inRequest": undefined,
-        "inResponse": Object {
+        "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_1",
           "statusCode": 200,
+          "type": "response",
         },
         "method": "GET",
         "pathId": "path_2",
@@ -1012,12 +1008,11 @@ Object {
       "diffHash": "f31dde2a282b48",
       "getJsonBodyToPreview": [Function],
       "location": Object {
-        "inQuery": undefined,
-        "inRequest": undefined,
-        "inResponse": Object {
+        "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_1",
           "statusCode": 200,
+          "type": "response",
         },
         "method": "GET",
         "pathId": "path_2",
@@ -1220,12 +1215,11 @@ Object {
       "diffHash": "63269210d11730b6",
       "getJsonBodyToPreview": [Function],
       "location": Object {
-        "inQuery": undefined,
-        "inRequest": undefined,
-        "inResponse": Object {
+        "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_1",
           "statusCode": 200,
+          "type": "response",
         },
         "method": "GET",
         "pathId": "path_2",
@@ -1494,12 +1488,11 @@ Object {
       "diffHash": "179f9d4a33ca4658",
       "getJsonBodyToPreview": [Function],
       "location": Object {
-        "inQuery": undefined,
-        "inRequest": undefined,
-        "inResponse": Object {
+        "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_1",
           "statusCode": 200,
+          "type": "response",
         },
         "method": "GET",
         "pathId": "path_2",
@@ -1789,12 +1782,11 @@ Object {
       "diffHash": "124b53ff9a034b57",
       "getJsonBodyToPreview": [Function],
       "location": Object {
-        "inQuery": undefined,
-        "inRequest": undefined,
-        "inResponse": Object {
+        "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_1",
           "statusCode": 200,
+          "type": "response",
         },
         "method": "GET",
         "pathId": "path_3",
@@ -2086,12 +2078,11 @@ Object {
       "diffHash": "3542ba6590d7ae3f",
       "getJsonBodyToPreview": [Function],
       "location": Object {
-        "inQuery": undefined,
-        "inRequest": undefined,
-        "inResponse": Object {
+        "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_1",
           "statusCode": 200,
+          "type": "response",
         },
         "method": "GET",
         "pathId": "path_3",
@@ -2384,12 +2375,11 @@ Object {
       "diffHash": "179f9d4a33ca4658",
       "getJsonBodyToPreview": [Function],
       "location": Object {
-        "inQuery": undefined,
-        "inRequest": undefined,
-        "inResponse": Object {
+        "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_1",
           "statusCode": 200,
+          "type": "response",
         },
         "method": "GET",
         "pathId": "path_2",
@@ -2639,12 +2629,11 @@ Object {
       "diffHash": "8d46ea69f9088574",
       "getJsonBodyToPreview": [Function],
       "location": Object {
-        "inQuery": undefined,
-        "inRequest": undefined,
-        "inResponse": Object {
+        "descriptor": Object {
           "contentType": "application/json",
           "responseId": "baseline-response_1",
           "statusCode": 200,
+          "type": "response",
         },
         "method": "GET",
         "pathId": "baseline-path_3",
@@ -2831,12 +2820,11 @@ Object {
       "diffHash": "d9d824261703f4be",
       "getJsonBodyToPreview": [Function],
       "location": Object {
-        "inQuery": undefined,
-        "inRequest": undefined,
-        "inResponse": Object {
+        "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_1",
           "statusCode": 200,
+          "type": "response",
         },
         "method": "GET",
         "pathId": "path_3",
@@ -3040,12 +3028,11 @@ Object {
       "diffHash": "d9d824261703f4be",
       "getJsonBodyToPreview": [Function],
       "location": Object {
-        "inQuery": undefined,
-        "inRequest": undefined,
-        "inResponse": Object {
+        "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_1",
           "statusCode": 200,
+          "type": "response",
         },
         "method": "GET",
         "pathId": "path_3",
@@ -3245,12 +3232,11 @@ Object {
       "diffHash": "9680b0bf6bd1b6b1",
       "getJsonBodyToPreview": [Function],
       "location": Object {
-        "inQuery": undefined,
-        "inRequest": undefined,
-        "inResponse": Object {
+        "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_1",
           "statusCode": 200,
+          "type": "response",
         },
         "method": "GET",
         "pathId": "path_3",
@@ -3523,12 +3509,11 @@ Object {
       "diffHash": "d9d824261703f4be",
       "getJsonBodyToPreview": [Function],
       "location": Object {
-        "inQuery": undefined,
-        "inRequest": undefined,
-        "inResponse": Object {
+        "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_1",
           "statusCode": 200,
+          "type": "response",
         },
         "method": "GET",
         "pathId": "path_3",
@@ -3818,12 +3803,11 @@ Object {
       "diffHash": "7cb55ecdc93fa003",
       "getJsonBodyToPreview": [Function],
       "location": Object {
-        "inQuery": undefined,
-        "inRequest": undefined,
-        "inResponse": Object {
+        "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_1",
           "statusCode": 200,
+          "type": "response",
         },
         "method": "GET",
         "pathId": "path_1",
@@ -4085,12 +4069,11 @@ Object {
       "diffHash": "7cb55ecdc93fa003",
       "getJsonBodyToPreview": [Function],
       "location": Object {
-        "inQuery": undefined,
-        "inRequest": undefined,
-        "inResponse": Object {
+        "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_1",
           "statusCode": 200,
+          "type": "response",
         },
         "method": "GET",
         "pathId": "path_1",
@@ -4340,12 +4323,11 @@ Object {
       "diffHash": "7cb55ecdc93fa003",
       "getJsonBodyToPreview": [Function],
       "location": Object {
-        "inQuery": undefined,
-        "inRequest": undefined,
-        "inResponse": Object {
+        "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_1",
           "statusCode": 200,
+          "type": "response",
         },
         "method": "GET",
         "pathId": "path_1",
@@ -4682,12 +4664,11 @@ Object {
       "diffHash": "601c9b4584024d27",
       "getJsonBodyToPreview": [Function],
       "location": Object {
-        "inQuery": undefined,
-        "inRequest": undefined,
-        "inResponse": Object {
+        "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_KBRwJqndED",
           "statusCode": 200,
+          "type": "response",
         },
         "method": "GET",
         "pathId": "path_SYRwhqD1XN",
@@ -5608,12 +5589,11 @@ Object {
       "diffHash": "59b1dc0fdc7951d3",
       "getJsonBodyToPreview": [Function],
       "location": Object {
-        "inQuery": undefined,
-        "inRequest": undefined,
-        "inResponse": Object {
+        "descriptor": Object {
           "contentType": "application/json",
           "responseId": "baseline-response_1",
           "statusCode": 200,
+          "type": "response",
         },
         "method": "GET",
         "pathId": "baseline-path_3",
@@ -5937,12 +5917,11 @@ Object {
       "diffHash": "59b1dc0fdc7951d3",
       "getJsonBodyToPreview": [Function],
       "location": Object {
-        "inQuery": undefined,
-        "inRequest": undefined,
-        "inResponse": Object {
+        "descriptor": Object {
           "contentType": "application/json",
           "responseId": "baseline-response_1",
           "statusCode": 200,
+          "type": "response",
         },
         "method": "GET",
         "pathId": "baseline-path_3",
@@ -6255,12 +6234,11 @@ Object {
       "diffHash": "5afaa9bc7e91e73c",
       "getJsonBodyToPreview": [Function],
       "location": Object {
-        "inQuery": undefined,
-        "inRequest": undefined,
-        "inResponse": Object {
+        "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_1",
           "statusCode": 200,
+          "type": "response",
         },
         "method": "GET",
         "pathId": "path_1",
@@ -6457,12 +6435,11 @@ Object {
       "diffHash": "d8b48b881aef10ca",
       "getJsonBodyToPreview": [Function],
       "location": Object {
-        "inQuery": undefined,
-        "inRequest": undefined,
-        "inResponse": Object {
+        "descriptor": Object {
           "contentType": "application/json",
           "responseId": "baseline-response_1",
           "statusCode": 200,
+          "type": "response",
         },
         "method": "GET",
         "pathId": "baseline-path_1",

--- a/workspaces/ui-v2/src/lib/__tests/diff-helpers/__snapshots__/trail-parsers.test.ts.snap
+++ b/workspaces/ui-v2/src/lib/__tests/diff-helpers/__snapshots__/trail-parsers.test.ts.snap
@@ -67,12 +67,11 @@ ParsedDiff {
 
 exports[`accurate spec trail for all diffs: 2d026d49eaf0fa95-parsed-location 1`] = `
 Object {
-  "inQuery": undefined,
-  "inRequest": undefined,
-  "inResponse": Object {
+  "descriptor": Object {
     "contentType": "application/json",
     "responseId": "response_dE2gzm1TWj",
     "statusCode": 200,
+    "type": "response",
   },
   "method": "GET",
   "pathId": "path_wPHNu8BDab",
@@ -146,12 +145,11 @@ ParsedDiff {
 
 exports[`accurate spec trail for all diffs: 4f2147e2d4a69bc0-parsed-location 1`] = `
 Object {
-  "inQuery": undefined,
-  "inRequest": undefined,
-  "inResponse": Object {
+  "descriptor": Object {
     "contentType": "application/json",
     "responseId": "response_RkkvxIt2RG",
     "statusCode": 200,
+    "type": "response",
   },
   "method": "GET",
   "pathId": "path_xhUZ8irdJO",
@@ -228,12 +226,11 @@ ParsedDiff {
 
 exports[`accurate spec trail for all diffs: 4fc531c016328e1-parsed-location 1`] = `
 Object {
-  "inQuery": undefined,
-  "inRequest": Object {
+  "descriptor": Object {
     "contentType": "application/json",
     "requestId": "request_gwQEFrHpO0",
+    "type": "request",
   },
-  "inResponse": undefined,
   "method": "GET",
   "pathId": "path_UOIsxzICu5",
 }
@@ -280,12 +277,11 @@ ParsedDiff {
 
 exports[`accurate spec trail for all diffs: 8de10f26b6ef26ca-parsed-location 1`] = `
 Object {
-  "inQuery": undefined,
-  "inRequest": Object {
+  "descriptor": Object {
     "contentType": "application/json",
     "requestId": undefined,
+    "type": "request",
   },
-  "inResponse": undefined,
   "method": "GET",
   "pathId": "path_it2OyjUysW",
 }
@@ -332,12 +328,11 @@ ParsedDiff {
 
 exports[`accurate spec trail for all diffs: 9a9d4567077e6388-parsed-location 1`] = `
 Object {
-  "inQuery": undefined,
-  "inRequest": Object {
+  "descriptor": Object {
     "contentType": "application/json",
     "requestId": undefined,
+    "type": "request",
   },
-  "inResponse": undefined,
   "method": "PATCH",
   "pathId": "path_it2OyjUysW",
 }
@@ -409,12 +404,11 @@ ParsedDiff {
 
 exports[`accurate spec trail for all diffs: 22d96b2ef2dd13d0-parsed-location 1`] = `
 Object {
-  "inQuery": undefined,
-  "inRequest": Object {
+  "descriptor": Object {
     "contentType": "application/json",
     "requestId": "request_3kjV3YMXdP",
+    "type": "request",
   },
-  "inResponse": undefined,
   "method": "GET",
   "pathId": "path_wPHNu8BDab",
 }
@@ -460,12 +454,11 @@ ParsedDiff {
 
 exports[`accurate spec trail for all diffs: 92a6b20a0d317304-parsed-location 1`] = `
 Object {
-  "inQuery": undefined,
-  "inRequest": Object {
+  "descriptor": Object {
     "contentType": "application/json",
     "requestId": undefined,
+    "type": "request",
   },
-  "inResponse": undefined,
   "method": "POST",
   "pathId": "path_UOIsxzICu5",
 }
@@ -542,12 +535,11 @@ ParsedDiff {
 
 exports[`accurate spec trail for all diffs: 92e989e4d821dcf1-parsed-location 1`] = `
 Object {
-  "inQuery": undefined,
-  "inRequest": undefined,
-  "inResponse": Object {
+  "descriptor": Object {
     "contentType": "application/json",
     "responseId": "response_Zv48g7lL5e",
     "statusCode": 200,
+    "type": "response",
   },
   "method": "GET",
   "pathId": "path_UOIsxzICu5",
@@ -594,12 +586,11 @@ ParsedDiff {
 
 exports[`accurate spec trail for all diffs: 312f75a76267c7f2-parsed-location 1`] = `
 Object {
-  "inQuery": undefined,
-  "inRequest": Object {
+  "descriptor": Object {
     "contentType": "application/json",
     "requestId": undefined,
+    "type": "request",
   },
-  "inResponse": undefined,
   "method": "GET",
   "pathId": "path_AsEexQkVwC",
 }
@@ -645,12 +636,11 @@ ParsedDiff {
 
 exports[`accurate spec trail for all diffs: 3871874498eaa9f3-parsed-location 1`] = `
 Object {
-  "inQuery": undefined,
-  "inRequest": Object {
+  "descriptor": Object {
     "contentType": "application/json",
     "requestId": undefined,
+    "type": "request",
   },
-  "inResponse": undefined,
   "method": "PATCH",
   "pathId": "path_it2OyjUysW",
 }
@@ -696,12 +686,11 @@ ParsedDiff {
 
 exports[`accurate spec trail for all diffs: d44b141a1439cf3d-parsed-location 1`] = `
 Object {
-  "inQuery": undefined,
-  "inRequest": Object {
+  "descriptor": Object {
     "contentType": "application/json",
     "requestId": undefined,
+    "type": "request",
   },
-  "inResponse": undefined,
   "method": "PATCH",
   "pathId": "path_it2OyjUysW",
 }
@@ -743,12 +732,11 @@ ParsedDiff {
 
 exports[`accurate spec trail for all diffs: dc68f0f84b0bd1db-parsed-location 1`] = `
 Object {
-  "inQuery": undefined,
-  "inRequest": undefined,
-  "inResponse": Object {
+  "descriptor": Object {
     "contentType": "application/json",
     "responseId": undefined,
     "statusCode": 200,
+    "type": "response",
   },
   "method": "GET",
   "pathId": "path_AsEexQkVwC",
@@ -792,12 +780,11 @@ ParsedDiff {
 
 exports[`accurate spec trail for all diffs: e958234709591c5f-parsed-location 1`] = `
 Object {
-  "inQuery": undefined,
-  "inRequest": undefined,
-  "inResponse": Object {
+  "descriptor": Object {
     "contentType": "application/json",
     "responseId": undefined,
     "statusCode": 200,
+    "type": "response",
   },
   "method": "GET",
   "pathId": "path_it2OyjUysW",
@@ -870,12 +857,11 @@ ParsedDiff {
 
 exports[`accurate spec trail for all diffs: f45959c6c23c8fc8-parsed-location 1`] = `
 Object {
-  "inQuery": undefined,
-  "inRequest": Object {
+  "descriptor": Object {
     "contentType": "application/json",
     "requestId": "request_SqY61Qc9Mi",
+    "type": "request",
   },
-  "inResponse": undefined,
   "method": "GET",
   "pathId": "path_xhUZ8irdJO",
 }
@@ -917,12 +903,11 @@ ParsedDiff {
 
 exports[`accurate spec trail for all diffs: fe447736f416eac6-parsed-location 1`] = `
 Object {
-  "inQuery": undefined,
-  "inRequest": undefined,
-  "inResponse": Object {
+  "descriptor": Object {
     "contentType": "application/json",
     "responseId": undefined,
     "statusCode": 200,
+    "type": "response",
   },
   "method": "POST",
   "pathId": "path_UOIsxzICu5",
@@ -968,12 +953,11 @@ ParsedDiff {
 
 exports[`accurate spec trail for all diffs: ffd0f3f68e0a185b-parsed-location 1`] = `
 Object {
-  "inQuery": undefined,
-  "inRequest": undefined,
-  "inResponse": Object {
+  "descriptor": Object {
     "contentType": "application/json",
     "responseId": undefined,
     "statusCode": 200,
+    "type": "response",
   },
   "method": "PATCH",
   "pathId": "path_it2OyjUysW",

--- a/workspaces/ui-v2/src/lib/diff-description-interpreter.ts
+++ b/workspaces/ui-v2/src/lib/diff-description-interpreter.ts
@@ -17,9 +17,11 @@ const getJsonBodyToPreview = (
   interaction: IHttpInteraction
 ): BodyPreview => {
   const body =
-    (location.data.type === 'query' && interaction.request.query) ||
-    (location.data.type === 'request' && interaction.request.body.value) ||
-    (location.data.type === 'response' && interaction.response.body.value);
+    (location.descriptor.type === 'query' && interaction.request.query) ||
+    (location.descriptor.type === 'request' &&
+      interaction.request.body.value) ||
+    (location.descriptor.type === 'response' &&
+      interaction.response.body.value);
 
   if (body) {
     const { shapeHashV1Base64, asText, asJsonString } = body;
@@ -53,22 +55,22 @@ export function descriptionForNewRegions(
   location: IParsedLocation
 ): IDiffDescription {
   let title: ICopy[] = [];
-  if (location.data.type === 'query') {
+  if (location.descriptor.type === 'query') {
     title = [plain('undocumented query parameters observed')];
   }
-  if (location.data.type === 'request') {
+  if (location.descriptor.type === 'request') {
     title = [
       plain('undocumented'),
-      code(location.data.contentType),
+      code(location.descriptor.contentType),
       plain('request observed'),
     ];
   }
-  if (location.data.type === 'response') {
+  if (location.descriptor.type === 'response') {
     title = [
       plain('undocumented'),
-      code(location.data.statusCode.toString()),
+      code(location.descriptor.statusCode.toString()),
       plain('response with'),
-      code(location.data.contentType || 'No Body'),
+      code(location.descriptor.contentType || 'No Body'),
       plain('observed'),
     ];
   }

--- a/workspaces/ui-v2/src/lib/diff-description-interpreter.ts
+++ b/workspaces/ui-v2/src/lib/diff-description-interpreter.ts
@@ -17,9 +17,9 @@ const getJsonBodyToPreview = (
   interaction: IHttpInteraction
 ): BodyPreview => {
   const body =
-    (location.inQuery && interaction.request.query) ||
-    (location.inRequest && interaction.request.body.value) ||
-    (location.inResponse && interaction.response.body.value);
+    (location.data.type === 'query' && interaction.request.query) ||
+    (location.data.type === 'request' && interaction.request.body.value) ||
+    (location.data.type === 'response' && interaction.response.body.value);
 
   if (body) {
     const { shapeHashV1Base64, asText, asJsonString } = body;
@@ -53,22 +53,22 @@ export function descriptionForNewRegions(
   location: IParsedLocation
 ): IDiffDescription {
   let title: ICopy[] = [];
-  if (location.inQuery) {
+  if (location.data.type === 'query') {
     title = [plain('undocumented query parameters observed')];
   }
-  if (location.inRequest) {
+  if (location.data.type === 'request') {
     title = [
       plain('undocumented'),
-      code(location.inRequest.contentType || 'No Body'),
+      code(location.data.contentType),
       plain('request observed'),
     ];
   }
-  if (location.inResponse) {
+  if (location.data.type === 'response') {
     title = [
       plain('undocumented'),
-      code(location.inResponse.statusCode.toString()),
+      code(location.data.statusCode.toString()),
       plain('response with'),
-      code(location.inResponse.contentType || 'No Body'),
+      code(location.data.contentType || 'No Body'),
       plain('observed'),
     ];
   }

--- a/workspaces/ui-v2/src/lib/new-regions-interpreter.ts
+++ b/workspaces/ui-v2/src/lib/new-regions-interpreter.ts
@@ -36,19 +36,22 @@ export async function newRegionInterpreters(
   }
 }
 
+// TODO QPB - move IInterpretation generation into ParsedDiff
 function newContentType(
   udiff: ParsedDiff,
   location: IParsedLocation,
   learnedBodies: ILearnedBodies
 ): IInterpretation {
   if (udiff.isA(DiffTypes.UnmatchedRequestBodyContentType)) {
+    const contentType =
+      location.data.type === 'request' ? location.data.contentType : '';
     const learnedRequestBody = learnedBodies.requests.find(
-      (i) => i.contentType === location.inRequest?.contentType
+      (i) => i.contentType === contentType
     );
 
     if (!learnedRequestBody) {
       console.error(
-        `Could not learn body for request with content type ${location.inRequest?.contentType}`
+        `Could not learn body for request with content type ${contentType}`
       );
       Sentry.captureEvent({
         message: 'No learned request body was found',
@@ -69,7 +72,7 @@ function newContentType(
           interactionPointers: udiff.interactions,
           invalid: true,
           jsonTrailsByInteractions: {},
-          title: `${location.inRequest?.contentType || 'No Body'} Request`,
+          title: `${contentType || 'No Body'} Request`,
         },
       ],
       diffDescription: descriptionForNewRegions(udiff, location),
@@ -79,7 +82,7 @@ function newContentType(
         shapes: [],
         copy: [
           plain('Document'),
-          code(location.inRequest!.contentType || 'null'),
+          code(contentType || 'null'),
           plain('Request'),
         ],
       },
@@ -90,16 +93,21 @@ function newContentType(
       },
     };
   } else if (udiff.isA(DiffTypes.UnmatchedResponseBodyContentType)) {
+    const { contentType, statusCode } =
+      location.data.type === 'response'
+        ? location.data
+        : {
+            contentType: '',
+            statusCode: 0,
+          };
     //learn status code too.... currently missing
     const learnedResponseBody = learnedBodies.responses.find(
-      (i) =>
-        i.contentType === location.inResponse?.contentType &&
-        i.statusCode === location.inResponse?.statusCode
+      (i) => i.contentType === contentType && i.statusCode === statusCode
     );
 
     if (!learnedResponseBody) {
       console.error(
-        `Could not learn body for response with status code ${location.inResponse?.statusCode} content type ${location.inResponse?.contentType}`
+        `Could not learn body for response with status code ${statusCode} content type ${contentType}`
       );
       Sentry.captureEvent({
         message: 'No learned response body was found',
@@ -120,9 +128,7 @@ function newContentType(
           interactionPointers: udiff.interactions,
           invalid: true,
           jsonTrailsByInteractions: {},
-          title: `${location.inResponse?.statusCode} ${
-            location.inResponse?.contentType || ''
-          } Response`,
+          title: `${statusCode} ${contentType} Response`,
         },
       ],
       diffDescription: descriptionForNewRegions(udiff, location),
@@ -132,7 +138,7 @@ function newContentType(
         shapes: [],
         copy: [
           plain('Document'),
-          code(location.inResponse!.statusCode.toString()),
+          code(statusCode.toString()),
           plain('Response'),
         ],
       },

--- a/workspaces/ui-v2/src/lib/new-regions-interpreter.ts
+++ b/workspaces/ui-v2/src/lib/new-regions-interpreter.ts
@@ -44,7 +44,9 @@ function newContentType(
 ): IInterpretation {
   if (udiff.isA(DiffTypes.UnmatchedRequestBodyContentType)) {
     const contentType =
-      location.data.type === 'request' ? location.data.contentType : '';
+      location.descriptor.type === 'request'
+        ? location.descriptor.contentType
+        : '';
     const learnedRequestBody = learnedBodies.requests.find(
       (i) => i.contentType === contentType
     );
@@ -94,8 +96,8 @@ function newContentType(
     };
   } else if (udiff.isA(DiffTypes.UnmatchedResponseBodyContentType)) {
     const { contentType, statusCode } =
-      location.data.type === 'response'
-        ? location.data
+      location.descriptor.type === 'response'
+        ? location.descriptor
         : {
             contentType: '',
             statusCode: 0,

--- a/workspaces/ui-v2/src/lib/parse-diff.ts
+++ b/workspaces/ui-v2/src/lib/parse-diff.ts
@@ -109,7 +109,7 @@ export class ParsedDiff {
     return {
       pathId: location.pathId,
       method: location.method,
-      data: DiffInQuery(this.diffType)
+      descriptor: DiffInQuery(this.diffType)
         ? {
             type: 'query',
             queryParametersId: location.queryParametersId!,

--- a/workspaces/ui-v2/src/lib/parse-diff.ts
+++ b/workspaces/ui-v2/src/lib/parse-diff.ts
@@ -25,7 +25,6 @@ import {
   CurrentSpecContext,
   DiffInQuery,
   DiffInRequest,
-  DiffInResponse,
   IParsedLocation,
   isBodyShapeDiff,
 } from './Interfaces';
@@ -110,22 +109,23 @@ export class ParsedDiff {
     return {
       pathId: location.pathId,
       method: location.method,
-      inQuery: DiffInQuery(this.diffType)
-        ? { queryParametersId: location.queryParametersId! }
-        : undefined,
-      inRequest: DiffInRequest(this.diffType)
+      data: DiffInQuery(this.diffType)
         ? {
-            contentType: location.contentType,
-            requestId: location.requestId,
+            type: 'query',
+            queryParametersId: location.queryParametersId!,
           }
-        : undefined,
-      inResponse: DiffInResponse(this.diffType)
+        : DiffInRequest(this.diffType)
         ? {
+            type: 'request',
+            contentType: location.contentType!,
+            requestId: location.requestId!,
+          }
+        : {
+            type: 'response',
             statusCode: location.statusCode!,
-            contentType: location.contentType,
-            responseId: location.responseId,
-          }
-        : undefined,
+            contentType: location.contentType!,
+            responseId: location.responseId!,
+          },
     };
   }
 

--- a/workspaces/ui-v2/src/lib/shape-diffs/root.ts
+++ b/workspaces/ui-v2/src/lib/shape-diffs/root.ts
@@ -92,20 +92,20 @@ function resetBaseShape(
   location: IParsedLocation,
   newShapeId: string
 ): CQRSCommand {
-  if (location.data.type === 'request') {
+  if (location.descriptor.type === 'request') {
     return SetRequestBodyShape(
-      location.data.requestId,
-      ShapedBodyDescriptor(location.data.contentType, newShapeId, false)
+      location.descriptor.requestId,
+      ShapedBodyDescriptor(location.descriptor.contentType, newShapeId, false)
     );
-  } else if (location.data.type === 'response') {
+  } else if (location.descriptor.type === 'response') {
     return SetResponseBodyShape(
-      location.data.responseId,
-      ShapedBodyDescriptor(location.data.contentType, newShapeId, false)
+      location.descriptor.responseId,
+      ShapedBodyDescriptor(location.descriptor.contentType, newShapeId, false)
     );
   } else {
     // Through typescript inference we know the only other possible shape is a query parameter
     return SetQueryParametersShape(
-      location.data.queryParametersId,
+      location.descriptor.queryParametersId,
       QueryParametersShapeDescriptor(newShapeId)
     );
   }

--- a/workspaces/ui-v2/src/pages/diffs/ReviewEndpointDiffPage/DiffLinks.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/ReviewEndpointDiffPage/DiffLinks.tsx
@@ -22,12 +22,12 @@ export function DiffLinks({
         return (
           <React.Fragment key={diffHash}>
             <ListSubheader className={classes.locationHeader}>
-              {location.data.type === 'query'
+              {location.descriptor.type === 'query'
                 ? 'Query Parameters'
-                : location.data.type === 'request'
-                ? `Request Body ${location.data.contentType}`
-                : location.data.type === 'response'
-                ? `${location.data.statusCode} Response ${location.data.contentType}`
+                : location.descriptor.type === 'request'
+                ? `Request Body ${location.descriptor.contentType}`
+                : location.descriptor.type === 'response'
+                ? `${location.descriptor.statusCode} Response ${location.descriptor.contentType}`
                 : 'Unknown location'}
             </ListSubheader>
             <ListItem button onClick={() => setSelectedDiff(i)}>

--- a/workspaces/ui-v2/src/pages/diffs/ReviewEndpointDiffPage/DiffLinks.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/ReviewEndpointDiffPage/DiffLinks.tsx
@@ -16,22 +16,26 @@ export function DiffLinks({
   const classes = useStyles();
   return (
     <List>
-      {allDiffs.map((diff, i) => (
-        <React.Fragment key={diff.diffDescription.diffHash}>
-          <ListSubheader className={classes.locationHeader}>
-            {diff.diffDescription.location.inQuery
-              ? 'Query Parameters'
-              : diff.diffDescription.location.inRequest
-              ? `Request Body ${diff.diffDescription.location.inRequest.contentType}`
-              : diff.diffDescription.location.inResponse
-              ? `${diff.diffDescription.location.inResponse.statusCode} Response ${diff.diffDescription.location.inResponse.contentType}`
-              : 'Unknown location'}
-          </ListSubheader>
-          <ListItem button onClick={() => setSelectedDiff(i)}>
-            <ICopyRender variant="" copy={diff.diffDescription.title} />
-          </ListItem>
-        </React.Fragment>
-      ))}
+      {allDiffs.map((diff, i) => {
+        const { location, diffHash, title } = diff.diffDescription;
+
+        return (
+          <React.Fragment key={diffHash}>
+            <ListSubheader className={classes.locationHeader}>
+              {location.data.type === 'query'
+                ? 'Query Parameters'
+                : location.data.type === 'request'
+                ? `Request Body ${location.data.contentType}`
+                : location.data.type === 'response'
+                ? `${location.data.statusCode} Response ${location.data.contentType}`
+                : 'Unknown location'}
+            </ListSubheader>
+            <ListItem button onClick={() => setSelectedDiff(i)}>
+              <ICopyRender variant="" copy={title} />
+            </ListItem>
+          </React.Fragment>
+        );
+      })}
     </List>
   );
 }

--- a/workspaces/ui-v2/src/pages/diffs/components/HighlightedLocation.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/components/HighlightedLocation.tsx
@@ -44,18 +44,18 @@ export const HighlightedLocation: FC<
 
     switch (props.expectedLocation) {
       case Location.Request:
-        return !!(
-          targetLocation.inRequest &&
-          targetLocation.inRequest.contentType === props.contentType
+        return (
+          targetLocation.data.type === 'request' &&
+          targetLocation.data.contentType === props.contentType
         );
       case Location.Response:
-        return !!(
-          targetLocation.inResponse &&
-          targetLocation.inResponse.contentType === props.contentType &&
-          targetLocation.inResponse.statusCode === props.statusCode
+        return (
+          targetLocation.data.type === 'response' &&
+          targetLocation.data.contentType === props.contentType &&
+          targetLocation.data.statusCode === props.statusCode
         );
       case Location.Query:
-        return !!targetLocation.inQuery;
+        return targetLocation.data.type === 'query';
       default:
         return false;
     }

--- a/workspaces/ui-v2/src/pages/diffs/components/HighlightedLocation.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/components/HighlightedLocation.tsx
@@ -45,17 +45,17 @@ export const HighlightedLocation: FC<
     switch (props.expectedLocation) {
       case Location.Request:
         return (
-          targetLocation.data.type === 'request' &&
-          targetLocation.data.contentType === props.contentType
+          targetLocation.descriptor.type === 'request' &&
+          targetLocation.descriptor.contentType === props.contentType
         );
       case Location.Response:
         return (
-          targetLocation.data.type === 'response' &&
-          targetLocation.data.contentType === props.contentType &&
-          targetLocation.data.statusCode === props.statusCode
+          targetLocation.descriptor.type === 'response' &&
+          targetLocation.descriptor.contentType === props.contentType &&
+          targetLocation.descriptor.statusCode === props.statusCode
         );
       case Location.Query:
-        return targetLocation.data.type === 'query';
+        return targetLocation.descriptor.type === 'query';
       default:
         return false;
     }


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Use type narrowing / inferences so we have better type safety - there's a bunch of things here that should really be included in the ParsedDiff class (it's a pretty leaky abstraction right now since it attempts to encapsulate diff logic, but you still need to pipe things together)

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
