### PR TITLE
fix(website): build CI correctly when merged to develop

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -28,7 +28,7 @@ jobs:
           then
             echo "Deploying to Production..."
             echo "APP_ENV=production" >> $GITHUB_ENV
-          else=
+          else
             echo "Deploying to Staging..."
             echo "APP_ENV=staging" >> $GITHUB_ENV
           fi

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -24,10 +24,12 @@ jobs:
       - name: Set APP_ENV
         run: |
           branch=${GITHUB_REF##*/}
-          if [[ "$branch" =~ "^(develop|release)$" ]]
+          if [[ "$branch" =~ ^(develop|release)$ ]]
           then
+            echo "Deploying to Production..."
             echo "APP_ENV=production" >> $GITHUB_ENV
-          else
+          else=
+            echo "Deploying to Staging..."
             echo "APP_ENV=staging" >> $GITHUB_ENV
           fi
 


### PR DESCRIPTION
the last (i hope so bad) in my series of "make CI work correctly" PRs. https://github.com/opticdev/optic/pull/1025 fixed a typo that was preventing CI from running when i expected it to. i noticed that after merging that we did a staging deploy when we expected prod. 

quoting the regex when we do the branch comparison causes it to be treated like a string, which is not the desired behavior.

```
bash-5.1$ [[ "develop" =~ "^(develop|release)$" ]] && echo "Hi"
bash-5.1$ [[ "develop" =~ ^(develop|release)$ ]] && echo "Hi"
Hi
```