### PR TITLE
Intercept: fix browser warning on Chrome, Windows

### DIFF
--- a/workspaces/local-cli/src/commands/intercept.ts
+++ b/workspaces/local-cli/src/commands/intercept.ts
@@ -32,6 +32,10 @@ export default class Intercept extends Command {
       description:
         'collect traffic to your deployed environment using Chrome network tab',
     }),
+    firefox: flags.boolean({
+      description:
+        'collect traffic to your deployed environment using Firefox network tab',
+    }),
   };
 
   static args = [
@@ -121,6 +125,7 @@ export default class Intercept extends Command {
       );
 
       if (flags.chrome) browsers.chrome();
+      if (flags.firefox) browsers.firefox();
     };
 
     let collected = 0;

--- a/workspaces/local-cli/src/commands/intercept.ts
+++ b/workspaces/local-cli/src/commands/intercept.ts
@@ -32,10 +32,6 @@ export default class Intercept extends Command {
       description:
         'collect traffic to your deployed environment using Chrome network tab',
     }),
-    firefox: flags.boolean({
-      description:
-        'collect traffic to your deployed environment using Firefox network tab',
-    }),
   };
 
   static args = [
@@ -125,7 +121,6 @@ export default class Intercept extends Command {
       );
 
       if (flags.chrome) browsers.chrome();
-      if (flags.firefox) browsers.firefox();
     };
 
     let collected = 0;

--- a/workspaces/local-cli/src/shared/intercept/browser-launchers.ts
+++ b/workspaces/local-cli/src/shared/intercept/browser-launchers.ts
@@ -32,6 +32,7 @@ export class BrowserLaunchers {
             options: [
               // Trust our CA certificate's fingerprint:
               `--ignore-certificate-errors-spki-list=${this.fingerprint}`,
+              `--test-type`,
               // Avoid annoying extra network noise:
               '--disable-background-networking',
             ],


### PR DESCRIPTION
## Why

On Windows, Chrome offers a warning that the certificate fingerprint option is "not supported". This warning does not persist on Mac. We were missing a flag to put Chrome in the proper mode. 

## What

- Added a single command line flag.

## Validation
* [ ] CI passes
* [ ] Verified in staging

