### PR TITLE
Fix changelog rendering for query parmaters

### DIFF
--- a/workspaces/ui-v2/src/components/HttpBodyPanel.tsx
+++ b/workspaces/ui-v2/src/components/HttpBodyPanel.tsx
@@ -11,7 +11,7 @@ type HttpBodyPanelProps = {
 export const HttpBodyPanel: FC<HttpBodyPanelProps> = ({ shapes, location }) => {
   return (
     <Panel header={location}>
-      <ShapeRenderer showExamples={false} shape={shapes} />
+      <ShapeRenderer showExamples={false} shapes={shapes} />
     </Panel>
   );
 };

--- a/workspaces/ui-v2/src/components/QueryParametersPanel.tsx
+++ b/workspaces/ui-v2/src/components/QueryParametersPanel.tsx
@@ -69,7 +69,7 @@ export const QueryParametersPanel: FC<QueryParametersPanelProps> = ({
             )}
           </div>
           <div className={classes.shapeContainer}>
-            <ShapeRenderer showExamples={false} shape={field.shapeChoices} />
+            <ShapeRenderer showExamples={false} shapes={field.shapeChoices} />
           </div>
         </div>
       ))}
@@ -87,7 +87,7 @@ const useStyles = makeStyles((theme) => ({
   },
   queryComponentContainer: {
     marginBottom: theme.spacing(1),
-    padding: theme.spacing(1, 0),
+    padding: theme.spacing(1),
     display: 'flex',
     '&:not(:first-child)': {
       borderTop: '1px solid #e4e8ed',

--- a/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRenderer.tsx
+++ b/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRenderer.tsx
@@ -5,20 +5,20 @@ import { IShapeRenderer } from './ShapeRenderInterfaces';
 
 type ShapeRendererProps = {
   showExamples: boolean;
-  shape: IShapeRenderer[];
+  shapes: IShapeRenderer[];
 };
 
 export const ShapeRenderer: FC<ShapeRendererProps> = ({
   showExamples,
-  shape,
+  shapes,
 }) => {
   return (
     <ShapeRenderStore showExamples={showExamples}>
-      {shape.length > 1 ? (
-        <OneOfRender shapes={shape} parentShapeId={'root'} />
-      ) : (
-        <RenderRootShape shape={shape} />
-      )}
+      {shapes.length > 1 ? (
+        <OneOfRender shapes={shapes} parentShapeId={'root'} />
+      ) : shapes.length === 1 ? (
+        <RenderRootShape shape={shapes[0]} />
+      ) : null}
     </ShapeRenderStore>
   );
 };

--- a/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRowBase.tsx
+++ b/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRowBase.tsx
@@ -119,14 +119,14 @@ export const RenderRootShape = ({
   shape,
   right,
 }: {
-  shape: IShapeRenderer[];
+  shape: IShapeRenderer;
   right?: any[];
 }) => {
   const { depth } = useDepth();
   return (
     <>
-      <ShapeRowBase depth={depth}>
-        <RenderFieldLeadingValue shapeRenderers={shape} />
+      <ShapeRowBase depth={depth} changes={shape.changes}>
+        <RenderFieldLeadingValue shapeRenderers={[shape]} />
         {right ? (
           <>
             <div style={{ flex: 1 }} />
@@ -134,7 +134,7 @@ export const RenderRootShape = ({
           </>
         ) : null}
       </ShapeRowBase>
-      <RenderFieldRowValues shapeRenderers={shape} />
+      <RenderFieldRowValues shapeRenderers={[shape]} />
     </>
   );
 };
@@ -215,9 +215,9 @@ export const RenderFieldRowValues = ({
             parentShapeId={shape.shapeId}
             shapes={shape.asArray.shapeChoices}
           />
-        ) : (
-          <RenderRootShape shape={shape.asArray.shapeChoices} />
-        );
+        ) : shape.asArray.shapeChoices.length === 1 ? (
+          <RenderRootShape shape={shape.asArray.shapeChoices[0]} />
+        ) : null;
 
       return (
         <>
@@ -266,7 +266,7 @@ export function OneOfRender({
     throw new Error(`expected to find the chosen shape`);
   }
   return (
-    <RenderRootShape right={[<OneOfTabs {...tabProps} />]} shape={[shape]} />
+    <RenderRootShape right={[<OneOfTabs {...tabProps} />]} shape={shape} />
   );
 }
 
@@ -281,7 +281,6 @@ const useStyles = makeStyles((theme) => ({
   },
   row: {
     flex: 1,
-    backgroundColor: '#f8fafc',
     display: 'flex',
     alignItems: 'flex-start',
     minHeight: 17,


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Now renders without a white background when there's a change - also added a little bit of horizontal padding
<img width="1137" alt="Screen Shot 2021-07-13 at 12 58 39 PM" src="https://user-images.githubusercontent.com/18374483/125517016-dacf9915-2b1c-4394-82c7-78787f258289.png">


## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
