### PR TITLE
Remove contributions in the diff flow

### DIFF
--- a/workspaces/ui-v2/src/components/PathParameters.tsx
+++ b/workspaces/ui-v2/src/components/PathParameters.tsx
@@ -1,16 +1,36 @@
 import React, { FC, ReactNode } from 'react';
-import makeStyles from '@material-ui/styles/makeStyles';
+import { Divider, Typography, makeStyles } from '@material-ui/core';
+
+import { FieldOrParameter } from './FieldOrParameter';
+import { IShapeRenderer, JsonLike } from './ShapeRenderer';
+
 import { IPathParameter } from '<src>/types';
-import { Divider, Typography } from '@material-ui/core';
 
 export type PathParametersProps = {
   parameters: IPathParameter[];
-  renderField: (pathParam: IPathParameter, index: number) => ReactNode;
+  renderField?: (pathParam: IPathParameter, index: number) => ReactNode;
+};
+
+const defaultFieldRender = (param: IPathParameter): ReactNode => {
+  const alwaysAString: IShapeRenderer = {
+    shapeId: param.id + 'shape',
+    jsonType: JsonLike.STRING,
+    value: undefined,
+  };
+  return (
+    <FieldOrParameter
+      key={param.id}
+      name={param.name}
+      shapes={[alwaysAString]}
+      depth={0}
+      value={param.description}
+    />
+  );
 };
 
 export const PathParameters: FC<PathParametersProps> = ({
   parameters,
-  renderField,
+  renderField = defaultFieldRender,
 }) => {
   const classes = useStyles();
 

--- a/workspaces/ui-v2/src/pages/changelog/ChangelogEndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/changelog/ChangelogEndpointRootPage.tsx
@@ -8,8 +8,6 @@ import ReactMarkdown from 'react-markdown';
 import {
   EndpointName,
   PathParameters,
-  IShapeRenderer,
-  JsonLike,
   PageLayout,
   FullWidth,
   FieldOrParameter,
@@ -132,25 +130,7 @@ const ChangelogRootComponent: FC<
                   />
                 }
               >
-                <PathParameters
-                  parameters={parameterizedPathParts}
-                  renderField={(param) => {
-                    const alwaysAString: IShapeRenderer = {
-                      shapeId: param.id + 'shape',
-                      jsonType: JsonLike.STRING,
-                      value: undefined,
-                    };
-                    return (
-                      <FieldOrParameter
-                        key={param.id}
-                        name={param.name}
-                        shapes={[alwaysAString]}
-                        depth={0}
-                        value={param.description}
-                      />
-                    );
-                  }}
-                />
+                <PathParameters parameters={parameterizedPathParts} />
                 <div
                   style={{
                     marginTop: 10,

--- a/workspaces/ui-v2/src/pages/diffs/EndpointDocumentationPane.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/EndpointDocumentationPane.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode } from 'react';
+import React, { FC } from 'react';
 import { makeStyles } from '@material-ui/core';
 
 import {
@@ -22,30 +22,26 @@ import {
   HighlightedLocation,
   Location,
 } from '<src>/pages/diffs/components/HighlightedLocation';
-import { useSharedDiffContext } from '<src>/pages/diffs/contexts/SharedDiffContext';
-import { useDebouncedFn, useStateWithSideEffect } from '<src>/hooks/util';
 import { selectors, useAppSelector } from '<src>/store';
-import { IPathParameter } from '<src>/types';
-import { getEndpointId } from '<src>/utils';
 
 type EndpointDocumentationPaneProps = {
+  name: string;
   method: string;
   pathId: string;
   lastBatchCommit?: string;
   highlightBodyChanges?: boolean;
   highlightedLocation?: DiffLocation;
-  renderHeader: () => ReactNode;
 };
 
 export const EndpointDocumentationPane: FC<
   EndpointDocumentationPaneProps & React.HtmlHTMLAttributes<HTMLDivElement>
 > = ({
+  name,
   method,
   pathId,
   lastBatchCommit,
   highlightedLocation,
   highlightBodyChanges,
-  renderHeader,
   ...props
 }) => {
   const classes = useStyles();
@@ -59,17 +55,13 @@ export const EndpointDocumentationPane: FC<
   const parameterizedPathParts = thisEndpoint.pathParameters.filter(
     (path) => path.isParameterized
   );
-  const endpointId = getEndpointId({
-    pathId: thisEndpoint.pathId,
-    method: thisEndpoint.method,
-  });
 
   return (
     <FullWidth
       style={{ padding: 30, paddingTop: 15, paddingBottom: 400 }}
       {...props}
     >
-      {renderHeader()}
+      <p className={classes.nameDisplay}>{name}</p>
       <div style={{ height: 20 }} />
       <Panel
         header={
@@ -84,11 +76,18 @@ export const EndpointDocumentationPane: FC<
         <PathParameters
           parameters={parameterizedPathParts}
           renderField={(param) => {
+            const alwaysAString: IShapeRenderer = {
+              shapeId: param.id + 'shape',
+              jsonType: JsonLike.STRING,
+              value: undefined,
+            };
             return (
-              <DiffPathParamField
+              <FieldOrParameter
                 key={param.id}
-                pathParameter={param}
-                endpointId={endpointId}
+                name={param.name}
+                shapes={[alwaysAString]}
+                depth={0}
+                value={param.description}
               />
             );
           }}
@@ -195,42 +194,6 @@ export const EndpointDocumentationPane: FC<
   );
 };
 
-const DiffPathParamField: FC<{
-  pathParameter: IPathParameter;
-  endpointId: string;
-}> = ({ pathParameter, endpointId }) => {
-  const alwaysAString: IShapeRenderer = {
-    shapeId: pathParameter.id + 'shape',
-    jsonType: JsonLike.STRING,
-    value: undefined,
-  };
-
-  const {
-    setPathDescription,
-    getContributedPathDescription,
-  } = useSharedDiffContext();
-
-  const debouncedAddContribution = useDebouncedFn(setPathDescription, 200);
-  const { value, setValue } = useStateWithSideEffect({
-    initialValue:
-      getContributedPathDescription(pathParameter.id) ||
-      pathParameter.description,
-    sideEffect: (description: string) =>
-      debouncedAddContribution(pathParameter.id, description, endpointId),
-  });
-
-  return (
-    <FieldOrParameter
-      isEditing={true}
-      shapes={[alwaysAString]}
-      depth={0}
-      name={pathParameter.name}
-      value={value}
-      setValue={setValue}
-    />
-  );
-};
-
 const useStyles = makeStyles((theme) => ({
   bodyContainer: {
     margin: theme.spacing(3, 0),
@@ -246,5 +209,11 @@ const useStyles = makeStyles((theme) => ({
   },
   bodyDetails: {
     padding: theme.spacing(0, 1),
+  },
+  nameDisplay: {
+    fontSize: '1.25rem',
+    fontFamily: 'Ubuntu, Inter',
+    fontWeight: 500,
+    lineHeight: 1.6,
   },
 }));

--- a/workspaces/ui-v2/src/pages/diffs/EndpointDocumentationPane.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/EndpointDocumentationPane.tsx
@@ -4,10 +4,7 @@ import { makeStyles } from '@material-ui/core';
 import {
   EndpointName,
   PathParameters,
-  FieldOrParameter,
   FullWidth,
-  IShapeRenderer,
-  JsonLike,
   ShapeFetcher,
   QueryParametersPanel,
   HttpBodyPanel,
@@ -73,25 +70,7 @@ export const EndpointDocumentationPane: FC<
           />
         }
       >
-        <PathParameters
-          parameters={parameterizedPathParts}
-          renderField={(param) => {
-            const alwaysAString: IShapeRenderer = {
-              shapeId: param.id + 'shape',
-              jsonType: JsonLike.STRING,
-              value: undefined,
-            };
-            return (
-              <FieldOrParameter
-                key={param.id}
-                name={param.name}
-                shapes={[alwaysAString]}
-                depth={0}
-                value={param.description}
-              />
-            );
-          }}
-        />
+        <PathParameters parameters={parameterizedPathParts} />
         <div
           style={{
             marginTop: 10,

--- a/workspaces/ui-v2/src/pages/diffs/PendingEndpointPage.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/PendingEndpointPage.tsx
@@ -286,11 +286,7 @@ export function PendingEndpointPage(props: any) {
               <EndpointDocumentationPane
                 method={stagedCommandsIds.method}
                 pathId={stagedCommandsIds.pathId}
-                renderHeader={() => (
-                  <Typography className={classes.nameDisplay}>
-                    {name === '' ? 'Unnamed Endpoint' : name}
-                  </Typography>
-                )}
+                name={name === '' ? 'Unnamed Endpoint' : name}
               />
             )}
           </SimulatedCommandStore>
@@ -355,11 +351,5 @@ const useStyles = makeStyles((theme) => ({
     marginTop: 25,
     display: 'flex',
     justifyContent: 'space-between;',
-  },
-  nameDisplay: {
-    fontSize: '1.25rem',
-    fontFamily: 'Ubuntu, Inter',
-    fontWeight: 500,
-    lineHeight: 1.6,
   },
 }));

--- a/workspaces/ui-v2/src/pages/diffs/ReviewEndpointDiffPage/ReviewEndpointDiffPage.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/ReviewEndpointDiffPage/ReviewEndpointDiffPage.tsx
@@ -1,22 +1,15 @@
 import React, { FC, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { Helmet } from 'react-helmet';
 
 import { IForkableSpectacle } from '@useoptic/spectacle';
 
-import { EditableTextField, TextFieldVariant } from '<src>/components';
 import { TwoColumnFullWidth } from '<src>/components';
 import { DiffCard } from '<src>/pages/diffs/components/DiffCard';
 import { SimulatedCommandStore } from '<src>/pages/diffs/contexts/SimulatedCommandContext';
 import { useSharedDiffContext } from '<src>/pages/diffs/contexts/SharedDiffContext';
-import {
-  useDebouncedFn,
-  useStateWithSideEffect,
-  useRunOnKeypress,
-} from '<src>/hooks/util';
+import { useRunOnKeypress } from '<src>/hooks/util';
 import { useDiffReviewCapturePageLink } from '<src>/components/navigation/Routes';
 import { IInterpretation } from '<src>/lib/Interfaces';
-import { getEndpointId } from '<src>/utils';
 
 import {
   RenderedDiffHeaderProps,
@@ -59,23 +52,12 @@ export const ReviewEndpointDiffPage: FC<ReviewEndpointDiffPageProps> = ({
   const {
     approveCommandsForDiff,
     isDiffHandled,
-    setEndpointName: setGlobalDiffEndpointName,
     addDiffHashIgnore,
     setCommitModalOpen,
     hasDiffChanges,
   } = useSharedDiffContext();
 
   const batchCommit = useLastBatchCommitId();
-
-  const debouncedSetName = useDebouncedFn(setGlobalDiffEndpointName, 200);
-  const {
-    value: endpointName,
-    setValue: setEndpointName,
-  } = useStateWithSideEffect({
-    initialValue: endpoint.purpose,
-    sideEffect: (newName: string) => debouncedSetName(endpointId, newName),
-  });
-  const endpointId = getEndpointId({ method, pathId });
 
   const getNextIncompleteDiff = (recentlyCompletedDiff?: string): number => {
     for (let i = 0; i < allDiffs.length; i++) {
@@ -161,22 +143,9 @@ export const ReviewEndpointDiffPage: FC<ReviewEndpointDiffPageProps> = ({
             highlightedLocation={
               allDiffs[currentIndex].diffDescription.location
             }
-            renderHeader={() => (
-              <>
-                <Helmet>
-                  <title>{endpointName || 'Unnamed Endpoint'}</title>
-                </Helmet>
-                <EditableTextField
-                  isEditing={true}
-                  setEditing={() => {}}
-                  value={endpointName}
-                  setValue={setEndpointName}
-                  helperText="Help consumers by naming this endpoint"
-                  defaultText="What does this endpoint do?"
-                  variant={TextFieldVariant.REGULAR}
-                />
-              </>
-            )}
+            name={
+              endpoint.purpose === '' ? 'Unnamed Endpoint' : endpoint.purpose
+            }
             onKeyPress={onKeyPress}
           />
         </SimulatedCommandStore>

--- a/workspaces/ui-v2/src/pages/diffs/contexts/SharedDiffContext.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/contexts/SharedDiffContext.tsx
@@ -64,14 +64,8 @@ type ISharedDiffContext = {
   handledCount: [number, number];
   startedFinalizing: () => void;
   setEndpointName: (id: string, name: string) => void;
-  setPathDescription: (
-    pathId: string,
-    description: string,
-    endpointId: string
-  ) => void;
   setPendingEndpointName: (id: string, name: string) => void;
   getContributedEndpointName: (endpointId: string) => string | undefined;
-  getContributedPathDescription: (pathId: string) => string | undefined;
   captureId: string;
   commitModalOpen: boolean;
   setCommitModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
@@ -262,26 +256,10 @@ export const SharedDiffStore: FC<SharedDiffStoreProps> = (props) => {
         type: 'UPDATE_PENDING_ENDPOINT_NAME',
       });
     },
-    setPathDescription: (
-      pathId: string,
-      description: string,
-      endpointId: string
-    ) => {
-      send({
-        type: 'SET_PATH_DESCRIPTION',
-        pathId,
-        command: AddContribution(pathId, 'description', description),
-        endpointId,
-      });
-    },
     captureId: props.captureId,
     getContributedEndpointName: (endpointId: string): string | undefined => {
       return context.choices.existingEndpointNameContributions[endpointId]
         ?.AddContribution.value;
-    },
-    getContributedPathDescription: (pathId: string): string | undefined => {
-      return context.choices.existingEndpointPathContributions[pathId]?.command
-        .AddContribution.value;
     },
     getUndocumentedUrls: () =>
       context.results.displayedUndocumentedUrls


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

In the diff flow, we cannot contribute to request / response body fields, but for some reason we can contribute to path parameters. This is confusing and distracting - and as part of streamlining / giving better clarity to each page's flow, I'm removing adding path contributions to this flow (naming an endpoint is still here, because I think that's not distracting to have)

<img width="1782" alt="Screen Shot 2021-07-14 at 4 22 38 PM" src="https://user-images.githubusercontent.com/18374483/125705209-935f9013-896e-4bb0-93f5-56bd2b3646dc.png">
<img width="1780" alt="Screen Shot 2021-07-14 at 4 22 29 PM" src="https://user-images.githubusercontent.com/18374483/125705211-3c2202cc-ec4e-4021-8934-d7dfa58d1ea8.png">

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
