### PR TITLE
Fix bug where duplicate diffs are generated for unmatched optional primitive fields

### DIFF
--- a/workspaces/optic-engine/src/shapes/visitors/diff.rs
+++ b/workspaces/optic-engine/src/shapes/visitors/diff.rs
@@ -110,12 +110,15 @@ impl BodyPrimitiveVisitor<ShapeDiffResult> for DiffPrimitiveVisitor {
         _ => unreachable!("should not call primitive visitor without a primitive value"),
       });
     if matched.is_empty() {
-      unmatched.iter().for_each(|&choice| {
-        self.results.push(ShapeDiffResult::UnmatchedShape {
-          json_trail: json_trail.clone(),
-          shape_trail: choice.shape_trail(),
+      unmatched
+        .iter()
+        .filter(|choice| !matches!(choice.core_shape_kind, ShapeKind::OptionalKind)) // prevent generating two diffs for optional primitives
+        .for_each(|&choice| {
+          self.results.push(ShapeDiffResult::UnmatchedShape {
+            json_trail: json_trail.clone(),
+            shape_trail: choice.shape_trail(),
+          });
         });
-      });
     }
   }
 }

--- a/workspaces/optic-engine/tests/fixtures/shape-diff-use-cases/optional single string or list of strings.json
+++ b/workspaces/optic-engine/tests/fixtures/shape-diff-use-cases/optional single string or list of strings.json
@@ -1,0 +1,326 @@
+{
+  "events": [
+    {
+      "BatchCommitStarted": {
+        "batchId": "28616e96-c9e0-4d13-bff7-1627db17d144",
+        "commitMessage": "Initialize specification attributes",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "unknown-session",
+          "clientCommandBatchId": "28616e96-c9e0-4d13-bff7-1627db17d144",
+          "createdAt": "2021-07-19T11:30:01.583102-04:00"
+        },
+        "parentId": "root"
+      }
+    },
+    {
+      "ContributionAdded": {
+        "id": "metadata",
+        "key": "id",
+        "value": "8c2d80c1-1ea9-4a14-a5e8-4d6938c49f83",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "unknown-session",
+          "clientCommandBatchId": "28616e96-c9e0-4d13-bff7-1627db17d144",
+          "createdAt": "2021-07-19T11:30:01.583102-04:00"
+        }
+      }
+    },
+    {
+      "BatchCommitEnded": {
+        "batchId": "28616e96-c9e0-4d13-bff7-1627db17d144",
+        "eventContext": {
+          "clientId": "anonymous",
+          "clientSessionId": "unknown-session",
+          "clientCommandBatchId": "28616e96-c9e0-4d13-bff7-1627db17d144",
+          "createdAt": "2021-07-19T11:30:01.583102-04:00"
+        }
+      }
+    },
+    {
+      "BatchCommitStarted": {
+        "batchId": "70a9ca7e-624b-4823-8e05-3c17442656ee",
+        "commitMessage": "init",
+        "eventContext": {
+          "clientId": "lous-data",
+          "clientSessionId": "746d9868-1cef-446f-b63a-ea981f4acc0f",
+          "clientCommandBatchId": "70a9ca7e-624b-4823-8e05-3c17442656ee",
+          "createdAt": "2021-07-20T22:40:25.716002-04:00"
+        },
+        "parentId": "28616e96-c9e0-4d13-bff7-1627db17d144"
+      }
+    },
+    {
+      "PathComponentAdded": {
+        "pathId": "path_rc_6hOb1QA",
+        "parentPathId": "root",
+        "name": "api",
+        "eventContext": {
+          "clientId": "lous-data",
+          "clientSessionId": "746d9868-1cef-446f-b63a-ea981f4acc0f",
+          "clientCommandBatchId": "70a9ca7e-624b-4823-8e05-3c17442656ee",
+          "createdAt": "2021-07-20T22:40:25.716002-04:00"
+        }
+      }
+    },
+    {
+      "PathComponentAdded": {
+        "pathId": "path_9Y67Ibcgf-",
+        "parentPathId": "path_rc_6hOb1QA",
+        "name": "todos",
+        "eventContext": {
+          "clientId": "lous-data",
+          "clientSessionId": "746d9868-1cef-446f-b63a-ea981f4acc0f",
+          "clientCommandBatchId": "70a9ca7e-624b-4823-8e05-3c17442656ee",
+          "createdAt": "2021-07-20T22:40:25.716002-04:00"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_IG--VqkrXJ",
+        "baseShapeId": "$string",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "lous-data",
+          "clientSessionId": "c1d3cec2-e4f0-4708-b92d-5e76204da6f1",
+          "clientCommandBatchId": "6acdc1c9-b39e-4c89-98a5-824465596426",
+          "createdAt": "2021-07-20T22:59:56.396854-04:00"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_tV7F9sLXIi",
+        "baseShapeId": "$list",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "lous-data",
+          "clientSessionId": "c1d3cec2-e4f0-4708-b92d-5e76204da6f1",
+          "clientCommandBatchId": "6acdc1c9-b39e-4c89-98a5-824465596426",
+          "createdAt": "2021-07-20T22:59:56.396854-04:00"
+        }
+      }
+    },
+    {
+      "ShapeParameterShapeSet": {
+        "shapeDescriptor": {
+          "ProviderInShape": {
+            "shapeId": "shape_tV7F9sLXIi",
+            "providerDescriptor": {
+              "ShapeProvider": {
+                "shapeId": "shape_IG--VqkrXJ"
+              }
+            },
+            "consumingParameterId": "$listItem"
+          }
+        },
+        "eventContext": {
+          "clientId": "lous-data",
+          "clientSessionId": "c1d3cec2-e4f0-4708-b92d-5e76204da6f1",
+          "clientCommandBatchId": "6acdc1c9-b39e-4c89-98a5-824465596426",
+          "createdAt": "2021-07-20T22:59:56.396854-04:00"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_UBgQQWw_sp",
+        "baseShapeId": "$optional",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "lous-data",
+          "clientSessionId": "c1d3cec2-e4f0-4708-b92d-5e76204da6f1",
+          "clientCommandBatchId": "6acdc1c9-b39e-4c89-98a5-824465596426",
+          "createdAt": "2021-07-20T22:59:56.396854-04:00"
+        }
+      }
+    },
+    {
+      "ShapeParameterShapeSet": {
+        "shapeDescriptor": {
+          "ProviderInShape": {
+            "shapeId": "shape_UBgQQWw_sp",
+            "providerDescriptor": {
+              "ShapeProvider": {
+                "shapeId": "shape_tV7F9sLXIi"
+              }
+            },
+            "consumingParameterId": "$optionalInner"
+          }
+        },
+        "eventContext": {
+          "clientId": "lous-data",
+          "clientSessionId": "c1d3cec2-e4f0-4708-b92d-5e76204da6f1",
+          "clientCommandBatchId": "6acdc1c9-b39e-4c89-98a5-824465596426",
+          "createdAt": "2021-07-20T22:59:56.396854-04:00"
+        }
+      }
+    },
+    {
+      "ShapeAdded": {
+        "shapeId": "shape_UFGsR-O9bt",
+        "baseShapeId": "$object",
+        "parameters": {
+          "DynamicParameterList": {
+            "shapeParameterIds": []
+          }
+        },
+        "name": "",
+        "eventContext": {
+          "clientId": "lous-data",
+          "clientSessionId": "746d9868-1cef-446f-b63a-ea981f4acc0f",
+          "clientCommandBatchId": "70a9ca7e-624b-4823-8e05-3c17442656ee",
+          "createdAt": "2021-07-20T22:40:25.716002-04:00"
+        }
+      }
+    },
+    {
+      "FieldAdded": {
+        "fieldId": "field_wDHyYzkU0V",
+        "shapeId": "shape_UFGsR-O9bt",
+        "name": "id",
+        "shapeDescriptor": {
+          "FieldShapeFromShape": {
+            "fieldId": "field_wDHyYzkU0V",
+            "shapeId": "shape_UBgQQWw_sp"
+          }
+        },
+        "eventContext": {
+          "clientId": "lous-data",
+          "clientSessionId": "c1d3cec2-e4f0-4708-b92d-5e76204da6f1",
+          "clientCommandBatchId": "6acdc1c9-b39e-4c89-98a5-824465596426",
+          "createdAt": "2021-07-20T22:59:56.396854-04:00"
+        }
+      }
+    },
+    {
+      "QueryParametersAdded": {
+        "queryParametersId": "query_params_3e-_oA3Y2O",
+        "httpMethod": "GET",
+        "pathId": "path_9Y67Ibcgf-",
+        "eventContext": {
+          "clientId": "lous-data",
+          "clientSessionId": "746d9868-1cef-446f-b63a-ea981f4acc0f",
+          "clientCommandBatchId": "70a9ca7e-624b-4823-8e05-3c17442656ee",
+          "createdAt": "2021-07-20T22:40:25.716002-04:00"
+        }
+      }
+    },
+    {
+      "QueryParametersShapeSet": {
+        "queryParametersId": "query_params_3e-_oA3Y2O",
+        "shapeDescriptor": {
+          "shapeId": "shape_UFGsR-O9bt",
+          "isRemoved": false
+        },
+        "eventContext": {
+          "clientId": "lous-data",
+          "clientSessionId": "746d9868-1cef-446f-b63a-ea981f4acc0f",
+          "clientCommandBatchId": "70a9ca7e-624b-4823-8e05-3c17442656ee",
+          "createdAt": "2021-07-20T22:40:25.716002-04:00"
+        }
+      }
+    },
+    {
+      "RequestAdded": {
+        "requestId": "request_bqZXCWa23y",
+        "pathId": "path_9Y67Ibcgf-",
+        "httpMethod": "GET",
+        "eventContext": {
+          "clientId": "lous-data",
+          "clientSessionId": "746d9868-1cef-446f-b63a-ea981f4acc0f",
+          "clientCommandBatchId": "70a9ca7e-624b-4823-8e05-3c17442656ee",
+          "createdAt": "2021-07-20T22:40:25.716002-04:00"
+        }
+      }
+    },
+    {
+      "ResponseAddedByPathAndMethod": {
+        "responseId": "response_pUJZHiREqQ",
+        "pathId": "path_9Y67Ibcgf-",
+        "httpMethod": "GET",
+        "httpStatusCode": 200,
+        "eventContext": {
+          "clientId": "lous-data",
+          "clientSessionId": "746d9868-1cef-446f-b63a-ea981f4acc0f",
+          "clientCommandBatchId": "70a9ca7e-624b-4823-8e05-3c17442656ee",
+          "createdAt": "2021-07-20T22:40:25.716002-04:00"
+        }
+      }
+    },
+    {
+      "BatchCommitEnded": {
+        "batchId": "70a9ca7e-624b-4823-8e05-3c17442656ee",
+        "eventContext": {
+          "clientId": "lous-data",
+          "clientSessionId": "746d9868-1cef-446f-b63a-ea981f4acc0f",
+          "clientCommandBatchId": "70a9ca7e-624b-4823-8e05-3c17442656ee",
+          "createdAt": "2021-07-20T22:40:25.716002-04:00"
+        }
+      }
+    }
+  ],
+  "session": {
+    "samples": [
+      {
+        "uuid": "9f6522e5-156c-471a-b825-cf58ab8e086d",
+        "request": {
+          "host": "",
+          "method": "GET",
+          "path": "/api/todos",
+          "query": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": "id=1"
+          },
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "response": {
+          "statusCode": 200,
+          "headers": {
+            "shapeHashV1Base64": null,
+            "asJsonString": null,
+            "asText": null
+          },
+          "body": {
+            "contentType": null,
+            "value": {
+              "shapeHashV1Base64": null,
+              "asJsonString": null,
+              "asText": null
+            }
+          }
+        },
+        "tags": []
+      }
+    ]
+  }
+}

