### PR TITLE
Fix bug where the UI could not interpret shape diffs with an optional inner shape trail

### DIFF
--- a/workspaces/ui-v2/src/lib/shape-trail-parser.ts
+++ b/workspaces/ui-v2/src/lib/shape-trail-parser.ts
@@ -6,6 +6,7 @@ import {
   IObjectTrail,
   IOneOfItemTrail,
   IOptionalTrail,
+  IOptionalItemTrail,
   IShapeTrail,
   IShapeTrailComponent,
 } from '@useoptic/cli-shared/build/diffs/shape-trail';
@@ -122,6 +123,27 @@ export async function shapeTrailParserLastId(
     if (lastTrail.hasOwnProperty('OptionalTrail')) {
       const shapeId = (lastTrail as IOptionalTrail).OptionalTrail.shapeId;
       const choices = await getChoices(shapeId, spectacle);
+      const lastItems = await shapeTrailParserLastId(
+        {
+          ...shapeTrail,
+          path: [...shapeTrail.path.slice(0, shapeTrail.path.length - 1)],
+        },
+        spectacle
+      );
+      return {
+        lastObject: lastItems.lastObject,
+        lastField: lastItems.lastField,
+        lastFieldShapeId: lastItems.lastFieldShapeId,
+        ...choices,
+      };
+    }
+    if (lastTrail.hasOwnProperty('OptionalItemTrail')) {
+      const optionalItemTrail = (lastTrail as IOptionalItemTrail)
+        .OptionalItemTrail;
+      const choices = await getChoices(
+        optionalItemTrail.innerShapeId,
+        spectacle
+      );
       const lastItems = await shapeTrailParserLastId(
         {
           ...shapeTrail,


### PR DESCRIPTION
## Why
During QA of the query parameters we noticed the browser crashing when updating the query parameters (an optional query param that was already a list, was sent as a single string). This caused a shape diff to appear with an `OptionalItemTrail` as a last component to it's shape trail, a variant the UI's ahem trail parser didn't handle yet, causing it to throw an uncaught error.

Important context: the diff that this shape trail occurred in is a duplicate of an identical shape diff and probably a bug. However, we're trying to make query parameters make the release train and the actual shape diff bug is harder to track. This fix unblocks us and is something the UI should be capable of anyway.

## What
The UI's shape trail parser is updated to handle `OptionalItemTrail`.

## Validation
* [x] CI passes
* [x] Browser no longer crashes upon a shape diff with `OptionalItemTrail` as it's last shape trail component.
