### PR TITLE
chore(ci): change the build announcement format to be easier to read/copy

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -130,7 +130,7 @@ tasks:
         * TAG — the Docker image tag
         * USER — the user to direct the message at
     vars:
-      MESSAGE: '{{.USER}}: `{{.REPO}}:{{.TAG}}` was pushed to our Docker registry.'
+      MESSAGE: '{{.USER}}: *{{.REPO}}* `{{.TAG}}` was pushed to our Docker registry.'
     env:
       DATA: '{"text":"{{.MESSAGE}}"}'
     cmds:


### PR DESCRIPTION
to make it easier to identify and copy image tags this changes the announce message format. there's a corresponding update to the monorail bits and more explanation in https://github.com/opticdev/monorail/pull/364