### PR TITLE
feat: build/deploy the website in CI

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -9,12 +9,14 @@ on:
       - website/**
       - .github/**
       - "**.md"
+      - "Taskfile.yml"
   pull_request:
     branches: [ 'develop' ]
     paths-ignore:
       - website/**
       - .github/**
       - "**.md"
+      - "Taskfile.yml"
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,0 +1,31 @@
+name: Website
+
+on:
+  pull_request:
+    branches: [develop]
+    paths:
+      - .github/wokflows/website.yml
+      - website/**
+  push:
+    branches: [release]
+    paths:
+      - website/**
+  workflow_dispatch:gs
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b # https://github.com/actions/checkout/commits/v2
+      - name: Setup Node
+        uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d # v1.4.4
+        with:
+          node-version: "14.x"
+      - name: Install Task
+        run: curl -sL https://taskfile.dev/install.sh | sudo bash -s -- -b /usr/local/bin/
+      - run: task website:build
+        env:
+          DRYRUN: "true"
+
+

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -10,7 +10,7 @@ on:
     branches: [release]
     paths:
       - website/**
-  workflow_dispatch:gs
+  workflow_dispatch:
 
 jobs:
   run:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -12,12 +12,18 @@ on:
       - website/**
   workflow_dispatch:
 
+env:
+  DRY_RUN: "true"
+  SKIP_VERIFY: "true"
+
 jobs:
   run:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b # https://github.com/actions/checkout/commits/v2
+
+      # TODO: set APP_ENV based on the branch
 
       - name: Setup Node
         uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d # v1.4.4
@@ -35,9 +41,4 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       - run: task website:deploy
-        env:
-          DRYRUN: "true"
-          SKIP_VERIFY: "true"
-          APP_ENV: "staging"
-
 

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -28,6 +28,7 @@ jobs:
           else
             echo "APP_ENV=staging" >> $GITHUB_ENV
           fi
+
       - name: Setup Node
         uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d # v1.4.4
         with:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -18,14 +18,26 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b # https://github.com/actions/checkout/commits/v2
+
       - name: Setup Node
         uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d # v1.4.4
         with:
           node-version: "14.x"
+
       - name: Install Task
         run: curl -sL https://taskfile.dev/install.sh | sudo bash -s -- -b /usr/local/bin/
-      - run: task website:build
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@32d908adfb55576ba0c59f3c557058e80b5194c3 # v1.5.3
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - run: task website:deploy
         env:
           DRYRUN: "true"
+          SKIP_VERIFY: "true"
+          APP_ENV: "staging"
 
 

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -10,7 +10,6 @@ on:
     branches: [release]
     paths:
       - website/**
-  workflow_dispatch:
 
 jobs:
   run:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -23,8 +23,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b # https://github.com/actions/checkout/commits/v2
 
-      # TODO: set APP_ENV based on the branch
-
+      - name: Set APP_ENV
+        run: |
+          branch=${GITHUB_REF##*/}
+          if [[ "$branch" =~ "^(develop|release)$" ]]
+          then
+            echo "APP_ENV=production" >> $GITHUB_ENV
+          else
+            echo "APP_ENV=staging" >> $GITHUB_ENV
+          fi
       - name: Setup Node
         uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d # v1.4.4
         with:
