### PR TITLE
Connect up remove field ui to command generation

### DIFF
--- a/workspaces/ui-v2/src/store/documentationEdit/slice.ts
+++ b/workspaces/ui-v2/src/store/documentationEdit/slice.ts
@@ -92,7 +92,8 @@ const documentationEditSlice = createSlice({
       state.removedEndpoints = newRemovedEndpoints;
     },
     removeField: (state, action: PayloadAction<{ fieldId: string }>) => {
-      // TODO FLEB filter any other removed fields that is now a child of the newly added field.
+      // @GOTCHA - selecting a field, and then selecting a parent of this field (e.g. an object that contains this removed field)
+      // will count as a two selected fields. This is still correct, just extra commands
       state.fieldEdits.removedFields.push(action.payload.fieldId);
     },
     unremoveField: (state, action: PayloadAction<{ fieldId: string }>) => {

--- a/workspaces/ui-v2/src/store/documentationEdit/thunks.ts
+++ b/workspaces/ui-v2/src/store/documentationEdit/thunks.ts
@@ -134,7 +134,7 @@ export const saveDocumentationChanges = createAsyncThunk<
       removedFields.map((fieldId) =>
         fetchFieldRemoveCommands(spectacle, fieldId)
       )
-    ).then((fieldCommands) => fieldCommands.flatMap((x) => x));
+    ).then((fieldCommands) => fieldCommands.flat());
 
     const removeEndpointCommandsPromise: Promise<CQRSCommand[]> = Promise.all(
       removedEndpoints.map(({ pathId, method }) =>
@@ -146,7 +146,7 @@ export const saveDocumentationChanges = createAsyncThunk<
           removeCommands.concat([PrunePathComponents()])
         )
       )
-    ).then((endpointCommands) => endpointCommands.flatMap((x) => x));
+    ).then((endpointCommands) => endpointCommands.flat());
 
     const [removeFieldCommands, removeEndpointCommands] = await Promise.all([
       removeFieldCommandsPromise,


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Connect up the remove fields to have an end to end flow

## What
What's changing? Anything of note to call out?

- I decided against trying to implement more complicated ui logic to dedupe remove field commands, as long as we apply them in order (remove field -> remove endpoint) there shouldn't be any issue . Presumably in the future, we could reuse shapes - this means shapes aren't necessarily tied to an endpoint so it doesn't make sense to make this a requirement (i.e. removing a field only if the shape is tied to an endpoint
- This is not going to work until the spectacle code is joined together, however since the UI is gated (i.e. users cannot remove a field without the FF), we should be fine to merge this non-working spectacle query

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