--- a/workspaces/optic-engine/tests/shape-diff-use-cases.rs
+++ b/workspaces/optic-engine/tests/shape-diff-use-cases.rs
@@ -1,4 +1,5 @@
 use insta::assert_debug_snapshot;
+use petgraph::dot::Dot;
 use serde::Deserialize;
 use std::collections::HashSet;
 use std::path::Path;
@@ -54,6 +55,52 @@ async fn deeply_nested_fields_inside_of_arrays() {
     &spec,
     interaction.clone(),
     &DiffInteractionConfig::default(),
+  );
+
+  let mut learned_shape_diff_affordances =
+    LearnedShapeDiffAffordancesProjection::from(diff_results);
+
+  let analysis = analyze_documented_bodies(&spec, interaction)
+    .collect::<Vec<_>>()
+    .pop()
+    .unwrap();
+
+  let tagged_analysis = TaggedInput(analysis, interaction_pointers);
+  learned_shape_diff_affordances.apply(tagged_analysis);
+
+  // TODO: add snapshot, once we figure out how to make the results order stable in a way
+  // that fits our performance budget.
+}
+
+#[tokio::main]
+#[test]
+async fn optional_single_string_or_list_of_strings() {
+  let mut capture = DebugCapture::from_name("optional single string or list of strings.json").await;
+
+  let spec = SpecProjection::from(capture.events);
+  let interaction = capture.session.samples.remove(0);
+  let interaction_pointers: HashSet<_> =
+    std::iter::once(String::from("test-interaction-1")).collect();
+
+  assert_debug_snapshot!(
+    "optional_single_string_or_list_of_strings__shape_graph",
+    Dot::with_config(&spec.shape().graph, &[])
+  );
+  assert_debug_snapshot!(
+    "optional_single_string_or_list_of_strings__shape_choice_mapping",
+    &spec.shape().to_choice_mapping()
+  );
+
+  let diff_results = diff_interaction(
+    &spec,
+    interaction.clone(),
+    &DiffInteractionConfig::default().with_query_params(true),
+  );
+
+  assert_eq!(diff_results.len(), 1);
+  assert_debug_snapshot!(
+    "optional_single_string_or_list_of_strings__diff_results",
+    &diff_results
   );
 
   let mut learned_shape_diff_affordances =

--- a/workspaces/optic-engine/tests/shape-diff-use-cases.rs
+++ b/workspaces/optic-engine/tests/shape-diff-use-cases.rs
@@ -94,7 +94,7 @@ async fn optional_single_string_or_list_of_strings() {
   let diff_results = diff_interaction(
     &spec,
     interaction.clone(),
-    &DiffInteractionConfig::default().with_query_params(true),
+    &DiffInteractionConfig::default(),
   );
 
   assert_eq!(diff_results.len(), 1);

--- a/workspaces/optic-engine/tests/shape_diff.rs
+++ b/workspaces/optic-engine/tests/shape_diff.rs
@@ -436,8 +436,9 @@ fn can_diff_optional() {
     &shape_id,
   );
 
+  dbg!(&results);
   assert_debug_snapshot!("can_diff_optional__results", results);
-  assert_eq!(results.len(), 2); //@BUG: this should be 1, right? and the trail looks wrong
+  assert_eq!(results.len(), 1); //@BUG: this should be 1, right? and the trail looks wrong
 }
 
 #[test]

--- a/workspaces/optic-engine/tests/shape_diff.rs
+++ b/workspaces/optic-engine/tests/shape_diff.rs
@@ -436,7 +436,6 @@ fn can_diff_optional() {
     &shape_id,
   );
 
-  dbg!(&results);
   assert_debug_snapshot!("can_diff_optional__results", results);
   assert_eq!(results.len(), 1); //@BUG: this should be 1, right? and the trail looks wrong
 }