@@ -39,6 +46,18 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
+
+      # if we're deploying to staging, we need to configure AWS credentials for that account
+      - name: Configure staging AWS credentials
+        uses: aws-actions/configure-aws-credentials@32d908adfb55576ba0c59f3c557058e80b5194c3 # v1.5.3
+        if: env.APP_ENV == 'staging'
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_STAGING_CI_ROLE_ARN }}
+          role-duration-seconds: 900 # 15m, minimum
+          role-session-name: GithubActionStagingDeploy
 
       - run: task website:deploy
 

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -12,10 +12,6 @@ on:
       - website/**
   workflow_dispatch:
 
-env:
-  DRY_RUN: "true"
-  SKIP_VERIFY: "true"
-
 jobs:
   run:
     runs-on: ubuntu-latest
@@ -60,4 +56,6 @@ jobs:
           role-session-name: GithubActionStagingDeploy
 
       - run: task website:deploy
-
+        env:
+          DRY_RUN: "false"
+          SKIP_VERIFY: "true"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -24,6 +24,9 @@ includes:
   verdaccio:
     taskfile: docker/private-npm-registry/Taskfile.yml
     dir: docker/private-npm-registry
+  website:
+    taskfile: website/Taskfile.yml
+    dir: website
 
 tasks:
   postpull:

--- a/website/Taskfile.yml
+++ b/website/Taskfile.yml
@@ -3,6 +3,8 @@ version: '3'
 tasks:
   deploy:
     desc: Deploy the website to S3
+    deps:
+      - install-deps
     cmds:
       - bin/deploy
     env:

--- a/website/Taskfile.yml
+++ b/website/Taskfile.yml
@@ -1,61 +1,24 @@
-# https://taskfile.dev
-
 version: '3'
 
 tasks:
-  default:
-    cmds:
-      - task --list
-    silent: true
-
-  check-credentials:
-    cmds:
-      - aws-mfa --profile parent
-    silent: true
-
   deploy:
-    desc: Deploys the web site (see --summary for detailed usage)
-    summary: |
-      Deploys the web site. Depends on having your AWS profiles set up properly with aws-mfa. This task deploys:
-
-      - to environment AWS_PROFILE, default is {{.AWS_PROFILE}}
-      - when DRY_RUN is false, default is {{.DRY_RUN}}
+    desc: Deploy the website to S3
     cmds:
       - bin/deploy
-    deps:
-      - check-credentials
     env:
-      AWS_PROFILE: '{{default "staging" .AWS_PROFILE}}'
+      APP_ENV: '{{default "staging" .APP_ENV}}'
       DRY_RUN: '{{default "true" .DRY_RUN}}'
+      SKIP_VERIFY: '{{default "false" .SKIP_VERIFY}}'
 
-  deploy:staging:
-    desc: Dry run of a deploy to staging
-    cmds: 
-      - task: deploy
-        vars:
-          AWS_PROFILE: staging
-          DRY_RUN: true
+  install-deps:
+    - yarn install
 
-  deploy:staging:doit:
-    desc: Deploy to staging
-    cmds: 
-      - task: deploy
-        vars:
-          AWS_PROFILE: staging
-          DRY_RUN: false  
+  build:
+    desc: Build the website
+    deps: [install-deps]
+    cmds: [yarn build]
 
-  deploy:prod:
-    desc: Dry run of a deploy to production
-    cmds: 
-      - task: deploy
-        vars:
-          AWS_PROFILE: production
-          DRY_RUN: true
-
-  deploy:prod:doit:
-    desc: Deploy to production
-    cmds: 
-      - task: deploy
-        vars:
-          AWS_PROFILE: production
-          DRY_RUN: false  
+  start:
+    desc: Run the website locally
+    deps: [install-deps]
+    cmds: [yarn start]

--- a/website/bin/deploy
+++ b/website/bin/deploy
@@ -22,7 +22,7 @@ S3_BUCKET="optic-${SITE_NAME}-website-${APP_ENV}"
 CLOUDFRONT_DIST=""
 
 function usage {
-    echo "AWS_PROFILE=(staging|production) DRY_RUN=(true|false) ./bin/deploy"
+    echo "APP_ENV=(staging|production) DRY_RUN=(true|false) SKIP_VERIFY=(true|false) ./bin/deploy"
 }
 
 function set_cloudfront_dist_arn {

--- a/website/bin/deploy
+++ b/website/bin/deploy
@@ -4,12 +4,21 @@ set -eu
 trap 'usage' ERR
 trap 'cleanup' EXIT
 
+# require APP_ENV to be set
+if [ -z "${APP_ENV}" ]
+then
+    echo "APP_ENV is not set"
+    usage
+fi
+
+DRY_RUN="${DRY_RUN:-true}"
+SKIP_VERIFY="${SKIP_VERIFY:-false}"
+
 # create a unique build directory so there's no monkey business
 BUILD_TIMESTAMP=$(date +%s)
 BUILD_PATH="/tmp/docs-build-${BUILD_TIMESTAMP}"
 SITE_NAME="marketing"
-S3_BUCKET="optic-${SITE_NAME}-website-${AWS_PROFILE}"
-DRY_RUN="${DRY_RUN:-true}"
+S3_BUCKET="optic-${SITE_NAME}-website-${APP_ENV}"
 CLOUDFRONT_DIST=""
 
 function usage {
@@ -29,7 +38,7 @@ function set_cloudfront_dist_arn {
 
     if [ -z "$CLOUDFRONT_DIST" ]
     then
-        echo "No CloudFront Distribution found with a 'service=docs' tag"
+        echo "No CloudFront Distribution found with a 'service=marketing-website' tag"
         exit 1
     fi
 }
@@ -39,14 +48,6 @@ function dependencies {
     if ! $(which jq > /dev/null 2>&1)
     then
         echo "You need jq installed, 'brew install jq'"
-        exit 1
-    fi
-}
-
-function aws_configuration {
-    if [[ ! "$AWS_PROFILE" =~ "staging" ]] && [[ ! "$AWS_PROFILE" =~ "production" ]]
-    then
-        echo 'AWS_PROFILE must be set to either "staging" or "production".'
         exit 1
     fi
 }
@@ -79,16 +80,11 @@ function build {
 }
 
 function deploy {
-    S3_SYNC_CMD="aws s3 sync $BUILD_PATH/ s3://${S3_BUCKET}/ --delete --sse AES256"
-    S3_DRY_RUN="--dryrun"
+    [ "$DRY_RUN" = "true" ] && S3_DRY_RUN="--dryrun" || S3_DRY_RUN=""
 
-    if [[ "$DRY_RUN" == "true" ]]
-    then
-        eval "$S3_SYNC_CMD $S3_DRY_RUN"
-    else
-        eval "$S3_SYNC_CMD"
-        create_cloudfront_invalidation
-    fi
+    aws s3 sync $BUILD_PATH/ s3://${S3_BUCKET}/ --delete --sse AES256 ${DRY_RUN}
+
+    [ "$DRY_RUN" != "true" ] && create_cloudfront_invalidation
     echo
 }
 
@@ -107,19 +103,18 @@ function cleanup {
 
 function preflight {
     dependencies
-    aws_configuration
 }
 
 function run {
     echo "Deploy \"$SITE_NAME\" site"
     echo
     echo "DRY RUN: $DRY_RUN"
-    echo "Environment: $AWS_PROFILE"
+    echo "Environment: $APP_ENV"
     echo "S3 Bucket: $S3_BUCKET"
     echo
 
     preflight
-    verify
+    [ "$SKIP_VERIFY" != "true" ] && verify || echo "Skipping verification..."
     build
     deploy
 

--- a/website/bin/deploy
+++ b/website/bin/deploy
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -eu
 
-trap 'usage' ERR
-trap 'cleanup' EXIT
-
 DRY_RUN="${DRY_RUN:-true}"
 SKIP_VERIFY="${SKIP_VERIFY:-false}"
 
@@ -113,6 +110,9 @@ function run {
 
     echo "Done!"
 }
+
+trap 'usage' ERR
+trap 'cleanup' EXIT
 
 #
 # entrypoint

--- a/website/bin/deploy
+++ b/website/bin/deploy
@@ -4,13 +4,6 @@ set -eu
 trap 'usage' ERR
 trap 'cleanup' EXIT
 
-# require APP_ENV to be set
-if [ -z "${APP_ENV}" ]
-then
-    echo "APP_ENV is not set"
-    usage
-fi
-
 DRY_RUN="${DRY_RUN:-true}"
 SKIP_VERIFY="${SKIP_VERIFY:-false}"
 

--- a/website/bin/deploy
+++ b/website/bin/deploy
@@ -82,7 +82,7 @@ function build {
 function deploy {
     [ "$DRY_RUN" = "true" ] && S3_DRY_RUN="--dryrun" || S3_DRY_RUN=""
 
-    aws s3 sync $BUILD_PATH/ s3://${S3_BUCKET}/ --delete --sse AES256 ${DRY_RUN}
+    aws s3 sync $BUILD_PATH/ s3://${S3_BUCKET}/ --delete --sse AES256 ${S3_DRY_RUN}
 
     [ "$DRY_RUN" != "true" ] && create_cloudfront_invalidation
     echo


### PR DESCRIPTION
deployment automation for the website. the gha workflow will deploy to either staging or production,
* pushes to a PR open against develop will deploy to staging
* pushes to develop or release (which will happen when changes are merged) will deploy to production

here's a successful deploy to staging from this branch, https://github.com/opticdev/optic/runs/3089397143. i'll verify prod deploys without a problem when this is merged.

i also included website's taskfile in the root taskfile. its tasks are available from the repo root under the "website" prefix,
```
➜ pwd
/Users/nate/code/optic/optic

➜ task -l | grep website
* website:build:                                        Build the website
* website:deploy:                                       Deploy the website to S3
* website:start:                                        Run the website locally
```

and you can still run them from the website dir as well, just drop the prefix,
```
➜ pwd
/Users/nate/code/optic/optic/website

➜ task -l
* build:        Build the website
* deploy:       Deploy the website to S3
* start:        Run the website locally
```