### PR TITLE
Fix Typescript compilation for ui-v2

### DIFF
--- a/workspaces/ui-v2/package.json
+++ b/workspaces/ui-v2/package.json
@@ -21,6 +21,7 @@
     "start:demo": "env OPTIC_WEBPACK_ENTRYPOINT=demo node scripts/start.js",
     "build": "yarn run build:local",
     "ws:test": "jest",
+    "ws:clean": "rm -rf build && rm -f tsconfig.tsbuildinfo",
     "ws:build": "yarn build:local"
   },
   "dependencies": {

--- a/workspaces/ui-v2/package.json
+++ b/workspaces/ui-v2/package.json
@@ -40,6 +40,7 @@
     "@useoptic/optic-engine-wasm": "10.2.3",
     "@useoptic/shape-hash": "10.2.3",
     "@useoptic/spectacle": "10.2.3",
+    "@useoptic/spectacle-shared": "10.2.3",
     "@xstate/react": "^1.3.1",
     "classnames": "^2.2.6",
     "color": "^3.1.3",

--- a/workspaces/ui-v2/tsconfig.json
+++ b/workspaces/ui-v2/tsconfig.json
@@ -17,6 +17,7 @@
     { "path": "../cli-config" },
     { "path": "../cli-shared" },
     { "path": "../shape-hash" },
-    { "path": "../spectacle" }
+    { "path": "../spectacle" },
+    { "path": "../spectacle-shared" }
   ]
 }


### PR DESCRIPTION
## Why
The changes in #1085 broke compilation for ui-v2.

## What
There were two issues:

- now that we're incrementally compiling between packages, `ui-v2` needed to also clean it's build cache to avoid stale builds.
- `ui-v2` depends on `spectacle-shared`, but wasn't specified to do so. For runtime this worked fine as `spectacle` pulled it in making it available to ui-v2 too, but during compile time the types could not be resolved.

## Validation
* [ ] CI passes
* [x] fresh `task postpull` works
* [x] compiling only ui-v2 from clean slate works
