### PR TITLE
Fix cloud viewer from being able to reach edit mode

### DIFF
--- a/workspaces/ui-v2/src/pages/docs/components/Contributions.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/Contributions.tsx
@@ -7,6 +7,7 @@ import {
   TextFieldVariant,
   FieldOrParameter,
 } from '<src>/components';
+import { useAppConfig } from '<src>/contexts/config/AppConfiguration';
 import {
   useAppSelector,
   useAppDispatch,
@@ -134,6 +135,8 @@ export function EndpointNameContribution({
   endpoint,
 }: EndpointNameContributionProps) {
   const endpointId = getEndpointId(endpoint);
+  const appConfig = useAppConfig();
+
   const isEditable = useAppSelector(selectors.isEndpointEditable(endpoint));
   const contributionValue = useAppSelector(
     (state) =>
@@ -142,6 +145,18 @@ export function EndpointNameContribution({
   const dispatch = useAppDispatch();
   const value =
     contributionValue !== undefined ? contributionValue : initialValue;
+
+  if (!appConfig.allowEditing) {
+    return (
+      <EditableTextField
+        isEditing={false}
+        setEditing={() => {}}
+        value={initialValue || 'Unnamed Endpoint'}
+        setValue={() => {}}
+        variant={TextFieldVariant.REGULAR}
+      />
+    );
+  }
 
   return (
     <>
@@ -184,6 +199,7 @@ export function EndpointNameMiniContribution({
   endpoint,
 }: EndpointNameContributionProps) {
   const endpointId = getEndpointId(endpoint);
+  const appConfig = useAppConfig();
   const isEditable = useAppSelector(selectors.isEndpointEditable(endpoint));
   const contributionValue = useAppSelector(
     (state) =>
@@ -192,6 +208,18 @@ export function EndpointNameMiniContribution({
   const dispatch = useAppDispatch();
   const value =
     contributionValue !== undefined ? contributionValue : initialValue;
+
+  if (!appConfig.allowEditing) {
+    return (
+      <EditableTextField
+        isEditing={false}
+        setEditing={() => {}}
+        value={initialValue || 'Unnamed Endpoint'}
+        setValue={() => {}}
+        variant={TextFieldVariant.SMALL}
+      />
+    );
+  }
 
   return (
     <EditableTextField


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Cloud viewer should not be able to reach edit mode - but with an unnamed endpoint, this was possible by clicking on the endpoint name.

<img width="970" alt="Screen Shot 2021-08-05 at 7 40 25 PM" src="https://user-images.githubusercontent.com/18374483/128434795-ff8913c7-d4ac-4772-b107-a57111c31030.png">

## What
What's changing? Anything of note to call out?

Added a branch in the endpoint components that looks for this. Ideally this is controlled not in these components - but these components are already super specialized.

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
