### PR TITLE
Prevent invalid interactions from generating diffs

### DIFF
--- a/workspaces/optic-engine/src/interactions/mod.rs
+++ b/workspaces/optic-engine/src/interactions/mod.rs
@@ -1,4 +1,4 @@
-use crate::events::http_interaction::{ArbitraryData, Body, HttpInteraction, Request, Response};
+use crate::events::http_interaction::{Body, HttpInteraction};
 use crate::learn_shape::{observe_body_trails, TrailObservationsResult, TrailValues};
 use crate::projections::{EndpointProjection, SpecProjection};
 use crate::protos::shapehash::ShapeDescriptor;

--- a/workspaces/optic-engine/src/interactions/mod.rs
+++ b/workspaces/optic-engine/src/interactions/mod.rs
@@ -17,49 +17,6 @@ pub use result::{
 };
 use visitors::{InteractionVisitors, PathVisitor};
 
-// An invalid http interaction are interactions we cannot generate diffs from
-fn is_invalid_http_interaction(http_interaction: &HttpInteraction) -> bool {
-  match http_interaction {
-    // Request with content type not-null and null body
-    HttpInteraction {
-      request:
-        Request {
-          body:
-            Body {
-              content_type: Some(_),
-              value:
-                ArbitraryData {
-                  shape_hash_v1_base64: None,
-                  as_json_string: None,
-                  as_text: None,
-                },
-            },
-          ..
-        },
-      ..
-    } => true,
-    // Response with null body
-    HttpInteraction {
-      response:
-        Response {
-          body:
-            Body {
-              value:
-                ArbitraryData {
-                  shape_hash_v1_base64: None,
-                  as_json_string: None,
-                  as_text: None,
-                },
-              ..
-            },
-          ..
-        },
-      ..
-    } => true,
-    _ => false,
-  }
-}
-
 /// Compute diffs based on a spec and an interaction.
 ///
 /// Will first try to match the interaction to a Request + Response pair from the spec. From there
