### PR TITLE
Only learn query parameters when observerd

### DIFF
--- a/workspaces/optic-engine/src/interactions/mod.rs
+++ b/workspaces/optic-engine/src/interactions/mod.rs
@@ -148,15 +148,19 @@ pub fn analyze_undocumented_bodies<'a>(
   results.into_iter().flat_map(move |result| match result {
     InteractionDiffResult::UnmatchedQueryParameters(diff) => {
       if include_query_params {
-        let maybe_query_params: Option<BodyDescriptor> = (&interaction.request.query).into();
-        let query_params = maybe_query_params.or_else(|| Some(BodyDescriptor::empty_object()));
+        if let UnmatchedQueryParameters::Observed(_) = &diff {
+          let maybe_query_params: Option<BodyDescriptor> = (&interaction.request.query).into();
+          let query_params = maybe_query_params.or_else(|| Some(BodyDescriptor::empty_object()));
 
-        let query_trail_observations = observe_body_trails(query_params);
+          let query_trail_observations = observe_body_trails(query_params);
 
-        vec![BodyAnalysisResult {
-          body_location: BodyAnalysisLocation::from(diff),
-          trail_observations: query_trail_observations,
-        }]
+          vec![BodyAnalysisResult {
+            body_location: BodyAnalysisLocation::from(diff),
+            trail_observations: query_trail_observations,
+          }]
+        } else {
+          vec![]
+        }
       } else {
         vec![]
       }


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Previously, we were learning query parameters everywhere (even if they were unobserved) - updating this to not do that. This was introduced to fix a previous bug  https://github.com/opticdev/optic/pull/984

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
