### PR TITLE
cli: update links for new docs, launching soon

### DIFF
--- a/workspaces/cli-config/src/helpers/default-ignore-rules.ts
+++ b/workspaces/cli-config/src/helpers/default-ignore-rules.ts
@@ -17,6 +17,6 @@ export const defaultIgnoreRules = [
 
 export const defaultIgnoreFile = `
 # Default Ignore Rules
-# Learn to configure your own at http://localhost:4000/docs/using/advanced-configuration#ignoring-api-paths
+# Learn to configure your own at http://localhost:4000/reference/optic-yaml/ignore
 ${defaultIgnoreRules.join('\n')}
 `.trim();

--- a/workspaces/cli-config/src/helpers/default-ignore-rules.ts
+++ b/workspaces/cli-config/src/helpers/default-ignore-rules.ts
@@ -17,6 +17,6 @@ export const defaultIgnoreRules = [
 
 export const defaultIgnoreFile = `
 # Default Ignore Rules
-# Learn to configure your own at http://localhost:4000/reference/optic-yaml/ignore
+# Learn to configure your own at https://www.useoptic.com/reference/optic-yaml/ignore
 ${defaultIgnoreRules.join('\n')}
 `.trim();

--- a/workspaces/cli-config/tests/ignore-files/examples/optic1.yml
+++ b/workspaces/cli-config/tests/ignore-files/examples/optic1.yml
@@ -1,6 +1,6 @@
 name: Todo API
 tasks: []
 ignoreRequests:
-# For more information on configuration, visit https://www.useoptic.com/docs/get-started/config
+# For more information on configuration, visit https://www.useoptic.com/reference/optic-yaml/ignore
 - OPTIONS (.*)
 - GET /main/resource

--- a/workspaces/cli-shared/src/index.ts
+++ b/workspaces/cli-shared/src/index.ts
@@ -95,7 +95,7 @@ export async function loadPathsAndConfig(cli: Command) {
       cli.log(
         fromOptic(
           `No Optic project found in this directory. Learn to add Optic to your project here ${colors.underline(
-            'https://www.useoptic.com/docs/get-started/config'
+            'https://www.useoptic.com/document'
           )}`
         )
       );

--- a/workspaces/local-cli/src/shared/ui-links.ts
+++ b/workspaces/local-cli/src/shared/ui-links.ts
@@ -9,4 +9,4 @@ export const linkToDocumentation = (uiBaseUrl: string, sessionId: string) =>
   `${uiBaseUrl}/apis/${sessionId}/documentation`;
 
 export const linkToSetup = (sessionId: string) =>
-  `https://useoptic.com/docs/get-started/config`;
+  `https://useoptic.com/document`;

--- a/workspaces/ui-v2/src/pages/diffs/components/AuthorIgnoreRule.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/components/AuthorIgnoreRule.tsx
@@ -100,7 +100,7 @@ export function AuthorIgnoreRules() {
               <div>
                 Want to match a pattern? See our{' '}
                 <a
-                  href="https://www.useoptic.com/docs/using/advanced-configuration/#ignoring-api-paths"
+                  href="https://www.useoptic.com/reference/optic-yaml/ignore"
                   target="_blank"
                   rel="noopener noreferrer"
                 >


### PR DESCRIPTION
## Why

Update links for the next version of Optic. Old versions of Optic will still work: all links are redirected in the new site.

## Note

This should not merge until new docs launches

## Validation
* [ ] CI passes