--- a/workspaces/optic-engine/tests/shape_diff.rs
+++ b/workspaces/optic-engine/tests/shape_diff.rs
@@ -437,7 +437,7 @@ fn can_diff_optional() {
   );
 
   assert_debug_snapshot!("can_diff_optional__results", results);
-  assert_eq!(results.len(), 1); //@BUG: this should be 1, right? and the trail looks wrong
+  assert_eq!(results.len(), 1);
 }
 
 #[test]

--- a/workspaces/optic-engine/tests/snapshots/interaction_diff_use_cases__scenario_23__results.snap
+++ b/workspaces/optic-engine/tests/snapshots/interaction_diff_use_cases__scenario_23__results.snap
@@ -1,63 +1,8 @@
 ---
-source: workspaces/optic-engine-native/tests/e2e-scenarios.rs
+source: workspaces/optic-engine/tests/interaction-diff-use-cases.rs
 expression: results
 ---
 [
-    UnmatchedResponseBodyShape(
-        UnmatchedResponseBodyShape {
-            interaction_trail: InteractionTrail {
-                path: [
-                    ResponseBody {
-                        content_type: "application/json",
-                        status_code: 200,
-                    },
-                ],
-            },
-            requests_trail: SpecResponseBody(
-                SpecResponseBody {
-                    response_id: "response_1",
-                },
-            ),
-            shape_diff_result: UnmatchedShape {
-                json_trail: JsonTrail {
-                    path: [
-                        JsonObjectKey {
-                            key: "location",
-                        },
-                        JsonObjectKey {
-                            key: "principality",
-                        },
-                        JsonObjectKey {
-                            key: "coordinates",
-                        },
-                    ],
-                },
-                shape_trail: ShapeTrail {
-                    root_shape_id: "shape_10",
-                    path: [
-                        ObjectFieldTrail {
-                            field_id: "field_7",
-                            field_shape_id: "shape_9",
-                            parent_object_shape_id: "shape_10",
-                        },
-                        ObjectFieldTrail {
-                            field_id: "field_6",
-                            field_shape_id: "shape_8",
-                            parent_object_shape_id: "shape_9",
-                        },
-                        ObjectFieldTrail {
-                            field_id: "field_4",
-                            field_shape_id: "shape_6",
-                            parent_object_shape_id: "shape_8",
-                        },
-                        OptionalTrail {
-                            shape_id: "shape_6",
-                        },
-                    ],
-                },
-            },
-        },
-    ),
     UnmatchedResponseBodyShape(
         UnmatchedResponseBodyShape {
             interaction_trail: InteractionTrail {

--- a/workspaces/optic-engine/tests/snapshots/shape_diff__can_diff_optional__results.snap
+++ b/workspaces/optic-engine/tests/snapshots/shape_diff__can_diff_optional__results.snap
@@ -1,37 +1,8 @@
 ---
-source: workspaces/optic-engine-native/tests/shape_diff.rs
+source: workspaces/optic-engine/tests/shape_diff.rs
 expression: results
 ---
 [
-    UnmatchedShape {
-        json_trail: JsonTrail {
-            path: [
-                JsonArrayItem {
-                    index: 1,
-                },
-                JsonObjectKey {
-                    key: "firstName",
-                },
-            ],
-        },
-        shape_trail: ShapeTrail {
-            root_shape_id: "list_1",
-            path: [
-                ListItemTrail {
-                    list_shape_id: "list_1",
-                    item_shape_id: "object_1",
-                },
-                ObjectFieldTrail {
-                    field_id: "field_1",
-                    field_shape_id: "optional_shape_1",
-                    parent_object_shape_id: "object_1",
-                },
-                OptionalTrail {
-                    shape_id: "optional_shape_1",
-                },
-            ],
-        },
-    },
     UnmatchedShape {
         json_trail: JsonTrail {
             path: [

--- a/workspaces/optic-engine/tests/snapshots/shape_diff_use_cases__optional_single_string_or_list_of_strings__diff_results.snap
+++ b/workspaces/optic-engine/tests/snapshots/shape_diff_use_cases__optional_single_string_or_list_of_strings__diff_results.snap
@@ -1,0 +1,46 @@
+---
+source: workspaces/optic-engine/tests/shape-diff-use-cases.rs
+expression: "&diff_results"
+---
+[
+    UnmatchedQueryParametersShape(
+        UnmatchedQueryParametersShape {
+            interaction_trail: InteractionTrail {
+                path: [
+                    QueryParameters,
+                ],
+            },
+            requests_trail: SpecQueryParameters(
+                SpecQueryParameters {
+                    query_parameters_id: "query_params_3e-_oA3Y2O",
+                },
+            ),
+            shape_diff_result: UnmatchedShape {
+                json_trail: JsonTrail {
+                    path: [
+                        JsonObjectKey {
+                            key: "id",
+                        },
+                    ],
+                },
+                shape_trail: ShapeTrail {
+                    root_shape_id: "shape_UFGsR-O9bt",
+                    path: [
+                        ObjectFieldTrail {
+                            field_id: "field_wDHyYzkU0V",
+                            field_shape_id: "shape_UBgQQWw_sp",
+                            parent_object_shape_id: "shape_UFGsR-O9bt",
+                        },
+                        OptionalTrail {
+                            shape_id: "shape_UBgQQWw_sp",
+                        },
+                        OptionalItemTrail {
+                            shape_id: "shape_UBgQQWw_sp",
+                            inner_shape_id: "shape_tV7F9sLXIi",
+                        },
+                    ],
+                },
+            },
+        },
+    ),
+]

--- a/workspaces/optic-engine/tests/snapshots/shape_diff_use_cases__optional_single_string_or_list_of_strings__shape_choice_mapping.snap
+++ b/workspaces/optic-engine/tests/snapshots/shape_diff_use_cases__optional_single_string_or_list_of_strings__shape_choice_mapping.snap
@@ -1,0 +1,53 @@
+---
+source: workspaces/optic-engine/tests/shape-diff-use-cases.rs
+expression: "&spec.shape().to_choice_mapping()"
+---
+{
+    "shape_IG--VqkrXJ": [
+        Primitive(
+            PrimitiveChoice {
+                shape_id: "shape_IG--VqkrXJ",
+                json_type: String,
+            },
+        ),
+    ],
+    "shape_UBgQQWw_sp": [
+        Primitive(
+            PrimitiveChoice {
+                shape_id: "shape_UBgQQWw_sp",
+                json_type: Undefined,
+            },
+        ),
+        Array(
+            ArrayChoice {
+                json_type: Array,
+                shape_id: "shape_tV7F9sLXIi",
+                item_shape_id: "shape_IG--VqkrXJ",
+            },
+        ),
+    ],
+    "shape_UFGsR-O9bt": [
+        Object(
+            ObjectChoice {
+                shape_id: "shape_UFGsR-O9bt",
+                json_type: Object,
+                fields: [
+                    ObjectFieldChoice {
+                        name: "id",
+                        field_id: "field_wDHyYzkU0V",
+                        shape_id: "shape_UBgQQWw_sp",
+                    },
+                ],
+            },
+        ),
+    ],
+    "shape_tV7F9sLXIi": [
+        Array(
+            ArrayChoice {
+                json_type: Array,
+                shape_id: "shape_tV7F9sLXIi",
+                item_shape_id: "shape_IG--VqkrXJ",
+            },
+        ),
+    ],
+}

--- a/workspaces/optic-engine/tests/snapshots/shape_diff_use_cases__optional_single_string_or_list_of_strings__shape_graph.snap
+++ b/workspaces/optic-engine/tests/snapshots/shape_diff_use_cases__optional_single_string_or_list_of_strings__shape_graph.snap
@@ -1,0 +1,38 @@
+---
+source: workspaces/optic-engine/tests/shape-diff-use-cases.rs
+expression: "Dot::with_config(&spec.shape().graph, &[])"
+---
+digraph {
+    0 [ label = "CoreShape(\l    CoreShapeNode {\l        shape_id: \"$string\",\l        descriptor: CoreShapeNodeDescriptor {\l            kind: StringKind,\l        },\l    },\l)\l" ]
+    1 [ label = "CoreShape(\l    CoreShapeNode {\l        shape_id: \"$number\",\l        descriptor: CoreShapeNodeDescriptor {\l            kind: NumberKind,\l        },\l    },\l)\l" ]
+    2 [ label = "CoreShape(\l    CoreShapeNode {\l        shape_id: \"$boolean\",\l        descriptor: CoreShapeNodeDescriptor {\l            kind: BooleanKind,\l        },\l    },\l)\l" ]
+    3 [ label = "CoreShape(\l    CoreShapeNode {\l        shape_id: \"$list\",\l        descriptor: CoreShapeNodeDescriptor {\l            kind: ListKind,\l        },\l    },\l)\l" ]
+    4 [ label = "ShapeParameter(\l    ShapeParameterNode {\l        parameter_id: \"$listItem\",\l        descriptor: ShapeParameterNodeDescriptor,\l    },\l)\l" ]
+    5 [ label = "CoreShape(\l    CoreShapeNode {\l        shape_id: \"$object\",\l        descriptor: CoreShapeNodeDescriptor {\l            kind: ObjectKind,\l        },\l    },\l)\l" ]
+    6 [ label = "CoreShape(\l    CoreShapeNode {\l        shape_id: \"$nullable\",\l        descriptor: CoreShapeNodeDescriptor {\l            kind: NullableKind,\l        },\l    },\l)\l" ]
+    7 [ label = "ShapeParameter(\l    ShapeParameterNode {\l        parameter_id: \"$nullableInner\",\l        descriptor: ShapeParameterNodeDescriptor,\l    },\l)\l" ]
+    8 [ label = "CoreShape(\l    CoreShapeNode {\l        shape_id: \"$unknown\",\l        descriptor: CoreShapeNodeDescriptor {\l            kind: UnknownKind,\l        },\l    },\l)\l" ]
+    9 [ label = "CoreShape(\l    CoreShapeNode {\l        shape_id: \"$optional\",\l        descriptor: CoreShapeNodeDescriptor {\l            kind: OptionalKind,\l        },\l    },\l)\l" ]
+    10 [ label = "ShapeParameter(\l    ShapeParameterNode {\l        parameter_id: \"$optionalInner\",\l        descriptor: ShapeParameterNodeDescriptor,\l    },\l)\l" ]
+    11 [ label = "CoreShape(\l    CoreShapeNode {\l        shape_id: \"$oneOf\",\l        descriptor: CoreShapeNodeDescriptor {\l            kind: OneOfKind,\l        },\l    },\l)\l" ]
+    12 [ label = "BatchCommit(\l    BatchCommitNode {\l        batch_id: \"28616e96-c9e0-4d13-bff7-1627db17d144\",\l        created_at: \"2021-07-19T11:30:01.583102-04:00\",\l    },\l)\l" ]
+    13 [ label = "BatchCommit(\l    BatchCommitNode {\l        batch_id: \"70a9ca7e-624b-4823-8e05-3c17442656ee\",\l        created_at: \"2021-07-20T22:40:25.716002-04:00\",\l    },\l)\l" ]
+    14 [ label = "Shape(\l    ShapeNode {\l        shape_id: \"shape_IG--VqkrXJ\",\l    },\l)\l" ]
+    15 [ label = "Shape(\l    ShapeNode {\l        shape_id: \"shape_tV7F9sLXIi\",\l    },\l)\l" ]
+    16 [ label = "Shape(\l    ShapeNode {\l        shape_id: \"shape_UBgQQWw_sp\",\l    },\l)\l" ]
+    17 [ label = "Shape(\l    ShapeNode {\l        shape_id: \"shape_UFGsR-O9bt\",\l    },\l)\l" ]
+    18 [ label = "Field(\l    FieldNode {\l        field_id: \"field_wDHyYzkU0V\",\l        descriptor: FieldNodeDescriptor {\l            name: \"id\",\l        },\l    },\l)\l" ]
+    4 -> 3 [ label = "IsParameterOf\l" ]
+    7 -> 6 [ label = "IsParameterOf\l" ]
+    10 -> 9 [ label = "IsParameterOf\l" ]
+    14 -> 0 [ label = "IsDescendantOf\l" ]
+    15 -> 3 [ label = "IsDescendantOf\l" ]
+    15 -> 4 [ label = "HasBinding(\l    ShapeParameterBinding {\l        shape_id: \"shape_IG--VqkrXJ\",\l    },\l)\l" ]
+    16 -> 9 [ label = "IsDescendantOf\l" ]
+    16 -> 10 [ label = "HasBinding(\l    ShapeParameterBinding {\l        shape_id: \"shape_tV7F9sLXIi\",\l    },\l)\l" ]
+    17 -> 5 [ label = "IsDescendantOf\l" ]
+    17 -> 13 [ label = "CreatedIn\l" ]
+    16 -> 18 [ label = "BelongsTo\l" ]
+    18 -> 17 [ label = "IsFieldOf\l" ]
+}
+

--- a/workspaces/ui-v2/src/lib/__tests/diff-helpers/__snapshots__/shape-interpretations.test.ts.snap
+++ b/workspaces/ui-v2/src/lib/__tests/diff-helpers/__snapshots__/shape-interpretations.test.ts.snap
@@ -1468,10 +1468,8 @@ Object {
   "expectations": Object {
     "allowedCoreShapeKindsByShapeId": Object {
       "shape_5": "$object",
-      "shape_6": "$optional",
     },
     "allowedCoreShapes": Array [
-      "$optional",
       "$object",
     ],
     "lastField": "field_4",
@@ -1487,11 +1485,11 @@ Object {
         },
         Object {
           "style": 1,
-          "text": "Object (optional)",
+          "text": "Object",
         },
       ],
       "changeType": 1,
-      "diffHash": "179f9d4a33ca4658",
+      "diffHash": "4ab53c17dd731f76",
       "getJsonBodyToPreview": [Function],
       "location": DiffLocation {
         "descriptor": Object {
@@ -1518,7 +1516,7 @@ Object {
         },
         Object {
           "style": 1,
-          "text": "Object (optional)",
+          "text": "Object",
         },
       ],
     },
@@ -1531,7 +1529,7 @@ Object {
           },
           Object {
             "style": 1,
-            "text": "Object (optional)",
+            "text": "Object",
           },
         ],
         "interactionPointers": Array [


### PR DESCRIPTION
## Why
While working on the shape diffing of query parameters, we ran into a bug where two diffs would be generated for a single unmatched field shape instead of one.

Scenario:

- an optional field has been documented for a certain shape.
- a shape with this field set to a primitive is diffed. 

Observed result:
- two `ShapeDiffResult`s are generated, only different in their shape:
  - `ObjectFieldTrail > OptionalTrail`.
  - `ObjectFieldTrail > OptionalTrail > OptionalItemTrail`.

Expected result
- A single `ShapeDiffResult` with shape trail `ObjectFieldTrail > OptionalTrail > OptionalItemTrail`.

## What
A new test was added to isolate the problem, to find out later there was a `@BUG` mark with an existing test as well remarking on the same issue (2 results instead of 1). Debugging the shape traverser and visitor, it became apparent that the `BodyPrimitiveVisitor<ShapeDiffResult>` was presented with 2 choices for optional fields, instead of the single one we'd expect. This caused 2 unmatched results instead of 1, with the shape diff results mapping straight over from the choices.

Subsequently, the `ShapeQueries.list_trail_choices`, which is responsible for returning the possible shapes given a spec trail, was changed to only generate the variant with the `OptionalItemTrail`. That makes sense: optionals only make sense within the context of the field of an object, not on their own. An optional without knowing what is described as optional (even if that place is unknown), makes little sense from the perspective of the diff visitors.

However, the `ShapeChoiceMapping` projection, used in testing, _did_ have a use for the now eliminated trail: as a way to encode that the choice for a shape might be `undefined`. To fix this, this is now derived from the `OptionalItemTrail`, instead.

## Validation
* [x] CI passes
* [x] Snapshots updated and verified
* [x] `diff-use-cases-with-events` working as expected
