### PR TITLE
Fix cloud viewer prod url

### DIFF
--- a/workspaces/ui-v2/src/entry-points/cloud/cloud-viewer.tsx
+++ b/workspaces/ui-v2/src/entry-points/cloud/cloud-viewer.tsx
@@ -53,7 +53,7 @@ const appConfig: OpticAppConfig = {
       // The UI needs to be context aware and know about _both_ staging and prod
       domain:
         window.location.hostname.indexOf('useoptic.com') >= 0
-          ? 'https://spec.useoptic.com' // production
+          ? 'https://api.useoptic.com' // production
           : 'https://api.o3c.info', // staging
     },
     sharing: { enabled: false },


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Cloud viewer wasn't working because prod was pointing to spec, instead of api

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
