### PR TITLE
Fix rust snapshot

### DIFF
--- a/workspaces/optic-engine/tests/snapshots/interaction_diff_use_cases__query_params_observed_for_the_first_time__results.snap
+++ b/workspaces/optic-engine/tests/snapshots/interaction_diff_use_cases__query_params_observed_for_the_first_time__results.snap
@@ -4,22 +4,24 @@ expression: results
 ---
 [
     UnmatchedQueryParameters(
-        UnmatchedQueryParameters {
-            interaction_trail: InteractionTrail {
-                path: [
-                    Url {
-                        path: "/api/todos",
-                    },
-                    Method {
-                        method: "GET",
-                    },
-                ],
-            },
-            requests_trail: SpecPath(
-                SpecPath {
-                    path_id: "path_1pomS4CVlc",
+        Observed(
+            UnmatchedQueryParametersDescriptor {
+                interaction_trail: InteractionTrail {
+                    path: [
+                        Url {
+                            path: "/api/todos",
+                        },
+                        Method {
+                            method: "GET",
+                        },
+                    ],
                 },
-            ),
-        },
+                requests_trail: SpecPath(
+                    SpecPath {
+                        path_id: "path_1pomS4CVlc",
+                    },
+                ),
+            },
+        ),
     ),
 ]


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

CI didn't run on https://github.com/opticdev/optic/pull/984 - think because this was pointed at a non-develop branch - updating the snapshot created in the test

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
