### PR TITLE
Handle array object fields being deleted

### DIFF
--- a/workspaces/ui-v2/src/store/selectors/__tests__/documentationEditSelectors.test.ts
+++ b/workspaces/ui-v2/src/store/selectors/__tests__/documentationEditSelectors.test.ts
@@ -98,7 +98,12 @@ test('isEndpointEditable', () => {
 test('isFieldRemoved', () => {
   store.documentationEdits.fieldEdits.removedFields.push('field_p1mYG7RoTV');
   // Fields and all nested fields should be removed
-  const removedFields = ['field_p1mYG7RoTV', 'field_y1zK0XALx0'];
+  const removedFields = [
+    'field_p1mYG7RoTV',
+    'field_y1zK0XALx0',
+    'field_a1zK0XALx0',
+    'field_qqzK0XALx0',
+  ];
   const nonRemovedFields = ['field_cOmYY7RoTV'];
   for (const fieldId of removedFields) {
     expect(isFieldRemoved(fieldId)(store)).toBe(true);

--- a/workspaces/ui-v2/src/store/selectors/__tests__/testHelpers.ts
+++ b/workspaces/ui-v2/src/store/selectors/__tests__/testHelpers.ts
@@ -618,13 +618,56 @@ export const getMockReduxStore = (): RootState =>
                   contributions: {},
                   changes: null,
                 },
+                {
+                  name: 'polymorphic_array_with_objects',
+                  fieldId: 'field_a1zK0XALx0',
+                  shapeId: 'shape_qTsqoMD123',
+                  contributions: {},
+                  changes: null,
+                },
               ],
             },
+          },
+        ],
+        shape_Tsqo312a23: [
+          {
+            shapeId: 'shape_Tsqo312a23',
+            jsonType: 'Object',
+            asObject: {
+              fields: [
+                {
+                  name: 'ah',
+                  fieldId: 'field_qqzK0XALx0',
+                  shapeId: 'shape_amsvoMD123',
+                  contributions: {},
+                  changes: null,
+                },
+              ],
+            },
+          },
+        ],
+        shape_qTsqoMD123: [
+          {
+            shapeId: 'shape_qTsqoMD123',
+            jsonType: 'Array',
+            asArray: {
+              shapeId: 'shape_Tsqo312a23',
+            },
+          },
+          {
+            shapeId: 'shape_qTsqoMD123',
+            jsonType: 'String',
           },
         ],
         shape_UmsvoMD123: [
           {
             shapeId: 'shape_UmsvoMD123',
+            jsonType: 'String',
+          },
+        ],
+        shape_amsvoMD123: [
+          {
+            shapeId: 'shape_amsvoMD123',
             jsonType: 'String',
           },
         ],

--- a/workspaces/ui-v2/src/store/selectors/documentationEditSelectors.ts
+++ b/workspaces/ui-v2/src/store/selectors/documentationEditSelectors.ts
@@ -26,6 +26,8 @@ const memoizedGetAllRemovedFields = createSelector<
               stack.push(field.shapeId);
               allRemovedFields.add(field.fieldId);
             }
+          } else if (shape.jsonType === JsonLike.ARRAY) {
+            stack.push(shape.asArray.shapeId);
           }
         }
       }


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

When handling removed fields, I didn't handle the case where arrays could have nested objects.

## What
What's changing? Anything of note to call out?

- Update includes a fix in memoizedGetRemovedFields to continue the DFS search for arrays

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
