### PR TITLE
Implement new Shape Editor UI

### DIFF
--- a/workspaces/ui-v2/package.json
+++ b/workspaces/ui-v2/package.json
@@ -38,6 +38,7 @@
     "@useoptic/analytics": "10.2.3",
     "@useoptic/cli-config": "10.2.3",
     "@useoptic/cli-shared": "10.2.3",
+    "@useoptic/optic-domain": "10.2.3",
     "@useoptic/optic-engine-wasm": "10.2.3",
     "@useoptic/shape-hash": "10.2.3",
     "@useoptic/spectacle": "10.2.3",

--- a/workspaces/ui-v2/src/components/HttpBodyPanel.tsx
+++ b/workspaces/ui-v2/src/components/HttpBodyPanel.tsx
@@ -22,7 +22,7 @@ export const HttpBodyPanel: FC<HttpBodyPanelProps> = ({
       const isContainerScrollable =
         contentRef.current.scrollHeight > contentRef.current.clientHeight;
       const fieldNode = contentRef.current.querySelector(
-        `[data-fieldId='${selectedFieldId}']`
+        `[data-fieldid='${selectedFieldId}']`
       );
       if (isContainerScrollable && fieldNode) {
         const scrollTopDiff =

--- a/workspaces/ui-v2/src/components/ShapeRenderer/ShapePrimitive.tsx
+++ b/workspaces/ui-v2/src/components/ShapeRenderer/ShapePrimitive.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import makeStyles from '@material-ui/styles/makeStyles';
 import { JsonType } from '@useoptic/optic-domain';
+import * as Theme from '<src>/styles/theme';
 
 import { useSharedStyles } from './SharedStyles';
 import { IShapeRenderer } from '<src>/types';
@@ -59,20 +60,20 @@ export const UnknownPrimitiveRender = ({ props }: any) => {
 
 const useStyles = makeStyles((theme) => ({
   stringClass: {
-    color: '#09825d',
+    color: Theme.jsonTypeColors[JsonType.STRING],
     whiteSpace: 'pre-line',
   },
   numberClass: {
-    color: '#e56f4a',
+    color: Theme.jsonTypeColors[JsonType.NUMBER],
   },
   unknownClass: {
-    color: '#857b79',
+    color: Theme.jsonTypeColors[JsonType.UNDEFINED],
   },
   booleanClass: {
-    color: '#067ab8',
+    color: Theme.jsonTypeColors[JsonType.BOOLEAN],
     fontWeight: 600,
   },
   nullClass: {
-    color: '#8792a2',
+    color: Theme.jsonTypeColors[JsonType.NULL],
   },
 }));

--- a/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRowBase.tsx
+++ b/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRowBase.tsx
@@ -70,7 +70,7 @@ export const RenderField = ({
           depth={depth}
           changes={changes}
           focused={fieldId === selectedFieldId}
-          data-fieldId={fieldId}
+          data-fieldid={fieldId}
         >
           <span className={sharedClasses.shapeFont}>"{name}"</span>
           <span className={sharedClasses.symbolFont}>: </span>
@@ -88,7 +88,7 @@ export const RenderField = ({
         depth={depth}
         changes={changes}
         focused={fieldId === selectedFieldId}
-        data-fieldId={fieldId}
+        data-fieldid={fieldId}
       >
         <span className={sharedClasses.shapeFont}>"{name}"</span>
         <span className={sharedClasses.symbolFont}>: </span>
@@ -113,7 +113,7 @@ export const RenderField = ({
           depth={depth}
           changes={changes}
           focused={fieldId === selectedFieldId}
-          data-fieldId={fieldId}
+          data-fieldid={fieldId}
         >
           <span className={sharedClasses.shapeFont}>"{name}"</span>
           <span className={sharedClasses.symbolFont}>: </span>

--- a/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
@@ -295,7 +295,8 @@ export const EndpointRootPage: FC<
                           }
                         }
 
-                        return (
+                        return process.env.REACT_APP_FF_FIELD_LEVEL_EDITS !==
+                          'true' ? (
                           <DocFieldContribution
                             key={
                               field.contribution.id +
@@ -312,6 +313,8 @@ export const EndpointRootPage: FC<
                             initialValue={field.contribution.value}
                             required={field.required}
                           />
+                        ) : (
+                          <ShapeEditor fields={fields} />
                         );
                       }}
                       fieldDetails={fields}
@@ -376,28 +379,37 @@ export const EndpointRootPage: FC<
                           {(selectedFieldId, setSelectedFieldId) => (
                             <div className={classes.bodyDetails}>
                               <div>
-                                <ContributionsList
-                                  renderField={(field) => (
-                                    <DocFieldContribution
-                                      key={
-                                        field.contribution.id +
-                                        field.contribution.contributionKey
-                                      }
-                                      endpoint={{
-                                        pathId,
-                                        method,
-                                      }}
-                                      name={field.name}
-                                      shapes={field.shapes}
-                                      depth={field.depth}
-                                      id={field.fieldId}
-                                      initialValue={field.contribution.value}
-                                      required={field.required}
-                                      setSelectedField={setSelectedFieldId}
-                                    />
-                                  )}
-                                  fieldDetails={fields}
-                                />
+                                {process.env.REACT_APP_FF_FIELD_LEVEL_EDITS !==
+                                'true' ? (
+                                  <ContributionsList
+                                    renderField={(field) => (
+                                      <DocFieldContribution
+                                        key={
+                                          field.contribution.id +
+                                          field.contribution.contributionKey
+                                        }
+                                        endpoint={{
+                                          pathId,
+                                          method,
+                                        }}
+                                        name={field.name}
+                                        shapes={field.shapes}
+                                        depth={field.depth}
+                                        id={field.fieldId}
+                                        initialValue={field.contribution.value}
+                                        required={field.required}
+                                        setSelectedField={setSelectedFieldId}
+                                      />
+                                    )}
+                                    fieldDetails={fields}
+                                  />
+                                ) : (
+                                  <ShapeEditor
+                                    fields={fields}
+                                    selectedFieldId={selectedFieldId}
+                                    setSelectedField={setSelectedFieldId}
+                                  />
+                                )}
                               </div>
                               <div className={classes.panel}>
                                 {isEditing ? (

--- a/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
@@ -26,7 +26,7 @@ import {
   selectors,
   documentationEditActions,
 } from '<src>/store';
-import { IShapeRenderer } from '<src>/types';
+import { IShapeRenderer, IFieldDetails } from '<src>/types';
 import { getEndpointId } from '<src>/utils';
 import { useRunOnKeypress } from '<src>/hooks/util';
 import {
@@ -38,6 +38,7 @@ import {
   MarkdownBodyContribution,
   DeleteEndpointConfirmationModal,
   SimulatedBody,
+  ShapeEditor,
 } from '<src>/pages/docs/components';
 import { useAnalytics } from '<src>/contexts/analytics';
 
@@ -471,28 +472,41 @@ export const EndpointRootPage: FC<
                             {(selectedFieldId, setSelectedFieldId) => (
                               <div className={classes.bodyDetails}>
                                 <div>
-                                  <ContributionsList
-                                    renderField={(field) => (
-                                      <DocFieldContribution
-                                        key={
-                                          field.contribution.id +
-                                          field.contribution.contributionKey
-                                        }
-                                        endpoint={{
-                                          pathId,
-                                          method,
-                                        }}
-                                        name={field.name}
-                                        shapes={field.shapes}
-                                        depth={field.depth}
-                                        id={field.fieldId}
-                                        initialValue={field.contribution.value}
-                                        required={field.required}
-                                        setSelectedField={setSelectedFieldId}
-                                      />
-                                    )}
-                                    fieldDetails={fields}
-                                  />
+                                  {process.env
+                                    .REACT_APP_FF_FIELD_LEVEL_EDITS !==
+                                  'true' ? (
+                                    <ContributionsList
+                                      renderField={(field) => (
+                                        <DocFieldContribution
+                                          key={
+                                            field.contribution.id +
+                                            field.contribution.contributionKey
+                                          }
+                                          endpoint={{
+                                            pathId,
+                                            method,
+                                          }}
+                                          name={field.name}
+                                          shapes={field.shapes}
+                                          depth={field.depth}
+                                          id={field.fieldId}
+                                          initialValue={
+                                            field.contribution.value
+                                          }
+                                          required={field.required}
+                                          setSelectedField={setSelectedFieldId}
+                                        />
+                                      )}
+                                      fieldDetails={fields}
+                                    />
+                                  ) : (
+                                    <ShapeEditor
+                                      fields={fields}
+                                      shapes={shapes}
+                                      selectedFieldId={selectedFieldId}
+                                      setSelectedField={setSelectedFieldId}
+                                    />
+                                  )}
                                 </div>
                                 <div className={classes.panel}>
                                   {isEditing ? (

--- a/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
@@ -26,7 +26,7 @@ import {
   selectors,
   documentationEditActions,
 } from '<src>/store';
-import { IShapeRenderer, IFieldDetails } from '<src>/types';
+import { IShapeRenderer } from '<src>/types';
 import { getEndpointId } from '<src>/utils';
 import { useRunOnKeypress } from '<src>/hooks/util';
 import {

--- a/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
@@ -502,7 +502,6 @@ export const EndpointRootPage: FC<
                                   ) : (
                                     <ShapeEditor
                                       fields={fields}
-                                      shapes={shapes}
                                       selectedFieldId={selectedFieldId}
                                       setSelectedField={setSelectedFieldId}
                                     />

--- a/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
@@ -1,0 +1,52 @@
+import React, { FC } from 'react';
+import { makeStyles } from '@material-ui/core';
+
+import { IFieldDetails, IShapeRenderer } from '<src>/types';
+
+export const ShapeEditor: FC<{
+  fields: IFieldDetails[];
+  shapes: IShapeRenderer[];
+  selectedFieldId: string | null;
+  setSelectedField: (fieldId: string | null) => void;
+}> = ({ fields, shapes, selectedFieldId, setSelectedField }) => {
+  const classes = useStyles();
+
+  return (
+    <div className={classes.container}>
+      {fields.length > 0 && (
+        <ul className={classes.rowsList}>
+          {fields.map((field) => (
+            <li className={classes.rowListItem}>
+              <Row field={field} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+const Row: FC<{
+  field: IFieldDetails;
+}> = function ShapeEditorRow({ field }) {
+  const classes = useStyles();
+
+  return (
+    <div className={classes.row}>
+      <Field name={field.name} />
+    </div>
+  );
+};
+
+const Field: FC<{ name: string }> = function ShapeEditorField({ name }) {
+  return <div>{name}</div>;
+};
+
+const useStyles = makeStyles((theme) => ({
+  container: {},
+  rowsList: {
+    listStyleType: 'none',
+  },
+  rowListItem: {},
+  row: {},
+}));

--- a/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, useCallback } from 'react';
 import {
   makeStyles,
   lighten,
@@ -23,8 +23,8 @@ export const ShapeEditor: FC<{
 }> = ({ fields, selectedFieldId, setSelectedField }) => {
   const classes = useStyles();
 
-  let onChangeFieldDescription = useMemo(
-    () => (fieldId: string, description: string) => {
+  let onChangeFieldDescription = useCallback(
+    (fieldId: string, description: string) => {
       console.log('description changed for field', fieldId, description);
     },
     []
@@ -67,22 +67,19 @@ const Row: FC<{
 }) {
   const classes = useStyles();
 
-  const onClickFieldHeader = useMemo(
-    () => () => {
-      if (onSelect) onSelect(field.fieldId);
-    },
-    [onSelect, field.fieldId]
-  );
+  const onClickFieldHeader = useCallback(() => {
+    if (onSelect) onSelect(field.fieldId);
+  }, [onSelect, field.fieldId]);
 
-  const onChangeType = useMemo(
-    () => (type: JsonType, enabled: boolean) => {
+  const onChangeType = useCallback(
+    (type: JsonType, enabled: boolean) => {
       console.log('changed type for field', type, enabled, field.fieldId);
     },
     [field.fieldId]
   );
 
-  const onChangeDescriptionHandler = useMemo(
-    () => (description: string) => {
+  const onChangeDescriptionHandler = useCallback(
+    (description: string) => {
       if (onChangeDescription) onChangeDescription(field.fieldId, description);
     },
     [field.fieldId, onChangeDescription]
@@ -131,19 +128,19 @@ const FieldEditor: FC<{
     (jsonType) => jsonType !== JsonType.UNDEFINED && jsonType !== JsonType.NULL
   );
 
-  let onClickTypeButton = useMemo(
-    () => (type: JsonType) => (e: React.MouseEvent) => {
+  let onClickTypeButton = useCallback(
+    (type: JsonType) => (e: React.MouseEvent) => {
       e.preventDefault();
       if (onChangeType) onChangeType(type, !currentJsonTypes.includes(type));
     },
-    [field.fieldId, currentJsonTypes, onChangeType]
+    [currentJsonTypes, onChangeType]
   );
 
-  let onChangeDescriptionField = useMemo(
-    () => (e: React.ChangeEvent<HTMLInputElement>) => {
+  let onChangeDescriptionField = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
       if (onChangeDescription) onChangeDescription(e.target.value);
     },
-    [field.fieldId, currentJsonTypes, onChangeDescription]
+    [onChangeDescription]
   );
 
   return (
@@ -244,22 +241,19 @@ const Field: FC<{
 }) {
   const classes = useFieldStyles();
 
-  const onClickHeaderHandler = useMemo(
-    () => (e: React.MouseEvent) => {
+  const onClickHeaderHandler = useCallback(
+    (e: React.MouseEvent) => {
       e.preventDefault();
       if (onClickHeader) onClickHeader();
     },
     [onClickHeader]
   );
 
-  const onClickRemove = useMemo(
-    () => (e: React.MouseEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
-      console.log('clicked remove');
-    },
-    []
-  );
+  const onClickRemove = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    console.log('clicked remove');
+  }, []);
 
   return (
     <div

--- a/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
@@ -5,6 +5,7 @@ import Color from 'color';
 import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
 
 import { IFieldDetails, IShapeRenderer } from '<src>/types';
+import { JsonType } from '@useoptic/optic-domain';
 import * as Theme from '<src>/styles/theme';
 
 export const ShapeEditor: FC<{
@@ -176,12 +177,27 @@ const Field: FC<{
 
 function summarizeTypes(shapes: IShapeRenderer[], required: boolean) {
   const optionalText = required ? '' : ' (optional)';
+  let components = shapes.map(({ jsonType }: { jsonType: JsonType }) => (
+    <span style={{ color: Theme.jsonTypeColors[jsonType] }}>
+      {jsonType.toString().toLowerCase()}
+    </span>
+  ));
   if (shapes.length === 1) {
-    return shapes[0].jsonType.toString().toLowerCase() + optionalText;
+    return (
+      <>
+        {components} {optionalText}
+      </>
+    );
   } else {
-    const allShapes = shapes.map((i) => i.jsonType.toString().toLowerCase());
-    const last = allShapes.pop();
-    return allShapes.join(', ') + ' or ' + last + optionalText;
+    const last = components.pop();
+    return (
+      <>
+        {components.map((component, i) => (
+          <span key={i}>{component},</span>
+        ))}{' '}
+        or {last} {optionalText}
+      </>
+    );
   }
 }
 

--- a/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
@@ -362,7 +362,7 @@ const useFieldStyles = makeStyles((theme) => ({
       marginTop: theme.spacing(1),
       marginBottom: theme.spacing(1),
       marginLeft: -1, // account for the added border
-      boxShadow: '0px 2px 1px -1px rgb(0 0 0 / 20%)',
+      boxShadow: '0px 8px 8px -5px rgb(0 0 0 / 12%)',
       borderRadius: theme.shape.borderRadius,
       border: `1px solid ${Color(Theme.OpticBlueReadable)
         .saturate(0.8)

--- a/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
@@ -18,8 +18,8 @@ import * as Theme from '<src>/styles/theme';
 
 export const ShapeEditor: FC<{
   fields: IFieldDetails[];
-  selectedFieldId: string | null;
-  setSelectedField: (fieldId: string | null) => void;
+  selectedFieldId?: string | null;
+  setSelectedField?: (fieldId: string | null) => void;
 }> = ({ fields, selectedFieldId, setSelectedField }) => {
   const classes = useStyles();
 

--- a/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
@@ -23,12 +23,19 @@ export const ShapeEditor: FC<{
 }> = ({ fields, selectedFieldId, setSelectedField }) => {
   const classes = useStyles();
 
-  let onChangeFieldDescription = useCallback(
+  const onChangeFieldDescription = useCallback(
     (fieldId: string, description: string) => {
       console.log('description changed for field', fieldId, description);
     },
     []
   );
+
+  const onFieldSelect = (fieldId: string) => () => {
+    if (setSelectedField) {
+      // Deselect the field if the field is already the currently selected field
+      setSelectedField(fieldId === selectedFieldId ? null : fieldId);
+    }
+  };
 
   return (
     <div className={classes.container}>
@@ -41,7 +48,7 @@ export const ShapeEditor: FC<{
                 description={''} // TODO FLEB: wire me in
                 selected={selectedFieldId === field.fieldId}
                 onChangeDescription={onChangeFieldDescription}
-                onSelect={setSelectedField}
+                onSelect={onFieldSelect(field.fieldId)}
               />
             </li>
           ))}
@@ -57,7 +64,7 @@ const Row: FC<{
   selected: boolean;
 
   onChangeDescription?: (fieldId: string, description: string) => void;
-  onSelect?: (fieldId: string) => void;
+  onSelect?: () => void;
 }> = function ShapeEditorRow({
   field,
   description,
@@ -66,10 +73,6 @@ const Row: FC<{
   onSelect,
 }) {
   const classes = useStyles();
-
-  const onClickFieldHeader = useCallback(() => {
-    if (onSelect) onSelect(field.fieldId);
-  }, [onSelect, field.fieldId]);
 
   const onChangeType = useCallback(
     (type: JsonType, enabled: boolean) => {
@@ -93,7 +96,7 @@ const Row: FC<{
         required={field.required}
         shapes={field.shapes}
         selected={selected}
-        onClickHeader={onClickFieldHeader}
+        onClickHeader={onSelect}
       >
         {selected && (
           <FieldEditor

--- a/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
@@ -1,7 +1,6 @@
 import React, { FC, useMemo } from 'react';
 import {
   makeStyles,
-  darken,
   lighten,
   IconButton,
   ButtonGroup,
@@ -86,7 +85,7 @@ const Row: FC<{
     () => (description: string) => {
       if (onChangeDescription) onChangeDescription(field.fieldId, description);
     },
-    [field.fieldId]
+    [field.fieldId, onChangeDescription]
   );
 
   return (
@@ -137,14 +136,14 @@ const FieldEditor: FC<{
       e.preventDefault();
       if (onChangeType) onChangeType(type, !currentJsonTypes.includes(type));
     },
-    [field.fieldId, currentJsonTypes]
+    [field.fieldId, currentJsonTypes, onChangeType]
   );
 
   let onChangeDescriptionField = useMemo(
     () => (e: React.ChangeEvent<HTMLInputElement>) => {
       if (onChangeDescription) onChangeDescription(e.target.value);
     },
-    [field.fieldId, currentJsonTypes]
+    [field.fieldId, currentJsonTypes, onChangeDescription]
   );
 
   return (

--- a/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useMemo } from 'react';
-import { makeStyles, ThemeProvider } from '@material-ui/core';
+import { makeStyles, darken, lighten } from '@material-ui/core';
+import ClassNames from 'classnames';
 
 import { IFieldDetails, IShapeRenderer } from '<src>/types';
 import * as Theme from '<src>/styles/theme';
@@ -19,7 +20,7 @@ export const ShapeEditor: FC<{
             <li className={classes.rowListItem}>
               <Row
                 field={field}
-                selected={selectedFieldId == field.fieldId}
+                selected={selectedFieldId === field.fieldId}
                 onSelect={setSelectedField}
               />
             </li>
@@ -52,6 +53,7 @@ const Row: FC<{
         name={field.name}
         required={field.required}
         shapes={field.shapes}
+        selected={selected}
         onClickHeader={onClickFieldHeader}
       >
         {selected && <FieldEditor field={field} />}
@@ -80,6 +82,11 @@ const useStyles = makeStyles((theme) => ({
   editor: {
     padding: theme.spacing(2, 3),
     minHeight: theme.spacing(10),
+    marginBottom: theme.spacing(2),
+
+    color: '#6b7384',
+
+    boxShadow: 'inset 0px 13px 10px -10px rgba(0, 0, 0, 0.07)',
   },
 }));
 
@@ -88,6 +95,7 @@ const Field: FC<{
   depth: number;
   name: string;
   required: boolean;
+  selected: boolean;
   shapes: IShapeRenderer[];
 
   onClickHeader?: () => void;
@@ -97,6 +105,7 @@ const Field: FC<{
   required,
   depth,
   children,
+  selected,
   onClickHeader,
 }) {
   const classes = useFieldStyles();
@@ -110,11 +119,19 @@ const Field: FC<{
   );
 
   return (
-    <div className={classes.container}>
+    <div
+      className={ClassNames(classes.container, {
+        [classes.isSelected]: selected,
+        [classes.isIndented]: depth > 0,
+      })}
+    >
       <header
         className={classes.header}
         onClick={onClickHeaderHandler}
-        style={{ marginLeft: depth * INDENT_WIDTH }}
+        style={{
+          paddingLeft: Math.max(depth - 1, 0) * INDENT_WIDTH,
+          backgroundImage: `url("${indentsImageUrl(depth - 1)}")`,
+        }}
       >
         <div className={classes.description}>
           <div className={classes.fieldName}>{name}</div>
@@ -142,22 +159,74 @@ function summarizeTypes(shapes: IShapeRenderer[], required: boolean) {
 
 const INDENT_WIDTH = 8 * 3;
 const INDENT_MARKER_WIDTH = 1;
+const INDENT_COLOR = '#E4E8ED';
+function indentsImageUrl(depth: number = 0) {
+  let range = Array(Math.max(depth, 0))
+    .fill(0)
+    .map((val, n) => n);
+  console.log(range);
+  let width = INDENT_WIDTH * depth;
+  return (
+    'data:image/svg+xml,' +
+    encodeURIComponent(
+      `<svg xmlns='http://www.w3.org/2000/svg' width='${width}' height='1' viewBox='0 0 ${width} 1'>
+        ${range
+          .map(
+            (n) => `
+            <rect fill="${INDENT_COLOR}" x="${
+              INDENT_WIDTH * n
+            }" y="0" height="1" width="${INDENT_MARKER_WIDTH}" />;
+          `
+          )
+          .join('')}
+      </svg>`
+    )
+  );
+}
+
 const useFieldStyles = makeStyles((theme) => ({
   container: {
     fontFamily: Theme.FontFamily,
     padding: theme.spacing(0, 0, 0, 1),
-    backgroundColor: '#fafafa',
-    backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='${INDENT_WIDTH}' height='1' viewBox='0 0 ${INDENT_WIDTH} 1'%3E%3Cg stroke='%23CCC' stroke-width='0' %3E%3Crect fill='%23E4E8ED' x='0' y='0' width='${INDENT_MARKER_WIDTH}' height='1'/%3E%3C/g%3E%3C/svg%3E")`,
-    backgroundPositionX: theme.spacing(1) + 1,
   },
+  isSelected: {},
+  isIndented: {},
+
   header: {
     display: 'flex',
-    backgroundColor: '#fafafa',
-    padding: theme.spacing(1, 0),
+    backgroundPositionX: 0,
+    backgroundRepeat: 'repeat-y',
+    padding: 0,
+    cursor: 'pointer',
+
+    '$isSelected &': {
+      borderBottom: `1px solid ${lighten(Theme.OpticBlueReadable, 0.5)}`,
+
+      '&:hover': {
+        borderBottom: `1px solid ${lighten(Theme.OpticBlueReadable, 0.2)}`,
+      },
+    },
   },
   description: {
     display: 'flex',
+    padding: theme.spacing(1, 0),
     alignItems: 'baseline',
+    borderLeft: `1px solid #E4E8ED`,
+    borderLeftWidth: 0,
+
+    '$isIndented &': {
+      paddingLeft: INDENT_WIDTH,
+      borderLeftWidth: '1px',
+    },
+
+    '$isIndented $header:hover &': {
+      borderLeftColor: darken(INDENT_COLOR, 0.3),
+    },
+
+    '$isIndented$isSelected &': {
+      borderLeftWidth: '1px',
+      borderLeftColor: lighten(Theme.OpticBlueReadable, 0.5),
+    },
   },
 
   fieldName: {
@@ -171,7 +240,5 @@ const useFieldStyles = makeStyles((theme) => ({
     color: '#8792a2',
   },
 
-  stage: {
-    background: '#fafafa',
-  },
+  stage: {},
 }));

--- a/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { makeStyles } from '@material-ui/core';
+import { makeStyles, ThemeProvider } from '@material-ui/core';
 
 import { IFieldDetails, IShapeRenderer } from '<src>/types';
 import * as Theme from '<src>/styles/theme';
@@ -47,6 +47,7 @@ const useStyles = makeStyles((theme) => ({
   container: {},
   rowsList: {
     listStyleType: 'none',
+    paddingLeft: 0,
   },
   rowListItem: {},
   row: {},
@@ -62,7 +63,10 @@ const Field: FC<{
 
   return (
     <div className={classes.container}>
-      <header className={classes.header} style={{ paddingLeft: depth * 14 }}>
+      <header
+        className={classes.header}
+        style={{ marginLeft: depth * INDENT_WIDTH }}
+      >
         <div className={classes.description}>
           <div className={classes.fieldName}>{name}</div>
           <div className={classes.typesSummary}>
@@ -85,14 +89,19 @@ function summarizeTypes(shapes: IShapeRenderer[], required: boolean) {
   }
 }
 
+const INDENT_WIDTH = 8 * 3;
+const INDENT_MARKER_WIDTH = 1;
 const useFieldStyles = makeStyles((theme) => ({
   container: {
-    borderTop: `1px solid #e4e8ed`,
     fontFamily: Theme.FontFamily,
-    padding: theme.spacing(0, 1),
+    padding: theme.spacing(0, 0, 0, 1),
+    backgroundColor: '#fafafa',
+    backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='${INDENT_WIDTH}' height='1' viewBox='0 0 ${INDENT_WIDTH} 1'%3E%3Cg stroke='%23CCC' stroke-width='0' %3E%3Crect fill='%23E4E8ED' x='0' y='0' width='${INDENT_MARKER_WIDTH}' height='1'/%3E%3C/g%3E%3C/svg%3E")`,
+    backgroundPositionX: theme.spacing(1) + 1,
   },
   header: {
     display: 'flex',
+    backgroundColor: '#fafafa',
     padding: theme.spacing(1, 0),
   },
   description: {

--- a/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
@@ -1,7 +1,8 @@
 import React, { FC, useMemo } from 'react';
-import { makeStyles, darken, lighten } from '@material-ui/core';
+import { makeStyles, darken, lighten, IconButton } from '@material-ui/core';
 import ClassNames from 'classnames';
 import Color from 'color';
+import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
 
 import { IFieldDetails, IShapeRenderer } from '<src>/types';
 import * as Theme from '<src>/styles/theme';
@@ -125,6 +126,15 @@ const Field: FC<{
     [onClickHeader]
   );
 
+  const onClickRemove = useMemo(
+    () => (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      console.log('clicked remove');
+    },
+    []
+  );
+
   return (
     <div
       className={ClassNames(classes.container, {
@@ -147,7 +157,15 @@ const Field: FC<{
           </div>
         </div>
         <div className={classes.controls}>
-          <div>remove</div>
+          {selected && (
+            <IconButton
+              className={classes.removeControl}
+              size="small"
+              onClick={onClickRemove}
+            >
+              <DeleteOutlineIcon />
+            </IconButton>
+          )}
         </div>
       </header>
 
@@ -197,7 +215,19 @@ function indentsImageUrl(depth: number = 0) {
 const useFieldStyles = makeStyles((theme) => ({
   container: {
     fontFamily: Theme.FontFamily,
-    padding: theme.spacing(0, 0, 0, 1),
+
+    '&$isSelected': {
+      marginTop: theme.spacing(1),
+      marginBottom: theme.spacing(1),
+      marginLeft: -1, // account for the added border
+      boxShadow: '0px 2px 1px -1px rgb(0 0 0 / 20%)',
+      borderRadius: theme.shape.borderRadius,
+      border: `1px solid ${Color(Theme.OpticBlueReadable)
+        .saturate(0.8)
+        .lighten(0.58)
+        .hsl()
+        .string()}`,
+    },
   },
   isSelected: {},
   isIndented: {},
@@ -214,9 +244,14 @@ const useFieldStyles = makeStyles((theme) => ({
     },
 
     '$isSelected &': {
+      background: `${Color(Theme.OpticBlueReadable)
+        .saturate(0.8)
+        .lighten(0.63)
+        .hsl()
+        .string()} !important`,
       borderBottom: `1px solid ${Color(Theme.OpticBlueReadable)
         .saturate(0.8)
-        .lighten(0.58)
+        .lighten(0.55)
         .hsl()
         .string()}`,
 
@@ -224,12 +259,6 @@ const useFieldStyles = makeStyles((theme) => ({
       //   borderBottom: `1px solid ${lighten(Theme.OpticBlueReadable, 0.2)}`,
       // },
     },
-  },
-
-  controls: {
-    display: 'flex',
-    color: '#ccc',
-    marginRight: theme.spacing(1),
   },
 
   description: {
@@ -246,12 +275,20 @@ const useFieldStyles = makeStyles((theme) => ({
     },
 
     '$isIndented $header:hover &': {
-      borderLeftColor: darken(INDENT_COLOR, 0.3),
+      borderLeftColor: Color(Theme.OpticBlueReadable)
+        .saturate(0.8)
+        .lighten(0.43)
+        .hsl()
+        .string(),
     },
 
     '$isIndented$isSelected &': {
       borderLeftWidth: '1px',
-      borderLeftColor: lighten(Theme.OpticBlueReadable, 0.5),
+      borderLeftColor: Color(Theme.OpticBlueReadable)
+        .saturate(0.8)
+        .lighten(0.53)
+        .hsl()
+        .string(),
     },
   },
 
@@ -264,6 +301,22 @@ const useFieldStyles = makeStyles((theme) => ({
   typesSummary: {
     fontFamily: Theme.FontFamilyMono,
     color: '#8792a2',
+  },
+
+  // Controls
+  //
+  controls: {
+    display: 'flex',
+    color: '#ccc',
+    marginRight: theme.spacing(1),
+  },
+
+  removeControl: {
+    color: Color(Theme.OpticBlueReadable)
+      .saturate(0.8)
+      .lighten(0.2)
+      .hsl()
+      .string(),
   },
 
   stage: {},

--- a/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useMemo } from 'react';
 import { makeStyles, darken, lighten } from '@material-ui/core';
 import ClassNames from 'classnames';
+import Color from 'color';
 
 import { IFieldDetails, IShapeRenderer } from '<src>/types';
 import * as Theme from '<src>/styles/theme';
@@ -205,27 +206,36 @@ const useFieldStyles = makeStyles((theme) => ({
     display: 'flex',
     justifyContent: 'space-between',
     cursor: 'pointer',
-    backgroundPositionX: 0,
+    backgroundPositionX: theme.spacing(1),
     backgroundRepeat: 'repeat-y',
-    padding: 0,
+
+    '&:hover': {
+      backgroundColor: lighten(Theme.OpticBlueReadable, 0.9),
+    },
 
     '$isSelected &': {
-      borderBottom: `1px solid ${lighten(Theme.OpticBlueReadable, 0.5)}`,
+      borderBottom: `1px solid ${Color(Theme.OpticBlueReadable)
+        .saturate(0.8)
+        .lighten(0.58)
+        .hsl()
+        .string()}`,
 
-      '&:hover': {
-        borderBottom: `1px solid ${lighten(Theme.OpticBlueReadable, 0.2)}`,
-      },
+      // '&:hover': {
+      //   borderBottom: `1px solid ${lighten(Theme.OpticBlueReadable, 0.2)}`,
+      // },
     },
   },
 
   controls: {
     display: 'flex',
     color: '#ccc',
+    marginRight: theme.spacing(1),
   },
 
   description: {
     display: 'flex',
     padding: theme.spacing(1, 0),
+    marginLeft: theme.spacing(1),
     alignItems: 'baseline',
     borderLeft: `1px solid #E4E8ED`,
     borderLeftWidth: 0,

--- a/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
@@ -57,6 +57,13 @@ const Row: FC<{
     [onSelect, field.fieldId]
   );
 
+  const onChangeType = useMemo(
+    () => (type: JsonType, enabled: boolean) => {
+      console.log('changed type for field', type, enabled, field.fieldId);
+    },
+    [field.fieldId]
+  );
+
   return (
     <div className={classes.row}>
       <Field
@@ -67,7 +74,7 @@ const Row: FC<{
         selected={selected}
         onClickHeader={onClickFieldHeader}
       >
-        {selected && <FieldEditor field={field} />}
+        {selected && <FieldEditor field={field} onChangeType={onChangeType} />}
       </Field>
     </div>
   );
@@ -75,12 +82,22 @@ const Row: FC<{
 
 const FieldEditor: FC<{
   field: IFieldDetails;
-}> = function ShapeEditorFieldEditor({ field }) {
+  onChangeType?: (type: JsonType, enabled: boolean) => void;
+}> = function ShapeEditorFieldEditor({ field, onChangeType }) {
   const classes = useStyles();
 
   let currentJsonTypes = field.shapes.map(({ jsonType }) => jsonType);
+  if (!field.required) currentJsonTypes.push(JsonType.UNDEFINED);
   let nonEditableTypes = currentJsonTypes.filter(
     (jsonType) => jsonType !== JsonType.UNDEFINED && jsonType !== JsonType.NULL
+  );
+
+  let onClickTypeButton = useMemo(
+    () => (type: JsonType) => (e: React.MouseEvent) => {
+      e.preventDefault();
+      if (onChangeType) onChangeType(type, !currentJsonTypes.includes(type));
+    },
+    [field.fieldId, currentJsonTypes]
   );
 
   return (
@@ -88,8 +105,13 @@ const FieldEditor: FC<{
       <ButtonGroup>
         <Button
           disableElevation
-          variant={!field.required ? 'contained' : 'outlined'}
+          variant={
+            currentJsonTypes.includes(JsonType.UNDEFINED)
+              ? 'contained'
+              : 'outlined'
+          }
           startIcon={<CheckIcon />}
+          onClick={onClickTypeButton(JsonType.UNDEFINED)}
         >
           Optional
         </Button>
@@ -98,6 +120,7 @@ const FieldEditor: FC<{
           variant={
             currentJsonTypes.includes(JsonType.NULL) ? 'contained' : 'outlined'
           }
+          onClick={onClickTypeButton(JsonType.NULL)}
         >
           Null
         </Button>

--- a/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
@@ -1,5 +1,13 @@
 import React, { FC, useMemo } from 'react';
-import { makeStyles, darken, lighten, IconButton } from '@material-ui/core';
+import {
+  makeStyles,
+  darken,
+  lighten,
+  IconButton,
+  ButtonGroup,
+  Button,
+} from '@material-ui/core';
+import { Check as CheckIcon } from '@material-ui/icons';
 import ClassNames from 'classnames';
 import Color from 'color';
 import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
@@ -70,10 +78,41 @@ const FieldEditor: FC<{
 }> = function ShapeEditorFieldEditor({ field }) {
   const classes = useStyles();
 
+  let currentJsonTypes = field.shapes.map(({ jsonType }) => jsonType);
+  let nonEditableTypes = currentJsonTypes.filter(
+    (jsonType) => jsonType !== JsonType.UNDEFINED && jsonType !== JsonType.NULL
+  );
+
   return (
     <div className={classes.editor}>
-      <div>toggle for optional</div>
-      <div>toggle for nullable</div>
+      <ButtonGroup>
+        <Button
+          disableElevation
+          variant={!field.required ? 'contained' : 'outlined'}
+          startIcon={<CheckIcon />}
+        >
+          Optional
+        </Button>
+        <Button
+          disableElevation
+          variant={
+            currentJsonTypes.includes(JsonType.NULL) ? 'contained' : 'outlined'
+          }
+        >
+          Null
+        </Button>
+
+        {nonEditableTypes.map((jsonType) => (
+          <Button
+            color="primary"
+            variant="contained"
+            disabled
+            startIcon={<CheckIcon />}
+          >
+            {jsonType}
+          </Button>
+        ))}
+      </ButtonGroup>
       <div>field for updating description</div>
     </div>
   );

--- a/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
@@ -63,7 +63,9 @@ const Row: FC<{
 const FieldEditor: FC<{
   field: IFieldDetails;
 }> = function ShapeEditorFieldEditor({ field }) {
-  return <div>Editor</div>;
+  const classes = useStyles();
+
+  return <div className={classes.editor}>Editor</div>;
 };
 
 const useStyles = makeStyles((theme) => ({
@@ -74,6 +76,11 @@ const useStyles = makeStyles((theme) => ({
   },
   rowListItem: {},
   row: {},
+
+  editor: {
+    padding: theme.spacing(2, 3),
+    minHeight: theme.spacing(10),
+  },
 }));
 
 const Field: FC<{
@@ -164,5 +171,7 @@ const useFieldStyles = makeStyles((theme) => ({
     color: '#8792a2',
   },
 
-  stage: {},
+  stage: {
+    background: '#fafafa',
+  },
 }));

--- a/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
@@ -2,13 +2,13 @@ import React, { FC } from 'react';
 import { makeStyles } from '@material-ui/core';
 
 import { IFieldDetails, IShapeRenderer } from '<src>/types';
+import * as Theme from '<src>/styles/theme';
 
 export const ShapeEditor: FC<{
   fields: IFieldDetails[];
-  shapes: IShapeRenderer[];
   selectedFieldId: string | null;
   setSelectedField: (fieldId: string | null) => void;
-}> = ({ fields, shapes, selectedFieldId, setSelectedField }) => {
+}> = ({ fields, selectedFieldId, setSelectedField }) => {
   const classes = useStyles();
 
   return (
@@ -33,13 +33,14 @@ const Row: FC<{
 
   return (
     <div className={classes.row}>
-      <Field name={field.name} />
+      <Field
+        depth={field.depth}
+        name={field.name}
+        required={field.required}
+        shapes={field.shapes}
+      />
     </div>
   );
-};
-
-const Field: FC<{ name: string }> = function ShapeEditorField({ name }) {
-  return <div>{name}</div>;
 };
 
 const useStyles = makeStyles((theme) => ({
@@ -49,4 +50,64 @@ const useStyles = makeStyles((theme) => ({
   },
   rowListItem: {},
   row: {},
+}));
+
+const Field: FC<{
+  depth: number;
+  name: string;
+  required: boolean;
+  shapes: IShapeRenderer[];
+}> = function ShapeEditorField({ name, shapes, required, depth }) {
+  const classes = useFieldStyles();
+
+  return (
+    <div className={classes.container}>
+      <header className={classes.header} style={{ paddingLeft: depth * 14 }}>
+        <div className={classes.description}>
+          <div className={classes.fieldName}>{name}</div>
+          <div className={classes.typesSummary}>
+            {summarizeTypes(shapes, required)}
+          </div>
+        </div>
+      </header>
+    </div>
+  );
+};
+
+function summarizeTypes(shapes: IShapeRenderer[], required: boolean) {
+  const optionalText = required ? '' : ' (optional)';
+  if (shapes.length === 1) {
+    return shapes[0].jsonType.toString().toLowerCase() + optionalText;
+  } else {
+    const allShapes = shapes.map((i) => i.jsonType.toString().toLowerCase());
+    const last = allShapes.pop();
+    return allShapes.join(', ') + ' or ' + last + optionalText;
+  }
+}
+
+const useFieldStyles = makeStyles((theme) => ({
+  container: {
+    borderTop: `1px solid #e4e8ed`,
+    fontFamily: Theme.FontFamily,
+    padding: theme.spacing(0, 1),
+  },
+  header: {
+    display: 'flex',
+    padding: theme.spacing(1, 0),
+  },
+  description: {
+    display: 'flex',
+    alignItems: 'baseline',
+  },
+
+  fieldName: {
+    color: '#3c4257',
+    fontWeight: theme.typography.fontWeightBold,
+    fontSize: theme.typography.fontSize - 1,
+    marginRight: theme.spacing(1),
+  },
+  typesSummary: {
+    fontFamily: Theme.FontFamilyMono,
+    color: '#8792a2',
+  },
 }));

--- a/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
@@ -67,7 +67,13 @@ const FieldEditor: FC<{
 }> = function ShapeEditorFieldEditor({ field }) {
   const classes = useStyles();
 
-  return <div className={classes.editor}>Editor</div>;
+  return (
+    <div className={classes.editor}>
+      <div>toggle for optional</div>
+      <div>toggle for nullable</div>
+      <div>field for updating description</div>
+    </div>
+  );
 };
 
 const useStyles = makeStyles((theme) => ({
@@ -84,7 +90,7 @@ const useStyles = makeStyles((theme) => ({
     minHeight: theme.spacing(10),
     marginBottom: theme.spacing(2),
 
-    color: '#6b7384',
+    color: lighten('#6b7384', 0.2),
 
     boxShadow: 'inset 0px 13px 10px -10px rgba(0, 0, 0, 0.07)',
   },
@@ -138,6 +144,9 @@ const Field: FC<{
           <div className={classes.typesSummary}>
             {summarizeTypes(shapes, required)}
           </div>
+        </div>
+        <div className={classes.controls}>
+          <div>remove</div>
         </div>
       </header>
 
@@ -194,10 +203,11 @@ const useFieldStyles = makeStyles((theme) => ({
 
   header: {
     display: 'flex',
+    justifyContent: 'space-between',
+    cursor: 'pointer',
     backgroundPositionX: 0,
     backgroundRepeat: 'repeat-y',
     padding: 0,
-    cursor: 'pointer',
 
     '$isSelected &': {
       borderBottom: `1px solid ${lighten(Theme.OpticBlueReadable, 0.5)}`,
@@ -207,6 +217,12 @@ const useFieldStyles = makeStyles((theme) => ({
       },
     },
   },
+
+  controls: {
+    display: 'flex',
+    color: '#ccc',
+  },
+
   description: {
     display: 'flex',
     padding: theme.spacing(1, 0),

--- a/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
@@ -157,7 +157,9 @@ const FieldEditor: FC<{
               ? 'contained'
               : 'outlined'
           }
-          startIcon={<CheckIcon />}
+          startIcon={
+            currentJsonTypes.includes(JsonType.UNDEFINED) ? <CheckIcon /> : null
+          }
           onClick={onClickTypeButton(JsonType.UNDEFINED)}
         >
           Optional
@@ -166,6 +168,9 @@ const FieldEditor: FC<{
           disableElevation
           variant={
             currentJsonTypes.includes(JsonType.NULL) ? 'contained' : 'outlined'
+          }
+          startIcon={
+            currentJsonTypes.includes(JsonType.NULL) ? <CheckIcon /> : null
           }
           onClick={onClickTypeButton(JsonType.NULL)}
         >

--- a/workspaces/ui-v2/src/pages/docs/components/index.ts
+++ b/workspaces/ui-v2/src/pages/docs/components/index.ts
@@ -5,3 +5,4 @@ export * from './EditContributionsButton';
 export * from './EndpointTOC';
 export * from './MarkdownBodyContribution';
 export * from './SimulatedBodyPreview';
+export * from './ShapeEditor';

--- a/workspaces/ui-v2/src/styles/theme.ts
+++ b/workspaces/ui-v2/src/styles/theme.ts
@@ -36,7 +36,7 @@ export const methodColorsDark: { [key: string]: string | undefined } = {
   DELETE: '#be5353',
 };
 
-export const jsonTypeColors = {
+export const jsonTypeColors: Record<JsonType, string> = {
   [JsonType.STRING]: '#09825d',
   [JsonType.NUMBER]: '#e56f4a',
   [JsonType.UNDEFINED]: '#857b79',

--- a/workspaces/ui-v2/src/styles/theme.ts
+++ b/workspaces/ui-v2/src/styles/theme.ts
@@ -1,4 +1,6 @@
 import { createMuiTheme } from '@material-ui/core';
+import { JsonType } from '@useoptic/optic-domain';
+
 export const primary = '#31366f';
 export const secondary = '#ea4a61';
 export const UpdatedBlue = '#2b7bd1';
@@ -32,6 +34,16 @@ export const methodColorsDark: { [key: string]: string | undefined } = {
   PUT: '#69340a',
   PATCH: '#796384',
   DELETE: '#be5353',
+};
+
+export const jsonTypeColors = {
+  [JsonType.STRING]: '#09825d',
+  [JsonType.NUMBER]: '#e56f4a',
+  [JsonType.UNDEFINED]: '#857b79',
+  [JsonType.BOOLEAN]: '#067ab8',
+  [JsonType.NULL]: '#8792a2',
+  [JsonType.OBJECT]: 'inherit',
+  [JsonType.ARRAY]: 'inherit',
 };
 
 export const FontFamily =

--- a/workspaces/ui-v2/tsconfig.json
+++ b/workspaces/ui-v2/tsconfig.json
@@ -16,6 +16,7 @@
     { "path": "../analytics" },
     { "path": "../cli-config" },
     { "path": "../cli-shared" },
+    { "path": "../optic-domain" },
     { "path": "../shape-hash" },
     { "path": "../spectacle" },
     { "path": "../spectacle-shared" }


### PR DESCRIPTION
## Why
To properly support field level edits we need a place where the edit UI lives.

## What
A new `ShapeEditor` component has been added, designed to rendered as part of the endpoint documentation page while in edit mode. It's not yet done, nor does it fulfil all the design constraints we've set ourselves, but the foundations seem strong enough to merge, so we can wire it up and iterate on it with separate PRs.

![Kapture 2021-08-11 at 18 15 49](https://user-images.githubusercontent.com/857549/129066168-3f254174-ffce-4aac-aeec-048d336c0748.gif)

## Validation
* [ ] CI passes
* [x] Only rendered with feature flag enabled
