### PR TITLE
Polish Query Parameters UI and UX

### DIFF
--- a/workspaces/ui-v2/public/example-sessions/diff-use-cases-with-events.json
+++ b/workspaces/ui-v2/public/example-sessions/diff-use-cases-with-events.json
@@ -2139,6 +2139,145 @@
           "createdAt": "2021-07-12T12:03:24.891+02:00"
         }
       }
+    },
+    {
+      "BatchCommitStarted": {
+        "batchId": "f64b139e-5637-407e-a85c-e4d3a2f01c27",
+        "commitMessage": "Add query parameter tags",
+        "eventContext": {
+          "clientId": "splendid-deer-13",
+          "clientSessionId": "9667c8ae-5c32-4bb5-b442-9170533935fe",
+          "clientCommandBatchId": "f64b139e-5637-407e-a85c-e4d3a2f01c27",
+          "createdAt": "2021-07-22T10:36:59.319+02:00"
+        },
+        "parentId": "65d32f89-4b62-42c8-a657-7a84ba5fe13d"
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_rUSV0iS4eM",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "splendid-deer-13",
+          "clientSessionId": "9667c8ae-5c32-4bb5-b442-9170533935fe",
+          "clientCommandBatchId": "f64b139e-5637-407e-a85c-e4d3a2f01c27",
+          "createdAt": "2021-07-22T10:36:59.319+02:00"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_CWf4c9BjdU",
+        "baseShapeId": "$list",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "splendid-deer-13",
+          "clientSessionId": "9667c8ae-5c32-4bb5-b442-9170533935fe",
+          "clientCommandBatchId": "f64b139e-5637-407e-a85c-e4d3a2f01c27",
+          "createdAt": "2021-07-22T10:36:59.319+02:00"
+        }
+      }
+    },
+    {
+      "ShapeParameterShapeSet": {
+        "shapeDescriptor": {
+          "ProviderInShape": {
+            "shapeId": "shape_CWf4c9BjdU",
+            "providerDescriptor": {
+              "ShapeProvider": {
+                "shapeId": "shape_rUSV0iS4eM"
+              }
+            },
+            "consumingParameterId": "$listItem"
+          }
+        },
+        "eventContext": {
+          "clientId": "splendid-deer-13",
+          "clientSessionId": "9667c8ae-5c32-4bb5-b442-9170533935fe",
+          "clientCommandBatchId": "f64b139e-5637-407e-a85c-e4d3a2f01c27",
+          "createdAt": "2021-07-22T10:36:59.319+02:00"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_osYNuUI2wF",
+        "baseShapeId": "$optional",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "splendid-deer-13",
+          "clientSessionId": "9667c8ae-5c32-4bb5-b442-9170533935fe",
+          "clientCommandBatchId": "f64b139e-5637-407e-a85c-e4d3a2f01c27",
+          "createdAt": "2021-07-22T10:36:59.319+02:00"
+        }
+      }
+    },
+    {
+      "ShapeParameterShapeSet": {
+        "shapeDescriptor": {
+          "ProviderInShape": {
+            "shapeId": "shape_osYNuUI2wF",
+            "providerDescriptor": {
+              "ShapeProvider": {
+                "shapeId": "shape_CWf4c9BjdU"
+              }
+            },
+            "consumingParameterId": "$optionalInner"
+          }
+        },
+        "eventContext": {
+          "clientId": "splendid-deer-13",
+          "clientSessionId": "9667c8ae-5c32-4bb5-b442-9170533935fe",
+          "clientCommandBatchId": "f64b139e-5637-407e-a85c-e4d3a2f01c27",
+          "createdAt": "2021-07-22T10:36:59.319+02:00"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_r6f6wgqAn",
+        "shapeId": "shape_Vkms3ZVee1",
+        "name": "tag",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_r6f6wgqAn",
+            "shapeId": "shape_osYNuUI2wF"
+          }
+        },
+        "eventContext": {
+          "clientId": "splendid-deer-13",
+          "clientSessionId": "9667c8ae-5c32-4bb5-b442-9170533935fe",
+          "clientCommandBatchId": "f64b139e-5637-407e-a85c-e4d3a2f01c27",
+          "createdAt": "2021-07-22T10:36:59.319+02:00"
+        }
+      }
+    },
+    {
+      "BatchCommitEnded": {
+        "batchId": "f64b139e-5637-407e-a85c-e4d3a2f01c27",
+        "eventContext": {
+          "clientId": "splendid-deer-13",
+          "clientSessionId": "9667c8ae-5c32-4bb5-b442-9170533935fe",
+          "clientCommandBatchId": "f64b139e-5637-407e-a85c-e4d3a2f01c27",
+          "createdAt": "2021-07-22T10:36:59.319+02:00"
+        }
+      }
     }
   ],
   "session": {
@@ -3442,7 +3581,7 @@
           "query": {
             "shapeHashV1Base64": null,
             "asJsonString": null,
-            "asText": "status=open&author=homer"
+            "asText": "status=open&author=homer&tag=cool&tag=bug"
           },
           "headers": {
             "shapeHashV1Base64": null,
@@ -3614,7 +3753,7 @@
           "query": {
             "shapeHashV1Base64": null,
             "asJsonString": null,
-            "asText": "created_before=yesterday"
+            "asText": "created_before=yesterday&tag=cool"
           },
           "headers": {
             "shapeHashV1Base64": null,

--- a/workspaces/ui-v2/src/components/QueryParametersPanel.tsx
+++ b/workspaces/ui-v2/src/components/QueryParametersPanel.tsx
@@ -1,6 +1,5 @@
 import React, { FC } from 'react';
-import { makeStyles, Tooltip } from '@material-ui/core';
-import { Help as HelpIcon } from '@material-ui/icons';
+import { makeStyles } from '@material-ui/core';
 import classnames from 'classnames';
 
 import {

--- a/workspaces/ui-v2/src/components/QueryParametersPanel.tsx
+++ b/workspaces/ui-v2/src/components/QueryParametersPanel.tsx
@@ -62,16 +62,7 @@ export const QueryParametersPanel: FC<QueryParametersPanelProps> = ({
 }) => {
   const classes = useStyles();
   return (
-    <Panel
-      header={
-        <Tooltip title="?key=value1&key=value2 is treated as an array of key=[value1, value2]">
-          <div className={classes.queryTooltipContainer}>
-            Query string parsing strategy
-            <HelpIcon fontSize="small" className={classes.queryTooltipIcon} />
-          </div>
-        </Tooltip>
-      }
-    >
+    <Panel header={<span>query string</span>}>
       {Object.entries(parameters).map(([key, field]) => (
         <div
           className={classnames(classes.queryComponentContainer, [

--- a/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRenderInterfaces.ts
+++ b/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRenderInterfaces.ts
@@ -9,6 +9,7 @@ export interface IFieldRenderer {
   required: boolean;
   changes?: IChanges;
   contributions: Record<string, string>;
+  additionalAttributes?: string[];
 }
 
 export interface IShapeRenderer {

--- a/workspaces/ui-v2/src/lib/diff-description-interpreter.ts
+++ b/workspaces/ui-v2/src/lib/diff-description-interpreter.ts
@@ -24,7 +24,7 @@ const getJsonBodyToPreview = (
   if (body) {
     const { shapeHashV1Base64, asText, asJsonString } = body;
 
-    if (asJsonString) {
+    if (asJsonString && !location.isQueryParameter()) {
       return {
         asJson: JSON.parse(asJsonString),
         asText: null,
@@ -33,7 +33,7 @@ const getJsonBodyToPreview = (
       };
     }
 
-    if (shapeHashV1Base64) {
+    if (shapeHashV1Base64 && !location.isQueryParameter()) {
       return {
         asJson: toJsonExample(shapeHashV1Base64),
         asText: null,

--- a/workspaces/ui-v2/src/lib/quick-namer.ts
+++ b/workspaces/ui-v2/src/lib/quick-namer.ts
@@ -2,7 +2,14 @@ import sortby from 'lodash.sortby';
 import { code, ICopy, plain } from '<src>/pages/diffs/components/ICopyRender';
 import { ICoreShapeKinds } from '@useoptic/optic-domain';
 
-export function namer(kinds: ICoreShapeKinds[]): string {
+export interface ICoreShapeKindNamer {
+  (kind: ICoreShapeKinds): string;
+}
+
+export function namer(
+  kinds: ICoreShapeKinds[],
+  coreShapeNamer: ICoreShapeKindNamer = nameForCoreShapeKind
+): string {
   const kindsFiltered = kinds.filter(
     (i) =>
       ![ICoreShapeKinds.NullableKind, ICoreShapeKinds.OptionalKind].includes(i)
@@ -12,9 +19,9 @@ export function namer(kinds: ICoreShapeKinds[]): string {
     if (kindsFiltered.length === 0) {
       return 'Unknown';
     } else if (kindsFiltered.length === 1) {
-      return nameForCoreShapeKind(kindsFiltered[0]);
+      return coreShapeNamer(kindsFiltered[0]);
     } else {
-      return namerForOneOf(kindsFiltered)
+      return namerForOneOf(kindsFiltered, coreShapeNamer)
         .map((i) => i.text)
         .join(' ');
     }
@@ -25,7 +32,10 @@ export function namer(kinds: ICoreShapeKinds[]): string {
   }${kinds.includes(ICoreShapeKinds.NullableKind) ? ' (nullable)' : ''}`;
 }
 
-export function namerForOptions(kinds: ICoreShapeKinds[]): string {
+export function namerForOptions(
+  kinds: ICoreShapeKinds[],
+  coreShapeNamer: ICoreShapeKindNamer = nameForCoreShapeKind
+): string {
   const kindsFiltered = kinds.filter(
     (i) =>
       ![ICoreShapeKinds.NullableKind, ICoreShapeKinds.OptionalKind].includes(i)
@@ -37,7 +47,7 @@ export function namerForOptions(kinds: ICoreShapeKinds[]): string {
     } else if (kindsFiltered.length === 0) {
       return 'Unknown';
     } else if (kindsFiltered.length === 1) {
-      return nameForCoreShapeKind(kindsFiltered[0]);
+      return coreShapeNamer(kindsFiltered[0]);
     } else {
       return namerForOneOf(kindsFiltered)
         .map((i) => i.text)
@@ -67,7 +77,10 @@ export function nameForCoreShapeKind(kind: ICoreShapeKinds): string {
   }
 }
 
-export function namerForOneOf(kinds: ICoreShapeKinds[]): ICopy[] {
+export function namerForOneOf(
+  kinds: ICoreShapeKinds[],
+  coreShapeNamer: ICoreShapeKindNamer = nameForCoreShapeKind
+): ICopy[] {
   return sortby(kinds).reduce(
     (
       before: ICopy[],
@@ -77,7 +90,7 @@ export function namerForOneOf(kinds: ICoreShapeKinds[]): ICopy[] {
     ) => [
       ...before,
       plain(before.length ? (i < array.length - 1 ? ',' : 'or') : ''),
-      code(nameForCoreShapeKind(value)),
+      code(coreShapeNamer(value)),
     ],
     []
   );

--- a/workspaces/ui-v2/src/pages/diffs/components/DiffCard.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/components/DiffCard.tsx
@@ -6,13 +6,14 @@ import {
   OpticBlueReadable,
   secondary,
 } from '<src>/styles';
-import { makeStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
 import { ICopyRender } from './ICopyRender';
 import WarningIcon from '@material-ui/icons/Warning';
 import CheckIcon from '@material-ui/icons/Check';
+import HelpIcon from '@material-ui/icons/Help';
 
-import { Tab, Tabs, Typography, withStyles } from '@material-ui/core';
+import { Tab, Tabs, Typography, Tooltip, withStyles } from '@material-ui/core';
 import InteractionBodyViewerAllJS from './IDiffExampleViewer';
 import {
   BodyPreview,
@@ -120,6 +121,20 @@ export function DiffCard({
             }
           })}
         </div>
+
+        {diffDescription.location.isQueryParameter() && (
+          <div className={classes.queryTooltipContainer}>
+            <Tooltip title="key=value pairs delimited by &">
+              <div className={classes.queryTooltip}>
+                Query string parsing
+                <HelpIcon
+                  fontSize="small"
+                  className={classes.queryTooltipIcon}
+                />
+              </div>
+            </Tooltip>
+          </div>
+        )}
       </div>
 
       <div className={classes.suggestionRegion}>
@@ -261,6 +276,25 @@ const useStyles = makeStyles((theme) => ({
     backgroundColor: 'white',
     padding: 8,
     paddingRight: 0,
+  },
+
+  queryTooltipContainer: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    padding: theme.spacing(0.5),
+    fontFamily: 'Ubuntu Mono',
+    fontSize: theme.typography.pxToRem(12),
+    color: 'rgba(255, 255, 255, 0.5)',
+  },
+
+  queryTooltip: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+
+  queryTooltipIcon: {
+    margin: theme.spacing(0, 1),
+    fontSize: theme.typography.pxToRem(13),
   },
 }));
 

--- a/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
@@ -270,23 +270,39 @@ export const EndpointRootPage: FC<
                 >
                   {(fields) => (
                     <ContributionsList
-                      renderField={(field) => (
-                        <DocsFieldOrParameterContribution
-                          key={
-                            field.contribution.id +
-                            field.contribution.contributionKey
+                      renderField={(field) => {
+                        let isArray = field.shapes.findIndex(
+                          (choice) => choice.jsonType === JsonLike.ARRAY
+                        );
+
+                        if (isArray > -1) {
+                          if (field.shapes.length > 1) {
+                            field.shapes.splice(isArray, 1);
+                          } else {
+                            field.shapes = field.shapes[
+                              isArray
+                            ].asArray!.shapeChoices;
                           }
-                          endpoint={{
-                            pathId,
-                            method,
-                          }}
-                          name={field.name}
-                          shapes={field.shapes}
-                          depth={field.depth}
-                          id={field.contribution.id}
-                          initialValue={field.contribution.value}
-                        />
-                      )}
+                        }
+
+                        return (
+                          <DocsFieldOrParameterContribution
+                            key={
+                              field.contribution.id +
+                              field.contribution.contributionKey
+                            }
+                            endpoint={{
+                              pathId,
+                              method,
+                            }}
+                            name={field.name}
+                            shapes={field.shapes}
+                            depth={field.depth}
+                            id={field.contribution.id}
+                            initialValue={field.contribution.value}
+                          />
+                        );
+                      }}
                       fieldDetails={fields}
                     />
                   )}


### PR DESCRIPTION
## Why
After our first pass of the UI and UX for Query Parameters, there were a couple of things left over to polish. Now that we now we there's no breaking bugs left for release, we can use the last of our appetite to revisit a couple of smaller things.

## What

- While we model multiple occurring query parameters as Lists in the spec, we can't actually say that this is how the server will interpret them. Nor do we support any of the other ways lists are expressed (e.g. through comma separate values). The only thing we can really say is whether the API that's being documented intents to allow keys to be sent multiple times (and knows what to do with them). So instead of rendering these as lists in the shape viewer, documentation and diff messaging, we now render the attribute "multiple". 
![Screenshot 2021-07-22 at 13 16 30](https://user-images.githubusercontent.com/857549/126630944-601c9459-5b46-472a-87ff-bd9edf0e3105.png)
![Screenshot 2021-07-22 at 11 32 56](https://user-images.githubusercontent.com/857549/126629616-69c09208-eb51-4eda-a431-685845468219.png)
- In some cases, the query string was being rendered as structured JSON inside the diff example. While this data is available in the interaction, it's actually intentionally not accepted by the Optic Engine at the moment, always parsing the raw query string itself (that's how we ensure the stability we've got at the moment). So to represent that as JSON in the UI that way, is giving a false sense of Optic's current capabilities. Therefor, all bodies are rendered as raw at the moment. In the future, we could enhance this rendering, but since that will have to be powered by the Optic Engine (as we want to rely on _its_ parsing semantics), that currently goes beyond our appetite.
- The query parameters parsing information was moved to the DiffCard. Especially as we're rendering raw query strings for diffing, it's the most important place to allow users to understand how Optic interprets the example. A stronger approach to this would for both the raw and parsed body to be rendered, allowing a user to see directly how parsing occurred. However, as said above, that goes beyond our current appetite, so we'll stick with the tooltip for now.
![Screenshot 2021-07-22 at 13 12 04](https://user-images.githubusercontent.com/857549/126630375-2eda8b31-5737-4c92-a6c0-5183c3d1bf21.png)


## Validation
* [x] CI passes
* [x] All changes are purely local UI, no Optic Engine, Spectacle, cli, etc.
* [x] All `diff-use-cases-with-events` examples manually verified
