### PR TITLE
Fix spectacle returning removed endpoints

### DIFF
--- a/workspaces/optic-engine/src/projections/spectacle/endpoints.rs
+++ b/workspaces/optic-engine/src/projections/spectacle/endpoints.rs
@@ -445,7 +445,7 @@ impl EndpointsProjection {
       });
 
     if let Some(Node::Endpoint(endpoint_node)) = self.graph.node_weight_mut(*endpoint_index) {
-      endpoint_node.is_removed = false;
+      endpoint_node.is_removed = true;
     }
   }
 

--- a/workspaces/spectacle/src/graphql/schema.ts
+++ b/workspaces/spectacle/src/graphql/schema.ts
@@ -113,11 +113,9 @@ type Endpoint {
   responses: [HttpResponse!]!
 
   # Contributions which define descriptions
-  # TODO figure out what this currently maps to in the contributions list
   contributions: JSON!
 
   # Is the endpoint removed
-  # TODO figure out how this gets mapped
   isRemoved: Boolean!
 
   commands: EndpointCommands!


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

This is a bug - spectacle is returning removed endpoints - this fixes it. We probably want to release a patch version for this (10.2.1)

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
