### PR TITLE
Only render the ShapeEditor and selected field highlights in edit mode

### DIFF
--- a/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
@@ -296,7 +296,7 @@ export const EndpointRootPage: FC<
                         }
 
                         return process.env.REACT_APP_FF_FIELD_LEVEL_EDITS !==
-                          'true' ? (
+                          'true' || !isEditing ? (
                           <DocFieldContribution
                             key={
                               field.contribution.id +
@@ -380,7 +380,7 @@ export const EndpointRootPage: FC<
                             <div className={classes.bodyDetails}>
                               <div>
                                 {process.env.REACT_APP_FF_FIELD_LEVEL_EDITS !==
-                                'true' ? (
+                                  'true' || !isEditing ? (
                                   <ContributionsList
                                     renderField={(field) => (
                                       <DocFieldContribution
@@ -429,7 +429,6 @@ export const EndpointRootPage: FC<
                                   <HttpBodyPanel
                                     shapes={shapes}
                                     location={request.body!.contentType}
-                                    selectedFieldId={selectedFieldId}
                                   />
                                 )}
                               </div>
@@ -486,7 +485,7 @@ export const EndpointRootPage: FC<
                                 <div>
                                   {process.env
                                     .REACT_APP_FF_FIELD_LEVEL_EDITS !==
-                                  'true' ? (
+                                    'true' || !isEditing ? (
                                     <ContributionsList
                                       renderField={(field) => (
                                         <DocFieldContribution
@@ -537,7 +536,6 @@ export const EndpointRootPage: FC<
                                     <HttpBodyPanel
                                       shapes={shapes}
                                       location={response.body!.contentType}
-                                      selectedFieldId={selectedFieldId}
                                     />
                                   )}
                                 </div>


### PR DESCRIPTION
## Why
We want the viewing and editing of the documentation to be different, as they serve different goals. To make sure the editor is understood to be interactive and capable of making changes, we don't just want to render it in an inactive, read-only mode.

## What
We render the original list of properties for viewing the documentation, while rendering the new editor when editing.

![Kapture 2021-08-12 at 10 21 50](https://user-images.githubusercontent.com/857549/129164160-6e7d90a8-843b-41d8-b50a-643944a96652.gif)

Note: there's ways to further optimise the transition to go from viewing into editing mode, but we'll consider that separately.

## Validation
* [ ] CI passes
