### PR TITLE
Consider interactions without query params in generating shape diff affordances

### DIFF
--- a/workspaces/optic-engine/src/interactions/mod.rs
+++ b/workspaces/optic-engine/src/interactions/mod.rs
@@ -220,7 +220,8 @@ pub fn analyze_documented_bodies(
 
   results.into_iter().filter_map(move |result| match result {
     InteractionDiffResult::MatchedQueryParameters(diff) => {
-      let query_params = &interaction.request.query;
+      let maybe_query_params: Option<BodyDescriptor> = (&interaction.request.query).into();
+      let query_params = maybe_query_params.or_else(|| Some(BodyDescriptor::empty_object()));
       let trail_observations = observe_body_trails(query_params);
 
       Some(BodyAnalysisResult {

--- a/workspaces/optic-engine/tests/fixtures/shape-diff-affordances-learner/query_param_new_and_optional.json
+++ b/workspaces/optic-engine/tests/fixtures/shape-diff-affordances-learner/query_param_new_and_optional.json
@@ -1,0 +1,526 @@
+{
+  "events": [
+    {
+      "BatchCommitStarted": {
+        "batchId": "b6cc38d6-f82f-445a-85b2-6acf2adafe27",
+        "commitMessage": "Initialize specification attributes",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a72c2710-1a0d-46d2-9a3f-c6c85f03798e",
+          "clientCommandBatchId": "b6cc38d6-f82f-445a-85b2-6acf2adafe27",
+          "createdAt": "2020-10-20T20:51:53.435Z"
+        }
+      }
+    },
+    {
+      "ContributionAdded": {
+        "id": "metadata",
+        "key": "id",
+        "value": "6190dbc1-8e2b-4409-a8c7-7b073db8f2b5",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a72c2710-1a0d-46d2-9a3f-c6c85f03798e",
+          "clientCommandBatchId": "b6cc38d6-f82f-445a-85b2-6acf2adafe27",
+          "createdAt": "2020-10-20T20:51:53.435Z"
+        }
+      }
+    },
+    {
+      "BatchCommitEnded": {
+        "batchId": "b6cc38d6-f82f-445a-85b2-6acf2adafe27",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "a72c2710-1a0d-46d2-9a3f-c6c85f03798e",
+          "clientCommandBatchId": "b6cc38d6-f82f-445a-85b2-6acf2adafe27",
+          "createdAt": "2020-10-20T20:51:53.435Z"
+        }
+      }
+    },
+    {
+      "BatchCommitStarted": {
+        "batchId": "6bab5462-1a6d-4d3a-a4e5-2a724d9db114",
+        "commitMessage": "Add listing of todos",
+        "eventContext": {
+          "clientId": "anon_id",
+          "clientSessionId": "89f1b1d3-9b5b-405e-9bfd-94446bab8a46",
+          "clientCommandBatchId": "6bab5462-1a6d-4d3a-a4e5-2a724d9db114",
+          "createdAt": "2021-07-08T12:38:34.706+02:00"
+        },
+        "parentId": "b6cc38d6-f82f-445a-85b2-6acf2adafe27"
+      }
+    },
+    {
+      "PathComponentAdded": {
+        "pathId": "path_vWk9FanJKA",
+        "parentPathId": "root",
+        "name": "api",
+        "eventContext": {
+          "clientId": "anon_id",
+          "clientSessionId": "89f1b1d3-9b5b-405e-9bfd-94446bab8a46",
+          "clientCommandBatchId": "6bab5462-1a6d-4d3a-a4e5-2a724d9db114",
+          "createdAt": "2021-07-08T12:38:34.706+02:00"
+        }
+      }
+    },
+    {
+      "PathComponentAdded": {
+        "pathId": "path_1pomS4CVlc",
+        "parentPathId": "path_vWk9FanJKA",
+        "name": "todos",
+        "eventContext": {
+          "clientId": "anon_id",
+          "clientSessionId": "89f1b1d3-9b5b-405e-9bfd-94446bab8a46",
+          "clientCommandBatchId": "6bab5462-1a6d-4d3a-a4e5-2a724d9db114",
+          "createdAt": "2021-07-08T12:38:34.706+02:00"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_X-OuIXHAsv",
+        "baseShapeId": "$object",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anon_id",
+          "clientSessionId": "89f1b1d3-9b5b-405e-9bfd-94446bab8a46",
+          "clientCommandBatchId": "6bab5462-1a6d-4d3a-a4e5-2a724d9db114",
+          "createdAt": "2021-07-08T12:38:34.706+02:00"
+        }
+      }
+    },
+    {
+      "QueryParametersAdded": {
+        "queryParametersId": "query_params_RlgOYxcG3a",
+        "httpMethod": "GET",
+        "pathId": "path_1pomS4CVlc",
+        "eventContext": {
+          "clientId": "anon_id",
+          "clientSessionId": "89f1b1d3-9b5b-405e-9bfd-94446bab8a46",
+          "clientCommandBatchId": "6bab5462-1a6d-4d3a-a4e5-2a724d9db114",
+          "createdAt": "2021-07-08T12:38:34.706+02:00"
+        }
+      }
+    },
+    {
+      "QueryParametersShapeSet": {
+        "queryParametersId": "query_params_RlgOYxcG3a",
+        "shapeDescriptor": {
+          "shapeId": "shape_X-OuIXHAsv",
+          "isRemoved": false
+        },
+        "eventContext": {
+          "clientId": "anon_id",
+          "clientSessionId": "89f1b1d3-9b5b-405e-9bfd-94446bab8a46",
+          "clientCommandBatchId": "6bab5462-1a6d-4d3a-a4e5-2a724d9db114",
+          "createdAt": "2021-07-08T12:38:34.706+02:00"
+        }
+      }
+    },
+    {
+      "RequestAdded": {
+        "requestId": "request_vO0xAwYhjZ",
+        "pathId": "path_1pomS4CVlc",
+        "httpMethod": "GET",
+        "eventContext": {
+          "clientId": "anon_id",
+          "clientSessionId": "89f1b1d3-9b5b-405e-9bfd-94446bab8a46",
+          "clientCommandBatchId": "6bab5462-1a6d-4d3a-a4e5-2a724d9db114",
+          "createdAt": "2021-07-08T12:38:34.706+02:00"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_s59DPL1y4C",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anon_id",
+          "clientSessionId": "89f1b1d3-9b5b-405e-9bfd-94446bab8a46",
+          "clientCommandBatchId": "6bab5462-1a6d-4d3a-a4e5-2a724d9db114",
+          "createdAt": "2021-07-08T12:38:34.706+02:00"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_qvKmGxh-nZ",
+        "baseShapeId": "$boolean",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anon_id",
+          "clientSessionId": "89f1b1d3-9b5b-405e-9bfd-94446bab8a46",
+          "clientCommandBatchId": "6bab5462-1a6d-4d3a-a4e5-2a724d9db114",
+          "createdAt": "2021-07-08T12:38:34.706+02:00"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_xXBDmbay66",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anon_id",
+          "clientSessionId": "89f1b1d3-9b5b-405e-9bfd-94446bab8a46",
+          "clientCommandBatchId": "6bab5462-1a6d-4d3a-a4e5-2a724d9db114",
+          "createdAt": "2021-07-08T12:38:34.706+02:00"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_fjzsDTs0rs",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anon_id",
+          "clientSessionId": "89f1b1d3-9b5b-405e-9bfd-94446bab8a46",
+          "clientCommandBatchId": "6bab5462-1a6d-4d3a-a4e5-2a724d9db114",
+          "createdAt": "2021-07-08T12:38:34.706+02:00"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_q6OD6W1YAb",
+        "baseShapeId": "$object",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anon_id",
+          "clientSessionId": "89f1b1d3-9b5b-405e-9bfd-94446bab8a46",
+          "clientCommandBatchId": "6bab5462-1a6d-4d3a-a4e5-2a724d9db114",
+          "createdAt": "2021-07-08T12:38:34.706+02:00"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_9CwetZOv0K",
+        "baseShapeId": "$optional",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anon_id",
+          "clientSessionId": "89f1b1d3-9b5b-405e-9bfd-94446bab8a46",
+          "clientCommandBatchId": "6bab5462-1a6d-4d3a-a4e5-2a724d9db114",
+          "createdAt": "2021-07-08T12:38:34.706+02:00"
+        }
+      }
+    },
+    {
+      "ShapeParameterShapeSet": {
+        "shapeDescriptor": {
+          "ProviderInShape": {
+            "shapeId": "shape_9CwetZOv0K",
+            "providerDescriptor": {
+              "ShapeProvider": {
+                "shapeId": "shape_fjzsDTs0rs"
+              }
+            },
+            "consumingParameterId": "$optionalInner"
+          }
+        },
+        "eventContext": {
+          "clientId": "anon_id",
+          "clientSessionId": "89f1b1d3-9b5b-405e-9bfd-94446bab8a46",
+          "clientCommandBatchId": "6bab5462-1a6d-4d3a-a4e5-2a724d9db114",
+          "createdAt": "2021-07-08T12:38:34.706+02:00"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_uOKkB-HlmR",
+        "shapeId": "shape_q6OD6W1YAb",
+        "name": "dueDate",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_uOKkB-HlmR",
+            "shapeId": "shape_9CwetZOv0K"
+          }
+        },
+        "eventContext": {
+          "clientId": "anon_id",
+          "clientSessionId": "89f1b1d3-9b5b-405e-9bfd-94446bab8a46",
+          "clientCommandBatchId": "6bab5462-1a6d-4d3a-a4e5-2a724d9db114",
+          "createdAt": "2021-07-08T12:38:34.706+02:00"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_Cu-cFjI4FI",
+        "shapeId": "shape_q6OD6W1YAb",
+        "name": "id",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_Cu-cFjI4FI",
+            "shapeId": "shape_xXBDmbay66"
+          }
+        },
+        "eventContext": {
+          "clientId": "anon_id",
+          "clientSessionId": "89f1b1d3-9b5b-405e-9bfd-94446bab8a46",
+          "clientCommandBatchId": "6bab5462-1a6d-4d3a-a4e5-2a724d9db114",
+          "createdAt": "2021-07-08T12:38:34.706+02:00"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_ce28JLQRAU",
+        "shapeId": "shape_q6OD6W1YAb",
+        "name": "isDone",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_ce28JLQRAU",
+            "shapeId": "shape_qvKmGxh-nZ"
+          }
+        },
+        "eventContext": {
+          "clientId": "anon_id",
+          "clientSessionId": "89f1b1d3-9b5b-405e-9bfd-94446bab8a46",
+          "clientCommandBatchId": "6bab5462-1a6d-4d3a-a4e5-2a724d9db114",
+          "createdAt": "2021-07-08T12:38:34.706+02:00"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_tToOrayR7C",
+        "shapeId": "shape_q6OD6W1YAb",
+        "name": "task",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_tToOrayR7C",
+            "shapeId": "shape_s59DPL1y4C"
+          }
+        },
+        "eventContext": {
+          "clientId": "anon_id",
+          "clientSessionId": "89f1b1d3-9b5b-405e-9bfd-94446bab8a46",
+          "clientCommandBatchId": "6bab5462-1a6d-4d3a-a4e5-2a724d9db114",
+          "createdAt": "2021-07-08T12:38:34.706+02:00"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_9pOqYqjpGb",
+        "baseShapeId": "$list",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "anon_id",
+          "clientSessionId": "89f1b1d3-9b5b-405e-9bfd-94446bab8a46",
+          "clientCommandBatchId": "6bab5462-1a6d-4d3a-a4e5-2a724d9db114",
+          "createdAt": "2021-07-08T12:38:34.706+02:00"
+        }
+      }
+    },
+    {
+      "ShapeParameterShapeSet": {
+        "shapeDescriptor": {
+          "ProviderInShape": {
+            "shapeId": "shape_9pOqYqjpGb",
+            "providerDescriptor": {
+              "ShapeProvider": {
+                "shapeId": "shape_q6OD6W1YAb"
+              }
+            },
+            "consumingParameterId": "$listItem"
+          }
+        },
+        "eventContext": {
+          "clientId": "anon_id",
+          "clientSessionId": "89f1b1d3-9b5b-405e-9bfd-94446bab8a46",
+          "clientCommandBatchId": "6bab5462-1a6d-4d3a-a4e5-2a724d9db114",
+          "createdAt": "2021-07-08T12:38:34.706+02:00"
+        }
+      }
+    },
+    {
+      "ResponseAddedByPathAndMethod": {
+        "responseId": "response_vqKyqUIUpv",
+        "pathId": "path_1pomS4CVlc",
+        "httpMethod": "GET",
+        "httpStatusCode": 200,
+        "eventContext": {
+          "clientId": "anon_id",
+          "clientSessionId": "89f1b1d3-9b5b-405e-9bfd-94446bab8a46",
+          "clientCommandBatchId": "6bab5462-1a6d-4d3a-a4e5-2a724d9db114",
+          "createdAt": "2021-07-08T12:38:34.706+02:00"
+        }
+      }
+    },
+    {
+      "ResponseBodySet": {
+        "responseId": "response_vqKyqUIUpv",
+        "bodyDescriptor": {
+          "httpContentType": "application/json",
+          "shapeId": "shape_9pOqYqjpGb",
+          "isRemoved": false
+        },
+        "eventContext": {
+          "clientId": "anon_id",
+          "clientSessionId": "89f1b1d3-9b5b-405e-9bfd-94446bab8a46",
+          "clientCommandBatchId": "6bab5462-1a6d-4d3a-a4e5-2a724d9db114",
+          "createdAt": "2021-07-08T12:38:34.706+02:00"
+        }
+      }
+    },
+    {
+      "ContributionAdded": {
+        "id": "path_1pomS4CVlc.GET",
+        "key": "purpose",
+        "value": "List Todos",
+        "eventContext": {
+          "clientId": "anon_id",
+          "clientSessionId": "89f1b1d3-9b5b-405e-9bfd-94446bab8a46",
+          "clientCommandBatchId": "6bab5462-1a6d-4d3a-a4e5-2a724d9db114",
+          "createdAt": "2021-07-08T12:38:34.706+02:00"
+        }
+      }
+    },
+    {
+      "BatchCommitEnded": {
+        "batchId": "6bab5462-1a6d-4d3a-a4e5-2a724d9db114",
+        "eventContext": {
+          "clientId": "anon_id",
+          "clientSessionId": "89f1b1d3-9b5b-405e-9bfd-94446bab8a46",
+          "clientCommandBatchId": "6bab5462-1a6d-4d3a-a4e5-2a724d9db114",
+          "createdAt": "2021-07-08T12:38:34.706+02:00"
+        }
+      }
+    }
+  ],
+  "session": {
+    "samples": [
+      {
+        "uuid": "id1",
+        "request": {
+          "host": "localhost",
+          "method": "GET",
+          "path": "/api/todos",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": "status=open"
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": "CAEaNQgAEgoKBHRhc2sSAggCEg0KB2R1ZURhdGUSAggCEgwKBmlzRG9uZRICCAQSCAoCaWQSAggCGiYIABIKCgR0YXNrEgIIAhIMCgZpc0RvbmUSAggEEggKAmlkEgIIAhomCAASCgoEdGFzaxICCAISDAoGaXNEb25lEgIIBBIICgJpZBICCAIaJggAEgoKBHRhc2sSAggCEgwKBmlzRG9uZRICCAQSCAoCaWQSAggCGiYIABIKCgR0YXNrEgIIAhIMCgZpc0RvbmUSAggEEggKAmlkEgIIAg==",
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "tags": []
+      },
+      {
+        "uuid": "id2",
+        "request": {
+          "host": "localhost",
+          "method": "GET",
+          "path": "/api/todos",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": "CAEaNQgAEgoKBHRhc2sSAggCEg0KB2R1ZURhdGUSAggCEgwKBmlzRG9uZRICCAQSCAoCaWQSAggCGiYIABIKCgR0YXNrEgIIAhIMCgZpc0RvbmUSAggEEggKAmlkEgIIAhomCAASCgoEdGFzaxICCAISDAoGaXNEb25lEgIIBBIICgJpZBICCAIaJggAEgoKBHRhc2sSAggCEgwKBmlzRG9uZRICCAQSCAoCaWQSAggCGiYIABIKCgR0YXNrEgIIAhIMCgZpc0RvbmUSAggEEggKAmlkEgIIAg==",
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "tags": []
+      }
+    ]
+  }
+}

--- a/workspaces/optic-engine/tests/snapshots/shape_diff_affordances_learner__query_param_new_and_optional__shape_diff_affordances.snap
+++ b/workspaces/optic-engine/tests/snapshots/shape_diff_affordances_learner__query_param_new_and_optional__shape_diff_affordances.snap
@@ -1,0 +1,79 @@
+---
+source: workspaces/optic-engine/tests/shape-diff-affordances-learner.rs
+expression: "&shape_diff_affordances"
+---
+[
+    (
+        "58d16d73c72faea8",
+        ShapeDiffAffordances {
+            affordances: [
+                TrailValues {
+                    trail: JsonTrail {
+                        path: [
+                            JsonObjectKey {
+                                key: "status",
+                            },
+                        ],
+                    },
+                    was_string: true,
+                    was_number: false,
+                    was_boolean: false,
+                    was_null: false,
+                    was_array: false,
+                    was_object: false,
+                    was_empty_array: false,
+                    field_sets: [],
+                },
+            ],
+            interactions: InteractionsAffordances {
+                was_string: {
+                    "id1",
+                },
+                was_number: {},
+                was_boolean: {},
+                was_null: {},
+                was_array: {},
+                was_empty_array: {},
+                was_object: {},
+                was_missing: {
+                    "id2",
+                },
+                was_string_trails: {
+                    "id1": {
+                        JsonTrail {
+                            path: [
+                                JsonObjectKey {
+                                    key: "status",
+                                },
+                            ],
+                        },
+                    },
+                },
+                was_number_trails: {},
+                was_boolean_trails: {},
+                was_null_trails: {},
+                was_array_trails: {},
+                was_empty_array_trails: {},
+                was_object_trails: {},
+                was_missing_trails: {
+                    "id2": {
+                        JsonTrail {
+                            path: [
+                                JsonObjectKey {
+                                    key: "status",
+                                },
+                            ],
+                        },
+                    },
+                },
+            },
+            root_trail: JsonTrail {
+                path: [
+                    JsonObjectKey {
+                        key: "status",
+                    },
+                ],
+            },
+        },
+    ),
+]

--- a/workspaces/ui-v2/src/lib/Interfaces.ts
+++ b/workspaces/ui-v2/src/lib/Interfaces.ts
@@ -46,6 +46,7 @@ export interface BodyPreview {
   asJson: any | null;
   asText: any | null;
   noBody: boolean;
+  empty: boolean;
 }
 export interface IDiffDescription {
   title: ICopy[];

--- a/workspaces/ui-v2/src/lib/diff-description-interpreter.ts
+++ b/workspaces/ui-v2/src/lib/diff-description-interpreter.ts
@@ -28,6 +28,7 @@ const getJsonBodyToPreview = (
         asJson: JSON.parse(asJsonString),
         asText: null,
         noBody: false,
+        empty: false,
       };
     }
 
@@ -36,14 +37,15 @@ const getJsonBodyToPreview = (
         asJson: toJsonExample(shapeHashV1Base64),
         asText: null,
         noBody: false,
+        empty: false,
       };
     }
     if (asText) {
-      return { asJson: null, asText: asText, noBody: false };
+      return { asJson: null, asText: asText, noBody: false, empty: false };
     }
