### PR TITLE
Filter out invalid interactions

### DIFF
--- a/workspaces/cli-shared/src/captures/avro/file-system/interaction-iterator.ts
+++ b/workspaces/cli-shared/src/captures/avro/file-system/interaction-iterator.ts
@@ -6,9 +6,6 @@ import avro from 'avsc';
 import { CaptureId } from '@useoptic/saas-types';
 import { IHttpInteraction, IInteractionBatch } from '@useoptic/optic-domain';
 
-export interface FilterPredicate<T> {
-  (item: T): boolean;
-}
 export type InteractionIteratorItem =
   | {
       hasMoreInteractions: false;
@@ -30,7 +27,7 @@ export type InteractionIteratorItem =
     };
 export async function* CaptureInteractionIterator(
   config: IFileSystemCaptureLoaderConfig,
-  filter: FilterPredicate<IHttpInteraction>
+  filter: (interaction: IHttpInteraction) => boolean
   //@TODO: add a way to check if the capture has completed
 ): AsyncGenerator<InteractionIteratorItem> {
   let shouldStop = false;

--- a/workspaces/cli-shared/src/httptoolkit-capturing-proxy.ts
+++ b/workspaces/cli-shared/src/httptoolkit-capturing-proxy.ts
@@ -16,6 +16,7 @@ import {
   IArbitraryData,
   IBody,
   IHttpInteraction,
+  isValidHttpInteraction,
 } from '@useoptic/optic-domain';
 
 export interface IHttpToolkitCapturingProxyConfig {
@@ -203,6 +204,11 @@ export class HttpToolkitCapturingProxy {
             getters: true,
           })
         );
+
+        if (!isValidHttpInteraction(sample)) {
+          developerDebugLogger('Filtering out invalid sample', sample);
+          return;
+        }
 
         if (this.config.hostnameFilter) {
           //when filter is set, verify a match

--- a/workspaces/optic-domain/src/interactions.ts
+++ b/workspaces/optic-domain/src/interactions.ts
@@ -1,3 +1,4 @@
+// Types
 export interface IRequest {
   host: string;
   method: string;
@@ -40,3 +41,31 @@ export interface IInteractionBatch {
   groupingIdentifiers: IGroupingIdentifiers;
   batchItems: IHttpInteraction[];
 }
+
+// Utility functions
+// There is a potential to capture invalid interactions - once this is captured, it's in the user's
+// system until they clear their captures folder. If we introduce bugs in our capture, we can filter them out here
+// Ideally, we should catch these and not have captures that are invalid
+const isArbitraryDataNull = (value: IArbitraryData): boolean => {
+  return (
+    value.asJsonString === null &&
+    value.asText === null &&
+    value.shapeHashV1Base64 === null
+  );
+};
+
+export const isValidHttpInteraction = (
+  interaction: IHttpInteraction
+): boolean => {
+  if (
+    interaction.request.body.contentType !== null &&
+    isArbitraryDataNull(interaction.request.body.value)
+  ) {
+    return false;
+  }
+  if (isArbitraryDataNull(interaction.response.body.value)) {
+    return false;
+  }
+
+  return true;
+};

--- a/workspaces/spectacle/src/in-memory/index.ts
+++ b/workspaces/spectacle/src/in-memory/index.ts
@@ -18,7 +18,12 @@ import {
   SpectacleInput,
   StartDiffResult,
 } from '../index';
-import { AsyncTools, Streams, IHttpInteraction } from '@useoptic/optic-domain';
+import {
+  AsyncTools,
+  Streams,
+  IHttpInteraction,
+  isValidHttpInteraction,
+} from '@useoptic/optic-domain';
 import {
   ILearnedBodies,
   IAffordanceTrailsDiffHashMap,
@@ -165,6 +170,7 @@ export class InMemoryCapturesService implements IOpticCapturesService {
 
     const events = await this.dependencies.specRepository.listEvents();
     const interactions = await this.listCapturedInteractions(captureId);
+    const filteredInteractions = interactions.filter(isValidHttpInteraction);
 
     const diff = new InMemoryDiff({
       opticEngine: this.dependencies.opticEngine,
@@ -175,13 +181,13 @@ export class InMemoryCapturesService implements IOpticCapturesService {
       diff,
       opticEngine: this.dependencies.opticEngine,
       specRepository: this.dependencies.specRepository,
-      interactions,
+      interactions: filteredInteractions,
     });
 
     const onComplete = new Promise<IOpticDiffService>((resolve, reject) => {
       notifications.once('complete', () => resolve(diffService));
     });
-    await diff.start(events, interactions);
+    await diff.start(events, filteredInteractions);
 
     await this.dependencies.diffRepository.add(diffId, diffService);
 

--- a/workspaces/ui-v2/src/lib/new-regions-interpreter.ts
+++ b/workspaces/ui-v2/src/lib/new-regions-interpreter.ts
@@ -18,7 +18,7 @@ export async function newRegionInterpreters(
   diff: ParsedDiff,
   opticDiffService: IOpticDiffService,
   currentSpecContext: CurrentSpecContext
-): Promise<IInterpretation | undefined> {
+): Promise<IInterpretation | null> {
   if (
     diff.isA(DiffTypes.UnmatchedRequestBodyContentType) ||
     diff.isA(DiffTypes.UnmatchedResponseBodyContentType) ||
@@ -34,6 +34,7 @@ export async function newRegionInterpreters(
 
     return newContentType(diff, location, learnedBodies);
   }
+  return null;
 }
 
 // TODO QPB - move IInterpretation generation into ParsedDiff
@@ -41,7 +42,7 @@ function newContentType(
   udiff: ParsedDiff,
   location: DiffLocation,
   learnedBodies: ILearnedBodies
-): IInterpretation {
+): IInterpretation | null {
   if (udiff.isA(DiffTypes.UnmatchedRequestBodyContentType)) {
     const requestDescriptor = location.getRequestDescriptor();
     const contentType = requestDescriptor ? requestDescriptor.contentType : '';
@@ -61,6 +62,7 @@ function newContentType(
           udiff,
         },
       });
+      return null;
     }
 
     const commands = learnedRequestBody ? learnedRequestBody.commands : [];
@@ -117,6 +119,7 @@ function newContentType(
           udiff,
         },
       });
+      return null;
     }
 
     const commands = learnedResponseBody ? learnedResponseBody.commands : [];

--- a/workspaces/ui-v2/src/pages/diffs/PendingEndpointPage.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/PendingEndpointPage.tsx
@@ -276,7 +276,6 @@ export function PendingEndpointPage(props: any) {
       right={
         <>
           <SimulatedCommandStore
-            key={JSON.stringify(newEndpointCommands)}
             spectacle={spectacle as IForkableSpectacle}
             previewCommands={newEndpointCommands}
           >


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

In https://github.com/opticdev/optic/pull/904/files - we fixed some issues with what Optic expects in terms of request / response bodies.

Optic crashes / does not learn diffs in the following scenario, request or response body is null (i.e. null for shapeHash, asText and asJsonString).

## What
What's changing? Anything of note to call out?

- Created a function isValidHttpInteraction
- Used this function in:
  - InMemoryCaptureService
  - LocalCliCaptureService
  - Http Proxy (which captures interactions)
  - (this function should be used for any other inputs to the diff flow, e.g. from slurp, or design by example)

TODO:
- [ ] Test out the proxy through a side channel, and make sure we aren't crashing anything
- [ ] Add in sentry to the local cli commands, so we can capture errors here (could be a follow up PR)

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
