### PR TITLE
Mock spectacle remove field interface

### DIFF
--- a/workspaces/optic-domain/src/index.ts
+++ b/workspaces/optic-domain/src/index.ts
@@ -1,10 +1,10 @@
 export * as AsyncTools from './async-tools';
 export * as Streams from './streams';
 export * as Commands from './commands';
-export * as Events from './events';
+export * as Shapes from './shapes';
 export * as Interactions from './interactions';
 
 export * from './commands';
-export * from './events';
+export * from './shapes';
 export * from './interactions';
 export * from './streams';

--- a/workspaces/optic-domain/src/shapes.ts
+++ b/workspaces/optic-domain/src/shapes.ts
@@ -29,3 +29,26 @@ export enum JsonLike {
   BOOLEAN = 'Boolean',
   UNDEFINED = 'Undefined',
 }
+
+// Matches optic-engine/src/projections/spectacle/shapes
+export type FieldShape = {
+  name: string;
+  fieldId: string;
+  shapeId: string;
+};
+
+export type ShapeChoice =
+  | {
+      shapeId: string;
+      jsonType: JsonLike.OBJECT;
+      fields: FieldShape[];
+    }
+  | {
+      shapeId: string;
+      jsonType: JsonLike.ARRAY;
+      itemShapeId: string;
+    }
+  | {
+      shapeId: string;
+      jsonType: Exclude<JsonLike, JsonLike.OBJECT | JsonLike.ARRAY>;
+    };

--- a/workspaces/optic-domain/src/shapes.ts
+++ b/workspaces/optic-domain/src/shapes.ts
@@ -37,6 +37,7 @@ export type FieldShape = {
   shapeId: string;
 };
 
