### PR TITLE
Handle query parameters deletion on endpoint deletion

### DIFF
--- a/workspaces/optic-engine/src/commands/endpoint.rs
+++ b/workspaces/optic-engine/src/commands/endpoint.rs
@@ -46,6 +46,7 @@ pub enum EndpointCommand {
   // Query parameters
   AddQueryParameters(AddQueryParameters),
   SetQueryParametersShape(SetQueryParametersShape),
+  RemoveQueryParameters(RemoveQueryParameters),
 
   // Headers
   AddHeaderParameter(AddHeaderParameter),
@@ -100,6 +101,12 @@ impl EndpointCommand {
         shape_id,
         is_removed,
       },
+    })
+  }
+
+  pub fn remove_query_parameters(query_parameters_id: QueryParametersId) -> EndpointCommand {
+    EndpointCommand::RemoveQueryParameters(RemoveQueryParameters {
+      query_parameters_id,
     })
   }
 
@@ -350,6 +357,12 @@ pub struct SetQueryParametersShape {
   pub shape_descriptor: QueryParametersShapeDescriptor,
 }
 
+#[derive(Deserialize, Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoveQueryParameters {
+  pub query_parameters_id: QueryParametersId,
+}
+
 // Headers
 // -------
 
@@ -572,6 +585,17 @@ impl AggregateCommand<EndpointProjection> for EndpointCommand {
 
         vec![EndpointEvent::from(
           endpoint_events::QueryParametersShapeSet::from(command),
+        )]
+      }
+
+      EndpointCommand::RemoveQueryParameters(command) => {
+        validation.require(
+          validation.query_parameters_id_exists(&command.query_parameters_id),
+          "query parameters must exist to be removed",
+        )?;
+
+        vec![EndpointEvent::from(
+          endpoint_events::QueryParametersRemoved::from(command),
         )]
       }
 

