### PR TITLE
fix intercom user id

### DIFF
--- a/workspaces/ui-v2/src/contexts/analytics/implementations/localCliAnalytics.ts
+++ b/workspaces/ui-v2/src/contexts/analytics/implementations/localCliAnalytics.ts
@@ -70,7 +70,7 @@ export const initialize: AnalyticsStoreProps['initialize'] = async (
   if (window.Intercom && appConfig.analytics.intercomAppId) {
     window.Intercom('boot', {
       app_id: appConfig.analytics.intercomAppId,
-      user_id: clientId,
+      user_id: metadata.clientAgent,
     });
     window.Intercom('hide');
   }


### PR DESCRIPTION
## Why
Realized the intercom id was being set to `clientId` not `clientAgent`
