### PR TITLE
fix(website): build for real

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -10,8 +10,8 @@ on:
     branches:
       - release
       - develop
-
     paths:
+      - .github/wokflows/website.yml
       - website/**
 
 jobs:


### PR DESCRIPTION
https://github.com/opticdev/optic/pull/1023 didnt build on merge, but it was because only the ci workflow changed and that wasnt a watched file. i dont think this is strictly necessary, but should trigger the develop build im looking for.