### PR TITLE
Fix/diff navigation prompting

### DIFF
--- a/workspaces/ui-v2/src/components/PromptNavigateAway.tsx
+++ b/workspaces/ui-v2/src/components/PromptNavigateAway.tsx
@@ -6,7 +6,8 @@ type PromptNavigateAwayProps = {
   shouldPrompt: boolean;
 };
 
-const isDiffsPage = (pathname: string) => /diffs/i.test(pathname);
+// the root diff page (i.e. /diffs) causes diffs to be regenerated
+const isDiffsPage = (pathname: string) => /diffs.+/i.test(pathname);
 
 const isNavigatingToSamePage = (locationToNavigateTo: string) => {
   const pageTesters = [isDiffsPage];

--- a/workspaces/ui-v2/src/pages/diffs/components/DiffAccessoryNavigation.tsx
+++ b/workspaces/ui-v2/src/pages/diffs/components/DiffAccessoryNavigation.tsx
@@ -18,11 +18,16 @@ export function DiffAccessoryNavigation() {
     handledCount,
     hasDiffChanges,
     getUndocumentedUrls,
+    wipPatterns,
   } = useSharedDiffContext();
   const diffReviewCapturePage = useDiffReviewCapturePageLink();
   const undocumentedUrlsPageLink = useDiffUndocumentedUrlsPageLink();
   const history = useHistory();
   const [handled, total] = handledCount;
+  const hasChanges =
+    hasDiffChanges() ||
+    Object.values(wipPatterns).filter((pattern) => pattern.isParameterized)
+      .length > 0;
 
   const numberOfUndocumented = getUndocumentedUrls().filter((i) => !i.hide)
     .length;
@@ -72,7 +77,7 @@ export function DiffAccessoryNavigation() {
       </div>
       <div className={classes.content}>
         <div className={classes.counter} style={{ marginRight: 10 }}>
-          <AskForCommitMessage hasChanges={hasDiffChanges()} />
+          <AskForCommitMessage hasChanges={hasChanges} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Previously, two things weren't picked up with the diff prompt navigate away (i.e. a prompt when users are about to lose their data)
- Any path pattern specification (i.e. parameterized paths)
- Navigating back to the diff root (which causes a new diff to generate, and we lose our data)

## What
What's changing? Anything of note to call out?


## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
