### PR TITLE
feat: permissive frame-ancestors for spec-viewer

### DIFF
--- a/workspaces/ui-v2/config/nginx/nginx.conf
+++ b/workspaces/ui-v2/config/nginx/nginx.conf
@@ -35,7 +35,7 @@ http {
         add_header x-frame-options SAMEORIGIN;
         add_header x-xss-protection "1; mode=block";
         add_header referrer-policy same-origin;
-        add_header content-security-policy "frame-ancestors https://*.useoptic.com https://useoptic.com https://*.o3c.info https://o3c.info; default-src 'self' 'unsafe-inline' data: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; object-src 'none'; font-src 'self' https://fonts.gstatic.com; connect-src 'self' 'unsafe-inline' wss://*.intercom.io https:";
+        add_header content-security-policy "frame-ancestors http://* https://*; default-src 'self' 'unsafe-inline' data: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; object-src 'none'; font-src 'self' https://fonts.gstatic.com; connect-src 'self' 'unsafe-inline' wss://*.intercom.io https:";
 
         location / {
             root /usr/share/nginx/html;

--- a/workspaces/ui-v2/config/nginx/nginx.conf
+++ b/workspaces/ui-v2/config/nginx/nginx.conf
@@ -35,7 +35,7 @@ http {
         add_header x-frame-options SAMEORIGIN;
         add_header x-xss-protection "1; mode=block";
         add_header referrer-policy same-origin;
-        add_header content-security-policy "frame-ancestors http: https: filesystem:; default-src 'self' 'unsafe-inline' data: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; object-src 'none'; font-src 'self' https://fonts.gstatic.com; connect-src 'self' 'unsafe-inline' wss://*.intercom.io https:";
+        add_header content-security-policy "default-src 'self' 'unsafe-inline' data: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; object-src 'none'; font-src 'self' https://fonts.gstatic.com; connect-src 'self' 'unsafe-inline' wss://*.intercom.io https:";
 
         location / {
             root /usr/share/nginx/html;

--- a/workspaces/ui-v2/config/nginx/nginx.conf
+++ b/workspaces/ui-v2/config/nginx/nginx.conf
@@ -35,7 +35,7 @@ http {
         add_header x-frame-options SAMEORIGIN;
         add_header x-xss-protection "1; mode=block";
         add_header referrer-policy same-origin;
-        add_header content-security-policy "frame-ancestors http://* https://*; default-src 'self' 'unsafe-inline' data: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; object-src 'none'; font-src 'self' https://fonts.gstatic.com; connect-src 'self' 'unsafe-inline' wss://*.intercom.io https:";
+        add_header content-security-policy "frame-ancestors http: https: filesystem:; default-src 'self' 'unsafe-inline' data: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; object-src 'none'; font-src 'self' https://fonts.gstatic.com; connect-src 'self' 'unsafe-inline' wss://*.intercom.io https:";
 
         location / {
             root /usr/share/nginx/html;

--- a/workspaces/ui-v2/config/nginx/nginx.conf
+++ b/workspaces/ui-v2/config/nginx/nginx.conf
@@ -32,7 +32,6 @@ http {
 
         add_header strict-transport-security "max-age=63072000; includeSubdomains; preload";
         add_header x-content-type-options nosniff;
-        add_header x-frame-options SAMEORIGIN;
         add_header x-xss-protection "1; mode=block";
         add_header referrer-policy same-origin;
         add_header content-security-policy "default-src 'self' 'unsafe-inline' data: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; object-src 'none'; font-src 'self' https://fonts.gstatic.com; connect-src 'self' 'unsafe-inline' wss://*.intercom.io https:";


### PR DESCRIPTION
as a stop-gap for vanity-urls, allow spec-viewer to be iframed. removed the `frame-anecestors` stanza from the CSP and the `x-frame-options` header. its alive,

<img width="1235" alt="image" src="https://user-images.githubusercontent.com/672246/127035586-1747af8c-d8ea-4e27-bd3c-271103d93017.png">