--- a/workspaces/optic-engine/src/projections/spectacle/endpoints.rs
+++ b/workspaces/optic-engine/src/projections/spectacle/endpoints.rs
@@ -107,38 +107,38 @@ impl AggregateEvent<EndpointsProjection> for EndpointEvent {
       EndpointEvent::PathComponentAdded(e) => {
         projection.with_path_component(e.parent_path_id, e.path_id.clone(), e.name);
         if let Some(c) = e.event_context {
-          projection.with_creation_history(&c.client_command_batch_id, &e.path_id);
+          projection.with_creation_history(c.client_command_batch_id, e.path_id);
         }
       }
       EndpointEvent::PathComponentRemoved(e) => {
         projection.without_path_component(&e.path_id);
         if let Some(c) = e.event_context {
-          projection.with_remove_history(&c.client_command_batch_id, &e.path_id);
+          projection.with_remove_history(c.client_command_batch_id, e.path_id);
         }
       }
       EndpointEvent::PathParameterAdded(e) => {
         projection.with_path_parameter(e.parent_path_id, e.path_id.clone(), e.name);
         if let Some(c) = e.event_context {
-          projection.with_creation_history(&c.client_command_batch_id, &e.path_id);
+          projection.with_creation_history(c.client_command_batch_id, e.path_id);
         }
       }
       EndpointEvent::PathParameterRemoved(e) => {
         projection.without_path_component(&e.path_id);
         if let Some(c) = e.event_context {
-          projection.with_remove_history(&c.client_command_batch_id, &e.path_id);
+          projection.with_remove_history(c.client_command_batch_id, e.path_id);
         }
       }
       EndpointEvent::RequestAdded(e) => {
         projection.with_request(e.request_id.clone(), e.path_id, e.http_method);
 
         if let Some(c) = e.event_context {
-          projection.with_creation_history(&c.client_command_batch_id, &e.request_id);
+          projection.with_creation_history(c.client_command_batch_id, e.request_id);
         }
       }
       EndpointEvent::RequestRemoved(e) => {
         projection.without_request(&e.request_id);
         if let Some(c) = e.event_context {
-          projection.with_remove_history(&c.client_command_batch_id, &e.request_id);
+          projection.with_remove_history(c.client_command_batch_id, e.request_id);
         }
       }
       EndpointEvent::ResponseAddedByPathAndMethod(e) => {
@@ -150,13 +150,13 @@ impl AggregateEvent<EndpointsProjection> for EndpointEvent {
         );
 
         if let Some(c) = e.event_context {
-          projection.with_creation_history(&c.client_command_batch_id, &e.response_id);
+          projection.with_creation_history(c.client_command_batch_id, e.response_id);
         }
       }
       EndpointEvent::ResponseRemoved(e) => {
         projection.without_response(&e.response_id);
         if let Some(c) = e.event_context {
-          projection.with_remove_history(&c.client_command_batch_id, &e.response_id);
+          projection.with_remove_history(c.client_command_batch_id, e.response_id);
         }
       }
       EndpointEvent::RequestBodySet(e) => {
@@ -168,23 +168,23 @@ impl AggregateEvent<EndpointsProjection> for EndpointEvent {
         );
 
         if let Some(c) = e.event_context {
-          projection.with_creation_history(&c.client_command_batch_id, &e.body_descriptor.shape_id);
+          projection.with_creation_history(c.client_command_batch_id, e.body_descriptor.shape_id);
         }
       }
       EndpointEvent::QueryParametersAdded(e) => {
         projection.with_query_parameters(e.path_id, e.http_method, e.query_parameters_id);
       }
       EndpointEvent::QueryParametersShapeSet(e) => {
-        projection.with_query_parameters_shape(&e.query_parameters_id, &e.shape_descriptor);
+        projection.with_query_parameters_shape(e.query_parameters_id.clone(), e.shape_descriptor);
         // We treat the query parameter only as created when there is a shape attached to it
         if let Some(c) = e.event_context {
-          projection.with_creation_history(&c.client_command_batch_id, &e.query_parameters_id);
+          projection.with_creation_history(c.client_command_batch_id, e.query_parameters_id);
         }
       }
       EndpointEvent::QueryParametersRemoved(e) => {
         projection.without_query_parameters(&e.query_parameters_id);
         if let Some(c) = e.event_context {
-          projection.with_remove_history(&c.client_command_batch_id, &e.query_parameters_id);
+          projection.with_remove_history(c.client_command_batch_id, e.query_parameters_id);
         }
       }
       EndpointEvent::ResponseBodySet(e) => {
@@ -196,7 +196,7 @@ impl AggregateEvent<EndpointsProjection> for EndpointEvent {
         );
 
         if let Some(c) = e.event_context {
-          projection.with_creation_history(&c.client_command_batch_id, &e.body_descriptor.shape_id);
+          projection.with_creation_history(c.client_command_batch_id, e.body_descriptor.shape_id);
         }
       }
       _ => eprintln!(
@@ -473,12 +473,12 @@ impl EndpointsProjection {
   ////////////////////////////////////////////////////////////////////////////////////////////////////
   pub fn with_query_parameters_shape(
     &mut self,
-    query_parameters_id: &QueryParametersId,
-    shape_descriptor: &QueryParametersShapeDescriptor,
+    query_parameters_id: QueryParametersId,
+    shape_descriptor: QueryParametersShapeDescriptor,
   ) {
     let query_index = *self
       .domain_id_to_index
-      .get(query_parameters_id)
+      .get(&query_parameters_id)
       .expect("expected node with domain_id $request_id to exist in the graph");
 
     if let Some(Node::QueryParameters(query_node)) = self.graph.node_weight_mut(query_index) {
@@ -539,13 +539,13 @@ impl EndpointsProjection {
     let node_index = self.graph.add_node(node);
     self.domain_id_to_index.insert(batch_id, node_index);
   }
-  pub fn with_creation_history(&mut self, batch_id: &str, created_node_id: &str) {
+  pub fn with_creation_history(&mut self, batch_id: String, created_node_id: String) {
     let created_node_index = self
       .domain_id_to_index
-      .get(created_node_id)
+      .get(&created_node_id)
       .expect("expected created_node_id to exist");
 
-    let batch_node_index_option = self.domain_id_to_index.get(batch_id);
+    let batch_node_index_option = self.domain_id_to_index.get(&batch_id);
 
     if let Some(batch_node_index) = batch_node_index_option {
       self
@@ -555,13 +555,13 @@ impl EndpointsProjection {
       eprintln!("bad implicit batch id {}", &batch_id);
     }
   }
-  pub fn with_update_history(&mut self, batch_id: &str, updated_node_id: &str) {
+  pub fn with_update_history(&mut self, batch_id: String, updated_node_id: String) {
     let updated_node_index = self
       .domain_id_to_index
-      .get(updated_node_id)
+      .get(&updated_node_id)
       .expect("expected updated_node_id to exist");
 
-    let batch_node_index_option = self.domain_id_to_index.get(batch_id);
+    let batch_node_index_option = self.domain_id_to_index.get(&batch_id);
 
     if let Some(batch_node_index) = batch_node_index_option {
       self
@@ -571,13 +571,13 @@ impl EndpointsProjection {
       eprintln!("bad implicit batch id {}", &batch_id);
     }
   }
-  pub fn with_remove_history(&mut self, batch_id: &str, removed_node_id: &str) {
+  pub fn with_remove_history(&mut self, batch_id: String, removed_node_id: String) {
     let removed_node_index = self
       .domain_id_to_index
-      .get(removed_node_id)
+      .get(&removed_node_id)
       .expect("expected removed_node_id to exist");
 
-    let batch_node_index_option = self.domain_id_to_index.get(batch_id);
+    let batch_node_index_option = self.domain_id_to_index.get(&batch_id);
 
     if let Some(batch_node_index) = batch_node_index_option {
       self

--- a/workspaces/optic-engine/src/queries/endpoint.rs
+++ b/workspaces/optic-engine/src/queries/endpoint.rs
@@ -391,6 +391,9 @@ impl<'a> EndpointQueries<'a> {
     path_id: &'a PathComponentId,
     method: &'a HttpMethod,
   ) -> Option<DeleteEndpointCommands> {
+    let query_param_id = self
+      .resolve_endpoint_query_params(path_id, method)
+      .map(|(query_param_id, _)| query_param_id);
     let request_ids = self
       .resolve_requests(path_id, method)?
       .map(|(request_id, _)| request_id);
@@ -398,6 +401,9 @@ impl<'a> EndpointQueries<'a> {
       .resolve_responses(path_id, method)?
       .map(|(response_id, _)| response_id);
 
+    let query_parameter_command = query_param_id
+      .cloned()
+      .map(EndpointCommand::remove_query_parameters);
     let request_commands = request_ids.cloned().map(EndpointCommand::remove_request);
     let response_commands = response_ids.cloned().map(EndpointCommand::remove_response);
 
@@ -406,6 +412,7 @@ impl<'a> EndpointQueries<'a> {
       method: method.clone(),
       commands: request_commands
         .chain(response_commands)
+        .chain(query_parameter_command)
         .map(SpecCommand::from)
         .collect(),
     })
@@ -620,6 +627,9 @@ mod test {
 
       {"RequestAdded": { "requestId": "request_3", "pathId": "path_3", "httpMethod": "GET"}},
       {"ResponseAddedByPathAndMethod": {"responseId": "response_3", "pathId": "path_3", "httpMethod": "GET", "httpStatusCode": 200 }},
+
+      {"QueryParametersAdded": {"queryParametersId": "query_1", "httpMethod": "GET", "pathId": "path_2"}},
+      {"QueryParametersShapeSet": {"queryParametersId": "query_1", "shapeDescriptor":{"shapeId":"shape_Ba53AWXhVW","isRemoved":false}}},
     ]))
     .expect("should be able to deserialize test events");
 
@@ -637,6 +647,8 @@ mod test {
     let updated_spec =
       assert_valid_commands(spec_projection.clone(), deleted_endpoint_commmands.commands);
     let updated_queries = EndpointQueries::new(&updated_spec.endpoint());
+    let remaining_query_parameters =
+      updated_queries.resolve_endpoint_query_params(&subject_path, &subject_method);
     let remaining_requests = updated_queries
       .resolve_requests(&subject_path, &subject_method)
       .unwrap()
@@ -648,6 +660,7 @@ mod test {
 
     // dbg!(Dot::with_config(&updated_spec.endpoint().graph, &[]));
 
+    assert!(remaining_query_parameters.is_none());
     assert_eq!(remaining_requests.len(), 0);
     assert_eq!(remaining_responses.len(), 0);
   }


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

When we delete an endpoint, we also need to delete query parameters (otherwise the rust engine cannot delete the paths since the paths are still in use)

## What
What's changing? Anything of note to call out?

- Added `EndpointCommand::RemoveQueryParameters` and `EndpointEvent::QueryParametersRemoved`
- Updated delete endpoint command generation to include query parameters
- Updated internal endpoint and spectacle endpoint projections to handle these events.

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