-    return { asJson: null, asText: null, noBody: false };
+    return { asJson: null, asText: null, noBody: false, empty: true };
   } else {
-    return { asJson: null, asText: null, noBody: true };
+    return { asJson: null, asText: null, noBody: true, empty: false };
   }
 };
 

--- a/workspaces/ui-v2/src/pages/diffs/components/IDiffExampleViewer.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/components/IDiffExampleViewer.tsx
@@ -26,6 +26,7 @@ export type InteractionViewerBody = {
   noBody?: boolean;
   asJson?: any;
   asText?: string;
+  empty?: boolean;
 };
 
 type InteractionBodyViewerProps = {
@@ -285,6 +286,16 @@ function RowValue({
     return null;
   }
 
+  if (type === 'empty') {
+    return (
+      <span
+        className={classNames(generalClasses.symbols, classes.emptyContent)}
+      >
+        empty
+      </span>
+    );
+  }
+
   throw new Error(`Cannot render RowValue for type '${type}'`);
 }
 RowValue.displayName = 'ShapeViewer/RowValue';
@@ -491,6 +502,11 @@ const useStyles = makeStyles((theme) => ({
     color: SymbolColor,
   },
 
+  emptyContent: {
+    color: SymbolColor,
+    fontStyle: 'italic',
+  },
+
   numberContent: {
     fontWeight: 600,
     fontFamily: "'Source Code Pro', monospace",
@@ -612,11 +628,17 @@ const useStyles = makeStyles((theme) => ({
 
 function createInitialState({ jsonTrails, body }: any) {
   const diffTrails = jsonTrails.map(toCommonJsPath);
-  const shape = !body.noBody ? body.asJson || body.asText : undefined;
 
-  const [rows, collapsedTrails] = shapeRows(shape, diffTrails);
+  if (!body.empty) {
+    const shape = !body.noBody ? body.asJson || body.asText : undefined;
+    const [rows, collapsedTrails] = shapeRows(shape, diffTrails);
 
-  return { body: shape, rows, collapsedTrails, diffTrails };
+    return { body: shape, rows, collapsedTrails, diffTrails };
+  } else {
+    const rows = [emptyRow()];
+    const collapsedTrails = [] as any[];
+    return { body: undefined, rows, collapsedTrails, diffTrails };
+  }
 }
 
 function updateState(state: any, action: any) {
@@ -953,6 +975,15 @@ function listRows(
   });
 
   rows.push(createRow({ type: 'array_close', indent, trail }));
+}
+
+function emptyRow() {
+  return createRow({
+    type: 'empty',
+    collapsed: false,
+    compliant: true,
+    trail: [],
+  });
 }
 
 function getFieldType(fieldValue: any): string {


### PR DESCRIPTION
## Why
Fixes a bug during query params QA, where new query params were not detected as optional correctly, due to interactions without any query parameters at all being ignored in the learning phase.

## What
As with the undocumented body learner, we now consider there being no query parameters as "empty" query parameters for learning purposes. That allows the necessary interactions to be picked up as a place where a new query parameter is missing.

In addition, it makes an adjustment to the example viewer UI, making sure empty bodies are rendered explicitly, rather than "null". In the case of the single line query parameters, this was confusing, as it might as well be a query parameter called "null". 

Before and after:
![Screenshot 2021-07-14 at 12 43 15](https://user-images.githubusercontent.com/857549/125615587-75d9a650-fd7a-4da9-ae04-f4df1cf0f13a.png)

![Screenshot 2021-07-14 at 13 13 29](https://user-images.githubusercontent.com/857549/125615585-28551aa1-7494-4cfa-92f8-ec293ba14bc0.png)

## Validation
* [ ] CI passes
* [x] End to end test coverage
