### PR TITLE
UI to use endpoint spectacle

### DIFF
--- a/workspaces/cli-shared/src/diffs/trail-parsers.ts
+++ b/workspaces/cli-shared/src/diffs/trail-parsers.ts
@@ -1,18 +1,17 @@
 import { IRequestSpecTrail } from './request-spec-trail';
 import { IInteractionTrail } from './interaction-trail';
 
-// This is a subset of IEndpoint in ui-v2
 type EndpointForTrails = {
   pathId: string;
   method: string;
   query: {
     queryParametersId: string;
   } | null;
-  requestBodies: {
+  requests: {
     requestId: string;
     contentType: string;
   }[];
-  responseBodies: {
+  responses: {
     responseId: string;
     statusCode: number;
     contentType: string;
@@ -68,11 +67,11 @@ export function locationForTrails(
     let contentType = '';
     const endpoint = endpoints.find(
       (endpoint) =>
-        !!endpoint.requestBodies.find((requestBody) => {
-          if (requestBody.requestId === requestId) {
-            contentType = requestBody.contentType;
+        !!endpoint.requests.find((request) => {
+          if (request.requestId === requestId) {
+            contentType = request.contentType;
           }
-          return requestBody.requestId === requestId;
+          return request.requestId === requestId;
         })
     );
 
@@ -104,12 +103,12 @@ export function locationForTrails(
     let statusCode = 0;
     const endpoint = endpoints.find(
       (endpoint) =>
-        !!endpoint.responseBodies.find((responseBody) => {
-          if (responseBody.responseId === responseId) {
-            contentType = responseBody.contentType;
-            statusCode = responseBody.statusCode;
+        !!endpoint.responses.find((response) => {
+          if (response.responseId === responseId) {
+            contentType = response.contentType;
+            statusCode = response.statusCode;
           }
-          return responseBody.responseId === responseId;
+          return response.responseId === responseId;
         })
     );
 

--- a/workspaces/local-cli/src/commands/status.ts
+++ b/workspaces/local-cli/src/commands/status.ts
@@ -206,7 +206,11 @@ export default class Status extends Command {
         const location = locationForTrails(
           extractRequestsTrail(diff),
           extractInteractionTrail(diff),
-          endpoints
+          endpoints.map((endpoint: any) => ({
+            ...endpoint,
+            requests: endpoint.requestBodies,
+            responses: endpoint.responseBodies,
+          }))
         );
         if (location) {
           return { pathId: location.pathId, method: location.method, diff };

--- a/workspaces/spectacle/src/graphql/schema.ts
+++ b/workspaces/spectacle/src/graphql/schema.ts
@@ -133,15 +133,15 @@ TODO @nic rename this
 """
 type HttpRequestNew {
   # Request Id
-  id: ID
+  id: ID!
 
   # Request body associated with this HTTP request
   body: HttpBody
 
-  contributions: JSON
+  contributions: JSON!
 
   # Is the request removed
-  isRemoved: Boolean
+  isRemoved: Boolean!
 }
 
 """
@@ -172,7 +172,7 @@ type QueryParameters {
   isRemoved: Boolean!
 
   # Contributions for the query parameter
-  contributions: JSON
+  contributions: JSON!
 }
 
 """

--- a/workspaces/ui-v2/public/example-sessions/multiple-bodies.json
+++ b/workspaces/ui-v2/public/example-sessions/multiple-bodies.json
@@ -1,0 +1,404 @@
+{
+  "events": [
+    {
+      "BatchCommitStarted": {
+        "batchId": "a98a5269-fd54-4239-a4fd-0be3ca4ca530",
+        "commitMessage": "Initialize specification attributes",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "unknown-session",
+          "clientCommandBatchId": "a98a5269-fd54-4239-a4fd-0be3ca4ca530",
+          "createdAt": "2021-07-14T15:46:33.287741-07:00"
+        },
+        "parentId": "root"
+      }
+    },
+    {
+      "ContributionAdded": {
+        "id": "metadata",
+        "key": "id",
+        "value": "78a28c84-f30e-4972-9a2c-429cc0125eb5",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "unknown-session",
+          "clientCommandBatchId": "a98a5269-fd54-4239-a4fd-0be3ca4ca530",
+          "createdAt": "2021-07-14T15:46:33.287741-07:00"
+        }
+      }
+    },
+    {
+      "BatchCommitEnded": {
+        "batchId": "a98a5269-fd54-4239-a4fd-0be3ca4ca530",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "unknown-session",
+          "clientCommandBatchId": "a98a5269-fd54-4239-a4fd-0be3ca4ca530",
+          "createdAt": "2021-07-14T15:46:33.287741-07:00"
+        }
+      }
+    },
+    {
+      "BatchCommitStarted": {
+        "batchId": "edf1f1b6-73ed-45cb-b567-f370d99e281e",
+        "commitMessage": "123",
+        "eventContext": {
+          "clientId": "anon",
+          "clientSessionId": "216d336c-1702-41c1-9bab-54f230b125a9",
+          "clientCommandBatchId": "edf1f1b6-73ed-45cb-b567-f370d99e281e",
+          "createdAt": "2021-07-14T15:46:39.735079-07:00"
+        },
+        "parentId": "a98a5269-fd54-4239-a4fd-0be3ca4ca530"
+      }
+    },
+    {
+      "PathComponentAdded": {
+        "pathId": "path_uhFLMNs_jV",
+        "parentPathId": "root",
+        "name": "api",
+        "eventContext": {
+          "clientId": "anon",
+          "clientSessionId": "216d336c-1702-41c1-9bab-54f230b125a9",
+          "clientCommandBatchId": "edf1f1b6-73ed-45cb-b567-f370d99e281e",
+          "createdAt": "2021-07-14T15:46:39.735079-07:00"
+        }
+      }
+    },
+    {
+      "PathComponentAdded": {
+        "pathId": "path_AKmq2BmaeI",
+        "parentPathId": "path_uhFLMNs_jV",
+        "name": "todos",
+        "eventContext": {
+          "clientId": "anon",
+          "clientSessionId": "216d336c-1702-41c1-9bab-54f230b125a9",
+          "clientCommandBatchId": "edf1f1b6-73ed-45cb-b567-f370d99e281e",
+          "createdAt": "2021-07-14T15:46:39.735079-07:00"
+        }
+      }
+    },
+    {
+      "PathComponentAdded": {
+        "pathId": "path_BaGsWf5tgh",
+        "parentPathId": "path_AKmq2BmaeI",
+        "name": "1",
+        "eventContext": {
+          "clientId": "anon",
+          "clientSessionId": "216d336c-1702-41c1-9bab-54f230b125a9",
+          "clientCommandBatchId": "edf1f1b6-73ed-45cb-b567-f370d99e281e",
+          "createdAt": "2021-07-14T15:46:39.735079-07:00"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_OhrLgc67-g",
+        "baseShapeId": "$string",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anon",
+          "clientSessionId": "216d336c-1702-41c1-9bab-54f230b125a9",
+          "clientCommandBatchId": "edf1f1b6-73ed-45cb-b567-f370d99e281e",
+          "createdAt": "2021-07-14T15:46:39.735079-07:00"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_zSvyDlJHqU",
+        "baseShapeId": "$object",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anon",
+          "clientSessionId": "216d336c-1702-41c1-9bab-54f230b125a9",
+          "clientCommandBatchId": "edf1f1b6-73ed-45cb-b567-f370d99e281e",
+          "createdAt": "2021-07-14T15:46:39.735079-07:00"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_35J9zpRase",
+        "shapeId": "shape_zSvyDlJHqU",
+        "name": "key",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_35J9zpRase",
+            "shapeId": "shape_OhrLgc67-g"
+          }
+        },
+        "eventContext": {
+          "clientId": "anon",
+          "clientSessionId": "216d336c-1702-41c1-9bab-54f230b125a9",
+          "clientCommandBatchId": "edf1f1b6-73ed-45cb-b567-f370d99e281e",
+          "createdAt": "2021-07-14T15:46:39.735079-07:00"
+        }
+      }
+    },
+    {
+      "RequestAdded": {
+        "requestId": "request_oRLopmXD_S",
+        "pathId": "path_BaGsWf5tgh",
+        "httpMethod": "POST",
+        "eventContext": {
+          "clientId": "anon",
+          "clientSessionId": "216d336c-1702-41c1-9bab-54f230b125a9",
+          "clientCommandBatchId": "edf1f1b6-73ed-45cb-b567-f370d99e281e",
+          "createdAt": "2021-07-14T15:46:39.735079-07:00"
+        }
+      }
+    },
+    {
+      "RequestBodySet": {
+        "requestId": "request_oRLopmXD_S",
+        "bodyDescriptor": {
+          "httpContentType": "text/html",
+          "shapeId": "shape_zSvyDlJHqU",
+          "isRemoved": false
+        },
+        "eventContext": {
+          "clientId": "anon",
+          "clientSessionId": "216d336c-1702-41c1-9bab-54f230b125a9",
+          "clientCommandBatchId": "edf1f1b6-73ed-45cb-b567-f370d99e281e",
+          "createdAt": "2021-07-14T15:46:39.735079-07:00"
+        }
+      }
+    },
+    {
+      "RequestAdded": {
+        "requestId": "request_4iUceRy6Xq",
+        "pathId": "path_BaGsWf5tgh",
+        "httpMethod": "POST",
+        "eventContext": {
+          "clientId": "anon",
+          "clientSessionId": "216d336c-1702-41c1-9bab-54f230b125a9",
+          "clientCommandBatchId": "edf1f1b6-73ed-45cb-b567-f370d99e281e",
+          "createdAt": "2021-07-14T15:46:39.735079-07:00"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_lRTpUKRTP1",
+        "baseShapeId": "$string",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anon",
+          "clientSessionId": "216d336c-1702-41c1-9bab-54f230b125a9",
+          "clientCommandBatchId": "edf1f1b6-73ed-45cb-b567-f370d99e281e",
+          "createdAt": "2021-07-14T15:46:39.735079-07:00"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_7YfyaWkj86",
+        "baseShapeId": "$object",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anon",
+          "clientSessionId": "216d336c-1702-41c1-9bab-54f230b125a9",
+          "clientCommandBatchId": "edf1f1b6-73ed-45cb-b567-f370d99e281e",
+          "createdAt": "2021-07-14T15:46:39.735079-07:00"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_rqSDratxUQ",
+        "shapeId": "shape_7YfyaWkj86",
+        "name": "key",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_rqSDratxUQ",
+            "shapeId": "shape_lRTpUKRTP1"
+          }
+        },
+        "eventContext": {
+          "clientId": "anon",
+          "clientSessionId": "216d336c-1702-41c1-9bab-54f230b125a9",
+          "clientCommandBatchId": "edf1f1b6-73ed-45cb-b567-f370d99e281e",
+          "createdAt": "2021-07-14T15:46:39.735079-07:00"
+        }
+      }
+    },
+    {
+      "RequestAdded": {
+        "requestId": "request_GW2fKMm3hP",
+        "pathId": "path_BaGsWf5tgh",
+        "httpMethod": "POST",
+        "eventContext": {
+          "clientId": "anon",
+          "clientSessionId": "216d336c-1702-41c1-9bab-54f230b125a9",
+          "clientCommandBatchId": "edf1f1b6-73ed-45cb-b567-f370d99e281e",
+          "createdAt": "2021-07-14T15:46:39.735079-07:00"
+        }
+      }
+    },
+    {
+      "RequestBodySet": {
+        "requestId": "request_GW2fKMm3hP",
+        "bodyDescriptor": {
+          "httpContentType": "application/json",
+          "shapeId": "shape_7YfyaWkj86",
+          "isRemoved": false
+        },
+        "eventContext": {
+          "clientId": "anon",
+          "clientSessionId": "216d336c-1702-41c1-9bab-54f230b125a9",
+          "clientCommandBatchId": "edf1f1b6-73ed-45cb-b567-f370d99e281e",
+          "createdAt": "2021-07-14T15:46:39.735079-07:00"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_3VOX_TAGxz",
+        "baseShapeId": "$object",
+        "parameters": { "DynamicParameterList": { "shapeParameterIds": [] } },
+        "name": "",
+        "eventContext": {
+          "clientId": "anon",
+          "clientSessionId": "216d336c-1702-41c1-9bab-54f230b125a9",
+          "clientCommandBatchId": "edf1f1b6-73ed-45cb-b567-f370d99e281e",
+          "createdAt": "2021-07-14T15:46:39.735079-07:00"
+        }
+      }
+    },
+    {
+      "ResponseAddedByPathAndMethod": {
+        "responseId": "response_-xJHDfqMg5",
+        "pathId": "path_BaGsWf5tgh",
+        "httpMethod": "POST",
+        "httpStatusCode": 404,
+        "eventContext": {
+          "clientId": "anon",
+          "clientSessionId": "216d336c-1702-41c1-9bab-54f230b125a9",
+          "clientCommandBatchId": "edf1f1b6-73ed-45cb-b567-f370d99e281e",
+          "createdAt": "2021-07-14T15:46:39.735079-07:00"
+        }
+      }
+    },
+    {
+      "ResponseBodySet": {
+        "responseId": "response_-xJHDfqMg5",
+        "bodyDescriptor": {
+          "httpContentType": "application/json",
+          "shapeId": "shape_3VOX_TAGxz",
+          "isRemoved": false
+        },
+        "eventContext": {
+          "clientId": "anon",
+          "clientSessionId": "216d336c-1702-41c1-9bab-54f230b125a9",
+          "clientCommandBatchId": "edf1f1b6-73ed-45cb-b567-f370d99e281e",
+          "createdAt": "2021-07-14T15:46:39.735079-07:00"
+        }
+      }
+    },
+    {
+      "BatchCommitEnded": {
+        "batchId": "edf1f1b6-73ed-45cb-b567-f370d99e281e",
+        "eventContext": {
+          "clientId": "anon",
+          "clientSessionId": "216d336c-1702-41c1-9bab-54f230b125a9",
+          "clientCommandBatchId": "edf1f1b6-73ed-45cb-b567-f370d99e281e",
+          "createdAt": "2021-07-14T15:46:39.735079-07:00"
+        }
+      }
+    }
+  ],
+  "session": {
+    "samples": [
+      {
+        "uuid": "0532115b-2b6a-45a1-9ff5-46a29105f756",
+        "request": {
+          "host": "",
+          "method": "POST",
+          "path": "/api/todos/1",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "contentable-content",
+            "value": {
+              "shapeHashV1Base64": "CAA=",
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 404,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "so-many-content-types",
+            "value": {
+              "shapeHashV1Base64": "CAA=",
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "tags": []
+      },
+      {
+        "uuid": "1532115b-2b6a-45a1-9ff5-46a29105f756",
+        "request": {
+          "host": "",
+          "method": "GET",
+          "path": "/api/null/endpoint",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": "application/json",
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 404,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "tags": []
+      }
+    ]
+  },
+  "examples": {}
+}

--- a/workspaces/ui-v2/src/components/HttpBodySelector.tsx
+++ b/workspaces/ui-v2/src/components/HttpBodySelector.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+import {
+  FormControl,
+  FormControlLabel,
+  makeStyles,
+  Radio,
+  RadioGroup,
+} from '@material-ui/core';
+
+import { FontFamily } from '<src>/styles';
+
+type HttpBodySelectorProps<T> = {
+  items: T[];
+  children: (body: T) => React.ReactNode;
+  getDisplayName: (item: T) => string;
+};
+
+/**
+ * A component that is used to select / handle different items
+ */
+export const HttpBodySelector: <T extends {}>(
+  props: HttpBodySelectorProps<T>
+) => React.ReactElement = ({ items, children, getDisplayName }) => {
+  const [selectedItem, setSelectedItem] = useState(0);
+  const inBoundsSelected = Math.min(selectedItem, items.length - 1);
+  const classes = useStyles();
+
+  return (
+    <>
+      {items.length === 0 ? (
+        <>No bodies found</>
+      ) : items.length === 1 ? (
+        children(items[0])
+      ) : (
+        <>
+          <FormControl component="fieldset" className={classes.formGroup}>
+            <RadioGroup
+              value={selectedItem}
+              onChange={(e) => {
+                setSelectedItem(Number(e.target.value));
+              }}
+              className={classes.radioGroup}
+            >
+              {items.map((item, i) => (
+                <FormControlLabel
+                  classes={{
+                    label: classes.radio,
+                  }}
+                  key={getDisplayName(item)}
+                  value={i}
+                  control={<Radio />}
+                  label={getDisplayName(item)}
+                />
+              ))}
+            </RadioGroup>
+          </FormControl>
+          {children(items[inBoundsSelected])}
+        </>
+      )}
+    </>
+  );
+};
+
+const useStyles = makeStyles((theme) => ({
+  formGroup: {
+    marginBottom: theme.spacing(2),
+  },
+  radioGroup: {
+    display: 'flex',
+    flexDirection: 'row',
+  },
+  radio: {
+    fontFamily: FontFamily,
+    fontSize: theme.typography.fontSize - 1,
+  },
+}));

--- a/workspaces/ui-v2/src/components/index.ts
+++ b/workspaces/ui-v2/src/components/index.ts
@@ -17,3 +17,4 @@ export * from './Panel';
 export * from './QueryParametersPanel';
 export * from './DataFetchers';
 export * from './HttpBodyPanel';
+export * from './HttpBodySelector';

--- a/workspaces/ui-v2/src/lib/__tests/diff-helpers/universes/makeCurrentSpecContext.ts
+++ b/workspaces/ui-v2/src/lib/__tests/diff-helpers/universes/makeCurrentSpecContext.ts
@@ -25,7 +25,7 @@ export async function makeCurrentSpecContext(
         variables: {},
       })
     ).data || {
-      requests: [],
+      endpoints: [],
     },
     null
   );

--- a/workspaces/ui-v2/src/lib/parse-diff.ts
+++ b/workspaces/ui-v2/src/lib/parse-diff.ts
@@ -174,12 +174,15 @@ export class ParsedDiff {
             requestId: request.requestId,
             contentType: request.body!.contentType,
           })),
-        responses: endpoint.responses.flatMap((response) =>
-          response.bodies.map((body) => ({
-            responseId: response.responseId,
-            statusCode: response.statusCode,
-            contentType: body.contentType,
-          }))
+        responses: Object.values(endpoint.responsesByStatusCode).flatMap(
+          (responses) =>
+            responses
+              .filter((response) => !!response.body)
+              .map((response) => ({
+                responseId: response.responseId,
+                statusCode: response.statusCode,
+                contentType: response.body!.contentType,
+              }))
         ),
       }))
     );

--- a/workspaces/ui-v2/src/lib/parse-diff.ts
+++ b/workspaces/ui-v2/src/lib/parse-diff.ts
@@ -160,10 +160,28 @@ export class ParsedDiff {
   }
 
   location(currentSpecContext: CurrentSpecContext): DiffLocation {
+    const endpoints = currentSpecContext.currentSpecEndpoints;
     const location = locationForTrails(
       this.requestsTrail(),
       this.interactionTrail(),
-      currentSpecContext.currentSpecEndpoints
+      endpoints.map((endpoint) => ({
+        pathId: endpoint.pathId,
+        method: endpoint.method,
+        query: endpoint.query,
+        requests: endpoint.requests
+          .filter((request) => !!request.body)
+          .map((request) => ({
+            requestId: request.requestId,
+            contentType: request.body!.contentType,
+          })),
+        responses: endpoint.responses.flatMap((response) =>
+          response.bodies.map((body) => ({
+            responseId: response.responseId,
+            statusCode: response.statusCode,
+            contentType: body.contentType,
+          }))
+        ),
+      }))
     );
 
     if (!location) {

--- a/workspaces/ui-v2/src/pages/changelog/ChangelogEndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/changelog/ChangelogEndpointRootPage.tsx
@@ -142,7 +142,7 @@ const ChangelogRootComponent: FC<
                   <EndpointTOC
                     query={thisEndpoint.query}
                     requests={thisEndpoint.requests}
-                    responses={thisEndpoint.responses}
+                    responsesByStatusCode={thisEndpoint.responsesByStatusCode}
                   />
                 </div>
               </Panel>
@@ -210,7 +210,7 @@ const ChangelogRootComponent: FC<
             <HttpBodySelector
               items={thisEndpoint.requests}
               getDisplayName={(request) =>
-                request.body?.contentType || 'No body'
+                request.body?.contentType || 'No Body'
               }
             >
               {(request) => (
@@ -270,74 +270,82 @@ const ChangelogRootComponent: FC<
             </HttpBodySelector>
           </div>
         )}
-        {thisEndpoint.responses.map((response) => (
-          <div
-            className={classes.bodyContainer}
-            id={response.responseId}
-            key={response.responseId}
-          >
-            <div className={classes.bodyHeaderContainer}>
-              <h6 className={classes.bodyHeader}>
-                {response.statusCode} Response
-              </h6>
-            </div>
-            <div className={classes.bodyContributionContainer}>
-              <ReactMarkdown
-                className={classes.contents}
-                source={response.description}
-              />
-            </div>
-            <div className={classes.bodyDetails}>
+        {selectors
+          .getResponsesInSortedOrder(thisEndpoint.responsesByStatusCode)
+          .map(([statusCode, responses]) => (
+            <div
+              className={classes.bodyContainer}
+              id={statusCode}
+              key={statusCode}
+            >
+              <div className={classes.bodyHeaderContainer}>
+                <h6 className={classes.bodyHeader}>{statusCode} Response</h6>
+              </div>
               <HttpBodySelector
-                items={response.bodies}
-                getDisplayName={(body) => body.contentType}
+                items={responses}
+                getDisplayName={(response) =>
+                  response.body?.contentType || 'No Body'
+                }
               >
-                {(body) => (
+                {(response) => (
                   <>
-                    <div>
-                      <ContributionFetcher
-                        rootShapeId={body.rootShapeId}
-                        endpointId={endpointId}
-                        changesSinceBatchCommit={batchId}
-                      >
-                        {(fields) => (
-                          <ContributionsList
-                            renderField={(field) => (
-                              <FieldOrParameter
-                                key={
-                                  field.contribution.id +
-                                  field.contribution.contributionKey
-                                }
-                                name={field.name}
-                                shapes={field.shapes}
-                                depth={field.depth}
-                                value={field.contribution.value}
-                              />
-                            )}
-                            fieldDetails={fields}
-                          />
-                        )}
-                      </ContributionFetcher>
+                    <div className={classes.bodyContributionContainer}>
+                      <ReactMarkdown
+                        className={classes.contents}
+                        source={response.description}
+                      />
                     </div>
-                    <div className={classes.panel}>
-                      <ShapeFetcher
-                        rootShapeId={body.rootShapeId}
-                        changesSinceBatchCommit={batchId}
-                      >
-                        {(shapes) => (
-                          <HttpBodyPanel
-                            shapes={shapes}
-                            location={body.contentType}
-                          />
-                        )}
-                      </ShapeFetcher>
+                    <div className={classes.bodyDetails}>
+                      {response.body ? (
+                        <>
+                          <div>
+                            <ContributionFetcher
+                              rootShapeId={response.body.rootShapeId}
+                              endpointId={endpointId}
+                              changesSinceBatchCommit={batchId}
+                            >
+                              {(fields) => (
+                                <ContributionsList
+                                  renderField={(field) => (
+                                    <FieldOrParameter
+                                      key={
+                                        field.contribution.id +
+                                        field.contribution.contributionKey
+                                      }
+                                      name={field.name}
+                                      shapes={field.shapes}
+                                      depth={field.depth}
+                                      value={field.contribution.value}
+                                    />
+                                  )}
+                                  fieldDetails={fields}
+                                />
+                              )}
+                            </ContributionFetcher>
+                          </div>
+                          <div className={classes.panel}>
+                            <ShapeFetcher
+                              rootShapeId={response.body.rootShapeId}
+                              changesSinceBatchCommit={batchId}
+                            >
+                              {(shapes) => (
+                                <HttpBodyPanel
+                                  shapes={shapes}
+                                  location={response.body!.contentType}
+                                />
+                              )}
+                            </ShapeFetcher>
+                          </div>
+                        </>
+                      ) : (
+                        <>No Body Response</>
+                      )}
                     </div>
                   </>
                 )}
               </HttpBodySelector>
             </div>
-          </div>
-        ))}
+          ))}
       </FullWidth>
     </>
   );

--- a/workspaces/ui-v2/src/pages/changelog/ChangelogEndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/changelog/ChangelogEndpointRootPage.tsx
@@ -209,7 +209,6 @@ const ChangelogRootComponent: FC<
 
             <HttpBodySelector
               items={thisEndpoint.requests}
-              // TODO nic make this a standard key
               getDisplayName={(request) =>
                 request.body?.contentType || 'No body'
               }
@@ -223,7 +222,7 @@ const ChangelogRootComponent: FC<
                     />
                   </div>
                   {request.body ? (
-                    <>
+                    <div className={classes.bodyDetails}>
                       <div>
                         <ContributionFetcher
                           rootShapeId={request.body.rootShapeId}
@@ -262,9 +261,8 @@ const ChangelogRootComponent: FC<
                           )}
                         </ShapeFetcher>
                       </div>
-                    </>
+                    </div>
                   ) : (
-                    // TODO change this
                     <>No Body Request</>
                   )}
                 </>

--- a/workspaces/ui-v2/src/pages/diffs/EndpointDocumentationPane.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/EndpointDocumentationPane.tsx
@@ -82,7 +82,7 @@ export const EndpointDocumentationPane: FC<
           <EndpointTOC
             query={thisEndpoint.query}
             requests={thisEndpoint.requests}
-            responses={thisEndpoint.responses}
+            responsesByStatusCode={thisEndpoint.responsesByStatusCode}
           />
         </div>
       </Panel>
@@ -150,44 +150,52 @@ export const EndpointDocumentationPane: FC<
         </HighlightedLocation>
       )}
 
-      {thisEndpoint.responses.map((response) => {
-        return (
-          <React.Fragment key={response.responseId}>
-            <HighlightedLocation
-              className={classes.bodyContainer}
-              targetLocation={highlightedLocation}
-              statusCode={response.statusCode}
-              expectedLocation={Location.Response}
-            >
-              <div id={response.responseId}>
-                <h6 className={classes.bodyHeader}>
-                  {response.statusCode} response
-                </h6>
-                <div className={classes.bodyDetails}>
-                  <HttpBodySelector
-                    items={response.bodies}
-                    getDisplayName={(body) => body.contentType}
-                  >
-                    {(body) => (
-                      <ShapeFetcher
-                        rootShapeId={body.rootShapeId}
-                        changesSinceBatchCommit={lastBatchCommit}
-                      >
-                        {(shapes) => (
-                          <HttpBodyPanel
-                            shapes={shapes}
-                            location={`${response.statusCode} response ${body.contentType}`}
-                          />
-                        )}
-                      </ShapeFetcher>
-                    )}
-                  </HttpBodySelector>
+      {selectors
+        .getResponsesInSortedOrder(thisEndpoint.responsesByStatusCode)
+        .map(([statusCode, responses]) => {
+          return (
+            <React.Fragment key={statusCode}>
+              <HighlightedLocation
+                className={classes.bodyContainer}
+                targetLocation={highlightedLocation}
+                statusCode={Number(statusCode)}
+                expectedLocation={Location.Response}
+              >
+                <div id={statusCode}>
+                  <h6 className={classes.bodyHeader}>{statusCode} response</h6>
+                  <div className={classes.bodyDetails}>
+                    <HttpBodySelector
+                      items={responses}
+                      getDisplayName={(response) =>
+                        response.body?.contentType || 'No Body'
+                      }
+                    >
+                      {(response) =>
+                        response.body ? (
+                          <ShapeFetcher
+                            rootShapeId={response.body.rootShapeId}
+                            changesSinceBatchCommit={lastBatchCommit}
+                          >
+                            {(shapes) => (
+                              <HttpBodyPanel
+                                shapes={shapes}
+                                location={`${response.statusCode} response ${
+                                  response.body!.contentType
+                                }`}
+                              />
+                            )}
+                          </ShapeFetcher>
+                        ) : (
+                          <div>No Body Request</div>
+                        )
+                      }
+                    </HttpBodySelector>
+                  </div>
                 </div>
-              </div>
-            </HighlightedLocation>
-          </React.Fragment>
-        );
-      })}
+              </HighlightedLocation>
+            </React.Fragment>
+          );
+        })}
     </FullWidth>
   );
 };

--- a/workspaces/ui-v2/src/pages/diffs/EndpointDocumentationPane.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/EndpointDocumentationPane.tsx
@@ -141,8 +141,7 @@ export const EndpointDocumentationPane: FC<
                       )}
                     </ShapeFetcher>
                   ) : (
-                    // TODO make this the same as the other three
-                    <div>No body details found</div>
+                    <div>No Body Request</div>
                   )
                 }
               </HttpBodySelector>

--- a/workspaces/ui-v2/src/pages/diffs/EndpointDocumentationPane.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/EndpointDocumentationPane.tsx
@@ -115,8 +115,6 @@ export const EndpointDocumentationPane: FC<
         <HighlightedLocation
           className={classes.bodyContainer}
           targetLocation={highlightedLocation}
-          // TODO remove content type from highlighted request?
-          contentType={'contentType'}
           expectedLocation={Location.Request}
         >
           <div id="request-body">
@@ -159,8 +157,6 @@ export const EndpointDocumentationPane: FC<
             <HighlightedLocation
               className={classes.bodyContainer}
               targetLocation={highlightedLocation}
-              // TODO fix content type
-              contentType={'body.contentType'}
               statusCode={response.statusCode}
               expectedLocation={Location.Response}
             >

--- a/workspaces/ui-v2/src/pages/diffs/EndpointDocumentationPane.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/EndpointDocumentationPane.tsx
@@ -8,6 +8,7 @@ import {
   ShapeFetcher,
   QueryParametersPanel,
   HttpBodyPanel,
+  HttpBodySelector,
   convertShapeToQueryParameters,
   Panel,
 } from '<src>/components';
@@ -80,8 +81,8 @@ export const EndpointDocumentationPane: FC<
         >
           <EndpointTOC
             query={thisEndpoint.query}
-            requests={thisEndpoint.requestBodies}
-            responses={thisEndpoint.responseBodies}
+            requests={thisEndpoint.requests}
+            responses={thisEndpoint.responses}
           />
         </div>
       </Panel>
@@ -92,7 +93,7 @@ export const EndpointDocumentationPane: FC<
           targetLocation={highlightedLocation}
           expectedLocation={Location.Query}
         >
-          <div id={thisEndpoint.query.queryParametersId}>
+          <div id="query-parameters">
             <h6 className={classes.bodyHeader}>Query Parameters</h6>
             <div className={classes.bodyDetails}>
               <ShapeFetcher
@@ -110,59 +111,82 @@ export const EndpointDocumentationPane: FC<
         </HighlightedLocation>
       )}
 
-      {thisEndpoint.requestBodies.map((requestBody) => (
-        <React.Fragment key={requestBody.requestId}>
-          <HighlightedLocation
-            className={classes.bodyContainer}
-            targetLocation={highlightedLocation}
-            contentType={requestBody.contentType}
-            expectedLocation={Location.Request}
-          >
-            <div id={requestBody.requestId}>
-              <h6 className={classes.bodyHeader}>Request Body</h6>
-              <div className={classes.bodyDetails}>
-                <ShapeFetcher
-                  rootShapeId={requestBody.rootShapeId}
-                  changesSinceBatchCommit={lastBatchCommit}
-                >
-                  {(shapes) => (
-                    <HttpBodyPanel
-                      shapes={shapes}
-                      location={`Request Body ${requestBody.contentType}`}
-                    />
-                  )}
-                </ShapeFetcher>
-              </div>
+      {thisEndpoint.requests.length > 0 && (
+        <HighlightedLocation
+          className={classes.bodyContainer}
+          targetLocation={highlightedLocation}
+          // TODO remove content type from highlighted request?
+          contentType={'contentType'}
+          expectedLocation={Location.Request}
+        >
+          <div id="request-body">
+            <h6 className={classes.bodyHeader}>Request Body</h6>
+            <div className={classes.bodyDetails}>
+              <HttpBodySelector
+                items={thisEndpoint.requests}
+                getDisplayName={(request) =>
+                  request.body?.contentType || 'No Body'
+                }
+              >
+                {(request) =>
+                  request.body ? (
+                    <ShapeFetcher
+                      rootShapeId={request.body.rootShapeId}
+                      changesSinceBatchCommit={lastBatchCommit}
+                    >
+                      {(shapes) => (
+                        <HttpBodyPanel
+                          shapes={shapes}
+                          // Typescript cannot infer through render props for some reason
+                          location={`Request Body ${request.body!.contentType}`}
+                        />
+                      )}
+                    </ShapeFetcher>
+                  ) : (
+                    // TODO make this the same as the other three
+                    <div>No body details found</div>
+                  )
+                }
+              </HttpBodySelector>
             </div>
-          </HighlightedLocation>
-        </React.Fragment>
-      ))}
-      {thisEndpoint.responseBodies.map((responseBody) => {
+          </div>
+        </HighlightedLocation>
+      )}
+
+      {thisEndpoint.responses.map((response) => {
         return (
-          <React.Fragment key={responseBody.responseId}>
+          <React.Fragment key={response.responseId}>
             <HighlightedLocation
               className={classes.bodyContainer}
               targetLocation={highlightedLocation}
-              contentType={responseBody.contentType}
-              statusCode={responseBody.statusCode}
+              // TODO fix content type
+              contentType={'body.contentType'}
+              statusCode={response.statusCode}
               expectedLocation={Location.Response}
             >
-              <div id={responseBody.responseId}>
+              <div id={response.responseId}>
                 <h6 className={classes.bodyHeader}>
-                  {responseBody.statusCode} response
+                  {response.statusCode} response
                 </h6>
                 <div className={classes.bodyDetails}>
-                  <ShapeFetcher
-                    rootShapeId={responseBody.rootShapeId}
-                    changesSinceBatchCommit={lastBatchCommit}
+                  <HttpBodySelector
+                    items={response.bodies}
+                    getDisplayName={(body) => body.contentType}
                   >
-                    {(shapes) => (
-                      <HttpBodyPanel
-                        shapes={shapes}
-                        location={`${responseBody.statusCode} response ${responseBody.contentType}`}
-                      />
+                    {(body) => (
+                      <ShapeFetcher
+                        rootShapeId={body.rootShapeId}
+                        changesSinceBatchCommit={lastBatchCommit}
+                      >
+                        {(shapes) => (
+                          <HttpBodyPanel
+                            shapes={shapes}
+                            location={`${response.statusCode} response ${body.contentType}`}
+                          />
+                        )}
+                      </ShapeFetcher>
                     )}
-                  </ShapeFetcher>
+                  </HttpBodySelector>
                 </div>
               </div>
             </HighlightedLocation>

--- a/workspaces/ui-v2/src/pages/diffs/PendingEndpointPage.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/PendingEndpointPage.tsx
@@ -110,7 +110,7 @@ export function PendingEndpointPage(props: any) {
   const history = useHistory();
   const diffUndocumentedUrlsPageLink = useDiffUndocumentedUrlsPageLink();
 
-  const requestCheckboxes = (learnedBodies?.requests || []).filter((i) =>
+  const filteredRequests = (learnedBodies?.requests || []).filter((i) =>
     Boolean(i.contentType)
   );
   const onKeyPress = useRunOnKeypress(
@@ -161,7 +161,7 @@ export function PendingEndpointPage(props: any) {
               />
 
               {learnedBodies.queryParameters ||
-              requestCheckboxes.length > 0 ||
+              filteredRequests.length > 0 ||
               learnedBodies.responses.length > 0 ? (
                 <Typography
                   component="div"
@@ -200,20 +200,18 @@ export function PendingEndpointPage(props: any) {
               )}
 
               <FormControl component="fieldset" onKeyPress={onKeyPress}>
-                {requestCheckboxes.map((i, index) => {
-                  if (!i.contentType) {
-                    return null;
-                  }
+                {filteredRequests.map((request) => {
+                  const contentType = request.contentType || '';
                   const body: IIgnoreBody = {
                     isRequest: true,
-                    contentType: i.contentType,
+                    contentType,
                   };
                   return (
                     <LearnBodyCheckBox
                       initialStatus={isIgnored(body)}
-                      key={index}
+                      key={request.rootShapeId}
                       primary="Request Body"
-                      subtext={i.contentType || 'no body'}
+                      subtext={contentType}
                       onChange={(ignore) => {
                         ignore ? ignoreBody(body) : includeBody(body);
                       }}
@@ -222,21 +220,21 @@ export function PendingEndpointPage(props: any) {
                 })}
               </FormControl>
 
-              {requestCheckboxes.length > 0 && <Divider />}
+              {filteredRequests.length > 0 && <Divider />}
 
               <FormControl component="fieldset" onKeyPress={onKeyPress}>
-                {learnedBodies!.responses.map((i, index) => {
+                {learnedBodies.responses.map((response) => {
                   const body: IIgnoreBody = {
                     isResponse: true,
-                    statusCode: i.statusCode,
-                    contentType: i.contentType,
+                    statusCode: response.statusCode,
+                    contentType: response.contentType,
                   };
                   return (
                     <LearnBodyCheckBox
                       initialStatus={isIgnored(body)}
-                      key={index}
-                      primary={`${i.statusCode} Response`}
-                      subtext={i.contentType}
+                      key={response.rootShapeId}
+                      primary={`${response.statusCode} Response`}
+                      subtext={response.contentType}
                       onChange={(ignore) => {
                         ignore ? ignoreBody(body) : includeBody(body);
                       }}

--- a/workspaces/ui-v2/src/pages/diffs/components/HighlightedLocation.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/components/HighlightedLocation.tsx
@@ -10,19 +10,16 @@ type IHighlightedLocation =
   | {
       targetLocation?: DiffLocation;
       statusCode?: undefined;
-      contentType?: undefined;
       expectedLocation: Location.Query;
     }
   | {
       targetLocation?: DiffLocation;
       statusCode?: undefined;
-      contentType: string;
       expectedLocation: Location.Request;
     }
   | {
       targetLocation?: DiffLocation;
       statusCode: number;
-      contentType: string;
       expectedLocation: Location.Response;
     };
 
@@ -44,16 +41,11 @@ export const HighlightedLocation: FC<
 
     switch (props.expectedLocation) {
       case Location.Request:
-        return (
-          targetLocation.getRequestDescriptor()?.contentType ===
-          props.contentType
-        );
+        return !!targetLocation.getRequestDescriptor();
       case Location.Response:
         return (
-          targetLocation.getResponseDescriptor()?.contentType ===
-            props.contentType &&
           targetLocation.getResponseDescriptor()?.statusCode ===
-            props.statusCode
+          props.statusCode
         );
       case Location.Query:
         return targetLocation.isQueryParameter();

--- a/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
@@ -241,7 +241,7 @@ export const EndpointRootPage: FC<
                   <EndpointTOC
                     query={thisEndpoint.query}
                     requests={thisEndpoint.requests}
-                    responses={thisEndpoint.responses}
+                    responsesByStatusCode={thisEndpoint.responsesByStatusCode}
                   />
                 </div>
               </Panel>
@@ -376,78 +376,84 @@ export const EndpointRootPage: FC<
             </HttpBodySelector>
           </div>
         )}
-        {thisEndpoint.responses.map((response) => (
-          <div
-            className={classes.bodyContainer}
-            id={response.responseId}
-            key={response.responseId}
-          >
-            <div className={classes.bodyHeaderContainer}>
-              <h6 className={classes.bodyHeader}>
-                {response.statusCode} Response
-              </h6>
-            </div>
-            <div className={classes.bodyContributionContainer}>
-              <MarkdownBodyContribution
-                id={response.responseId}
-                contributionKey={'description'}
-                defaultText={'Add a description'}
-                initialValue={response.description}
-                endpoint={thisEndpoint}
-              />
-            </div>
-            <div className={classes.bodyDetails}>
+        {selectors
+          .getResponsesInSortedOrder(thisEndpoint.responsesByStatusCode)
+          .map(([statusCode, responses]) => (
+            <div
+              className={classes.bodyContainer}
+              id={statusCode}
+              key={statusCode}
+            >
+              <div className={classes.bodyHeaderContainer}>
+                <h6 className={classes.bodyHeader}>{statusCode} Response</h6>
+              </div>
               <HttpBodySelector
-                items={response.bodies}
-                getDisplayName={(body) => body.contentType}
+                items={responses}
+                getDisplayName={(response) =>
+                  response.body?.contentType || 'No Body'
+                }
               >
-                {(body) => (
+                {(response) => (
                   <>
-                    <div>
-                      <ContributionFetcher
-                        rootShapeId={body.rootShapeId}
-                        endpointId={endpointId}
-                      >
-                        {(fields) => (
-                          <ContributionsList
-                            renderField={(field) => (
-                              <DocsFieldOrParameterContribution
-                                key={
-                                  field.contribution.id +
-                                  field.contribution.contributionKey
-                                }
-                                endpoint={{
-                                  pathId,
-                                  method,
-                                }}
-                                name={field.name}
-                                shapes={field.shapes}
-                                depth={field.depth}
-                                id={field.contribution.id}
-                                initialValue={field.contribution.value}
+                    <div className={classes.bodyContributionContainer}>
+                      <MarkdownBodyContribution
+                        id={response.responseId}
+                        contributionKey={'description'}
+                        defaultText={'Add a description'}
+                        initialValue={response.description}
+                        endpoint={thisEndpoint}
+                      />
+                    </div>
+                    {response.body ? (
+                      <div className={classes.bodyDetails}>
+                        <div>
+                          <ContributionFetcher
+                            rootShapeId={response.body.rootShapeId}
+                            endpointId={endpointId}
+                          >
+                            {(fields) => (
+                              <ContributionsList
+                                renderField={(field) => (
+                                  <DocsFieldOrParameterContribution
+                                    key={
+                                      field.contribution.id +
+                                      field.contribution.contributionKey
+                                    }
+                                    endpoint={{
+                                      pathId,
+                                      method,
+                                    }}
+                                    name={field.name}
+                                    shapes={field.shapes}
+                                    depth={field.depth}
+                                    id={field.contribution.id}
+                                    initialValue={field.contribution.value}
+                                  />
+                                )}
+                                fieldDetails={fields}
                               />
                             )}
-                            fieldDetails={fields}
-                          />
-                        )}
-                      </ContributionFetcher>
-                    </div>
-                    <div className={classes.panel}>
-                      <ShapeFetcher rootShapeId={body.rootShapeId}>
-                        {(shapes) => (
-                          <HttpBodyPanel
-                            shapes={shapes}
-                            location={body.contentType}
-                          />
-                        )}
-                      </ShapeFetcher>
-                    </div>
+                          </ContributionFetcher>
+                        </div>
+                        <div className={classes.panel}>
+                          <ShapeFetcher rootShapeId={response.body.rootShapeId}>
+                            {(shapes) => (
+                              <HttpBodyPanel
+                                shapes={shapes}
+                                location={response.body!.contentType}
+                              />
+                            )}
+                          </ShapeFetcher>
+                        </div>
+                      </div>
+                    ) : (
+                      <>No Body Request</>
+                    )}
                   </>
                 )}
               </HttpBodySelector>
             </div>
-          </div>
-        ))}
+          ))}
       </FullWidth>
     </>
   );

--- a/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
@@ -312,7 +312,7 @@ export const EndpointRootPage: FC<
             <HttpBodySelector
               items={thisEndpoint.requests}
               getDisplayName={(request) =>
-                request.body?.contentType || 'No Body Request'
+                request.body?.contentType || 'No Body'
               }
             >
               {(request) => (

--- a/workspaces/ui-v2/src/pages/docs/components/EndpointTOC.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/EndpointTOC.tsx
@@ -3,13 +3,13 @@ import makeStyles from '@material-ui/styles/makeStyles';
 import { getReasonPhrase } from 'http-status-codes';
 import { List, ListItem, Typography } from '@material-ui/core';
 import { SubtleGreyBackground } from '<src>/styles';
-import { IQueryParameters, IRequestBody, IResponseBody } from '<src>/types';
+import { IQueryParameters, IRequest, IResponse } from '<src>/types';
 import { goToAnchor } from '<src>/utils';
 
 export type EndpointTOCProps = {
   query: IQueryParameters | null;
-  requests: IRequestBody[];
-  responses: IResponseBody[];
+  requests: IRequest[];
+  responses: IResponse[];
 };
 
 function Code({ value }: { value: string }) {
@@ -41,34 +41,45 @@ export function EndpointTOC(props: EndpointTOCProps) {
         <EndpointTOCRow
           label={'Query Parameters'}
           anchorLink="query-parameters"
-          detail={<>consumes query string</>}
+          detail={<></>}
         />
       )}
 
-      {props.requests.map((request) => (
+      {props.requests.length > 0 && (
         <EndpointTOCRow
-          key={request.requestId}
           label={'Request Body'}
-          anchorLink={request.requestId}
+          anchorLink={'request-body'}
           detail={
             <>
-              consumes <Code value={request.contentType} />
+              consumes{' '}
+              {props.requests.length > 1 ? (
+                <>{props.requests.length} content types</>
+              ) : (
+                <Code
+                  value={props.requests[0].body?.contentType || 'No body'}
+                />
+              )}
             </>
           }
         />
-      ))}
+      )}
 
-      {props.responses.map((body, index) => {
+      {props.responses.map((response) => {
         return (
           <EndpointTOCRow
-            label={`${getReasonPhrase(body.statusCode)} - ${
-              body.statusCode
+            label={`${getReasonPhrase(response.statusCode)} - ${
+              response.statusCode
             } Response`}
-            anchorLink={body.responseId}
-            key={index}
+            anchorLink={response.responseId}
+            key={response.responseId}
             detail={
               <>
-                produces <Code value={body.contentType} />
+                produces{' '}
+                {response.bodies.length > 1 ? (
+                  <>{response.bodies.length} content types</>
+                ) : (
+                  <Code value={response.bodies[0].contentType} />
+                )}
               </>
             }
           />

--- a/workspaces/ui-v2/src/pages/docs/components/EndpointTOC.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/EndpointTOC.tsx
@@ -123,7 +123,6 @@ const useStyles = makeStyles((theme) => ({
     alignItems: 'center',
     justifyItems: 'center',
     color: 'rgb(79, 86, 107)',
-    minWidth: 130,
     fontSize: 13,
     fontWeight: 600,
     justifyContent: 'flex-end',

--- a/workspaces/ui-v2/src/pages/docs/components/EndpointTOC.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/EndpointTOC.tsx
@@ -30,7 +30,6 @@ function Code({ value }: { value: string }) {
 export function EndpointTOC(props: EndpointTOCProps) {
   const classes = useStyles();
 
-  console.log(props.responsesByStatusCode);
   return (
     <List dense>
       {props.query === null &&

--- a/workspaces/ui-v2/src/store/selectors/endpointSelectors.ts
+++ b/workspaces/ui-v2/src/store/selectors/endpointSelectors.ts
@@ -1,4 +1,9 @@
-import { IEndpoint, IEndpointWithChanges, ChangeType } from '<src>/types';
+import {
+  IEndpoint,
+  IEndpointWithChanges,
+  ChangeType,
+  IResponse,
+} from '<src>/types';
 import { getEndpointId } from '<src>/utils';
 
 import { RootState } from '../root';
@@ -44,5 +49,13 @@ export const getEndpoint = ({
 
   return state.endpoints.results.data?.endpoints.find(
     (endpoint) => getEndpointId(endpoint) === endpointId
+  );
+};
+
+export const getResponsesInSortedOrder = (
+  responses: IEndpoint['responsesByStatusCode']
+): [string, IResponse[]][] => {
+  return Object.entries(responses).sort(
+    ([statusCode1], [statusCode2]) => Number(statusCode1) - Number(statusCode2)
   );
 };

--- a/workspaces/ui-v2/src/types/endpoints.ts
+++ b/workspaces/ui-v2/src/types/endpoints.ts
@@ -18,6 +18,7 @@ export interface IPath {
 }
 
 export interface IEndpoint {
+  id: string;
   pathId: string;
   method: string;
   purpose: string;
@@ -26,8 +27,8 @@ export interface IEndpoint {
   pathParameters: IPathParameter[];
   isRemoved: boolean;
   query: IQueryParameters | null;
-  requestBodies: IRequestBody[];
-  responseBodies: IResponseBody[];
+  requests: IRequest[];
+  responses: IResponse[];
 }
 
 export interface IEndpointWithChanges extends IEndpoint {
@@ -39,23 +40,31 @@ export interface IQueryParameters {
   rootShapeId: string;
   isRemoved: boolean;
   description: string;
-}
-
-export interface IRequestBody {
-  requestId: string;
-  contentType: string;
-  rootShapeId: string;
+  endpointId: string;
   pathId: string;
   method: string;
-  description: string;
 }
 
-export interface IResponseBody {
+export interface IRequest {
+  requestId: string;
+  description: string;
+  endpointId: string;
+  pathId: string;
+  method: string;
+  body: IBody | null;
+}
+
+export interface IResponse {
   responseId: string;
   statusCode: number;
-  contentType: string;
-  rootShapeId: string;
+  endpointId: string;
   pathId: string;
   method: string;
   description: string;
+  bodies: IBody[];
+}
+
+export interface IBody {
+  contentType: string;
+  rootShapeId: string;
 }

--- a/workspaces/ui-v2/src/types/endpoints.ts
+++ b/workspaces/ui-v2/src/types/endpoints.ts
@@ -28,7 +28,8 @@ export interface IEndpoint {
   isRemoved: boolean;
   query: IQueryParameters | null;
   requests: IRequest[];
-  responses: IResponse[];
+  // Grouped by status code
+  responsesByStatusCode: Record<number, IResponse[]>;
 }
 
 export interface IEndpointWithChanges extends IEndpoint {
@@ -61,7 +62,7 @@ export interface IResponse {
   pathId: string;
   method: string;
   description: string;
-  bodies: IBody[];
+  body: IBody | null;
 }
 
 export interface IBody {


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

This one is a big one, apologies for the large diff - it started trying to migrate incrementally, but kept finding things we needed to update and change to get this to work "properly".

In moving to the new endpoint projection, its now easier to handle multiple request and response bodies. In doing so, there were a number of places to update in the UI.

This also fixes a number of bugs:
- Requests showing up multiple times because of different content types https://github.com/opticdev/optic/issues/929#issuecomment-876749434
- UI now displays when there is no body requests or responses (to actually generate this is a little weird for requests, since requests only get treated as "no body requests" when they attach a content-type on to it). There's actually more we should do, since if we have a request that accepts _both_ application/json AND no request body, we don't actually show a no body request until we send a request with contentType: Something, body: None. This is something we _kind of_ model, but aren't handling correctly when handling the interaction, but i figured this was a smallish edge case and I've already spent enough time digging into this.

## What
What's changing? Anything of note to call out?

<img width="1389" alt="Screen Shot 2021-07-20 at 3 18 09 PM" src="https://user-images.githubusercontent.com/18374483/126402766-e2078527-4f20-44a6-b65d-0c01fa2f5c97.png">


## Validation

* [ ] CI passes
* [ ] Verified in staging
* etc...
