### PR TITLE
Add analytics for documenting query parameters

### DIFF
--- a/workspaces/analytics/src/uiEvents.ts
+++ b/workspaces/analytics/src/uiEvents.ts
@@ -146,10 +146,12 @@ export class OpticUIEvents {
 
   // Temporary
   // 2021/07/13- can remove 2021/10/13
-  queryParameterDocumented() {
+  queryParameterDocumented(numberOfQueryParameterBodies: number) {
     this.dispatch({
       type: 'query_parameter_documented',
-      data: {},
+      data: {
+        numberOfQueryParameterBodies,
+      },
     });
   }
 

--- a/workspaces/analytics/src/uiEvents.ts
+++ b/workspaces/analytics/src/uiEvents.ts
@@ -144,6 +144,15 @@ export class OpticUIEvents {
     });
   }
 
+  // Temporary
+  // 2021/07/13- can remove 2021/10/13
+  queryParameterDocumented() {
+    this.dispatch({
+      type: 'query_parameter_documented',
+      data: {},
+    });
+  }
+
   // proposed
 
   // deprecated

--- a/workspaces/ui-v2/src/pages/diffs/components/AskForCommitMessage.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/components/AskForCommitMessage.tsx
@@ -91,6 +91,14 @@ export default function AskForCommitMessageDiffPage(props: {
           clientSessionId,
         },
       });
+
+      const hasQueryParametersDocumented = commands.some(
+        (command) => 'AddQueryParameters' in command
+      );
+      if (hasQueryParametersDocumented) {
+        analytics.queryParameterDocumented();
+      }
+
       analytics.userSavedChanges(
         pendingEndpointsCount,
         changedEndpointsCount,

--- a/workspaces/ui-v2/src/pages/diffs/components/AskForCommitMessage.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/components/AskForCommitMessage.tsx
@@ -92,11 +92,11 @@ export default function AskForCommitMessageDiffPage(props: {
         },
       });
 
-      const hasQueryParametersDocumented = commands.some(
+      const numberOfQueryParametersDocumented = commands.filter(
         (command) => 'AddQueryParameters' in command
-      );
-      if (hasQueryParametersDocumented) {
-        analytics.queryParameterDocumented();
+      ).length;
+      if (numberOfQueryParametersDocumented > 0) {
+        analytics.queryParameterDocumented(numberOfQueryParametersDocumented);
       }
 
       analytics.userSavedChanges(


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

This will fire on:
- documenting an unrecognized endpoint with query parameters
- documenting an unmatched query parameter body

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
