### PR TITLE
Check if daemon running

### DIFF
--- a/workspaces/cli-client/src/client.ts
+++ b/workspaces/cli-client/src/client.ts
@@ -5,6 +5,10 @@ import { TrackingEventBase } from '@useoptic/analytics/lib/interfaces/TrackingEv
 class Client {
   constructor(private baseUrl: string) {}
 
+  health() {
+    return JsonHttpClient.getJson(`${this.baseUrl}/health`);
+  }
+
   getIdentity() {
     const url = `${this.baseUrl}/identity`;
     return JsonHttpClient.getJsonWithoutHandlingResponse(url);

--- a/workspaces/cli-client/src/client.ts
+++ b/workspaces/cli-client/src/client.ts
@@ -5,8 +5,8 @@ import { TrackingEventBase } from '@useoptic/analytics/lib/interfaces/TrackingEv
 class Client {
   constructor(private baseUrl: string) {}
 
-  health() {
-    return JsonHttpClient.getJson(`${this.baseUrl}/health`);
+  daemonStatus() {
+    return JsonHttpClient.getJson(`${this.baseUrl}/daemon/status`);
   }
 
   getIdentity() {

--- a/workspaces/cli-server/src/server.ts
+++ b/workspaces/cli-server/src/server.ts
@@ -98,6 +98,10 @@ class CliServer {
 
     const anonIdPromise = getOrCreateAnonId();
 
+    app.get('/api/health', async (req, res) => {
+      res.json({ status: 'ok' });
+    });
+
     app.get('/api/identity', async (req, res: express.Response) => {
       res.json({ user, anonymousId: await anonIdPromise });
     });

--- a/workspaces/cli-server/src/server.ts
+++ b/workspaces/cli-server/src/server.ts
@@ -98,10 +98,6 @@ class CliServer {
 
     const anonIdPromise = getOrCreateAnonId();
 
-    app.get('/api/health', async (req, res) => {
-      res.json({ status: 'ok' });
-    });
-
     app.get('/api/identity', async (req, res: express.Response) => {
       res.json({ user, anonymousId: await anonIdPromise });
     });

--- a/workspaces/ui-v2/src/constants/SupportLinks.ts
+++ b/workspaces/ui-v2/src/constants/SupportLinks.ts
@@ -1,4 +1,5 @@
 const docsBaseLink = 'https://www.useoptic.com/docs';
+const referneceBaseLink = 'https://www.useoptic.com/reference';
 
 export const OpticDocs = docsBaseLink + '/';
 export const AddOpticLink = docsBaseLink + '/get-started/config';
@@ -13,3 +14,4 @@ export const RunTestsLink = docsBaseLink + '/get-started/testing';
 export const InterceptWithChromeLink =
   docsBaseLink + '/get-started/config/intercept';
 export const LiveTrafficLink = docsBaseLink + '/deploy/live';
+export const DebugLink = `${referneceBaseLink}/optic-cli/commands/debug`;

--- a/workspaces/ui-v2/src/entry-points/local/EnsureDaemonRunning.tsx
+++ b/workspaces/ui-v2/src/entry-points/local/EnsureDaemonRunning.tsx
@@ -48,7 +48,15 @@ const CliDaemonUnreachableError: FC = () => {
       <p>
         If this continues to happen, please reach out to{' '}
         <a href={SupportLinks.Contact('Optic App crash report')}>our team</a>{' '}
-        for assistance.
+        for assistance. Further debug information can be found from our{' '}
+        <a
+          href="https://useoptic.com/reference/optic-cli/commands/debug"
+          target="_blank"
+          rel="noreferrer"
+        >
+          debugging instructions
+        </a>
+        .
       </p>
     </div>
   );

--- a/workspaces/ui-v2/src/entry-points/local/EnsureDaemonRunning.tsx
+++ b/workspaces/ui-v2/src/entry-points/local/EnsureDaemonRunning.tsx
@@ -63,8 +63,7 @@ const HasMismatchedVersionsError: FC = () => {
       </p>
       <p>
         To fix this, you can run <code>api daemon:stop</code> and then rerun{' '}
-        <code>api spec</code> or
-        <code>api start</code> to restart the server
+        <code>api spec</code> or <code>api start</code> to restart the server
       </p>
       <p>
         If this continues to happen, please reach out to{' '}

--- a/workspaces/ui-v2/src/entry-points/local/EnsureDaemonRunning.tsx
+++ b/workspaces/ui-v2/src/entry-points/local/EnsureDaemonRunning.tsx
@@ -1,0 +1,65 @@
+import React, { FC, useEffect, useState } from 'react';
+import { makeStyles } from '@material-ui/core';
+import { Client } from '@useoptic/cli-client';
+
+import { FullPageLoader } from '<src>/components';
+import * as SupportLinks from '<src>/constants/SupportLinks';
+
+export const EnsureDaemonRunning: FC = ({ children }) => {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      const cliClient = new Client('/api');
+      try {
+        await cliClient.health();
+        setLoading(false);
+      } catch (e) {
+        setError(true);
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  return loading ? (
+    <FullPageLoader title="loading" />
+  ) : error ? (
+    <CliDaemonUnreachableError />
+  ) : (
+    <>{children}</>
+  );
+};
+
+const CliDaemonUnreachableError: FC = () => {
+  const classes = useStyles();
+
+  return (
+    <div className={classes.errorContainer}>
+      <h2>Error reaching daemon</h2>
+      <p>
+        It appears the cli daemon is unreachable. This usually means that the
+        daemon crashed and needs to be restarted.
+      </p>
+      <p>
+        You can restart the daemon by running <code>api daemon:start</code> or
+        rerunning <code>api start</code>.
+      </p>
+      <p>
+        If this continues to happen, please reach out to{' '}
+        <a href={SupportLinks.Contact('Optic App crash report')}>our team</a>{' '}
+        for assistance.
+      </p>
+    </div>
+  );
+};
+
+const useStyles = makeStyles((theme) => ({
+  errorContainer: {
+    display: 'flex',
+    margin: 'auto',
+    flexDirection: 'column',
+    maxWidth: 1000,
+    width: '100%',
+  },
+}));

--- a/workspaces/ui-v2/src/entry-points/local/local-cli.tsx
+++ b/workspaces/ui-v2/src/entry-points/local/local-cli.tsx
@@ -41,6 +41,7 @@ import { store } from '<src>/store';
 import { MetadataLoader } from '<src>/contexts/MetadataLoader';
 import { Auth0Provider } from '@auth0/auth0-react';
 import { SpecRepositoryStore } from '<src>/contexts/SpecRepositoryContext';
+import { EnsureDaemonRunning } from './EnsureDaemonRunning';
 
 const appConfig: OpticAppConfig = {
   config: {
@@ -94,36 +95,38 @@ export default function LocalCli() {
                     clientId={AUTH0_CLIENT_ID}
                     audience={appConfig.config.backendApi.domain}
                   >
-                    <MetadataLoader>
-                      <AnalyticsStore
-                        getMetadata={getMetadata(() =>
-                          data.configRepository.getApiName()
-                        )}
-                        initialize={initialize}
-                        track={track}
-                      >
-                        <DebugOpticComponent />
-                        <Switch>
-                          <Route
-                            path={`${match.path}/history`}
-                            component={ChangelogHistory}
-                          />
-                          <Route
-                            path={`${match.path}/changes-since/:batchId`}
-                            component={ChangelogPages}
-                          />
-                          <Route
-                            path={`${match.path}/documentation`}
-                            component={DocumentationPages}
-                          />
-                          <Route
-                            path={`${match.path}/diffs`}
-                            component={DiffReviewEnvironments}
-                          />
-                          <Redirect to={`${match.path}/documentation`} />
-                        </Switch>
-                      </AnalyticsStore>
-                    </MetadataLoader>
+                    <EnsureDaemonRunning>
+                      <MetadataLoader>
+                        <AnalyticsStore
+                          getMetadata={getMetadata(() =>
+                            data.configRepository.getApiName()
+                          )}
+                          initialize={initialize}
+                          track={track}
+                        >
+                          <DebugOpticComponent />
+                          <Switch>
+                            <Route
+                              path={`${match.path}/history`}
+                              component={ChangelogHistory}
+                            />
+                            <Route
+                              path={`${match.path}/changes-since/:batchId`}
+                              component={ChangelogPages}
+                            />
+                            <Route
+                              path={`${match.path}/documentation`}
+                              component={DocumentationPages}
+                            />
+                            <Route
+                              path={`${match.path}/diffs`}
+                              component={DiffReviewEnvironments}
+                            />
+                            <Redirect to={`${match.path}/documentation`} />
+                          </Switch>
+                        </AnalyticsStore>
+                      </MetadataLoader>
+                    </EnsureDaemonRunning>
                   </Auth0Provider>
                 </BaseUrlProvider>
               </SpecRepositoryStore>


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

The daemon can crash for a number of reasons. Sometimes, there's a recurring bug, other times we can power through this. We should ideally figure out why daemons crash - but for a user, they can retry and restart the daemon. This is not immediately obvious for users who are not familiar with how optic works. As a result, i've added a check to see if the daemon is reachable for the local cli ui builds.

## What
What's changing? Anything of note to call out?

<img width="950" alt="Screen Shot 2021-08-10 at 3 56 09 PM" src="https://user-images.githubusercontent.com/18374483/128926853-74bcec8c-86c2-49be-9168-ac215b869dc9.png">


- Add `/api/health` endpoint as a health check
- Add a EnsureDaemonRunning component

In the future, we could also validate expected versions such that the daemon and UI are running in sync in the same versions. Although there's probably different work to do to handle the case where we could have multiple daemons running in the background.

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
