### PR TITLE
feature: Include spec ID in all analytics events

### DIFF
--- a/workspaces/analytics/src/cliEvents.ts
+++ b/workspaces/analytics/src/cliEvents.ts
@@ -49,6 +49,7 @@ export const ApiCheckCompleted = (
 type StartedTaskWithLocalCliProps = {
   captureId: string;
   cwd: string;
+  createdAt: string;
   inputs: {
     task: string;
   } & Record<string, string>;

--- a/workspaces/analytics/src/uiEvents.ts
+++ b/workspaces/analytics/src/uiEvents.ts
@@ -32,6 +32,13 @@ export class OpticUIEvents {
     });
   }
 
+  userLoggedIn(backendUserId: string) {
+    this.dispatch({
+      type: 'user_logged_in',
+      data: { backendUserId },
+    });
+  }
+
   userStartedSharing() {
     this.dispatch({
       type: 'user_started_sharing',

--- a/workspaces/cli-client/src/client.ts
+++ b/workspaces/cli-client/src/client.ts
@@ -15,13 +15,9 @@ class Client {
     return JsonHttpClient.postJson(url, { events });
   }
 
-  postTrackingEventsWithApi(
-    apiName: string,
-    specId: string,
-    events: TrackingEventBase<any>[]
-  ) {
+  postTrackingEventsWithApi(apiName: string, events: TrackingEventBase<any>[]) {
     const url = `${this.baseUrl}/tracking/events/apiname`;
-    return JsonHttpClient.postJson(url, { apiName, specId, events });
+    return JsonHttpClient.postJson(url, { apiName, events });
   }
 
   findSession(

--- a/workspaces/cli-client/src/client.ts
+++ b/workspaces/cli-client/src/client.ts
@@ -15,9 +15,13 @@ class Client {
     return JsonHttpClient.postJson(url, { events });
   }
 
-  postTrackingEventsWithApi(apiName: string, events: TrackingEventBase<any>[]) {
+  postTrackingEventsWithApi(
+    apiName: string,
+    specId: string,
+    events: TrackingEventBase<any>[]
+  ) {
     const url = `${this.baseUrl}/tracking/events/apiname`;
-    return JsonHttpClient.postJson(url, { apiName, events });
+    return JsonHttpClient.postJson(url, { apiName, specId, events });
   }
 
   findSession(

--- a/workspaces/local-cli/src/commands/ingest/s3.ts
+++ b/workspaces/local-cli/src/commands/ingest/s3.ts
@@ -8,8 +8,10 @@ import { cleanupAndExit, makeUiBaseUrl } from '@useoptic/cli-shared';
 import { getPathsRelativeToConfig, readApiConfig } from '@useoptic/cli-config';
 import { Client } from '@useoptic/cli-client';
 import { trackUserEvent } from '../../shared/analytics';
+import * as opticEngine from '@useoptic/optic-engine-wasm';
 import openBrowser from 'react-dev-utils/openBrowser';
 import { linkToCapture } from '../../shared/ui-links';
+import { LocalCliSpectacle } from '@useoptic/spectacle-shared';
 export default class IngestS3 extends Command {
   static description = 'Ingest from S3';
   static hidden: boolean = true;
@@ -50,12 +52,24 @@ export default class IngestS3 extends Command {
 
       const apiCfg = await readApiConfig(paths.configPath);
 
+      const spectacle = new LocalCliSpectacle(apiBaseUrl, opticEngine);
+      const requestQuery = await spectacle.query<any>({
+        query: `{
+          metadata {
+            id
+          }
+        }`,
+        variables: {},
+      });
+      const specId = requestQuery?.data?.metadata?.id;
+
       /*
         captureId: Joi.string().required(),
         interactionCount: Joi.number().required()
       */
       await trackUserEvent(
         apiCfg.name,
+        specId,
         LiveTrafficIngestedWithLocalCli({
           captureId,
           interactionCount,

--- a/workspaces/local-cli/src/commands/ingest/s3.ts
+++ b/workspaces/local-cli/src/commands/ingest/s3.ts
@@ -67,14 +67,14 @@ export default class IngestS3 extends Command {
         captureId: Joi.string().required(),
         interactionCount: Joi.number().required()
       */
-      await trackUserEvent(
-        apiCfg.name,
+      await trackUserEvent({
+        apiName: apiCfg.name,
         specId,
-        LiveTrafficIngestedWithLocalCli({
+        event: LiveTrafficIngestedWithLocalCli({
           captureId,
           interactionCount,
-        })
-      );
+        }),
+      });
 
       cleanupAndExit();
     } catch (e) {

--- a/workspaces/local-cli/src/commands/ingest/s3.ts
+++ b/workspaces/local-cli/src/commands/ingest/s3.ts
@@ -52,7 +52,10 @@ export default class IngestS3 extends Command {
 
       const apiCfg = await readApiConfig(paths.configPath);
 
-      const spectacle = new LocalCliSpectacle(apiBaseUrl, opticEngine);
+      const spectacle = new LocalCliSpectacle(
+        `${apiBaseUrl}/specs/${cliSession.session.id}`,
+        opticEngine
+      );
       const requestQuery = await spectacle.query<any>({
         query: `{
           metadata {

--- a/workspaces/local-cli/src/commands/ingest/s3.ts
+++ b/workspaces/local-cli/src/commands/ingest/s3.ts
@@ -61,7 +61,7 @@ export default class IngestS3 extends Command {
         }`,
         variables: {},
       });
-      const specId = requestQuery?.data?.metadata?.id;
+      const specId = requestQuery?.data?.metadata?.id ?? 'anon-spec-id';
 
       /*
         captureId: Joi.string().required(),

--- a/workspaces/local-cli/src/commands/init.ts
+++ b/workspaces/local-cli/src/commands/init.ts
@@ -93,7 +93,10 @@ export default class Init extends Command {
       const cliSession = await cliClient.findSession(paths.cwd, null, null);
       developerDebugLogger({ cliSession });
       openBrowser(linkToSetup(cliSession.session.id));
-      const spectacle = new LocalCliSpectacle(apiBaseUrl, opticEngine);
+      const spectacle = new LocalCliSpectacle(
+        `${apiBaseUrl}/specs/${cliSession.session.id}`,
+        opticEngine
+      );
       const requestQuery = await spectacle.query<any>({
         query: `{
           metadata {

--- a/workspaces/local-cli/src/commands/init.ts
+++ b/workspaces/local-cli/src/commands/init.ts
@@ -6,6 +6,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import { developerDebugLogger, fromOptic } from '@useoptic/cli-shared';
 import { trackUserEvent } from '../shared/analytics';
+import * as opticEngine from '@useoptic/optic-engine-wasm';
 import { ApiInitializedInProject } from '@useoptic/analytics';
 import { buildTask } from '@useoptic/cli-config/build/helpers/initial-task';
 import { ensureDaemonStarted } from '@useoptic/cli-server';
@@ -14,6 +15,7 @@ import { Config } from '../config';
 import { Client } from '@useoptic/cli-client';
 import openBrowser from 'react-dev-utils/openBrowser';
 import { linkToSetup } from '../shared/ui-links';
+import { LocalCliSpectacle } from '@useoptic/spectacle-shared';
 
 export default class Init extends Command {
   static description = 'add Optic to your API';
@@ -91,12 +93,23 @@ export default class Init extends Command {
       const cliSession = await cliClient.findSession(paths.cwd, null, null);
       developerDebugLogger({ cliSession });
       openBrowser(linkToSetup(cliSession.session.id));
+      const spectacle = new LocalCliSpectacle(apiBaseUrl, opticEngine);
+      const requestQuery = await spectacle.query<any>({
+        query: `{
+          metadata {
+            id
+          }
+        }`,
+        variables: {},
+      });
+      return requestQuery?.data?.metadata?.id;
     }
 
-    await startInitFlow();
+    const specId = await startInitFlow();
 
     await trackUserEvent(
       name,
+      specId,
       ApiInitializedInProject({
         cwd: cwd,
         source:

--- a/workspaces/local-cli/src/commands/init.ts
+++ b/workspaces/local-cli/src/commands/init.ts
@@ -102,7 +102,7 @@ export default class Init extends Command {
         }`,
         variables: {},
       });
-      return requestQuery?.data?.metadata?.id;
+      return requestQuery?.data?.metadata?.id ?? 'anon-spec-id';
     }
 
     const specId = await startInitFlow();

--- a/workspaces/local-cli/src/commands/init.ts
+++ b/workspaces/local-cli/src/commands/init.ts
@@ -107,18 +107,18 @@ export default class Init extends Command {
 
     const specId = await startInitFlow();
 
-    await trackUserEvent(
-      name,
+    await trackUserEvent({
+      apiName: name,
       specId,
-      ApiInitializedInProject({
+      event: ApiInitializedInProject({
         cwd: cwd,
         source:
           Object.entries(flags).length === 0
             ? 'documentation'
             : 'on-boarding-flow',
         apiName: name,
-      })
-    );
+      }),
+    });
     process.exit(0);
   }
 }

--- a/workspaces/local-cli/src/commands/login.ts
+++ b/workspaces/local-cli/src/commands/login.ts
@@ -55,11 +55,11 @@ export default class Login extends Command {
       const decodedToken = await getUserFromCredentials(credentials!);
       cli.action.stop('Received Credentials');
 
-      await trackUserEvent(
-        '',
-        '',
-        UserLoggedInFromCLI({ userId: decodedToken.sub })
-      );
+      await trackUserEvent({
+        apiName: '',
+        specId: '',
+        event: UserLoggedInFromCLI({ userId: decodedToken.sub }),
+      });
 
       await server.stop();
       await ensureDaemonStarted(lockFilePath, Config.apiBaseUrl);

--- a/workspaces/local-cli/src/commands/login.ts
+++ b/workspaces/local-cli/src/commands/login.ts
@@ -57,6 +57,7 @@ export default class Login extends Command {
 
       await trackUserEvent(
         '',
+        '',
         UserLoggedInFromCLI({ userId: decodedToken.sub })
       );
 

--- a/workspaces/local-cli/src/commands/status.ts
+++ b/workspaces/local-cli/src/commands/status.ts
@@ -242,16 +242,16 @@ export default class Status extends Command {
       await printCoverage(paths, coverage.with_diffs, coverage.without_diffs);
     }
 
-    await trackUserEvent(
-      config.name,
+    await trackUserEvent({
+      apiName: config.name,
       specId,
-      StatusRun({
+      event: StatusRun({
         captureId,
         diffCount: diffs.length,
         undocumentedCount: urls.length,
         timeMs: Date.now() - timeStated,
-      })
-    );
+      }),
+    });
 
     const diffFound = diffs.length > 0 || urls.length > 0;
 

--- a/workspaces/local-cli/src/commands/status.ts
+++ b/workspaces/local-cli/src/commands/status.ts
@@ -154,7 +154,7 @@ export default class Status extends Command {
       variables: {},
     });
 
-    const specId = requestQuery.data?.metadata?.id;
+    const specId = requestQuery.data?.metadata?.id ?? 'anon-spec-id';
 
     const endpoints = requestQuery.data.requests.map((request: any) => {
       return {

--- a/workspaces/local-cli/src/commands/status.ts
+++ b/workspaces/local-cli/src/commands/status.ts
@@ -112,6 +112,9 @@ export default class Status extends Command {
 
     const requestQuery = await spectacle.query<any>({
       query: `{
+        metadata {
+          id
+        }
         requests {
           id
           pathId
@@ -150,6 +153,8 @@ export default class Status extends Command {
       }`,
       variables: {},
     });
+
+    const specId = requestQuery.data?.metadata?.id;
 
     const endpoints = requestQuery.data.requests.map((request: any) => {
       return {
@@ -239,6 +244,7 @@ export default class Status extends Command {
 
     await trackUserEvent(
       config.name,
+      specId,
       StatusRun({
         captureId,
         diffCount: diffs.length,

--- a/workspaces/local-cli/src/shared/analytics.ts
+++ b/workspaces/local-cli/src/shared/analytics.ts
@@ -8,11 +8,15 @@ import { ensureDaemonStarted } from '@useoptic/cli-server';
 import { lockFilePath } from './paths';
 import { Config } from '../config';
 
-export async function trackUserEvent(
-  apiName: string,
-  specId: string,
-  event: TrackingEventBase<any>
-) {
+export async function trackUserEvent({
+  apiName,
+  specId,
+  event,
+}: {
+  apiName: string;
+  specId: string;
+  event: TrackingEventBase<any>;
+}) {
   const daemonState = await ensureDaemonStarted(
     lockFilePath,
     Config.apiBaseUrl

--- a/workspaces/local-cli/src/shared/analytics.ts
+++ b/workspaces/local-cli/src/shared/analytics.ts
@@ -10,6 +10,7 @@ import { Config } from '../config';
 
 export async function trackUserEvent(
   apiName: string,
+  specId: string,
   event: TrackingEventBase<any>
 ) {
   const daemonState = await ensureDaemonStarted(
@@ -21,7 +22,7 @@ export async function trackUserEvent(
     `http://localhost:${daemonState.port}/api`
   );
 
-  await cliServerClient.postTrackingEventsWithApi(apiName, [event]);
+  await cliServerClient.postTrackingEventsWithApi(apiName, specId, [event]);
 }
 
 export function opticTaskToProps(

--- a/workspaces/local-cli/src/shared/local-cli-task-runner.ts
+++ b/workspaces/local-cli/src/shared/local-cli-task-runner.ts
@@ -260,7 +260,7 @@ export class LocalCliTaskRunner implements IOpticTaskRunner {
 
     const createdAt = batchCommitQuery?.data?.batchCommits
       ?.map((commit: any) => new Date(commit?.createdAt))
-      ?.sort()?.[0];
+      ?.sort((a: Date, b: Date) => a.getTime() - b.getTime())?.[0];
 
     await trackUserEvent({
       apiName: config.name,

--- a/workspaces/local-cli/src/shared/local-cli-task-runner.ts
+++ b/workspaces/local-cli/src/shared/local-cli-task-runner.ts
@@ -241,16 +241,21 @@ export class LocalCliTaskRunner implements IOpticTaskRunner {
         metadata {
           id
         }
+        batchCommits {
+          createdAt
+        }
       }`,
       variables: {},
     });
     const specId = requestQuery?.data?.metadata?.id;
+    const createdAt = requestQuery?.data?.batchCommits?.[0]?.createdAt;
 
     await trackUserEvent(
       config.name,
       specId,
       StartedTaskWithLocalCli({
         inputs: opticTaskToProps(this.taskName, taskConfig),
+        createdAt,
         cwd: this.paths.cwd,
         captureId: this.captureId,
       })

--- a/workspaces/local-cli/src/shared/local-cli-task-runner.ts
+++ b/workspaces/local-cli/src/shared/local-cli-task-runner.ts
@@ -259,16 +259,16 @@ export class LocalCliTaskRunner implements IOpticTaskRunner {
       ?.map((commit: any) => commit?.createdAt)
       ?.sort()?.[0]?.createdAt;
 
-    await trackUserEvent(
-      config.name,
+    await trackUserEvent({
+      apiName: config.name,
       specId,
-      StartedTaskWithLocalCli({
+      event: StartedTaskWithLocalCli({
         inputs: opticTaskToProps(this.taskName, taskConfig),
         createdAt,
         cwd: this.paths.cwd,
         captureId: this.captureId,
-      })
-    );
+      }),
+    });
     ////////////////////////////////////////////////////////////////////////////////
     developerDebugLogger('finding matching daemon session');
 
@@ -366,15 +366,15 @@ export class LocalCliTaskRunner implements IOpticTaskRunner {
     const sampleCount = summary.interactionsCount;
     const hasDiff = summary.diffsCount > 0;
 
-    await trackUserEvent(
-      config.name,
+    await trackUserEvent({
+      apiName: config.name,
       specId,
-      ExitedTaskWithLocalCli({
+      event: ExitedTaskWithLocalCli({
         interactionCount: sampleCount,
         inputs: opticTaskToProps('', taskConfig),
         captureId: this.captureId,
-      })
-    );
+      }),
+    });
 
     if (hasDiff) {
       const uiUrl = linkToCapture(uiBaseUrl, cliSession.session.id, captureId);

--- a/workspaces/local-cli/src/shared/local-cli-task-runner.ts
+++ b/workspaces/local-cli/src/shared/local-cli-task-runner.ts
@@ -235,7 +235,20 @@ export class LocalCliTaskRunner implements IOpticTaskRunner {
     const cliClient = new Client(apiBaseUrl);
 
     ////////////////////////////////////////////////////////////////////////////////
-    const spectacle = new LocalCliSpectacle(apiBaseUrl, opticEngine);
+    developerDebugLogger('finding matching daemon session');
+
+    const { cwd } = this.paths;
+    const cliSession = await cliClient.findSession(
+      cwd,
+      taskConfig,
+      this.captureId
+    );
+    developerDebugLogger({ cliSession });
+
+    const spectacleBaseUrl = `${apiBaseUrl}/specs/${cliSession.session.id}`;
+
+    ////////////////////////////////////////////////////////////////////////////////
+    const spectacle = new LocalCliSpectacle(spectacleBaseUrl, opticEngine);
     const idQuery = await spectacle.query<any>({
       query: `{
         metadata {
@@ -272,16 +285,6 @@ export class LocalCliTaskRunner implements IOpticTaskRunner {
         captureId: this.captureId,
       }),
     });
-    ////////////////////////////////////////////////////////////////////////////////
-    developerDebugLogger('finding matching daemon session');
-
-    const { cwd } = this.paths;
-    const cliSession = await cliClient.findSession(
-      cwd,
-      taskConfig,
-      this.captureId
-    );
-    developerDebugLogger({ cliSession });
 
     ////////////////////////////////////////////////////////////////////////////////
 

--- a/workspaces/local-cli/src/shared/local-cli-task-runner.ts
+++ b/workspaces/local-cli/src/shared/local-cli-task-runner.ts
@@ -244,7 +244,7 @@ export class LocalCliTaskRunner implements IOpticTaskRunner {
       }`,
       variables: {},
     });
-    const specId = idQuery?.data?.metadata?.id;
+    const specId = idQuery?.data?.metadata?.id ?? 'anon-spec-id';
 
     const batchCommitQuery = await spectacle.query<any>({
       query: `{
@@ -256,8 +256,8 @@ export class LocalCliTaskRunner implements IOpticTaskRunner {
     });
 
     const createdAt = batchCommitQuery?.data?.batchCommits
-      ?.map((commit: any) => commit?.createdAt)
-      ?.sort()?.[0]?.createdAt;
+      ?.map((commit: any) => new Date(commit?.createdAt))
+      ?.sort()?.[0];
 
     await trackUserEvent({
       apiName: config.name,

--- a/workspaces/local-cli/src/shared/local-cli-task-runner.ts
+++ b/workspaces/local-cli/src/shared/local-cli-task-runner.ts
@@ -236,19 +236,28 @@ export class LocalCliTaskRunner implements IOpticTaskRunner {
 
     ////////////////////////////////////////////////////////////////////////////////
     const spectacle = new LocalCliSpectacle(apiBaseUrl, opticEngine);
-    const requestQuery = await spectacle.query<any>({
+    const idQuery = await spectacle.query<any>({
       query: `{
         metadata {
           id
         }
+      }`,
+      variables: {},
+    });
+    const specId = idQuery?.data?.metadata?.id;
+
+    const batchCommitQuery = await spectacle.query<any>({
+      query: `{
         batchCommits {
           createdAt
         }
       }`,
       variables: {},
     });
-    const specId = requestQuery?.data?.metadata?.id;
-    const createdAt = requestQuery?.data?.batchCommits?.[0]?.createdAt;
+
+    const createdAt = batchCommitQuery?.data?.batchCommits
+      ?.map((commit: any) => commit?.createdAt)
+      ?.sort()?.[0]?.createdAt;
 
     await trackUserEvent(
       config.name,

--- a/workspaces/local-cli/src/shared/local-cli-task-runner.ts
+++ b/workspaces/local-cli/src/shared/local-cli-task-runner.ts
@@ -246,6 +246,9 @@ export class LocalCliTaskRunner implements IOpticTaskRunner {
     });
     const specId = idQuery?.data?.metadata?.id ?? 'anon-spec-id';
 
+    // See here for why this is split into separate queries: https://github.com/opticdev/optic/pull/1083#issuecomment-893522118
+    // TL;DR querying for specId will create if it doesn't exist (which adds a batch commit), and then reload spectacle
+    // but that could race with the `batchCommits` query, so better to serialize the queries to make sure things are loaded
     const batchCommitQuery = await spectacle.query<any>({
       query: `{
         batchCommits {

--- a/workspaces/ui-v2/src/components/sharing/ShareButton.tsx
+++ b/workspaces/ui-v2/src/components/sharing/ShareButton.tsx
@@ -48,9 +48,10 @@ export const ShareButton: React.FC<{}> = (props) => {
         headers: { Authorization: `Bearer ${token}` },
       });
       const resp_data = await response.json();
+      analytics.userLoggedIn(resp_data.id);
       return resp_data.id;
     }
-  }, [getAccessTokenSilently, isAuthenticated, baseDomain]);
+  }, [getAccessTokenSilently, isAuthenticated, baseDomain, analytics]);
 
   const share = useCallback(
     async (target: ShareTarget) => {

--- a/workspaces/ui-v2/src/contexts/analytics/AnalyticsStore.tsx
+++ b/workspaces/ui-v2/src/contexts/analytics/AnalyticsStore.tsx
@@ -91,7 +91,7 @@ export const AnalyticsStore: FC<AnalyticsStoreProps> = ({
       if (appConfig.analytics.enabled) {
         refTrack.current(event, {
           ...cfgRef.current.metadata,
-          specId: cfgRef.current.specId,
+          specId: cfgRef.current.specId ?? 'anon-spec-id',
         });
       }
     })

--- a/workspaces/ui-v2/src/contexts/analytics/AnalyticsStore.tsx
+++ b/workspaces/ui-v2/src/contexts/analytics/AnalyticsStore.tsx
@@ -1,11 +1,4 @@
-import React, {
-  FC,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { FC, useContext, useEffect, useRef, useState } from 'react';
 import { OpticUIEvents, TrackingEventBase } from '@useoptic/analytics';
 import { InvariantViolationError } from '<src>/errors';
 import { useAppConfig } from '../config/AppConfiguration';

--- a/workspaces/ui-v2/src/contexts/analytics/AnalyticsStore.tsx
+++ b/workspaces/ui-v2/src/contexts/analytics/AnalyticsStore.tsx
@@ -25,18 +25,20 @@ type AnalyticsMetadata = {
   clientId: string;
   clientAgent: string;
   apiName: string;
-  specId?: string;
+  specId: string;
 };
-const defaultMetadata: AnalyticsMetadata = {
+type InputAnalyticsMetadata = Omit<AnalyticsMetadata, 'specId'>;
+
+const defaultMetadata: InputAnalyticsMetadata = {
   clientId,
   clientAgent: 'anon_id',
   apiName: '',
 };
 
 export type AnalyticsStoreProps = {
-  getMetadata: () => Promise<AnalyticsMetadata>;
+  getMetadata: () => Promise<InputAnalyticsMetadata>;
   initialize: (
-    metadata: AnalyticsMetadata,
+    metadata: InputAnalyticsMetadata,
     appConfig: ReturnType<typeof useAppConfig>
   ) => Promise<void>;
   track: (
@@ -56,7 +58,9 @@ export const AnalyticsStore: FC<AnalyticsStoreProps> = ({
   const refInitialize = useRef(initialize);
   const refTrack = useRef(track);
 
-  const [metadata, setMetadata] = useState<AnalyticsMetadata>(defaultMetadata);
+  const [metadata, setMetadata] = useState<InputAnalyticsMetadata>(
+    defaultMetadata
+  );
 
   const specId = useAppSelector(
     (state) => state.metadata.data?.specificationId!
@@ -83,7 +87,7 @@ export const AnalyticsStore: FC<AnalyticsStoreProps> = ({
   }, [appConfig]);
 
   const opticUITrackingEvents = useRef(
-    new OpticUIEvents(async (event) => {
+    new OpticUIEvents(async (event: any) => {
       if (appConfig.analytics.enabled) {
         refTrack.current(event, {
           ...cfgRef.current.metadata,

--- a/workspaces/ui-v2/src/contexts/analytics/AnalyticsStore.tsx
+++ b/workspaces/ui-v2/src/contexts/analytics/AnalyticsStore.tsx
@@ -62,6 +62,16 @@ export const AnalyticsStore: FC<AnalyticsStoreProps> = ({
     (state) => state.metadata.data?.specificationId!
   );
 
+  const cfgRef = useRef({
+    metadata,
+    specId,
+  });
+
+  useEffect(() => {
+    cfgRef.current.metadata = metadata;
+    cfgRef.current.specId = specId;
+  }, [metadata, specId, cfgRef]);
+
   useEffect(() => {
     (async function () {
       if (appConfig.analytics.enabled) {
@@ -72,16 +82,21 @@ export const AnalyticsStore: FC<AnalyticsStoreProps> = ({
     })();
   }, [appConfig]);
 
-  const opticUITrackingEvents = useMemo(() => {
-    return new OpticUIEvents(async (event) => {
+  const opticUITrackingEvents = useRef(
+    new OpticUIEvents(async (event) => {
       if (appConfig.analytics.enabled) {
-        refTrack.current(event, { ...metadata, specId });
+        refTrack.current(event, {
+          ...cfgRef.current.metadata,
+          specId: cfgRef.current.specId,
+        });
       }
-    });
-  }, [appConfig, metadata, specId]);
+    })
+  );
 
   return (
-    <AnalyticsContext.Provider value={{ trackEvent: opticUITrackingEvents }}>
+    <AnalyticsContext.Provider
+      value={{ trackEvent: opticUITrackingEvents.current }}
+    >
       {children}
     </AnalyticsContext.Provider>
   );

--- a/workspaces/ui-v2/src/contexts/analytics/implementations/cloudViewerAnalytics.ts
+++ b/workspaces/ui-v2/src/contexts/analytics/implementations/cloudViewerAnalytics.ts
@@ -67,6 +67,7 @@ export const track: AnalyticsStoreProps['track'] = async (event, metadata) => {
         ...event.data,
         clientId,
         apiName: metadata.apiName,
+        specId: metadata.specId,
         uiVariant: 'cloudViewer',
       },
     });

--- a/workspaces/ui-v2/src/contexts/analytics/implementations/localCliAnalytics.ts
+++ b/workspaces/ui-v2/src/contexts/analytics/implementations/localCliAnalytics.ts
@@ -88,10 +88,10 @@ export const track: AnalyticsStoreProps['track'] = async (event, metadata) => {
   cliClient.postTrackingEvents([
     {
       type: event.type,
-      data: event.data,
+      data: { ...event.data, specId: metadata.specId },
     },
   ]);
   try {
-    FullStory.event(event.type, event.data);
+    FullStory.event(event.type, { ...event.data, specId: metadata.specId });
   } catch (e) {}
 };

--- a/workspaces/ui-v2/src/contexts/analytics/implementations/publicExampleAnalytics.ts
+++ b/workspaces/ui-v2/src/contexts/analytics/implementations/publicExampleAnalytics.ts
@@ -89,6 +89,7 @@ export const track: AnalyticsStoreProps['track'] = async (event, metadata) => {
         ...event.data,
         clientId,
         apiName: metadata.apiName,
+        specId: metadata.specId,
         uiVariant: 'publicExample',
       },
     });

--- a/workspaces/ui-v2/src/entry-points/cloud/cloud-viewer.tsx
+++ b/workspaces/ui-v2/src/entry-points/cloud/cloud-viewer.tsx
@@ -123,15 +123,15 @@ export default function CloudViewer() {
             <ReduxProvider store={store}>
               <SpecRepositoryStore specRepo={data.opticContext.specRepository}>
                 <BaseUrlProvider value={{ url: match.url }}>
-                  <AnalyticsStore
-                    getMetadata={getMetadata(() =>
-                      data.opticContext.configRepository.getApiName()
-                    )}
-                    initialize={initialize}
-                    track={track}
-                  >
-                    <DebugOpticComponent />
-                    <MetadataLoader>
+                  <MetadataLoader>
+                    <AnalyticsStore
+                      getMetadata={getMetadata(() =>
+                        data.opticContext.configRepository.getApiName()
+                      )}
+                      initialize={initialize}
+                      track={track}
+                    >
+                      <DebugOpticComponent />
                       <Switch>
                         <Route
                           path={`${match.path}/history`}
@@ -151,8 +151,8 @@ export default function CloudViewer() {
                         />
                         <Redirect to={`${match.path}/documentation`} />
                       </Switch>
-                    </MetadataLoader>
-                  </AnalyticsStore>
+                    </AnalyticsStore>
+                  </MetadataLoader>
                 </BaseUrlProvider>
               </SpecRepositoryStore>
             </ReduxProvider>

--- a/workspaces/ui-v2/src/entry-points/demo/demo-examples.tsx
+++ b/workspaces/ui-v2/src/entry-points/demo/demo-examples.tsx
@@ -94,15 +94,15 @@ export default function DemoExamples(props: { lookupDir: string }) {
             <ReduxProvider store={store}>
               <SpecRepositoryStore specRepo={data.opticContext.specRepository}>
                 <BaseUrlProvider value={{ url: match.url }}>
-                  <AnalyticsStore
-                    getMetadata={getMetadata(() =>
-                      data.opticContext.configRepository.getApiName()
-                    )}
-                    initialize={initialize}
-                    track={track}
-                  >
-                    <DebugOpticComponent />
-                    <MetadataLoader>
+                  <MetadataLoader>
+                    <AnalyticsStore
+                      getMetadata={getMetadata(() =>
+                        data.opticContext.configRepository.getApiName()
+                      )}
+                      initialize={initialize}
+                      track={track}
+                    >
+                      <DebugOpticComponent />
                       <Switch>
                         <Route
                           path={`${match.path}/history`}
@@ -122,8 +122,8 @@ export default function DemoExamples(props: { lookupDir: string }) {
                         />
                         <Redirect to={`${match.path}/documentation`} />
                       </Switch>
-                    </MetadataLoader>
-                  </AnalyticsStore>
+                    </AnalyticsStore>
+                  </MetadataLoader>
                 </BaseUrlProvider>
               </SpecRepositoryStore>
             </ReduxProvider>

--- a/workspaces/ui-v2/src/entry-points/local/local-cli.tsx
+++ b/workspaces/ui-v2/src/entry-points/local/local-cli.tsx
@@ -94,15 +94,15 @@ export default function LocalCli() {
                     clientId={AUTH0_CLIENT_ID}
                     audience={appConfig.config.backendApi.domain}
                   >
-                    <AnalyticsStore
-                      getMetadata={getMetadata(() =>
-                        data.configRepository.getApiName()
-                      )}
-                      initialize={initialize}
-                      track={track}
-                    >
-                      <DebugOpticComponent />
-                      <MetadataLoader>
+                    <MetadataLoader>
+                      <AnalyticsStore
+                        getMetadata={getMetadata(() =>
+                          data.configRepository.getApiName()
+                        )}
+                        initialize={initialize}
+                        track={track}
+                      >
+                        <DebugOpticComponent />
                         <Switch>
                           <Route
                             path={`${match.path}/history`}
@@ -122,8 +122,8 @@ export default function LocalCli() {
                           />
                           <Redirect to={`${match.path}/documentation`} />
                         </Switch>
-                      </MetadataLoader>
-                    </AnalyticsStore>
+                      </AnalyticsStore>
+                    </MetadataLoader>
                   </Auth0Provider>
                 </BaseUrlProvider>
               </SpecRepositoryStore>

--- a/workspaces/ui-v2/src/entry-points/local/public-examples.tsx
+++ b/workspaces/ui-v2/src/entry-points/local/public-examples.tsx
@@ -94,15 +94,15 @@ export default function PublicExamples(props: { lookupDir: string }) {
             <ReduxProvider store={store}>
               <SpecRepositoryStore specRepo={data.opticContext.specRepository}>
                 <BaseUrlProvider value={{ url: match.url }}>
-                  <AnalyticsStore
-                    getMetadata={getMetadata(() =>
-                      data.opticContext.configRepository.getApiName()
-                    )}
-                    initialize={initialize}
-                    track={track}
-                  >
-                    <DebugOpticComponent />
-                    <MetadataLoader>
+                  <MetadataLoader>
+                    <AnalyticsStore
+                      getMetadata={getMetadata(() =>
+                        data.opticContext.configRepository.getApiName()
+                      )}
+                      initialize={initialize}
+                      track={track}
+                    >
+                      <DebugOpticComponent />
                       <Switch>
                         <Route
                           path={`${match.path}/history`}
@@ -122,8 +122,8 @@ export default function PublicExamples(props: { lookupDir: string }) {
                         />
                         <Redirect to={`${match.path}/documentation`} />
                       </Switch>
-                    </MetadataLoader>
-                  </AnalyticsStore>
+                    </AnalyticsStore>
+                  </MetadataLoader>
                 </BaseUrlProvider>
               </SpecRepositoryStore>
             </ReduxProvider>


### PR DESCRIPTION
## Why
This is one of the pieces of analytics that was missing. Now most (all?) analytics events should have the spec ID.

## Validation
* [ ] Test in side-channel
