### PR TITLE
Highlight shape field when edited in contribution

### DIFF
--- a/workspaces/ui-v2/src/components/EditableTextField.tsx
+++ b/workspaces/ui-v2/src/components/EditableTextField.tsx
@@ -19,7 +19,9 @@ export enum TextFieldVariant {
   FIELDORPARAM,
 }
 
-export const EditableTextField: FC<EditableTextFieldProps> = ({
+export const EditableTextField: FC<
+  EditableTextFieldProps & React.HtmlHTMLAttributes<HTMLInputElement>
+> = ({
   isEditing,
   setEditing,
   value,
@@ -27,6 +29,7 @@ export const EditableTextField: FC<EditableTextFieldProps> = ({
   helperText,
   defaultText,
   variant,
+  ...props
 }) => {
   const classes = useStyles();
   const isEmpty = !value.trim();
@@ -60,6 +63,7 @@ export const EditableTextField: FC<EditableTextFieldProps> = ({
   return isEditing ? (
     <TextField
       inputProps={{
+        ...props,
         className: variants[variant].className,
         ...variants[variant].inputProps,
       }}

--- a/workspaces/ui-v2/src/components/FieldOrParameter.tsx
+++ b/workspaces/ui-v2/src/components/FieldOrParameter.tsx
@@ -13,7 +13,9 @@ export type FieldOrParameterProps = {
   required: boolean;
 };
 
-export const FieldOrParameter: FC<FieldOrParameterProps> = ({
+export const FieldOrParameter: FC<
+  FieldOrParameterProps & React.HtmlHTMLAttributes<HTMLInputElement>
+> = ({
   name,
   shapes,
   depth,
@@ -21,6 +23,7 @@ export const FieldOrParameter: FC<FieldOrParameterProps> = ({
   setValue = () => {},
   isEditing = false,
   required,
+  ...props
 }) => {
   const classes = useStyles();
   return (
@@ -30,6 +33,7 @@ export const FieldOrParameter: FC<FieldOrParameterProps> = ({
         <div className={classes.shape}>{summarizeTypes(shapes, required)}</div>
       </div>
       <EditableTextField
+        {...props}
         isEditing={isEditing}
         value={value}
         setValue={setValue}

--- a/workspaces/ui-v2/src/components/HighlightController.tsx
+++ b/workspaces/ui-v2/src/components/HighlightController.tsx
@@ -1,0 +1,15 @@
+import React, { FC, useState } from 'react';
+
+type HighlightControllerProps = {
+  children: (
+    selectedItem: string | null,
+    setSelectedItem: (selectedItem: string | null) => void
+  ) => React.ReactElement;
+};
+
+export const HighlightController: FC<HighlightControllerProps> = ({
+  children,
+}) => {
+  const [selectedItem, setSelectedItem] = useState<string | null>(null);
+  return <>{children(selectedItem, setSelectedItem)}</>;
+};

--- a/workspaces/ui-v2/src/components/HttpBodyPanel.tsx
+++ b/workspaces/ui-v2/src/components/HttpBodyPanel.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect, useRef } from 'react';
 
 import { IShapeRenderer } from '<src>/types';
 import { ShapeRenderer } from './ShapeRenderer';
@@ -7,12 +7,39 @@ import { Panel } from './Panel';
 type HttpBodyPanelProps = {
   shapes: IShapeRenderer[];
   location: string;
+  selectedFieldId?: string | null;
 };
 
-export const HttpBodyPanel: FC<HttpBodyPanelProps> = ({ shapes, location }) => {
+export const HttpBodyPanel: FC<HttpBodyPanelProps> = ({
+  shapes,
+  location,
+  selectedFieldId,
+}) => {
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (selectedFieldId && contentRef.current) {
+      const isContainerScrollable =
+        contentRef.current.scrollHeight > contentRef.current.clientHeight;
+      const fieldNode = contentRef.current.querySelector(
+        `[data-fieldId='${selectedFieldId}']`
+      );
+      if (isContainerScrollable && fieldNode) {
+        const scrollTopDiff =
+          fieldNode.getBoundingClientRect().top -
+          contentRef.current.getBoundingClientRect().top;
+        contentRef.current.scrollTop += scrollTopDiff;
+      }
+    }
+  }, [selectedFieldId]);
+
   return (
-    <Panel header={location}>
-      <ShapeRenderer showExamples={false} shapes={shapes} />
+    <Panel header={location} contentRef={contentRef}>
+      <ShapeRenderer
+        showExamples={false}
+        shapes={shapes}
+        selectedFieldId={selectedFieldId}
+      />
     </Panel>
   );
 };

--- a/workspaces/ui-v2/src/components/HttpBodyPanel.tsx
+++ b/workspaces/ui-v2/src/components/HttpBodyPanel.tsx
@@ -28,7 +28,10 @@ export const HttpBodyPanel: FC<HttpBodyPanelProps> = ({
         const scrollTopDiff =
           fieldNode.getBoundingClientRect().top -
           contentRef.current.getBoundingClientRect().top;
-        contentRef.current.scrollTop += scrollTopDiff;
+
+        // set scroll position to the selected field being in the middle
+        contentRef.current.scrollTop +=
+          scrollTopDiff - contentRef.current.clientHeight / 2;
       }
     }
   }, [selectedFieldId]);

--- a/workspaces/ui-v2/src/components/Panel.tsx
+++ b/workspaces/ui-v2/src/components/Panel.tsx
@@ -1,22 +1,25 @@
-import React, { FC } from 'react';
+import React, { FC, Ref } from 'react';
 import classNames from 'classnames';
 import { makeStyles } from '@material-ui/core';
 import { FontFamilyMono } from '<src>/styles';
 
 type PanelProps = {
   header: React.ReactNode;
+  contentRef?: Ref<HTMLDivElement>;
 };
 
 export const Panel: FC<
   PanelProps & React.HtmlHTMLAttributes<HTMLDivElement>
-> = ({ children, header, className, ...props }) => {
+> = ({ children, header, className, contentRef, ...props }) => {
   const classes = useStyles();
   return (
     <div {...props} className={classNames(classes.wrapper, className)}>
       <div className={classes.header}>
         <div>{header}</div>
       </div>
-      <div className={classes.content}>{children}</div>
+      <div className={classes.content} ref={contentRef}>
+        {children}
+      </div>
     </div>
   );
 };

--- a/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRenderContext.tsx
+++ b/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRenderContext.tsx
@@ -4,6 +4,7 @@ import { DepthStore } from './DepthContext';
 import { OneOfTabsProps } from './OneOfTabs';
 
 type IShapeRenderContext = {
+  selectedFieldId?: string | null;
   showExamples: boolean;
   getChoice: (branch: OneOfTabsProps) => string;
   updateChoice: (parentShapeId: string, branchId: string) => void;
@@ -13,11 +14,16 @@ export const ShapeRenderContext = React.createContext<IShapeRenderContext | null
   null
 );
 
-type ShapeRenderContextProps = { children: any; showExamples: boolean };
+type ShapeRenderContextProps = {
+  children: React.ReactNode;
+  showExamples: boolean;
+  selectedFieldId?: string | null;
+};
 
 export const ShapeRenderStore = ({
   children,
   showExamples,
+  selectedFieldId,
 }: ShapeRenderContextProps) => {
   const [selectedOneOfChoices, updateSelectedOneOfChoices]: [
     { [key: string]: string },
@@ -41,7 +47,7 @@ export const ShapeRenderStore = ({
 
   return (
     <ShapeRenderContext.Provider
-      value={{ showExamples, getChoice, updateChoice }}
+      value={{ showExamples, getChoice, updateChoice, selectedFieldId }}
     >
       <DepthStore depth={0}>{children}</DepthStore>
     </ShapeRenderContext.Provider>

--- a/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRenderer.tsx
+++ b/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRenderer.tsx
@@ -6,14 +6,19 @@ import { IShapeRenderer } from '<src>/types';
 type ShapeRendererProps = {
   showExamples: boolean;
   shapes: IShapeRenderer[];
+  selectedFieldId?: string | null;
 };
 
 export const ShapeRenderer: FC<ShapeRendererProps> = ({
   showExamples,
   shapes,
+  selectedFieldId,
 }) => {
   return (
-    <ShapeRenderStore showExamples={showExamples}>
+    <ShapeRenderStore
+      showExamples={showExamples}
+      selectedFieldId={selectedFieldId}
+    >
       {shapes.length > 1 ? (
         <OneOfRender shapes={shapes} parentShapeId={'root'} />
       ) : shapes.length === 1 ? (

--- a/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRowBase.tsx
+++ b/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRowBase.tsx
@@ -16,12 +16,15 @@ type ShapeRowBaseProps = {
   depth: number;
   style?: any;
   changes?: ChangeType | null;
-};
+  focused?: boolean;
+} & React.HtmlHTMLAttributes<HTMLDivElement>;
 export const ShapeRowBase = ({
   children,
   depth = 0,
   style,
   changes,
+  focused,
+  ...props
 }: ShapeRowBaseProps) => {
   const classes = useStyles();
   const sharedClasses = useSharedStyles();
@@ -31,11 +34,13 @@ export const ShapeRowBase = ({
       className={classNames(classes.rowWrap, { [classes.allowHover]: false })}
     >
       <div
+        {...props}
         className={classNames(
           classes.row,
           { [sharedClasses.added]: changes === 'added' },
           { [sharedClasses.changed]: changes === 'updated' },
-          { [sharedClasses.removed]: changes === 'removed' }
+          { [sharedClasses.removed]: changes === 'removed' },
+          { [classes.focused]: focused }
         )}
         style={{ paddingLeft: depth * IndentSpaces + 4 }}
       >
@@ -51,16 +56,22 @@ export const RenderField = ({
   required,
   parentId,
   changes,
+  fieldId,
 }: IFieldRenderer & { parentId: string }) => {
   const sharedClasses = useSharedStyles();
   const { depth } = useDepth();
 
-  const { getChoice } = useShapeRenderContext();
+  const { getChoice, selectedFieldId } = useShapeRenderContext();
 
   if (shapeChoices.length === 1) {
     return (
       <>
-        <ShapeRowBase depth={depth} changes={changes}>
+        <ShapeRowBase
+          depth={depth}
+          changes={changes}
+          focused={fieldId === selectedFieldId}
+          data-fieldId={fieldId}
+        >
           <span className={sharedClasses.shapeFont}>"{name}"</span>
           <span className={sharedClasses.symbolFont}>: </span>
           <RenderFieldLeadingValue shapeRenderers={shapeChoices} />
@@ -73,7 +84,12 @@ export const RenderField = ({
     );
   } else if (shapeChoices.length === 0) {
     return (
-      <ShapeRowBase depth={depth} changes={changes}>
+      <ShapeRowBase
+        depth={depth}
+        changes={changes}
+        focused={fieldId === selectedFieldId}
+        data-fieldId={fieldId}
+      >
         <span className={sharedClasses.shapeFont}>"{name}"</span>
         <span className={sharedClasses.symbolFont}>: </span>
         <UnknownPrimitiveRender />
@@ -93,7 +109,12 @@ export const RenderField = ({
     //one of
     return (
       <>
-        <ShapeRowBase depth={depth} changes={changes}>
+        <ShapeRowBase
+          depth={depth}
+          changes={changes}
+          focused={fieldId === selectedFieldId}
+          data-fieldId={fieldId}
+        >
           <span className={sharedClasses.shapeFont}>"{name}"</span>
           <span className={sharedClasses.symbolFont}>: </span>
           {toRenderShape && (
@@ -183,9 +204,9 @@ export const RenderFieldRowValues = ({
     if (shape.asObject) {
       return (
         <>
-          {shape.asObject.fields.map((i, index) => (
-            <Indent key={index}>
-              <RenderField {...i} key={i.fieldId} parentId={shape.shapeId} />
+          {shape.asObject.fields.map((field) => (
+            <Indent key={field.fieldId}>
+              <RenderField {...field} parentId={shape.shapeId} />
             </Indent>
           ))}
           <ShapeRowBase depth={depth}>
@@ -280,5 +301,8 @@ const useStyles = makeStyles((theme) => ({
     display: 'flex',
     alignItems: 'flex-start',
     minHeight: 17,
+  },
+  focused: {
+    borderBottom: '1px solid black',
   },
 }));

--- a/workspaces/ui-v2/src/components/index.ts
+++ b/workspaces/ui-v2/src/components/index.ts
@@ -19,3 +19,4 @@ export * from './DataFetchers';
 export * from './HttpBodyPanel';
 export * from './HttpBodySelector';
 export * from './SimulatedCommandStore';
+export * from './HighlightController';

--- a/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
@@ -16,6 +16,7 @@ import {
   HttpBodyPanel,
   HttpBodySelector,
   Panel,
+  HighlightController,
 } from '<src>/components';
 import { useDocumentationPageLink } from '<src>/components/navigation/Routes';
 import { FontFamily, SubtleBlueBackground } from '<src>/styles';
@@ -370,51 +371,58 @@ export const EndpointRootPage: FC<
                       endpointId={endpointId}
                     >
                       {(shapes, fields) => (
-                        <div className={classes.bodyDetails}>
-                          <div>
-                            <ContributionsList
-                              renderField={(field) => (
-                                <DocFieldContribution
-                                  key={
-                                    field.contribution.id +
-                                    field.contribution.contributionKey
-                                  }
-                                  endpoint={{
-                                    pathId,
-                                    method,
-                                  }}
-                                  name={field.name}
-                                  shapes={field.shapes}
-                                  depth={field.depth}
-                                  id={field.contribution.id}
-                                  initialValue={field.contribution.value}
-                                  required={field.required}
+                        <HighlightController>
+                          {(selectedFieldId, setSelectedFieldId) => (
+                            <div className={classes.bodyDetails}>
+                              <div>
+                                <ContributionsList
+                                  renderField={(field) => (
+                                    <DocFieldContribution
+                                      key={
+                                        field.contribution.id +
+                                        field.contribution.contributionKey
+                                      }
+                                      endpoint={{
+                                        pathId,
+                                        method,
+                                      }}
+                                      name={field.name}
+                                      shapes={field.shapes}
+                                      depth={field.depth}
+                                      id={field.fieldId}
+                                      initialValue={field.contribution.value}
+                                      required={field.required}
+                                      setSelectedField={setSelectedFieldId}
+                                    />
+                                  )}
+                                  fieldDetails={fields}
                                 />
-                              )}
-                              fieldDetails={fields}
-                            />
-                          </div>
-                          <div className={classes.panel}>
-                            {isEditing ? (
-                              <SimulatedBody
-                                rootShapeId={request.body!.rootShapeId}
-                                endpointId={endpointId}
-                              >
-                                {(shapes) => (
+                              </div>
+                              <div className={classes.panel}>
+                                {isEditing ? (
+                                  <SimulatedBody
+                                    rootShapeId={request.body!.rootShapeId}
+                                    endpointId={endpointId}
+                                  >
+                                    {(shapes) => (
+                                      <HttpBodyPanel
+                                        shapes={shapes}
+                                        location={request.body!.contentType}
+                                        selectedFieldId={selectedFieldId}
+                                      />
+                                    )}
+                                  </SimulatedBody>
+                                ) : (
                                   <HttpBodyPanel
                                     shapes={shapes}
                                     location={request.body!.contentType}
+                                    selectedFieldId={selectedFieldId}
                                   />
                                 )}
-                              </SimulatedBody>
-                            ) : (
-                              <HttpBodyPanel
-                                shapes={shapes}
-                                location={request.body!.contentType}
-                              />
-                            )}
-                          </div>
-                        </div>
+                              </div>
+                            </div>
+                          )}
+                        </HighlightController>
                       )}
                     </ShapeFetcher>
                   ) : (
@@ -459,51 +467,58 @@ export const EndpointRootPage: FC<
                         endpointId={endpointId}
                       >
                         {(shapes, fields) => (
-                          <div className={classes.bodyDetails}>
-                            <div>
-                              <ContributionsList
-                                renderField={(field) => (
-                                  <DocFieldContribution
-                                    key={
-                                      field.contribution.id +
-                                      field.contribution.contributionKey
-                                    }
-                                    endpoint={{
-                                      pathId,
-                                      method,
-                                    }}
-                                    name={field.name}
-                                    shapes={field.shapes}
-                                    depth={field.depth}
-                                    id={field.contribution.id}
-                                    initialValue={field.contribution.value}
-                                    required={field.required}
+                          <HighlightController>
+                            {(selectedFieldId, setSelectedFieldId) => (
+                              <div className={classes.bodyDetails}>
+                                <div>
+                                  <ContributionsList
+                                    renderField={(field) => (
+                                      <DocFieldContribution
+                                        key={
+                                          field.contribution.id +
+                                          field.contribution.contributionKey
+                                        }
+                                        endpoint={{
+                                          pathId,
+                                          method,
+                                        }}
+                                        name={field.name}
+                                        shapes={field.shapes}
+                                        depth={field.depth}
+                                        id={field.fieldId}
+                                        initialValue={field.contribution.value}
+                                        required={field.required}
+                                        setSelectedField={setSelectedFieldId}
+                                      />
+                                    )}
+                                    fieldDetails={fields}
                                   />
-                                )}
-                                fieldDetails={fields}
-                              />
-                            </div>
-                            <div className={classes.panel}>
-                              {isEditing ? (
-                                <SimulatedBody
-                                  rootShapeId={response.body!.rootShapeId}
-                                  endpointId={endpointId}
-                                >
-                                  {(shapes) => (
+                                </div>
+                                <div className={classes.panel}>
+                                  {isEditing ? (
+                                    <SimulatedBody
+                                      rootShapeId={response.body!.rootShapeId}
+                                      endpointId={endpointId}
+                                    >
+                                      {(shapes) => (
+                                        <HttpBodyPanel
+                                          shapes={shapes}
+                                          location={response.body!.contentType}
+                                          selectedFieldId={selectedFieldId}
+                                        />
+                                      )}
+                                    </SimulatedBody>
+                                  ) : (
                                     <HttpBodyPanel
                                       shapes={shapes}
                                       location={response.body!.contentType}
+                                      selectedFieldId={selectedFieldId}
                                     />
                                   )}
-                                </SimulatedBody>
-                              ) : (
-                                <HttpBodyPanel
-                                  shapes={shapes}
-                                  location={response.body!.contentType}
-                                />
-                              )}
-                            </div>
-                          </div>
+                                </div>
+                              </div>
+                            )}
+                          </HighlightController>
                         )}
                       </ShapeFetcher>
                     ) : (

--- a/workspaces/ui-v2/src/pages/docs/components/Contributions.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/Contributions.tsx
@@ -26,11 +26,13 @@ export type DocsFieldOrParameterContributionProps = {
     pathId: string;
   };
   required: boolean;
+  setSelectedField?: (selectedFieldId: string | null) => void;
 };
 
 export function DocFieldContribution(
   props: DocsFieldOrParameterContributionProps
 ) {
+  const { setSelectedField } = props;
   const isEditing = useAppSelector(
     (state) => state.documentationEdits.isEditing
   );
@@ -49,7 +51,15 @@ export function DocFieldContribution(
   return process.env.REACT_APP_FF_FIELD_LEVEL_EDITS === 'true' ? (
     <div className={classes.fieldContainer}>
       <div className={classes.contributionContainer}>
-        <DocsFieldOrParameterContribution {...props} />
+        <DocsFieldOrParameterContribution
+          {...props}
+          onFocus={() => {
+            setSelectedField && setSelectedField(fieldId);
+          }}
+          onBlur={() => {
+            setSelectedField && setSelectedField(null);
+          }}
+        />
       </div>
       {isEditing &&
         (isFieldRemoved ? (
@@ -75,7 +85,9 @@ export function DocsFieldOrParameterContribution({
   initialValue,
   endpoint,
   required,
-}: DocsFieldOrParameterContributionProps) {
+  ...props
+}: DocsFieldOrParameterContributionProps &
+  React.HtmlHTMLAttributes<HTMLInputElement>) {
   const contributionKey = 'description';
   const endpointId = getEndpointId(endpoint);
   const isEditable = useAppSelector(
@@ -94,6 +106,7 @@ export function DocsFieldOrParameterContribution({
 
   return (
     <FieldOrParameter
+      {...props}
       name={name}
       shapes={shapes}
       depth={depth}

--- a/workspaces/ui-v2/src/store/selectors/__tests__/__snapshots__/shapeSelectors.test.ts.snap
+++ b/workspaces/ui-v2/src/store/selectors/__tests__/__snapshots__/shapeSelectors.test.ts.snap
@@ -43,6 +43,7 @@ Array [
       "value": "",
     },
     "depth": 1,
+    "fieldId": "field_LRYtHDYkVO",
     "name": "task",
     "required": true,
     "shapes": Array [
@@ -60,6 +61,7 @@ Array [
       "value": "",
     },
     "depth": 1,
+    "fieldId": "field_XM7KRqWOlV",
     "name": "isDone",
     "required": true,
     "shapes": Array [
@@ -77,6 +79,7 @@ Array [
       "value": "",
     },
     "depth": 1,
+    "fieldId": "field_9mczOWgNnu",
     "name": "id",
     "required": true,
     "shapes": Array [
@@ -94,6 +97,7 @@ Array [
       "value": "",
     },
     "depth": 1,
+    "fieldId": "field_5GCvc8KB2p",
     "name": "dueDate",
     "required": true,
     "shapes": Array [

--- a/workspaces/ui-v2/src/store/selectors/shapeSelectors.ts
+++ b/workspaces/ui-v2/src/store/selectors/shapeSelectors.ts
@@ -99,6 +99,7 @@ export function createFlatList(
     if (shape.asObject) {
       shape.asObject.fields.forEach((field) => {
         fieldDetails.push({
+          fieldId: field.fieldId,
           name: field.name,
           contribution: {
             id: field.fieldId,

--- a/workspaces/ui-v2/src/types/shapes.ts
+++ b/workspaces/ui-v2/src/types/shapes.ts
@@ -16,6 +16,7 @@ export interface IFieldRenderer {
 
 // Used to render an objects field details and contributions
 export interface IFieldDetails {
+  fieldId: string;
   name: string;
   contribution: IContribution;
   shapes: IShapeRenderer[];


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

When editing a large body, it can be unclear what field the left contribution field refers to on the right. 

## What
What's changing? Anything of note to call out?

Connected the two together which hopefully adds some sort of connection and flow between the left and right sides. The intent here is that the left side is a user input side, which causes the right side to be more of a preview flow. There's still a little more to do to make this more intuitive (especially since polymorphics are still controlled on the right side).

I'm not convinced this is the right trigger (i.e. highlights when editing the contribution field), but i think once we have more UI elements in place, we'll have a better spot to place this.

This is behind the FF so for now, this should be fine to have some poor styling here - currently it's a single black underline

TODO
- [ ] Find a better way to highlight this - the border bottom is temporary and we already use highlighted colors to 

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
