### PR TITLE
Correct docs to match JS framework examples

### DIFF
--- a/website/docs/frameworks/express.mdx
+++ b/website/docs/frameworks/express.mdx
@@ -57,13 +57,13 @@ Using a basic [Express](https://expressjs.com/) server proxying to [httpbin](htt
 const express = require('express')
 const bodyParser = require('body-parser')
 const { createProxyMiddleware } = require('http-proxy-middleware');
-const optic = require('@useoptic/express-middleware');
+const { OpticMiddleware } = require('@useoptic/express-middleware');
 
 const app = express()
 const port = 3000
 
 app.use(bodyParser())
-app.use(optic({
+app.use(OpticMiddleware({
     enabled: true,
 }))
 

--- a/website/docs/frameworks/hapi.mdx
+++ b/website/docs/frameworks/hapi.mdx
@@ -53,7 +53,7 @@ Using a basic [hapi](https://hapi.dev/) server.
 
 ```js
 const Hapi = require('@hapi/hapi')
-const Optic = require('@useoptic/hapi-middleware')
+const { OpticPlugin } = require('@useoptic/hapi-middleware')
 
 const init = async () => {
   const server = Hapi.server({
@@ -62,7 +62,7 @@ const init = async () => {
   })
 
   await server.register({
-    plugin: Optic,
+    plugin: OpticPlugin,
     options: {
       enabled: true
     }


### PR DESCRIPTION
## Why
The export/import of the node frameworks has change https://github.com/opticdev/optic-node/pull/18

## What
Changed the example references to match the changed export setup of the hapi/express frameworks