### PR TITLE
Add in redirects to diff flow

### DIFF
--- a/workspaces/spectacle/src/in-memory/index.ts
+++ b/workspaces/spectacle/src/in-memory/index.ts
@@ -109,10 +109,7 @@ class InMemoryInteractionsRepository implements IOpticInteractionsRepository {
 
   async listById(id: string): Promise<any[]> {
     const interactions = this.map.get(id);
-    if (!interactions) {
-      throw new Error(`no interactions found for capture id ${id}`);
-    }
-    return interactions;
+    return interactions || [];
   }
 
   async set(id: string, interactions: any[]) {

--- a/workspaces/ui-v2/src/pages/diffs/ReviewDiffPages.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/ReviewDiffPages.tsx
@@ -158,6 +158,7 @@ export function DiffReviewEnvironments(props: any) {
         component={CapturePageWithoutDiffOrRedirect}
       />
       <Route path={diffEnvironmentsRoot.path} component={DiffReviewPages} />
+      <Redirect to={diffRoot.path} />
     </Switch>
   );
 }

--- a/workspaces/ui-v2/src/pages/diffs/components/DiffCard.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/components/DiffCard.tsx
@@ -151,6 +151,7 @@ function RenderExampleBody({
   assertion: any;
 }) {
   const { captureId } = useSharedDiffContext();
+  // TODO add loading and error states to useInteraction
   const { data } = useInteraction(captureId, interactionPointer);
   const actualBody = useMemo<BodyPreview | undefined>(() => {
     if (data) {


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Two changes:
- If you land on `/diffs/environment` - or any other path that doesn't match, redirect to `/diffs` which handles further redirection to a valid capture.
- In the inMemory diff, don't throw an error with an invalid captureId (the local cli version does not throw an error) - the behaviors should match

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
