### PR TITLE
Add support for removing field to Optic Engine

### DIFF
--- a/workspaces/optic-engine/src/commands/shape.rs
+++ b/workspaces/optic-engine/src/commands/shape.rs
@@ -699,8 +699,11 @@ mod test {
   pub fn can_handle_remove_field_command() {
     let initial_events: Vec<ShapeEvent> = serde_json::from_value(json!([
       {"ShapeAdded":{"shapeId":"object_shape_1","baseShapeId":"$object", "name": "" }},
-      {"ShapeAdded":{"shapeId":"string_shape_1","baseShapeId":"$number", "name": "" }},
-      {"FieldAdded":{"fieldId": "field_1", "shapeId": "object_shape_1", "name": "likesCount", "shapeDescriptor":{ "FieldShapeFromShape": { "shapeId": "string_shape_1", "fieldId": "field_1"}}}}
+      {"ShapeAdded":{"shapeId":"string_shape_1","baseShapeId":"$string", "name": "" }},
+      {"ShapeAdded":{"shapeId":"string_shape_2","baseShapeId":"$string", "name": "" }},
+      {"FieldAdded":{"fieldId": "field_1", "shapeId": "object_shape_1", "name": "firstName", "shapeDescriptor":{ "FieldShapeFromShape": { "shapeId": "string_shape_1", "fieldId": "field_1"}}}},
+      {"FieldAdded":{"fieldId": "field_2", "shapeId": "object_shape_1", "name": "lastName", "shapeDescriptor":{ "FieldShapeFromShape": { "shapeId": "string_shape_2", "fieldId": "field_2"}}}},
+      {"FieldRemoved":{"fieldId": "field_2" }}
     ]))
     .expect("initial events should be valid shape events");
 
@@ -729,7 +732,16 @@ mod test {
     );
 
 
-    // @TODO: verify removed field can't be removed again
+    let already_removed_field: ShapeCommand = serde_json::from_value(json!(
+      {"RemoveField":{ "fieldId": "field_2" }}
+    ))
+    .unwrap();
+    let already_removed_field_result = projection.execute(already_removed_field);
+    assert!(already_removed_field_result.is_err());
+    assert_debug_snapshot!(
+      "already_removed_field_result",
+      already_removed_field_result.unwrap_err()
+    );
 
     for event in new_events {
       projection.apply(event); // verify this doesn't panic goes a long way to verifying the events

--- a/workspaces/optic-engine/src/commands/shape.rs
+++ b/workspaces/optic-engine/src/commands/shape.rs
@@ -59,6 +59,12 @@ impl ShapeCommand {
       })
     })
   }
+
+  pub fn remove_field(field_id: FieldId) -> Self {
+    Self::RemoveField(RemoveField {
+      field_id
+    })
+  }
 }
 
 #[derive(Deserialize, Debug, Clone, Serialize)]
@@ -151,7 +157,7 @@ pub struct RenameField {
 #[derive(Deserialize, Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RemoveField {
-  field_id: FieldId,
+  pub field_id: FieldId,
 }
 
 #[derive(Deserialize, Debug, Clone, Serialize)]
@@ -314,6 +320,15 @@ impl AggregateCommand<ShapeProjection> for ShapeCommand {
           vec![ShapeEvent::from(shape_events::FieldShapeSet::from(command))]
         }
       },
+
+      ShapeCommand::RemoveField(command) => {
+        validation.require(
+          validation.field_id_exists(&command.field_id),
+          "field must exist to remove field"
+        )?;
+
+        vec![ShapeEvent::FieldRemoved(shape_events::FieldRemoved::from(command))]
+      }
 
       // Parameters
       // ----------
@@ -674,6 +689,47 @@ mod test {
       "can_handle_set_field_shape_command__unexisting_field_shape_result",
       unexisting_field_shape_result.unwrap_err()
     );
