### PR TITLE
Fix race condition diff

### DIFF
--- a/workspaces/cli-server/src/spectacle/index.ts
+++ b/workspaces/cli-server/src/spectacle/index.ts
@@ -230,7 +230,7 @@ class LocalCliDiff {
     //@TODO: should this be writing output to the file system?
     // Consume stream instantly for now, resulting in a Promise that resolves once exhausted
     this.diffing = AsyncTools.toArray(worker.results);
-    worker.onWriteComplete.then(() => {
+    Promise.all([this.diffing, worker.onWriteComplete]).then(() => {
       this.dependencies.notifications.emit('complete');
     });
   }

--- a/workspaces/cli-server/src/spectacle/index.ts
+++ b/workspaces/cli-server/src/spectacle/index.ts
@@ -230,7 +230,7 @@ class LocalCliDiff {
     //@TODO: should this be writing output to the file system?
     // Consume stream instantly for now, resulting in a Promise that resolves once exhausted
     this.diffing = AsyncTools.toArray(worker.results);
-    this.diffing.then(() => {
+    worker.onWriteComplete.then(() => {
       this.dependencies.notifications.emit('complete');
     });
   }

--- a/workspaces/cli-shared/src/diffs/interaction-diff-worker-rust.ts
+++ b/workspaces/cli-shared/src/diffs/interaction-diff-worker-rust.ts
@@ -12,6 +12,7 @@ import { PassThrough } from 'stream';
 import { parseIgnore } from '@useoptic/cli-config/build/helpers/ignore-parser';
 interface WorkerResult {
   results: AsyncIterable<DiffResult>;
+  onWriteComplete: Promise<void>;
 }
 
 interface WorkerConfig {
@@ -121,6 +122,14 @@ export class InteractionDiffWorkerRust {
     workerProcessOutput.pipe(fork([inMemorySink, fsSink]));
     return {
       results,
+      onWriteComplete: new Promise((resolve, reject) => {
+        fsSink.on('close', () => {
+          resolve();
+        });
+        fsSink.on('error', () => {
+          reject();
+        });
+      }),
     };
   }
 }

--- a/workspaces/spectacle-shared/src/local-cli/client.ts
+++ b/workspaces/spectacle-shared/src/local-cli/client.ts
@@ -115,6 +115,8 @@ export class LocalCliCapturesService implements IOpticCapturesService {
         captureId,
       },
     });
+    // This assumes that the onComplete implementation in the cli-server has completed, and that
+    // the fsWriteSink has completed, so that we can read the correct commands
     const onComplete = Promise.resolve(
       new LocalCliDiffService({ ...this.dependencies, diffId, captureId })
     );

--- a/workspaces/spectacle/src/spectacle.ts
+++ b/workspaces/spectacle/src/spectacle.ts
@@ -159,9 +159,12 @@ export async function makeSpectacle(opticContext: IOpticContext) {
         context: GraphQLContext
       ) => {
         const { diffId, captureId } = args;
-        await context
+        const {
+          onComplete,
+        } = await context
           .spectacleContext()
           .opticContext.capturesService.startDiff(diffId, captureId);
+        await onComplete;
         return {
           notificationsUrl: '',
         };


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

In the interaction diff worker, we have two outputs to diff results, an InMemorySink, and a fsWriteStream. `listDiffs` and `listUnrecognizedUrls` read from the in memory diff, where learnShapeDiffAffordances reads from the fs. The diff shouldn't be marked as complete until the fsWriteStream completes, otherwise we get into a race condition between the fsWriteStream and the learnShapeDiffAffordances (which reads from the fs)

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
