### PR TITLE
Raise errors when calling listDiffs and listUnrecognizedUrls

### DIFF
--- a/workspaces/spectacle-shared/src/local-cli/client.ts
+++ b/workspaces/spectacle-shared/src/local-cli/client.ts
@@ -151,7 +151,16 @@ export class LocalCliDiffService implements IOpticDiffService {
   }
 
   async listDiffs(): Promise<IListDiffsResponse> {
-    const result = await this.dependencies.spectacle.query<any, any>({
+    const result = await this.dependencies.spectacle.query<
+      {
+        diff: {
+          diffs: IListDiffsResponse;
+        };
+      },
+      {
+        diffId: string;
+      }
+    >({
       query: `query X($diffId: ID!) {
         diff(diffId: $diffId) {
           diffs
@@ -161,11 +170,25 @@ export class LocalCliDiffService implements IOpticDiffService {
         diffId: this.dependencies.diffId,
       },
     });
-    return result.data!.diff.diffs;
+    if (result.errors || !result.data) {
+      const errors = result.errors || 'result.data was unexpectedly undefined';
+      console.error(errors);
+      throw new Error(JSON.stringify(errors));
+    }
+    return result.data.diff.diffs;
   }
 
   async listUnrecognizedUrls(): Promise<IListUnrecognizedUrlsResponse> {
-    const result = await this.dependencies.spectacle.query<any, any>({
+    const result = await this.dependencies.spectacle.query<
+      {
+        diff: {
+          unrecognizedUrls: IListUnrecognizedUrlsResponse;
+        };
+      },
+      {
+        diffId: string;
+      }
+    >({
       query: `query X($diffId: ID!) {
         diff(diffId: $diffId) {
           unrecognizedUrls
@@ -175,7 +198,12 @@ export class LocalCliDiffService implements IOpticDiffService {
         diffId: this.dependencies.diffId,
       },
     });
-    return result.data!.diff.unrecognizedUrls;
+    if (result.errors || !result.data) {
+      const errors = result.errors || 'result.data was unexpectedly undefined';
+      console.error(errors);
+      throw new Error(JSON.stringify(errors));
+    }
+    return result.data.diff.unrecognizedUrls;
   }
 }
 

--- a/workspaces/spectacle-shared/src/local-cli/client.ts
+++ b/workspaces/spectacle-shared/src/local-cli/client.ts
@@ -21,7 +21,7 @@ import {
   IAffordanceTrailsDiffHashMap,
 } from '@useoptic/cli-shared/build/diffs/initial-types';
 import { IApiCliConfig } from '@useoptic/cli-config';
-import { IHttpInteraction } from '@useoptic/optic-domain';
+import { CQRSCommand, IHttpInteraction } from '@useoptic/optic-domain';
 import { EventEmitter } from 'events';
 
 export class LocalCliSpectacle implements IForkableSpectacle {
@@ -142,7 +142,7 @@ export class LocalCliDiffService implements IOpticDiffService {
   async learnUndocumentedBodies(
     pathId: string,
     method: string,
-    newPathCommands: any[]
+    newPathCommands: CQRSCommand[]
   ): Promise<ILearnedBodies> {
     return JsonHttpClient.postJson(
       `${this.dependencies.baseUrl}/captures/${this.dependencies.captureId}/initial-bodies`,
@@ -171,7 +171,7 @@ export class LocalCliDiffService implements IOpticDiffService {
       },
     });
     if (result.errors || !result.data) {
-      const errors = result.errors || 'result.data was unexpectedly undefined';
+      const errors = result.errors || 'result.data was unexpectedly falsy';
       console.error(errors);
       throw new Error(JSON.stringify(errors));
     }
@@ -199,7 +199,7 @@ export class LocalCliDiffService implements IOpticDiffService {
       },
     });
     if (result.errors || !result.data) {
-      const errors = result.errors || 'result.data was unexpectedly undefined';
+      const errors = result.errors || 'result.data was unexpectedly falsy';
       console.error(errors);
       throw new Error(JSON.stringify(errors));
     }
@@ -222,7 +222,7 @@ export class LocalCliConfigRepository implements IOpticConfigRepository {
   }
 
   async listIgnoreRules(): Promise<string[]> {
-    throw new Error('should never be called');
+    throw new Error('unimplemented');
   }
 
   async getApiName(): Promise<string> {


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

This is happening because [this line](https://github.com/opticdev/optic/blob/a45dbd315df4d1f5308dd186b96600095bde9e19/workspaces/spectacle/src/in-memory/index.ts#L423-L429) cannot find a diff repository (i.e. an error is throwing because it cannot find a diffService with that id).

I've checked and I don't believe this is a race condition - we are awaiting on the correct promises.

Looking at the code, the reasons this _could_ happen:
- There are multiple daemons running (but i dont think this makes sense, since all spectacle calls should go to the same place)
- The spec-router instance is reset / reloaded somehow https://github.com/opticdev/optic/blob/develop/workspaces/cli-server/src/routers/spec-router.ts#L234-L261 - perhaps a cli-server reloading or session id being different? this creates a new context (probably not this)
- the diff ids somehow are different (i traced the code, and I don't think this is possible)

I've dug into this and don't have any more leads, and don't have a great answer, so I'm going to stop here with some slightly better debugging.

If this happens, some debug steps to try are:
- `api daemon:stop`
- clearing out the captures directory

## What
What's changing? Anything of note to call out?

- Updated to raise errors which gets bubbled up to sentry

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