+// Matches optic-engine/src/projections/spectacle/shapes
 export type ShapeChoice =
   | {
       shapeId: string;

--- a/workspaces/optic-domain/src/shapes.ts
+++ b/workspaces/optic-domain/src/shapes.ts
@@ -1,3 +1,4 @@
+// Shape events
 export enum ICoreShapeKinds {
   ObjectKind = '$object',
   ListKind = '$list',
@@ -11,8 +12,20 @@ export enum ICoreShapeKinds {
   OptionalKind = '$optional',
   UnknownKind = '$unknown',
 }
+
 export enum ICoreShapeInnerParameterNames {
   ListInner = '$listItem',
   NullableInner = '$nullableInner',
   OptionalInner = '$optionalInner',
+}
+
+// Optic engine shape types
+export enum JsonLike {
+  OBJECT = 'Object',
+  ARRAY = 'Array',
+  NULL = 'Null',
+  STRING = 'String',
+  NUMBER = 'Number',
+  BOOLEAN = 'Boolean',
+  UNDEFINED = 'Undefined',
 }

--- a/workspaces/spectacle/src/graphql/schema.ts
+++ b/workspaces/spectacle/src/graphql/schema.ts
@@ -49,6 +49,8 @@ type Query {
 
   endpoint(pathId: ID!, method: String!): Endpoint
 
+  field(fieldId: ID!): ObjectField
+
   # Metadata about the current spec
   metadata: SpecMetadata
 }
@@ -265,20 +267,22 @@ type HttpResponse {
 """
 Object Field Metadata, which provides information about a field
 """
-type ObjectFieldMetadata {
-  name: String
+type ObjectField {
+  name: String!
   
   # Field ID for the given field
-  fieldId: ID
+  fieldId: ID!
   
   # Changes for the field based on the give batch commit ID
   changes(sinceBatchCommitId: String): ChangesResult
   
   # Shape ID of field. Use the shapeChoice query to get shape information.
-  shapeId: ID
+  shapeId: ID!
   
   # Field contributions which define descriptions
-  contributions: JSON
+  contributions: JSON!
+
+  isRemoved: Boolean!
 }
 
 """
@@ -286,7 +290,7 @@ Object Metadata, which provides information about an object
 """
 type ObjectMetadata {
   # Fields for the given object
-  fields: [ObjectFieldMetadata]
+  fields: [ObjectField]
 }
 
 """

--- a/workspaces/spectacle/src/graphql/schema.ts
+++ b/workspaces/spectacle/src/graphql/schema.ts
@@ -282,7 +282,15 @@ type ObjectField {
   # Field contributions which define descriptions
   contributions: JSON!
 
+  # Has the field been removed
   isRemoved: Boolean!
+
+  # Commands to mutate the field
+  commands: FieldCommands!
+}
+
+type FieldCommands {
+  remove: [JSON!]!
 }
 
 """

--- a/workspaces/spectacle/src/helpers.ts
+++ b/workspaces/spectacle/src/helpers.ts
@@ -506,4 +506,11 @@ export class CommandGenerator {
       return JSON.parse(specEndpointDeleteCommands).commands;
     },
   };
+
+  public field = {
+    remove: (fieldId: string): CQRSCommand[] => {
+      // TODO FLEB connect up to optic-engine command generation
+      return [];
+    },
+  };
 }

--- a/workspaces/spectacle/src/spectacle.ts
+++ b/workspaces/spectacle/src/spectacle.ts
@@ -17,12 +17,11 @@ import {
   CommandGenerator,
 } from './helpers';
 import { endpoints, shapes } from '@useoptic/graph-lib';
-import { CQRSCommand, ShapeChoice, JsonLike } from '@useoptic/optic-domain';
+import { FieldShape, JsonLike, ShapeChoice } from '@useoptic/optic-domain';
 import {
   IOpticContext,
   IOpticDiffService,
   SpectacleInput,
-  FieldShape,
   ShapeViewerProjection,
   GraphQLContext,
 } from './types';
@@ -62,11 +61,7 @@ export async function makeSpectacle(opticContext: IOpticContext) {
     shapeQueries: shapes.GraphQueries,
     shapeViewerProjection: ShapeViewerProjection,
     contributionsProjection: ContributionsProjection,
-    commandGenerator: {
-      endpoint: {
-        remove: (pathId: string, method: string) => CQRSCommand[];
-      };
-    };
+    commandGenerator: CommandGenerator;
 
   // TODO: consider debouncing reloads (head and tail?)
   async function reload(opticContext: IOpticContext) {
@@ -651,7 +646,7 @@ export async function makeSpectacle(opticContext: IOpticContext) {
         );
       },
     },
-    ObjectFieldMetadata: {
+    ObjectField: {
       changes: (
         parent: FieldShape,
         args: {
@@ -673,6 +668,15 @@ export async function makeSpectacle(opticContext: IOpticContext) {
           context.spectacleContext().contributionsProjection[parent.fieldId] ||
             {}
         );
+      },
+      isRemoved: (parent: FieldShape, _: {}, context: GraphQLContext) => {
+        // TODO FLEB - connect up to optic engine
+        return false;
+      },
+      commands: (parent: FieldShape) => {
+        return {
+          remove: commandGenerator.field.remove(parent.fieldId),
+        };
       },
     },
     EndpointChanges: {

--- a/workspaces/spectacle/src/types.ts
+++ b/workspaces/spectacle/src/types.ts
@@ -5,7 +5,7 @@ import {
   ILearnedBodies,
   IAffordanceTrailsDiffHashMap,
 } from '@useoptic/cli-shared/build/diffs/initial-types';
-import { IHttpInteraction } from '@useoptic/optic-domain';
+import { IHttpInteraction, ShapeChoice } from '@useoptic/optic-domain';
 import { endpoints, shapes } from '@useoptic/graph-lib';
 import { CommandGenerator, ContributionsProjection } from './helpers';
 import { IOpticCommandContext } from './in-memory';
@@ -173,6 +173,9 @@ export interface IForkableSpectacle extends IBaseSpectacle {
   fork(): Promise<IBaseSpectacle>;
 }
 
+// Record<ShapeId, ShapeChoice[]>
+export type ShapeViewerProjection = Record<string, ShapeChoice[]>;
+
 export interface SpectacleInput<
   T extends {
     [key: string]: any;
@@ -188,7 +191,7 @@ export type GraphQLContext = {
     opticContext: IOpticContext;
     endpointsQueries: endpoints.GraphQueries;
     shapeQueries: shapes.GraphQueries;
-    shapeViewerProjection: any;
+    shapeViewerProjection: ShapeViewerProjection;
     contributionsProjection: ContributionsProjection;
     commandGenerator: CommandGenerator;
   };

--- a/workspaces/ui-v2/src/components/PathParameters.tsx
+++ b/workspaces/ui-v2/src/components/PathParameters.tsx
@@ -1,9 +1,10 @@
 import React, { FC, ReactNode } from 'react';
 import { Divider, Typography, makeStyles } from '@material-ui/core';
+import { JsonLike } from '@useoptic/optic-domain';
 
 import { FieldOrParameter } from './FieldOrParameter';
 
-import { IPathParameter, IShapeRenderer, JsonLike } from '<src>/types';
+import { IPathParameter, IShapeRenderer } from '<src>/types';
 
 export type PathParametersProps = {
   parameters: IPathParameter[];

--- a/workspaces/ui-v2/src/components/ShapeRenderer/ShapePrimitive.tsx
+++ b/workspaces/ui-v2/src/components/ShapeRenderer/ShapePrimitive.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import makeStyles from '@material-ui/styles/makeStyles';
+import { JsonLike } from '@useoptic/optic-domain';
+
 import { useSharedStyles } from './SharedStyles';
-import { IShapeRenderer, JsonLike } from '<src>/types';
+import { IShapeRenderer } from '<src>/types';
 import classNames from 'classnames';
 
 export const ShapePrimitiveRender = ({ jsonType }: IShapeRenderer) => {

--- a/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRowBase.tsx
+++ b/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRowBase.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import makeStyles from '@material-ui/styles/makeStyles';
+import { JsonLike } from '@useoptic/optic-domain';
+
 import { IndentSpaces, useSharedStyles } from './SharedStyles';
-import { IFieldRenderer, IShapeRenderer, JsonLike } from '<src>/types';
+import { IFieldRenderer, IShapeRenderer } from '<src>/types';
 import { ShapePrimitiveRender, UnknownPrimitiveRender } from './ShapePrimitive';
 import { useDepth } from './DepthContext';
 import classNames from 'classnames';

--- a/workspaces/ui-v2/src/lib/shape-trail-parser.ts
+++ b/workspaces/ui-v2/src/lib/shape-trail-parser.ts
@@ -10,8 +10,7 @@ import {
   IShapeTrail,
   IShapeTrailComponent,
 } from '@useoptic/cli-shared/build/diffs/shape-trail';
-import { JsonLike } from '<src>/types';
-import { ICoreShapeKinds } from '@useoptic/optic-domain';
+import { ICoreShapeKinds, JsonLike } from '@useoptic/optic-domain';
 import { InvariantViolationError } from '<src>/errors';
 
 export interface IExpectationHelper {

--- a/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
@@ -3,6 +3,7 @@ import { Redirect, RouteComponentProps } from 'react-router-dom';
 import { Button, LinearProgress, makeStyles } from '@material-ui/core';
 import { Alert } from '@material-ui/lab';
 import { Delete as DeleteIcon, Undo as UndoIcon } from '@material-ui/icons';
+import { JsonLike } from '@useoptic/optic-domain';
 
 import {
   EndpointName,
@@ -24,7 +25,7 @@ import {
   selectors,
   documentationEditActions,
 } from '<src>/store';
-import { IShapeRenderer, JsonLike } from '<src>/types';
+import { IShapeRenderer } from '<src>/types';
 import { getEndpointId } from '<src>/utils';
 import { useRunOnKeypress } from '<src>/hooks/util';
 import {

--- a/workspaces/ui-v2/src/store/selectors/shapeSelectors.ts
+++ b/workspaces/ui-v2/src/store/selectors/shapeSelectors.ts
@@ -1,12 +1,12 @@
 import { SerializedError } from '@reduxjs/toolkit';
 import * as Sentry from '@sentry/react';
 import sortBy from 'lodash.sortby';
+import { JsonLike } from '@useoptic/optic-domain';
 
 import {
   AsyncStatus,
   IShapeRenderer,
   IFieldDetails,
-  JsonLike,
   QueryParameters,
 } from '<src>/types';
 import { RootState } from '../root';

--- a/workspaces/ui-v2/src/store/shapes/thunks.ts
+++ b/workspaces/ui-v2/src/store/shapes/thunks.ts
@@ -2,7 +2,7 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 import * as Sentry from '@sentry/react';
 
 import { IForkableSpectacle } from '@useoptic/spectacle';
-import { JsonLike } from '<src>/types';
+import { JsonLike } from '@useoptic/optic-domain';
 import {
   convertSpectacleChangeToChangeType,
   SpectacleChange,
@@ -63,7 +63,6 @@ type SpectacleShape =
   | {
       id: string;
       jsonType: Exclude<JsonLike, JsonLike.OBJECT | JsonLike.ARRAY>;
-
       asArray?: undefined;
       asObject?: undefined;
     };

--- a/workspaces/ui-v2/src/store/shapes/types.ts
+++ b/workspaces/ui-v2/src/store/shapes/types.ts
@@ -1,4 +1,5 @@
-import { ChangeType, JsonLike } from '<src>/types';
+import { JsonLike } from '@useoptic/optic-domain';
+import { ChangeType } from '<src>/types';
 
 export type ShapeId = string;
 

--- a/workspaces/ui-v2/src/types/shapes.ts
+++ b/workspaces/ui-v2/src/types/shapes.ts
@@ -1,3 +1,4 @@
+import { JsonLike } from '@useoptic/optic-domain';
 import { ChangeType } from './changes';
 import { IContribution } from './contributions';
 
@@ -49,14 +50,4 @@ export type IShapeRenderer =
 export interface IArrayRender {
   shapeChoices: IShapeRenderer[];
   shapeId: string;
-}
-
-export enum JsonLike {
-  OBJECT = 'Object',
-  ARRAY = 'Array',
-  NULL = 'Null',
-  STRING = 'String',
-  NUMBER = 'Number',
-  BOOLEAN = 'Boolean',
-  UNDEFINED = 'Undefined',
 }


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Mock out the spectacle interfaces for removing a field

## What
What's changing? Anything of note to call out?

- Moved around some types (JsonLike and ShapeChoice) into optic-domain
- Added typing to shapeViewerProjection in the spectacle layer
- Mocked out usage of command generation and isRemoved field query

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