@@ -70,10 +27,6 @@ pub fn diff(
   http_interaction: HttpInteraction,
   config: &DiffConfig,
 ) -> Vec<InteractionDiffResult> {
-  if is_invalid_http_interaction(&http_interaction) {
-    return Vec::new();
-  }
-
   let endpoint_projection = spec_projection.endpoint();
   let endpoint_queries = EndpointQueries::new(endpoint_projection);
   let interaction_traverser = traverser::Traverser::new(&endpoint_queries);

--- a/workspaces/optic-engine/src/interactions/visitors/diff.rs
+++ b/workspaces/optic-engine/src/interactions/visitors/diff.rs
@@ -196,15 +196,16 @@ impl RequestBodyVisitor<InteractionDiffResult> for DiffRequestBodyVisitor {
 
   fn visit(&mut self, interaction: &HttpInteraction, context: &RequestBodyVisitorContext) {
     if let Some(operation) = context.operation {
-      let actual_content_type = &interaction.request.body.content_type;
-      let actual_body: Option<BodyDescriptor> = (&interaction.request.body.value).into();
-      let (request_id, request_body_descriptor) = operation;
-      //dbg!( actual_content_type);
-      //dbg!(&request_body_descriptor);
+      let maybe_interaction_content_type = &interaction.request.body.content_type;
+      let maybe_interaction_body_descriptor: Option<BodyDescriptor> =
+        (&interaction.request.body.value).into();
+      let (request_id, request_descriptor) = operation;
+      //dbg!( maybe_interaction_content_type);
+      //dbg!(&request_descriptor);
       match (
-        &request_body_descriptor.body,
-        actual_content_type,
-        actual_body,
+        &request_descriptor.body,
+        maybe_interaction_content_type,
+        maybe_interaction_body_descriptor,
       ) {
         (None, None, _) => {
           self
@@ -259,7 +260,7 @@ impl RequestBodyVisitor<InteractionDiffResult> for DiffRequestBodyVisitor {
   fn end(&mut self, interaction: &HttpInteraction, context: &PathVisitorContext) {
     if let Some(path_id) = context.path {
       if self.visited_with_matched_content_types.is_empty() {
-        let actual_content_type = &interaction.request.body.content_type;
+        let maybe_interaction_content_type = &interaction.request.body.content_type;
         let mut interaction_trail_components = vec![
           InteractionTrailPathComponent::Url {
             path: interaction.request.path.clone(),
@@ -268,7 +269,7 @@ impl RequestBodyVisitor<InteractionDiffResult> for DiffRequestBodyVisitor {
             method: interaction.request.method.clone(),
           },
         ];
-        if let Some(content_type) = actual_content_type {
+        if let Some(content_type) = maybe_interaction_content_type {
           interaction_trail_components.push(InteractionTrailPathComponent::RequestBody {
             content_type: content_type.clone(),
           });
@@ -316,18 +317,19 @@ impl ResponseBodyVisitor<InteractionDiffResult> for DiffResponseBodyVisitor {
   fn visit(&mut self, interaction: &HttpInteraction, context: &ResponseBodyVisitorContext) {
     //dbg!("visit response body");
     if let Some(response) = context.response {
-      let actual_content_type = &interaction.response.body.content_type;
-      let actual_body: Option<BodyDescriptor> = (&interaction.response.body.value).into();
-      let (response_id, response_body_descriptor) = response;
-      //dbg!("actual response content type", actual_content_type);
+      let maybe_interaction_content_type = &interaction.response.body.content_type;
+      let maybe_interaction_body_descriptor: Option<BodyDescriptor> =
+        (&interaction.response.body.value).into();
+      let (response_id, response_descriptor) = response;
+      //dbg!("actual response content type", maybe_interaction_content_type);
       // dbg!(
       //   "expecting response content type",
-      //   &response_body_descriptor
+      //   &response_descriptor
       // );
       match (
-        &response_body_descriptor.body,
-        actual_content_type,
-        actual_body,
+        &response_descriptor.body,
+        maybe_interaction_content_type,
+        maybe_interaction_body_descriptor,
       ) {
         (None, None, _) => {
           self

--- a/workspaces/optic-engine/src/interactions/visitors/diff.rs
+++ b/workspaces/optic-engine/src/interactions/visitors/diff.rs
@@ -197,26 +197,36 @@ impl RequestBodyVisitor<InteractionDiffResult> for DiffRequestBodyVisitor {
   fn visit(&mut self, interaction: &HttpInteraction, context: &RequestBodyVisitorContext) {
     if let Some(operation) = context.operation {
       let actual_content_type = &interaction.request.body.content_type;
+      let actual_body: Option<BodyDescriptor> = (&interaction.request.body.value).into();
       let (request_id, request_body_descriptor) = operation;
       //dbg!( actual_content_type);
       //dbg!(&request_body_descriptor);
-      match (&request_body_descriptor.body, actual_content_type) {
-        (None, None) => {
+      match (
+        &request_body_descriptor.body,
+        actual_content_type,
+        actual_body,
+      ) {
+        (None, None, _) => {
           self
             .visited_with_matched_content_types
             .insert(request_id.clone());
         }
-        (None, Some(content_type)) => {
+        (None, Some(content_type), None) => {
+          self
+            .visited_with_matched_content_types
+            .insert(request_id.clone());
+        }
+        (None, Some(content_type), Some(interaction_body)) => {
           self
             .visited_with_unmatched_content_types
             .insert(request_id.clone());
         }
-        (Some(body), None) => {
+        (Some(body), None, _) => {
           self
             .visited_with_unmatched_content_types
             .insert(request_id.clone());
         }
-        (Some(body), Some(content_type)) => {
+        (Some(body), Some(content_type), _) => {
           if body.http_content_type == *content_type {
             self
               .visited_with_matched_content_types
@@ -307,29 +317,40 @@ impl ResponseBodyVisitor<InteractionDiffResult> for DiffResponseBodyVisitor {
     //dbg!("visit response body");
     if let Some(response) = context.response {
       let actual_content_type = &interaction.response.body.content_type;
+      let actual_body: Option<BodyDescriptor> = (&interaction.response.body.value).into();
       let (response_id, response_body_descriptor) = response;
       //dbg!("actual response content type", actual_content_type);
       // dbg!(
       //   "expecting response content type",
       //   &response_body_descriptor
       // );
-      match (&response_body_descriptor.body, actual_content_type) {
-        (None, None) => {
+      match (
+        &response_body_descriptor.body,
+        actual_content_type,
+        actual_body,
+      ) {
+        (None, None, _) => {
           self
             .visited_with_matched_content_types
             .insert(response_id.clone());
         }
-        (None, Some(content_type)) => {
+        (None, Some(content_type), None) => {
+          self
+            .visited_with_matched_content_types
+            .insert(response_id.clone());
+        }
+        (None, Some(content_type), Some(interaction_body)) => {
           self
             .visited_with_unmatched_content_types
             .insert(response_id.clone());
         }
-        (Some(body), None) => {
+        (Some(body), None, _) => {
           self
             .visited_with_unmatched_content_types
             .insert(response_id.clone());
         }
-        (Some(body), Some(content_type)) => {
+        (Some(body), Some(content_type), _) => {
+          // TODO investigate this branch
           if body.http_content_type == *content_type {
             self
               .visited_with_matched_content_types

--- a/workspaces/optic-engine/tests/interaction_diff.rs
+++ b/workspaces/optic-engine/tests/interaction_diff.rs
@@ -56,7 +56,11 @@ async fn can_yield_interactive_diff_result() {
       },
       "body": {
         "contentType": null,
-        "value": {}
+        "value": {
+          "asJsonString": null,
+          "asText": "hello",
+          "asShapeHashBytes": null
+        }
       }
     },
     "response": {
@@ -68,7 +72,11 @@ async fn can_yield_interactive_diff_result() {
       },
       "body": {
         "contentType": "application/jsonxxx",
-        "value": {}
+        "value": {
+          "asJsonString": null,
+          "asText": "hello",
+          "asShapeHashBytes": null
+        }
       }
     },
     "tags": []
@@ -139,7 +147,11 @@ fn can_yield_unmatched_request_url() {
       },
       "body": {
         "contentType": null,
-        "value": {}
+        "value": {
+          "asJsonString": null,
+          "asText": "hello",
+          "asShapeHashBytes": null
+        }
       }
     },
     "response": {
@@ -151,7 +163,11 @@ fn can_yield_unmatched_request_url() {
       },
       "body": {
         "contentType": null,
-        "value": {}
+        "value": {
+          "asJsonString": null,
+          "asText": "hello",
+          "asShapeHashBytes": null
+        }
       }
     },
     "tags": []

--- a/workspaces/optic-engine/tests/interaction_diff.rs
+++ b/workspaces/optic-engine/tests/interaction_diff.rs
@@ -194,9 +194,8 @@ fn can_yield_unmatched_request_url() {
   assert_eq!(results.len(), 1);
 }
 
-#[tokio::main]
 #[test]
-async fn can_yield_unmatched_shape() {
+fn can_yield_unmatched_shape() {
   let events: Vec<SpecEvent> = serde_json::from_value(
     json!([
       {"PathComponentAdded":{"pathId":"path_1","parentPathId":"root","name":"xyz"}},
@@ -256,15 +255,29 @@ async fn can_yield_unmatched_shape() {
   )
   .expect("example http interaction should deserialize");
 
-  let mut results = diff_interaction(
+  let results = diff_interaction(
     &spec_projection,
     compliant_interaction,
     &DiffInteractionConfig::default(),
   );
   assert_debug_snapshot!(results);
   assert_eq!(results.len(), 0);
+}
 
-  let incompliant_interaction = HttpInteraction::from_json_str(
+#[test]
+fn can_handle_no_request_and_response_body() {
+  // This is how the diff would be learnt with no request or response body
+  let events: Vec<SpecEvent> = serde_json::from_value(
+    json!([
+      {"PathComponentAdded":{"pathId":"path_1","parentPathId":"root","name":"xyz"}},
+      {"RequestAdded":{"requestId":"request_1","pathId":"path_1","httpMethod":"POST"}},
+      {"ResponseAddedByPathAndMethod":{"responseId":"response_1", "httpStatusCode":200,"pathId":"path_1","httpMethod":"POST"}},
+    ]),
+  ).expect("should be able to deserialize shape added events as spec events");
+
+  let spec_projection = SpecProjection::from(events);
+
+  let no_body_interaction = HttpInteraction::from_json_str(
     r#"{
     "uuid": "5",
     "request": {
@@ -284,7 +297,7 @@ async fn can_yield_unmatched_shape() {
       "body": {
         "contentType": "application/json",
         "value": {
-          "asJsonString": "null",
+          "asJsonString": null,
           "asText": null,
           "asShapeHashBytes": null
         }
@@ -311,15 +324,10 @@ async fn can_yield_unmatched_shape() {
   )
   .expect("example http interaction should deserialize");
 
-  results = diff_interaction(
+  let results = diff_interaction(
     &spec_projection,
-    incompliant_interaction,
+    no_body_interaction,
     &DiffInteractionConfig::default(),
   );
-  let fingerprints = results
-    .iter()
-    .map(|result| result.fingerprint())
-    .collect::<Vec<_>>();
-  assert_debug_snapshot!(results);
-  assert_debug_snapshot!("can_yield_unmatched_shape__fingerprints", fingerprints);
+  assert_eq!(results.len(), 0);
 }

--- a/workspaces/optic-engine/tests/snapshots/interaction_diff__can_yield_unmatched_shape-2.snap
+++ b/workspaces/optic-engine/tests/snapshots/interaction_diff__can_yield_unmatched_shape-2.snap
@@ -1,5 +1,0 @@
----
-source: workspaces/optic-engine/tests/interaction_diff.rs
-expression: results
----
-[]

--- a/workspaces/optic-engine/tests/snapshots/interaction_diff__can_yield_unmatched_shape-2.snap
+++ b/workspaces/optic-engine/tests/snapshots/interaction_diff__can_yield_unmatched_shape-2.snap
@@ -1,31 +1,5 @@
 ---
-source: workspaces/optic-engine-native/tests/interaction_diff.rs
+source: workspaces/optic-engine/tests/interaction_diff.rs
 expression: results
 ---
-[
-    UnmatchedRequestBodyShape(
-        UnmatchedRequestBodyShape {
-            interaction_trail: InteractionTrail {
-                path: [
-                    RequestBody {
-                        content_type: "application/json",
-                    },
-                ],
-            },
-            requests_trail: SpecRequestBody(
-                SpecRequestBody {
-                    request_id: "request_1",
-                },
-            ),
-            shape_diff_result: UnmatchedShape {
-                json_trail: JsonTrail {
-                    path: [],
-                },
-                shape_trail: ShapeTrail {
-                    root_shape_id: "shape_1",
-                    path: [],
-                },
-            },
-        },
-    ),
-]
+[]

--- a/workspaces/optic-engine/tests/snapshots/interaction_diff__can_yield_unmatched_shape__fingerprints.snap
+++ b/workspaces/optic-engine/tests/snapshots/interaction_diff__can_yield_unmatched_shape__fingerprints.snap
@@ -2,6 +2,4 @@
 source: workspaces/optic-engine/tests/interaction_diff.rs
 expression: fingerprints
 ---
-[
-    "4d8f067aafde64ba",
-]
+[]

--- a/workspaces/optic-engine/tests/snapshots/interaction_diff__can_yield_unmatched_shape__fingerprints.snap
+++ b/workspaces/optic-engine/tests/snapshots/interaction_diff__can_yield_unmatched_shape__fingerprints.snap
@@ -1,5 +1,0 @@
----
-source: workspaces/optic-engine/tests/interaction_diff.rs
-expression: fingerprints
----
-[]

--- a/workspaces/ui-v2/src/lib/__tests/diff-helpers/__snapshots__/new-regions-interpretations.test.ts.snap
+++ b/workspaces/ui-v2/src/lib/__tests/diff-helpers/__snapshots__/new-regions-interpretations.test.ts.snap
@@ -7,42 +7,42 @@ Object {
       "AddShape": Object {
         "baseShapeId": "$string",
         "name": "",
-        "shapeId": "shape_6707",
+        "shapeId": "shape_6687",
       },
     },
     Object {
       "AddShape": Object {
         "baseShapeId": "$boolean",
         "name": "",
-        "shapeId": "shape_6708",
+        "shapeId": "shape_6688",
       },
     },
     Object {
       "AddShape": Object {
         "baseShapeId": "$string",
         "name": "",
-        "shapeId": "shape_6709",
+        "shapeId": "shape_6689",
       },
     },
     Object {
       "AddShape": Object {
         "baseShapeId": "$string",
         "name": "",
-        "shapeId": "shape_6710",
+        "shapeId": "shape_6690",
       },
     },
     Object {
       "AddShape": Object {
         "baseShapeId": "$object",
         "name": "",
-        "shapeId": "shape_6716",
+        "shapeId": "shape_6696",
       },
     },
     Object {
       "AddShape": Object {
         "baseShapeId": "$optional",
         "name": "",
-        "shapeId": "shape_6712",
+        "shapeId": "shape_6692",
       },
     },
     Object {
@@ -52,71 +52,71 @@ Object {
             "consumingParameterId": "$optionalInner",
             "providerDescriptor": Object {
               "ShapeProvider": Object {
-                "shapeId": "shape_6710",
+                "shapeId": "shape_6690",
               },
             },
-            "shapeId": "shape_6712",
+            "shapeId": "shape_6692",
           },
         },
       },
     },
     Object {
       "AddField": Object {
-        "fieldId": "field_6711",
+        "fieldId": "field_6691",
         "name": "dueDate",
         "shapeDescriptor": Object {
           "FieldShapeFromShape": Object {
-            "fieldId": "field_6711",
-            "shapeId": "shape_6712",
+            "fieldId": "field_6691",
+            "shapeId": "shape_6692",
           },
         },
-        "shapeId": "shape_6716",
+        "shapeId": "shape_6696",
       },
     },
     Object {
       "AddField": Object {
-        "fieldId": "field_6713",
+        "fieldId": "field_6693",
         "name": "id",
         "shapeDescriptor": Object {
           "FieldShapeFromShape": Object {
-            "fieldId": "field_6713",
-            "shapeId": "shape_6709",
+            "fieldId": "field_6693",
+            "shapeId": "shape_6689",
           },
         },
-        "shapeId": "shape_6716",
+        "shapeId": "shape_6696",
       },
     },
     Object {
       "AddField": Object {
-        "fieldId": "field_6714",
+        "fieldId": "field_6694",
         "name": "isDone",
         "shapeDescriptor": Object {
           "FieldShapeFromShape": Object {
-            "fieldId": "field_6714",
-            "shapeId": "shape_6708",
+            "fieldId": "field_6694",
+            "shapeId": "shape_6688",
           },
         },
-        "shapeId": "shape_6716",
+        "shapeId": "shape_6696",
       },
     },
     Object {
       "AddField": Object {
-        "fieldId": "field_6715",
+        "fieldId": "field_6695",
         "name": "task",
         "shapeDescriptor": Object {
           "FieldShapeFromShape": Object {
-            "fieldId": "field_6715",
-            "shapeId": "shape_6707",
+            "fieldId": "field_6695",
+            "shapeId": "shape_6687",
           },
         },
-        "shapeId": "shape_6716",
+        "shapeId": "shape_6696",
       },
     },
     Object {
       "AddShape": Object {
         "baseShapeId": "$list",
         "name": "",
-        "shapeId": "shape_6717",
+        "shapeId": "shape_6697",
       },
     },
     Object {
@@ -126,10 +126,10 @@ Object {
             "consumingParameterId": "$listItem",
             "providerDescriptor": Object {
               "ShapeProvider": Object {
-                "shapeId": "shape_6716",
+                "shapeId": "shape_6696",
               },
             },
-            "shapeId": "shape_6717",
+            "shapeId": "shape_6697",
           },
         },
       },
@@ -138,7 +138,7 @@ Object {
       "AddRequest": Object {
         "httpMethod": "GET",
         "pathId": "path_it2OyjUysW",
-        "requestId": "request_6718",
+        "requestId": "request_6698",
       },
     },
     Object {
@@ -146,9 +146,9 @@ Object {
         "bodyDescriptor": Object {
           "httpContentType": "application/json",
           "isRemoved": false,
-          "shapeId": "shape_6717",
+          "shapeId": "shape_6697",
         },
-        "requestId": "request_6718",
+        "requestId": "request_6698",
       },
     },
   ],
@@ -229,42 +229,42 @@ Object {
       "AddShape": Object {
         "baseShapeId": "$string",
         "name": "",
-        "shapeId": "shape_6731",
+        "shapeId": "shape_6667",
       },
     },
     Object {
       "AddShape": Object {
         "baseShapeId": "$boolean",
         "name": "",
-        "shapeId": "shape_6732",
+        "shapeId": "shape_6668",
       },
     },
     Object {
       "AddShape": Object {
         "baseShapeId": "$string",
         "name": "",
-        "shapeId": "shape_6733",
+        "shapeId": "shape_6669",
       },
     },
     Object {
       "AddShape": Object {
         "baseShapeId": "$string",
         "name": "",
-        "shapeId": "shape_6734",
+        "shapeId": "shape_6670",
       },
     },
     Object {
       "AddShape": Object {
         "baseShapeId": "$object",
         "name": "",
-        "shapeId": "shape_6740",
+        "shapeId": "shape_6676",
       },
     },
     Object {
       "AddShape": Object {
         "baseShapeId": "$optional",
         "name": "",
-        "shapeId": "shape_6736",
+        "shapeId": "shape_6672",
       },
     },
     Object {
@@ -274,71 +274,71 @@ Object {
             "consumingParameterId": "$optionalInner",
             "providerDescriptor": Object {
               "ShapeProvider": Object {
-                "shapeId": "shape_6734",
+                "shapeId": "shape_6670",
               },
             },
-            "shapeId": "shape_6736",
+            "shapeId": "shape_6672",
           },
         },
       },
     },
     Object {
       "AddField": Object {
-        "fieldId": "field_6735",
+        "fieldId": "field_6671",
         "name": "dueDate",
         "shapeDescriptor": Object {
           "FieldShapeFromShape": Object {
-            "fieldId": "field_6735",
-            "shapeId": "shape_6736",
+            "fieldId": "field_6671",
+            "shapeId": "shape_6672",
           },
         },
-        "shapeId": "shape_6740",
+        "shapeId": "shape_6676",
       },
     },
     Object {
       "AddField": Object {
-        "fieldId": "field_6737",
+        "fieldId": "field_6673",
         "name": "id",
         "shapeDescriptor": Object {
           "FieldShapeFromShape": Object {
-            "fieldId": "field_6737",
-            "shapeId": "shape_6733",
+            "fieldId": "field_6673",
+            "shapeId": "shape_6669",
           },
         },
-        "shapeId": "shape_6740",
+        "shapeId": "shape_6676",
       },
     },
     Object {
       "AddField": Object {
-        "fieldId": "field_6738",
+        "fieldId": "field_6674",
         "name": "isDone",
         "shapeDescriptor": Object {
           "FieldShapeFromShape": Object {
-            "fieldId": "field_6738",
-            "shapeId": "shape_6732",
+            "fieldId": "field_6674",
+            "shapeId": "shape_6668",
           },
         },
-        "shapeId": "shape_6740",
+        "shapeId": "shape_6676",
       },
     },
     Object {
       "AddField": Object {
-        "fieldId": "field_6739",
+        "fieldId": "field_6675",
         "name": "task",
         "shapeDescriptor": Object {
           "FieldShapeFromShape": Object {
-            "fieldId": "field_6739",
-            "shapeId": "shape_6731",
+            "fieldId": "field_6675",
+            "shapeId": "shape_6667",
           },
         },
-        "shapeId": "shape_6740",
+        "shapeId": "shape_6676",
       },
     },
     Object {
       "AddShape": Object {
         "baseShapeId": "$list",
         "name": "",
-        "shapeId": "shape_6741",
+        "shapeId": "shape_6677",
       },
     },
     Object {
@@ -348,10 +348,10 @@ Object {
             "consumingParameterId": "$listItem",
             "providerDescriptor": Object {
               "ShapeProvider": Object {
-                "shapeId": "shape_6740",
+                "shapeId": "shape_6676",
               },
             },
-            "shapeId": "shape_6741",
+            "shapeId": "shape_6677",
           },
         },
       },
@@ -361,7 +361,7 @@ Object {
         "httpMethod": "GET",
         "httpStatusCode": 200,
         "pathId": "path_it2OyjUysW",
-        "responseId": "response_6742",
+        "responseId": "response_6678",
       },
     },
     Object {
@@ -369,9 +369,9 @@ Object {
         "bodyDescriptor": Object {
           "httpContentType": "application/json",
           "isRemoved": false,
-          "shapeId": "shape_6741",
+          "shapeId": "shape_6677",
         },
-        "responseId": "response_6742",
+        "responseId": "response_6678",
       },
     },
   ],


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

As a follow up to this https://github.com/opticdev/optic/pull/1007, moved the invalid interactions filtering logic into the diff flow. What happens is we potentially generate interactions that are invalid

An example interaction (with invalid requests and responses) - copy paste this into todos-partial

```json
      {
        "uuid": "aaaf782f-8e44-4e1327-806d-032323fb0a4fd",
        "request": {
          "host": "localhost",
          "method": "GET",
          "path": "/api/lists/list123/completed",
          "query": {
            "shapeHashV1Base64": null,
            "asJsonString": null,
            "asText": null
          },
          "headers": {
            "shapeHashV1Base64": null,
            "asJsonString": null,
            "asText": null
          },
          "body": {
            "contentType": "application/json",
            "value": {
              "shapeHashV1Base64": null,
              "asJsonString": null,
              "asText": null
            }
          }
        },
        "response": {
          "statusCode": 200,
          "headers": {
            "shapeHashV1Base64": null,
            "asJsonString": null,
            "asText": null
          },
          "body": {
            "contentType": ,
            "value": {
              "shapeHashV1Base64": null,
              "asJsonString": null,
              "asText": null
            }
          }
        },
        "tags": []
      },

```

## What
What's changing? Anything of note to call out?

I'm not sure if this is the right place to put this. I thought about putting this logic in the interaction visitor, but I'm also not sure that the visitor is the right place to put this. The visitor visits multiple nodes in the endpoints graph, given a single http interaction, given that the http interaction is "invalid" - i.e. we cannot create and learn from this interaction, it seems right to remove it up front?

The only other thing is, lets say we send a request with valid query + request bodies, but the response is invalid. Should we discard the entire interaction, or should we learn from the valid query and request bodies and discard the response body? If that's the case, we should move this block https://github.com/opticdev/optic/blob/develop/workspaces/optic-engine/src/interactions/traverser.rs#L32-L98 (perhaps as part of the Visitor structs)?

Thoughts?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
