### PR TITLE
Fix diff trails

### DIFF
--- a/workspaces/cli-shared/src/diffs/trail-parsers.ts
+++ b/workspaces/cli-shared/src/diffs/trail-parsers.ts
@@ -42,7 +42,7 @@ export type LocationDescriptor =
   | {
       type: 'path_response';
       statusCode: number;
-      contentType?: string; // TODO find out why contentType is nullable
+      contentType?: string; // Content type is nullable for responses without bodies
     }
   | {
       type: 'path_query';

--- a/workspaces/cli-shared/src/diffs/trail-parsers.ts
+++ b/workspaces/cli-shared/src/diffs/trail-parsers.ts
@@ -19,6 +19,35 @@ type EndpointForTrails = {
   }[];
 };
 
+export type LocationDescriptor =
+  | {
+      type: 'request';
+      requestId: string;
+      contentType: string;
+    }
+  | {
+      type: 'response';
+      responseId: string;
+      contentType: string;
+      statusCode: number;
+    }
+  | {
+      type: 'query';
+      queryParametersId: string;
+    }
+  | {
+      type: 'path_request';
+      contentType: string;
+    }
+  | {
+      type: 'path_response';
+      statusCode: number;
+      contentType?: string; // TODO find out why contentType is nullable
+    }
+  | {
+      type: 'path_query';
+    };
+
 export function locationForTrails(
   trail: IRequestSpecTrail,
   interactionTrail: IInteractionTrail,
@@ -26,33 +55,7 @@ export function locationForTrails(
 ): {
   pathId: string;
   method: string;
-  descriptor:
-    | {
-        type: 'request';
-        requestId: string;
-        contentType: string;
-      }
-    | {
-        type: 'response';
-        responseId: string;
-        contentType: string;
-        statusCode: number;
-      }
-    | {
-        type: 'query';
-        queryParametersId: string;
-      }
-    // TODO figure out when path_request and path_response variants are generated
-    // These aren't currently handled by the UI
-    | {
-        type: 'path_request';
-        contentType: string;
-      }
-    | {
-        type: 'path_response';
-        statusCode: number;
-        contentType?: string; // TODO find out why contentType is nullable
-      };
+  descriptor: LocationDescriptor;
 } | null {
   if ('SpecRoot' in trail) {
     return null;
@@ -159,8 +162,13 @@ export function locationForTrails(
         },
       };
     } else {
-      console.error('SpecPath trail was not found in request or response');
-      return null;
+      return {
+        pathId,
+        method,
+        descriptor: {
+          type: 'path_query',
+        },
+      };
     }
   } else if ('SpecQueryParameters' in trail) {
     const { queryParametersId } = trail.SpecQueryParameters;

--- a/workspaces/ui-v2/src/lib/Interfaces.ts
+++ b/workspaces/ui-v2/src/lib/Interfaces.ts
@@ -7,6 +7,7 @@ import {
 import { ICopy } from '<src>/pages/diffs/components/ICopyRender';
 import { IJsonTrail } from '../../../cli-shared/build/diffs/json-trail';
 import { DomainIdGenerator } from './domain-id-generator';
+import { DiffLocation } from './parse-diff';
 import { IEndpoint } from '<src>/types';
 
 export interface IInterpretation {
@@ -49,7 +50,7 @@ export interface BodyPreview {
 export interface IDiffDescription {
   title: ICopy[];
   assertion: ICopy[];
-  location: IParsedLocation;
+  location: DiffLocation;
   changeType: IChangeType;
   getJsonBodyToPreview: (interaction: IHttpInteraction) => BodyPreview;
   unknownDiffBehavior?: boolean;
@@ -174,36 +175,6 @@ export const isBodyShapeDiff = (key: string): boolean =>
   allowedDiffTypes[key]?.isBodyShapeDiff;
 export const isDiffForKnownEndpoint = (key: string): boolean =>
   !allowedDiffTypes[key]?.unmatchedUrl;
-
-export interface IParsedLocation {
-  pathId: string;
-  method: string;
-  descriptor:
-    | {
-        type: 'query';
-        queryParametersId: string;
-      }
-    | {
-        type: 'request';
-        requestId: string;
-        contentType: string;
-      }
-    | {
-        type: 'response';
-        statusCode: number;
-        contentType: string;
-        responseId: string;
-      }
-    | {
-        type: 'path_request';
-        contentType: string;
-      }
-    | {
-        type: 'path_response';
-        statusCode: number;
-        contentType?: string;
-      };
-}
 
 ///////////////////////////////////////
 export type CurrentSpecContext = {

--- a/workspaces/ui-v2/src/lib/__tests/diff-helpers/__snapshots__/new-regions-interpretations.test.ts.snap
+++ b/workspaces/ui-v2/src/lib/__tests/diff-helpers/__snapshots__/new-regions-interpretations.test.ts.snap
@@ -163,7 +163,7 @@ Object {
       "changeType": 0,
       "diffHash": "8de10f26b6ef26ca",
       "getJsonBodyToPreview": [Function],
-      "location": Object {
+      "location": DiffLocation {
         "descriptor": Object {
           "contentType": "application/json",
           "type": "path_request",
@@ -386,7 +386,7 @@ Object {
       "changeType": 0,
       "diffHash": "e958234709591c5f",
       "getJsonBodyToPreview": [Function],
-      "location": Object {
+      "location": DiffLocation {
         "descriptor": Object {
           "contentType": "application/json",
           "statusCode": 200,

--- a/workspaces/ui-v2/src/lib/__tests/diff-helpers/__snapshots__/shape-interpretations.test.ts.snap
+++ b/workspaces/ui-v2/src/lib/__tests/diff-helpers/__snapshots__/shape-interpretations.test.ts.snap
@@ -63,7 +63,7 @@ Object {
       "changeType": 1,
       "diffHash": "84167c0c7595d4d6",
       "getJsonBodyToPreview": [Function],
-      "location": Object {
+      "location": DiffLocation {
         "descriptor": Object {
           "contentType": "application/json",
           "responseId": "baseline-response_1",
@@ -304,7 +304,7 @@ Object {
       "changeType": 1,
       "diffHash": "d9a9a649152793af",
       "getJsonBodyToPreview": [Function],
-      "location": Object {
+      "location": DiffLocation {
         "descriptor": Object {
           "contentType": "application/json",
           "responseId": "baseline-response_1",
@@ -519,7 +519,7 @@ Object {
       "changeType": 0,
       "diffHash": "c1c137f409e885dc",
       "getJsonBodyToPreview": [Function],
-      "location": Object {
+      "location": DiffLocation {
         "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_1",
@@ -781,7 +781,7 @@ Object {
       "changeType": 0,
       "diffHash": "c1c137f409e885dc",
       "getJsonBodyToPreview": [Function],
-      "location": Object {
+      "location": DiffLocation {
         "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_1",
@@ -1011,7 +1011,7 @@ Object {
       "changeType": 0,
       "diffHash": "f31dde2a282b48",
       "getJsonBodyToPreview": [Function],
-      "location": Object {
+      "location": DiffLocation {
         "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_1",
@@ -1219,7 +1219,7 @@ Object {
       "changeType": 0,
       "diffHash": "63269210d11730b6",
       "getJsonBodyToPreview": [Function],
-      "location": Object {
+      "location": DiffLocation {
         "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_1",
@@ -1493,7 +1493,7 @@ Object {
       "changeType": 1,
       "diffHash": "179f9d4a33ca4658",
       "getJsonBodyToPreview": [Function],
-      "location": Object {
+      "location": DiffLocation {
         "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_1",
@@ -1788,7 +1788,7 @@ Object {
       "changeType": 1,
       "diffHash": "124b53ff9a034b57",
       "getJsonBodyToPreview": [Function],
-      "location": Object {
+      "location": DiffLocation {
         "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_1",
@@ -2085,7 +2085,7 @@ Object {
       "changeType": 1,
       "diffHash": "3542ba6590d7ae3f",
       "getJsonBodyToPreview": [Function],
-      "location": Object {
+      "location": DiffLocation {
         "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_1",
@@ -2383,7 +2383,7 @@ Object {
       "changeType": 1,
       "diffHash": "179f9d4a33ca4658",
       "getJsonBodyToPreview": [Function],
-      "location": Object {
+      "location": DiffLocation {
         "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_1",
@@ -2638,7 +2638,7 @@ Object {
       "changeType": 0,
       "diffHash": "8d46ea69f9088574",
       "getJsonBodyToPreview": [Function],
-      "location": Object {
+      "location": DiffLocation {
         "descriptor": Object {
           "contentType": "application/json",
           "responseId": "baseline-response_1",
@@ -2830,7 +2830,7 @@ Object {
       "changeType": 1,
       "diffHash": "d9d824261703f4be",
       "getJsonBodyToPreview": [Function],
-      "location": Object {
+      "location": DiffLocation {
         "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_1",
@@ -3039,7 +3039,7 @@ Object {
       "changeType": 1,
       "diffHash": "d9d824261703f4be",
       "getJsonBodyToPreview": [Function],
-      "location": Object {
+      "location": DiffLocation {
         "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_1",
@@ -3244,7 +3244,7 @@ Object {
       "changeType": 1,
       "diffHash": "9680b0bf6bd1b6b1",
       "getJsonBodyToPreview": [Function],
-      "location": Object {
+      "location": DiffLocation {
         "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_1",
@@ -3522,7 +3522,7 @@ Object {
       "changeType": 1,
       "diffHash": "d9d824261703f4be",
       "getJsonBodyToPreview": [Function],
-      "location": Object {
+      "location": DiffLocation {
         "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_1",
@@ -3817,7 +3817,7 @@ Object {
       "changeType": 1,
       "diffHash": "7cb55ecdc93fa003",
       "getJsonBodyToPreview": [Function],
-      "location": Object {
+      "location": DiffLocation {
         "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_1",
@@ -4084,7 +4084,7 @@ Object {
       "changeType": 1,
       "diffHash": "7cb55ecdc93fa003",
       "getJsonBodyToPreview": [Function],
-      "location": Object {
+      "location": DiffLocation {
         "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_1",
@@ -4339,7 +4339,7 @@ Object {
       "changeType": 1,
       "diffHash": "7cb55ecdc93fa003",
       "getJsonBodyToPreview": [Function],
-      "location": Object {
+      "location": DiffLocation {
         "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_1",
@@ -4681,7 +4681,7 @@ Object {
       "changeType": 1,
       "diffHash": "601c9b4584024d27",
       "getJsonBodyToPreview": [Function],
-      "location": Object {
+      "location": DiffLocation {
         "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_KBRwJqndED",
@@ -5607,7 +5607,7 @@ Object {
       "changeType": 1,
       "diffHash": "59b1dc0fdc7951d3",
       "getJsonBodyToPreview": [Function],
-      "location": Object {
+      "location": DiffLocation {
         "descriptor": Object {
           "contentType": "application/json",
           "responseId": "baseline-response_1",
@@ -5936,7 +5936,7 @@ Object {
       "changeType": 1,
       "diffHash": "59b1dc0fdc7951d3",
       "getJsonBodyToPreview": [Function],
-      "location": Object {
+      "location": DiffLocation {
         "descriptor": Object {
           "contentType": "application/json",
           "responseId": "baseline-response_1",
@@ -6254,7 +6254,7 @@ Object {
       "changeType": 1,
       "diffHash": "5afaa9bc7e91e73c",
       "getJsonBodyToPreview": [Function],
-      "location": Object {
+      "location": DiffLocation {
         "descriptor": Object {
           "contentType": "application/json",
           "responseId": "response_1",
@@ -6456,7 +6456,7 @@ Object {
       "changeType": 1,
       "diffHash": "d8b48b881aef10ca",
       "getJsonBodyToPreview": [Function],
-      "location": Object {
+      "location": DiffLocation {
         "descriptor": Object {
           "contentType": "application/json",
           "responseId": "baseline-response_1",

--- a/workspaces/ui-v2/src/lib/__tests/diff-helpers/__snapshots__/trail-parsers.test.ts.snap
+++ b/workspaces/ui-v2/src/lib/__tests/diff-helpers/__snapshots__/trail-parsers.test.ts.snap
@@ -66,7 +66,7 @@ ParsedDiff {
 `;
 
 exports[`accurate spec trail for all diffs: 2d026d49eaf0fa95-parsed-location 1`] = `
-Object {
+DiffLocation {
   "descriptor": Object {
     "contentType": "application/json",
     "responseId": "response_dE2gzm1TWj",
@@ -144,7 +144,7 @@ ParsedDiff {
 `;
 
 exports[`accurate spec trail for all diffs: 4f2147e2d4a69bc0-parsed-location 1`] = `
-Object {
+DiffLocation {
   "descriptor": Object {
     "contentType": "application/json",
     "responseId": "response_RkkvxIt2RG",
@@ -225,7 +225,7 @@ ParsedDiff {
 `;
 
 exports[`accurate spec trail for all diffs: 4fc531c016328e1-parsed-location 1`] = `
-Object {
+DiffLocation {
   "descriptor": Object {
     "contentType": "application/json",
     "requestId": "request_gwQEFrHpO0",
@@ -276,7 +276,7 @@ ParsedDiff {
 `;
 
 exports[`accurate spec trail for all diffs: 8de10f26b6ef26ca-parsed-location 1`] = `
-Object {
+DiffLocation {
   "descriptor": Object {
     "contentType": "application/json",
     "type": "path_request",
@@ -326,7 +326,7 @@ ParsedDiff {
 `;
 
 exports[`accurate spec trail for all diffs: 9a9d4567077e6388-parsed-location 1`] = `
-Object {
+DiffLocation {
   "descriptor": Object {
     "contentType": "application/json",
     "type": "path_request",
@@ -401,7 +401,7 @@ ParsedDiff {
 `;
 
 exports[`accurate spec trail for all diffs: 22d96b2ef2dd13d0-parsed-location 1`] = `
-Object {
+DiffLocation {
   "descriptor": Object {
     "contentType": "application/json",
     "requestId": "request_3kjV3YMXdP",
@@ -451,7 +451,7 @@ ParsedDiff {
 `;
 
 exports[`accurate spec trail for all diffs: 92a6b20a0d317304-parsed-location 1`] = `
-Object {
+DiffLocation {
   "descriptor": Object {
     "contentType": "application/json",
     "type": "path_request",
@@ -531,7 +531,7 @@ ParsedDiff {
 `;
 
 exports[`accurate spec trail for all diffs: 92e989e4d821dcf1-parsed-location 1`] = `
-Object {
+DiffLocation {
   "descriptor": Object {
     "contentType": "application/json",
     "responseId": "response_Zv48g7lL5e",
@@ -582,7 +582,7 @@ ParsedDiff {
 `;
 
 exports[`accurate spec trail for all diffs: 312f75a76267c7f2-parsed-location 1`] = `
-Object {
+DiffLocation {
   "descriptor": Object {
     "contentType": "application/json",
     "type": "path_request",
@@ -631,7 +631,7 @@ ParsedDiff {
 `;
 
 exports[`accurate spec trail for all diffs: 3871874498eaa9f3-parsed-location 1`] = `
-Object {
+DiffLocation {
   "descriptor": Object {
     "contentType": "application/json",
     "type": "path_request",
@@ -680,7 +680,7 @@ ParsedDiff {
 `;
 
 exports[`accurate spec trail for all diffs: d44b141a1439cf3d-parsed-location 1`] = `
-Object {
+DiffLocation {
   "descriptor": Object {
     "contentType": "application/json",
     "type": "path_request",
@@ -725,7 +725,7 @@ ParsedDiff {
 `;
 
 exports[`accurate spec trail for all diffs: dc68f0f84b0bd1db-parsed-location 1`] = `
-Object {
+DiffLocation {
   "descriptor": Object {
     "contentType": "application/json",
     "statusCode": 200,
@@ -772,7 +772,7 @@ ParsedDiff {
 `;
 
 exports[`accurate spec trail for all diffs: e958234709591c5f-parsed-location 1`] = `
-Object {
+DiffLocation {
   "descriptor": Object {
     "contentType": "application/json",
     "statusCode": 200,
@@ -848,7 +848,7 @@ ParsedDiff {
 `;
 
 exports[`accurate spec trail for all diffs: f45959c6c23c8fc8-parsed-location 1`] = `
-Object {
+DiffLocation {
   "descriptor": Object {
     "contentType": "application/json",
     "requestId": "request_SqY61Qc9Mi",
@@ -894,7 +894,7 @@ ParsedDiff {
 `;
 
 exports[`accurate spec trail for all diffs: fe447736f416eac6-parsed-location 1`] = `
-Object {
+DiffLocation {
   "descriptor": Object {
     "contentType": "application/json",
     "statusCode": 200,
@@ -943,7 +943,7 @@ ParsedDiff {
 `;
 
 exports[`accurate spec trail for all diffs: ffd0f3f68e0a185b-parsed-location 1`] = `
-Object {
+DiffLocation {
   "descriptor": Object {
     "contentType": "application/json",
     "statusCode": 200,

--- a/workspaces/ui-v2/src/lib/shape-diffs/field.ts
+++ b/workspaces/ui-v2/src/lib/shape-diffs/field.ts
@@ -46,7 +46,7 @@ export function fieldShapeDiffInterpreter(
     copy: [],
     shapes: [],
     isField: true,
-    isQueryParam: shapeDiff.location.descriptor.type === 'query',
+    isQueryParam: shapeDiff.location.isQueryParameter(),
   };
 
   // field is in the spec, the value was not what we expected to see

--- a/workspaces/ui-v2/src/lib/shape-diffs/list.ts
+++ b/workspaces/ui-v2/src/lib/shape-diffs/list.ts
@@ -32,7 +32,7 @@ export function listItemShapeDiffInterpreter(
     copy: [],
     shapes: [],
     isField: false,
-    isQueryParam: shapeDiff.location.descriptor.type === 'query',
+    isQueryParam: shapeDiff.location.isQueryParameter(),
   };
 
   if (isUnmatched) {

--- a/workspaces/ui-v2/src/pages/diffs/EndpointDocumentationPane.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/EndpointDocumentationPane.tsx
@@ -17,7 +17,7 @@ import {
 import { EndpointTOC } from '<src>/pages/docs/components/EndpointTOC';
 import { SubtleBlueBackground, FontFamily } from '<src>/styles';
 
-import { IParsedLocation } from '<src>/lib/Interfaces';
+import { DiffLocation } from '<src>/lib/parse-diff';
 import {
   HighlightedLocation,
   Location,
@@ -33,7 +33,7 @@ type EndpointDocumentationPaneProps = {
   pathId: string;
   lastBatchCommit?: string;
   highlightBodyChanges?: boolean;
-  highlightedLocation?: IParsedLocation;
+  highlightedLocation?: DiffLocation;
   renderHeader: () => ReactNode;
 };
 

--- a/workspaces/ui-v2/src/pages/diffs/ReviewEndpointDiffPage/DiffLinks.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/ReviewEndpointDiffPage/DiffLinks.tsx
@@ -18,16 +18,19 @@ export function DiffLinks({
     <List>
       {allDiffs.map((diff, i) => {
         const { location, diffHash, title } = diff.diffDescription;
+        const isQueryParameter = location.isQueryParameter();
+        const requestDescriptor = location.getRequestDescriptor();
+        const responseDescriptor = location.getResponseDescriptor();
 
         return (
           <React.Fragment key={diffHash}>
             <ListSubheader className={classes.locationHeader}>
-              {location.descriptor.type === 'query'
+              {isQueryParameter
                 ? 'Query Parameters'
-                : location.descriptor.type === 'request'
-                ? `Request Body ${location.descriptor.contentType}`
-                : location.descriptor.type === 'response'
-                ? `${location.descriptor.statusCode} Response ${location.descriptor.contentType}`
+                : requestDescriptor
+                ? `Request Body ${requestDescriptor.contentType}`
+                : responseDescriptor
+                ? `${responseDescriptor.statusCode} Response ${responseDescriptor.contentType}`
                 : 'Unknown location'}
             </ListSubheader>
             <ListItem button onClick={() => setSelectedDiff(i)}>

--- a/workspaces/ui-v2/src/pages/diffs/components/HighlightedLocation.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/components/HighlightedLocation.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { IParsedLocation } from '../../../lib/Interfaces';
+import { DiffLocation } from '<src>/lib/parse-diff';
 import { OpticBlueReadable, SubtleBlueBackground } from '<src>/styles';
 //@ts-ignore
 import ScrollIntoViewIfNeeded from 'react-scroll-into-view-if-needed';
@@ -8,19 +8,19 @@ import classnames from 'classnames';
 
 type IHighlightedLocation =
   | {
-      targetLocation?: IParsedLocation;
+      targetLocation?: DiffLocation;
       statusCode?: undefined;
       contentType?: undefined;
       expectedLocation: Location.Query;
     }
   | {
-      targetLocation?: IParsedLocation;
+      targetLocation?: DiffLocation;
       statusCode?: undefined;
       contentType: string;
       expectedLocation: Location.Request;
     }
   | {
-      targetLocation?: IParsedLocation;
+      targetLocation?: DiffLocation;
       statusCode: number;
       contentType: string;
       expectedLocation: Location.Response;
@@ -45,17 +45,18 @@ export const HighlightedLocation: FC<
     switch (props.expectedLocation) {
       case Location.Request:
         return (
-          targetLocation.descriptor.type === 'request' &&
-          targetLocation.descriptor.contentType === props.contentType
+          targetLocation.getRequestDescriptor()?.contentType ===
+          props.contentType
         );
       case Location.Response:
         return (
-          targetLocation.descriptor.type === 'response' &&
-          targetLocation.descriptor.contentType === props.contentType &&
-          targetLocation.descriptor.statusCode === props.statusCode
+          targetLocation.getResponseDescriptor()?.contentType ===
+            props.contentType &&
+          targetLocation.getResponseDescriptor()?.statusCode ===
+            props.statusCode
         );
       case Location.Query:
-        return targetLocation.descriptor.type === 'query';
+        return targetLocation.isQueryParameter();
       default:
         return false;
     }


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

So turns out I added in bugs (classic) - this PR fixes this and now i have a better idea of how these work (only takes breaking the diff flow for me to understand this) - requestId, responseId and queryParameterId are only set if there is an existing, learnt body (when it's unrecognized, it's not set) - these are not needed in most locations, and this is implicitly relied on. I changed this to be explicitly typed so you have to check for the presense of these (rather than blindly casting `!`).

What I think would really really help the diff flow, is to instead have different implementations for each diff, which handle their own usage, and certain diff variants (e.g. new regions or shape diffs) can only be used in certain contexts, where they would have things like "get node id" implemented.

## What
What's changing? Anything of note to call out?

@JaapRood  I'm going to merge this in first, since it fixes the diff flow for query parameters, but if you have any comments, i'll address them as a follow up

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