+
+    for event in new_events {
+      projection.apply(event); // verify this doesn't panic goes a long way to verifying the events
+    }
+  }
+
+  #[test]
+  pub fn can_handle_remove_field_command() {
+    let initial_events: Vec<ShapeEvent> = serde_json::from_value(json!([
+      {"ShapeAdded":{"shapeId":"object_shape_1","baseShapeId":"$object", "name": "" }},
+      {"ShapeAdded":{"shapeId":"string_shape_1","baseShapeId":"$number", "name": "" }},
+      {"FieldAdded":{"fieldId": "field_1", "shapeId": "object_shape_1", "name": "likesCount", "shapeDescriptor":{ "FieldShapeFromShape": { "shapeId": "string_shape_1", "fieldId": "field_1"}}}}
+    ]))
+    .expect("initial events should be valid shape events");
+
+    let mut projection = ShapeProjection::from(initial_events);
+
+    let valid_command: ShapeCommand = serde_json::from_value(json!(
+      {"RemoveField":{ "fieldId": "field_1" }}
+    ))
+    .expect("example command should be a valid command");
+
+    let new_events = projection
+      .execute(valid_command)
+      .expect("valid command should yield new events");
+    assert_eq!(new_events.len(), 1);
+    assert_debug_snapshot!("can_handle_remove_field_command__new_events", new_events);
+
+    let unexisting_field: ShapeCommand = serde_json::from_value(json!(
+      {"RemoveField":{ "fieldId": "not_a_field" }}
+    ))
+    .unwrap();
+    let unexisting_field_result = projection.execute(unexisting_field);
+    assert!(unexisting_field_result.is_err());
+    assert_debug_snapshot!(
+      "can_handle_remove_field_command__unexisting_field_result",
+      unexisting_field_result.unwrap_err()
+    );
+
+
+    // @TODO: verify removed field can't be removed again
 
     for event in new_events {
       projection.apply(event); // verify this doesn't panic goes a long way to verifying the events

--- a/workspaces/optic-engine/src/commands/snapshots/optic_engine__commands__shape__test__already_removed_field_result.snap
+++ b/workspaces/optic-engine/src/commands/snapshots/optic_engine__commands__shape__test__already_removed_field_result.snap
@@ -1,0 +1,7 @@
+---
+source: workspaces/optic-engine/src/commands/shape.rs
+expression: already_removed_field_result.unwrap_err()
+---
+Validation(
+    "Command failed validation: field must exist to remove field, \"RemoveField(RemoveField { field_id: \\\"field_2\\\" })\"",
+)

--- a/workspaces/optic-engine/src/commands/snapshots/optic_engine__commands__shape__test__can_handle_remove_field_command__new_events.snap
+++ b/workspaces/optic-engine/src/commands/snapshots/optic_engine__commands__shape__test__can_handle_remove_field_command__new_events.snap
@@ -1,0 +1,12 @@
+---
+source: workspaces/optic-engine/src/commands/shape.rs
+expression: new_events
+---
+[
+    FieldRemoved(
+        FieldRemoved {
+            field_id: "field_1",
+            event_context: None,
+        },
+    ),
+]

--- a/workspaces/optic-engine/src/commands/snapshots/optic_engine__commands__shape__test__can_handle_remove_field_command__unexisting_field_result.snap
+++ b/workspaces/optic-engine/src/commands/snapshots/optic_engine__commands__shape__test__can_handle_remove_field_command__unexisting_field_result.snap
@@ -1,0 +1,7 @@
+---
+source: workspaces/optic-engine/src/commands/shape.rs
+expression: unexisting_field_result.unwrap_err()
+---
+Validation(
+    "Command failed validation: field must exist to remove field, \"RemoveField(RemoveField { field_id: \\\"not_a_field\\\" })\"",
+)

--- a/workspaces/optic-engine/src/events/shape.rs
+++ b/workspaces/optic-engine/src/events/shape.rs
@@ -36,7 +36,10 @@ pub enum ShapeEvent {
 pub struct ShapeAdded {
   pub shape_id: ShapeId,
   pub base_shape_id: ShapeId,
+
+  #[serde(default = "ShapeParametersDescriptor::empty_dynamic")]
   pub parameters: ShapeParametersDescriptor,
+
   pub name: String,
   pub event_context: Option<EventContext>,
 }
@@ -264,6 +267,12 @@ impl From<FieldShapeSet> for ShapeEvent {
   }
 }
 
+impl From<FieldRemoved> for ShapeEvent {
+  fn from(event: FieldRemoved) -> Self {
+    Self::FieldRemoved(event)
+  }
+}
+
 impl From<ShapeParameterAdded> for ShapeEvent {
   fn from(event: ShapeParameterAdded) -> Self {
     Self::ShapeParameterAdded(event)
@@ -285,6 +294,7 @@ impl From<ShapeCommand> for ShapeEvent {
       ShapeCommand::AddShape(command) => ShapeEvent::from(ShapeAdded::from(command)),
       ShapeCommand::SetBaseShape(command) => ShapeEvent::from(BaseShapeSet::from(command)),
       ShapeCommand::AddField(command) => ShapeEvent::from(FieldAdded::from(command)),
+      ShapeCommand::RemoveField(command) => ShapeEvent::from(FieldRemoved::from(command)),
       ShapeCommand::AddShapeParameter(command) => {
         ShapeEvent::from(ShapeParameterAdded::from(command))
       }
@@ -328,6 +338,15 @@ impl From<shape_commands::AddField> for FieldAdded {
       shape_id: command.shape_id,
       name: command.name,
       shape_descriptor: command.shape_descriptor,
+      event_context: None,
+    }
+  }
+}
+
+impl From<shape_commands::RemoveField> for FieldRemoved {
+  fn from(command: shape_commands::RemoveField) -> Self {
+    Self {
+      field_id: command.field_id,
       event_context: None,
     }
   }

--- a/workspaces/optic-engine/src/projections/shape.rs
+++ b/workspaces/optic-engine/src/projections/shape.rs
@@ -636,12 +636,17 @@ impl ShapeProjection {
   }
 
   pub fn get_field_node_index(&self, node_id: &NodeId) -> Option<&NodeIndex> {
-    let node_index = self.node_id_to_index.get(node_id)?;
-    let node = self.graph.node_weight(*node_index);
+    self
+      .get_field_node(node_id)
+      .map(|(node_index, _)| node_index)
+  }
+
+  pub fn get_field_node(&self, field_id: &FieldId) -> Option<(&NodeIndex, &FieldNode)> {
+    let node_index = self.node_id_to_index.get(field_id)?;
+    let node = self.graph.node_weight(*node_index)?;
     match node {
-      Some(&Node::Field(ref node)) => Some(node_index),
-      Some(_) => None,
-      None => None,
+      Node::Field(ref node) => Some((node_index, node)),
+      _ => None,
     }
   }
 


### PR DESCRIPTION
## Why
The ability to remove an object's field from an API spec is something we want to support. To allow for that, the Engine needs the ability to generate the right commands and allow those to be applied to its internal spec representation.

## What
We implement the already existing `RemoveField` command and `FieldRemoved` events. The generation of this command can be initiated through a newly added `remove_field_commands` on `ShapesQuery`.

Planned follow up in separate PRs:

- adding an interface to this query through Spectacle.
- updating the changelog projection to reflect the field's removal
- wiring it up to the CI

Since there's no interface to this new query yet, there's no need for a feature flag yet.

## Validation
* [ ] CI passes
* [x] New behaviour covered in tests
