### PR TITLE
Provide stronger contextual link between Shape's preview and editor

### DIFF
--- a/workspaces/ui-v2/src/components/HighlightController.tsx
+++ b/workspaces/ui-v2/src/components/HighlightController.tsx
@@ -1,9 +1,10 @@
-import React, { FC, useState } from 'react';
+import React, { FC, useState, useRef, useEffect } from 'react';
 
 type HighlightControllerProps = {
   children: (
     selectedItem: string | null,
-    setSelectedItem: (selectedItem: string | null) => void
+    setSelectedItem: (selectedItem: string | null) => void,
+    rootElementRef: React.RefObject<HTMLElement | null>
   ) => React.ReactElement;
 };
 
@@ -11,5 +12,26 @@ export const HighlightController: FC<HighlightControllerProps> = ({
   children,
 }) => {
   const [selectedItem, setSelectedItem] = useState<string | null>(null);
-  return <>{children(selectedItem, setSelectedItem)}</>;
+  const rootElementRef: React.RefObject<HTMLElement | null> = useRef(null);
+
+  useEffect(() => {
+    console.log('root element', rootElementRef?.current);
+
+    const onDocumentClick = (event: MouseEvent) => {
+      const rootElement = rootElementRef?.current;
+
+      console.log(rootElement?.contains(event.target as Node));
+      if (rootElement && !rootElement.contains(event.target as Node)) {
+        setSelectedItem(null);
+      }
+    };
+
+    document.addEventListener('click', onDocumentClick);
+
+    return () => {
+      document.removeEventListener('click', onDocumentClick);
+    };
+  }, [rootElementRef, setSelectedItem]);
+
+  return <>{children(selectedItem, setSelectedItem, rootElementRef)}</>;
 };

--- a/workspaces/ui-v2/src/components/HighlightController.tsx
+++ b/workspaces/ui-v2/src/components/HighlightController.tsx
@@ -1,10 +1,9 @@
-import React, { FC, useState, useRef, useEffect } from 'react';
+import React, { FC, useState } from 'react';
 
 type HighlightControllerProps = {
   children: (
     selectedItem: string | null,
-    setSelectedItem: (selectedItem: string | null) => void,
-    rootElementRef: React.RefObject<HTMLElement | null>
+    setSelectedItem: (selectedItem: string | null) => void
   ) => React.ReactElement;
 };
 
@@ -12,26 +11,5 @@ export const HighlightController: FC<HighlightControllerProps> = ({
   children,
 }) => {
   const [selectedItem, setSelectedItem] = useState<string | null>(null);
-  const rootElementRef: React.RefObject<HTMLElement | null> = useRef(null);
-
-  useEffect(() => {
-    console.log('root element', rootElementRef?.current);
-
-    const onDocumentClick = (event: MouseEvent) => {
-      const rootElement = rootElementRef?.current;
-
-      console.log(rootElement?.contains(event.target as Node));
-      if (rootElement && !rootElement.contains(event.target as Node)) {
-        setSelectedItem(null);
-      }
-    };
-
-    document.addEventListener('click', onDocumentClick);
-
-    return () => {
-      document.removeEventListener('click', onDocumentClick);
-    };
-  }, [rootElementRef, setSelectedItem]);
-
-  return <>{children(selectedItem, setSelectedItem, rootElementRef)}</>;
+  return <>{children(selectedItem, setSelectedItem)}</>;
 };

--- a/workspaces/ui-v2/src/components/HttpBodyPanel.tsx
+++ b/workspaces/ui-v2/src/components/HttpBodyPanel.tsx
@@ -8,12 +8,18 @@ type HttpBodyPanelProps = {
   shapes: IShapeRenderer[];
   location: string;
   selectedFieldId?: string | null;
+
+  selectableFields?: boolean;
+  setSelectedField?: (fieldId: string) => void;
 };
 
 export const HttpBodyPanel: FC<HttpBodyPanelProps> = ({
   shapes,
   location,
   selectedFieldId,
+
+  selectableFields,
+  setSelectedField,
 }) => {
   const contentRef = useRef<HTMLDivElement>(null);
 
@@ -42,6 +48,8 @@ export const HttpBodyPanel: FC<HttpBodyPanelProps> = ({
         showExamples={false}
         shapes={shapes}
         selectedFieldId={selectedFieldId}
+        selectableFields={selectableFields}
+        setSelectedField={setSelectedField}
       />
     </Panel>
   );

--- a/workspaces/ui-v2/src/components/HttpBodyPanel.tsx
+++ b/workspaces/ui-v2/src/components/HttpBodyPanel.tsx
@@ -9,7 +9,7 @@ type HttpBodyPanelProps = {
   location: string;
   selectedFieldId?: string | null;
 
-  selectableFields?: boolean;
+  fieldsAreSelectable?: boolean;
   setSelectedField?: (fieldId: string) => void;
 };
 
@@ -18,7 +18,7 @@ export const HttpBodyPanel: FC<HttpBodyPanelProps> = ({
   location,
   selectedFieldId,
 
-  selectableFields,
+  fieldsAreSelectable,
   setSelectedField,
 }) => {
   const contentRef = useRef<HTMLDivElement>(null);
@@ -48,7 +48,7 @@ export const HttpBodyPanel: FC<HttpBodyPanelProps> = ({
         showExamples={false}
         shapes={shapes}
         selectedFieldId={selectedFieldId}
-        selectableFields={selectableFields}
+        fieldsAreSelectable={fieldsAreSelectable}
         setSelectedField={setSelectedField}
       />
     </Panel>

--- a/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRenderContext.tsx
+++ b/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRenderContext.tsx
@@ -6,7 +6,7 @@ import { OneOfTabsProps } from './OneOfTabs';
 type IShapeRenderContext = {
   selectedFieldId?: string | null;
   showExamples: boolean;
-  selectableFields: boolean;
+  fieldsAreSelectable: boolean;
   getChoice: (branch: OneOfTabsProps) => string;
   updateChoice: (parentShapeId: string, branchId: string) => void;
   selectField: (fieldId: string) => void;
@@ -20,7 +20,7 @@ type ShapeRenderContextProps = {
   children: React.ReactNode;
   showExamples: boolean;
   selectedFieldId?: string | null;
-  selectableFields?: boolean;
+  fieldsAreSelectable?: boolean;
   setSelectedField?: (fieldId: string) => void;
 };
 
@@ -28,7 +28,7 @@ export const ShapeRenderStore = ({
   children,
   showExamples,
   selectedFieldId,
-  selectableFields,
+  fieldsAreSelectable,
   setSelectedField,
 }: ShapeRenderContextProps) => {
   const [selectedOneOfChoices, updateSelectedOneOfChoices]: [
@@ -55,7 +55,7 @@ export const ShapeRenderStore = ({
     (fieldId) => {
       if (setSelectedField) setSelectedField(fieldId);
     },
-    [selectedFieldId, setSelectedField]
+    [setSelectedField]
   );
 
   return (
@@ -66,7 +66,7 @@ export const ShapeRenderStore = ({
         updateChoice,
         selectedFieldId,
         selectField,
-        selectableFields: !!selectableFields,
+        fieldsAreSelectable: !!fieldsAreSelectable,
       }}
     >
       <DepthStore depth={0}>{children}</DepthStore>

--- a/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRenderContext.tsx
+++ b/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRenderContext.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
-import { useContext, useState } from 'react';
+import { useContext, useState, useCallback } from 'react';
 import { DepthStore } from './DepthContext';
 import { OneOfTabsProps } from './OneOfTabs';
 
 type IShapeRenderContext = {
   selectedFieldId?: string | null;
   showExamples: boolean;
+  selectableFields: boolean;
   getChoice: (branch: OneOfTabsProps) => string;
   updateChoice: (parentShapeId: string, branchId: string) => void;
+  selectField: (fieldId: string) => void;
 };
 
 export const ShapeRenderContext = React.createContext<IShapeRenderContext | null>(
@@ -18,12 +20,16 @@ type ShapeRenderContextProps = {
   children: React.ReactNode;
   showExamples: boolean;
   selectedFieldId?: string | null;
+  selectableFields?: boolean;
+  setSelectedField?: (fieldId: string) => void;
 };
 
 export const ShapeRenderStore = ({
   children,
   showExamples,
   selectedFieldId,
+  selectableFields,
+  setSelectedField,
 }: ShapeRenderContextProps) => {
   const [selectedOneOfChoices, updateSelectedOneOfChoices]: [
     { [key: string]: string },
@@ -45,9 +51,23 @@ export const ShapeRenderStore = ({
     }));
   };
 
+  const selectField = useCallback(
+    (fieldId) => {
+      if (setSelectedField) setSelectedField(fieldId);
+    },
+    [selectedFieldId, setSelectedField]
+  );
+
   return (
     <ShapeRenderContext.Provider
-      value={{ showExamples, getChoice, updateChoice, selectedFieldId }}
+      value={{
+        showExamples,
+        getChoice,
+        updateChoice,
+        selectedFieldId,
+        selectField,
+        selectableFields: !!selectableFields,
+      }}
     >
       <DepthStore depth={0}>{children}</DepthStore>
     </ShapeRenderContext.Provider>

--- a/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRenderer.tsx
+++ b/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRenderer.tsx
@@ -8,7 +8,7 @@ type ShapeRendererProps = {
   shapes: IShapeRenderer[];
   selectedFieldId?: string | null;
 
-  selectableFields?: boolean;
+  fieldsAreSelectable?: boolean;
   setSelectedField?: (fieldId: string) => void;
 };
 
@@ -17,14 +17,14 @@ export const ShapeRenderer: FC<ShapeRendererProps> = ({
   shapes,
   selectedFieldId,
 
-  selectableFields,
+  fieldsAreSelectable,
   setSelectedField,
 }) => {
   return (
     <ShapeRenderStore
       showExamples={showExamples}
       selectedFieldId={selectedFieldId}
-      selectableFields={selectableFields}
+      fieldsAreSelectable={fieldsAreSelectable}
       setSelectedField={setSelectedField}
     >
       {shapes.length > 1 ? (

--- a/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRenderer.tsx
+++ b/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRenderer.tsx
@@ -7,17 +7,25 @@ type ShapeRendererProps = {
   showExamples: boolean;
   shapes: IShapeRenderer[];
   selectedFieldId?: string | null;
+
+  selectableFields?: boolean;
+  setSelectedField?: (fieldId: string) => void;
 };
 
 export const ShapeRenderer: FC<ShapeRendererProps> = ({
   showExamples,
   shapes,
   selectedFieldId,
+
+  selectableFields,
+  setSelectedField,
 }) => {
   return (
     <ShapeRenderStore
       showExamples={showExamples}
       selectedFieldId={selectedFieldId}
+      selectableFields={selectableFields}
+      setSelectedField={setSelectedField}
     >
       {shapes.length > 1 ? (
         <OneOfRender shapes={shapes} parentShapeId={'root'} />

--- a/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRowBase.tsx
+++ b/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRowBase.tsx
@@ -38,6 +38,7 @@ export const ShapeRowBase = ({
     (e: React.MouseEvent) => {
       if (!clickable) return;
       e.preventDefault();
+      e.stopPropagation();
       if (onClick) onClick();
     },
     [clickable, onClick]

--- a/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRowBase.tsx
+++ b/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRowBase.tsx
@@ -83,7 +83,7 @@ export const RenderField = ({
   const {
     getChoice,
     selectedFieldId,
-    selectableFields,
+    fieldsAreSelectable,
     selectField,
   } = useShapeRenderContext();
 
@@ -97,7 +97,7 @@ export const RenderField = ({
         <ShapeRowBase
           depth={depth}
           changes={changes}
-          clickable={selectableFields}
+          clickable={fieldsAreSelectable}
           focused={!selectedFieldId || fieldId === selectedFieldId}
           data-fieldid={fieldId}
           onClick={onClickRow}
@@ -117,7 +117,7 @@ export const RenderField = ({
       <ShapeRowBase
         depth={depth}
         changes={changes}
-        clickable={selectableFields}
+        clickable={fieldsAreSelectable}
         focused={!selectedFieldId || fieldId === selectedFieldId}
         data-fieldid={fieldId}
         onClick={onClickRow}
@@ -144,7 +144,7 @@ export const RenderField = ({
         <ShapeRowBase
           depth={depth}
           changes={changes}
-          clickable={selectableFields}
+          clickable={fieldsAreSelectable}
           focused={!selectedFieldId || fieldId === selectedFieldId}
           data-fieldid={fieldId}
           onClick={onClickRow}

--- a/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRowBase.tsx
+++ b/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRowBase.tsx
@@ -38,7 +38,6 @@ export const ShapeRowBase = ({
     (e: React.MouseEvent) => {
       if (!clickable) return;
       e.preventDefault();
-      e.stopPropagation();
       if (onClick) onClick();
     },
     [clickable, onClick]

--- a/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRowBase.tsx
+++ b/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRowBase.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import makeStyles from '@material-ui/styles/makeStyles';
+import { makeStyles } from '@material-ui/core';
 import { JsonType } from '@useoptic/optic-domain';
 
 import { IndentSpaces, useSharedStyles } from './SharedStyles';
@@ -31,7 +31,10 @@ export const ShapeRowBase = ({
   return (
     <div
       style={style}
-      className={classNames(classes.rowWrap, { [classes.allowHover]: false })}
+      className={classNames(classes.rowWrap, {
+        [classes.allowHover]: false,
+        [classes.isFocused]: focused,
+      })}
     >
       <div
         {...props}
@@ -39,8 +42,7 @@ export const ShapeRowBase = ({
           classes.row,
           { [sharedClasses.added]: changes === 'added' },
           { [sharedClasses.changed]: changes === 'updated' },
-          { [sharedClasses.removed]: changes === 'removed' },
-          { [classes.focused]: focused }
+          { [sharedClasses.removed]: changes === 'removed' }
         )}
         style={{ paddingLeft: depth * IndentSpaces + 4 }}
       >
@@ -69,7 +71,7 @@ export const RenderField = ({
         <ShapeRowBase
           depth={depth}
           changes={changes}
-          focused={fieldId === selectedFieldId}
+          focused={!selectedFieldId || fieldId === selectedFieldId}
           data-fieldid={fieldId}
         >
           <span className={sharedClasses.shapeFont}>"{name}"</span>
@@ -87,7 +89,7 @@ export const RenderField = ({
       <ShapeRowBase
         depth={depth}
         changes={changes}
-        focused={fieldId === selectedFieldId}
+        focused={!selectedFieldId || fieldId === selectedFieldId}
         data-fieldid={fieldId}
       >
         <span className={sharedClasses.shapeFont}>"{name}"</span>
@@ -112,7 +114,7 @@ export const RenderField = ({
         <ShapeRowBase
           depth={depth}
           changes={changes}
-          focused={fieldId === selectedFieldId}
+          focused={!selectedFieldId || fieldId === selectedFieldId}
           data-fieldid={fieldId}
         >
           <span className={sharedClasses.shapeFont}>"{name}"</span>
@@ -142,9 +144,11 @@ export const RenderRootShape = ({
   right?: React.ReactElement;
 }) => {
   const { depth } = useDepth();
+  const { selectedFieldId } = useShapeRenderContext();
+
   return (
     <>
-      <ShapeRowBase depth={depth}>
+      <ShapeRowBase depth={depth} focused={!selectedFieldId}>
         <RenderFieldLeadingValue shapeRenderers={[shape]} />
         {right ? (
           <>
@@ -199,6 +203,8 @@ export const RenderFieldRowValues = ({
 }: RenderFieldValueProps) => {
   const sharedClasses = useSharedStyles();
   const { Indent, depth } = useDepth();
+  const { selectedFieldId } = useShapeRenderContext();
+
   if (shapeRenderers.length === 1) {
     const shape = shapeRenderers[0];
     if (shape.asObject) {
@@ -209,7 +215,7 @@ export const RenderFieldRowValues = ({
               <RenderField {...field} parentId={shape.shapeId} />
             </Indent>
           ))}
-          <ShapeRowBase depth={depth}>
+          <ShapeRowBase depth={depth} focused={!selectedFieldId}>
             <span className={sharedClasses.symbolFont}>{'}'}</span>
           </ShapeRowBase>
         </>
@@ -221,7 +227,7 @@ export const RenderFieldRowValues = ({
         return (
           <>
             <ShapePrimitiveRender {...shape} />
-            <ShapeRowBase depth={depth}>
+            <ShapeRowBase depth={depth} focused={!selectedFieldId}>
               <span className={sharedClasses.symbolFont}>{']'}</span>
             </ShapeRowBase>
           </>
@@ -241,7 +247,7 @@ export const RenderFieldRowValues = ({
       return (
         <>
           <Indent>{inner}</Indent>
-          <ShapeRowBase depth={depth}>
+          <ShapeRowBase depth={depth} focused={!selectedFieldId}>
             <span className={sharedClasses.symbolFont}>{']'}</span>
           </ShapeRowBase>
         </>
@@ -290,6 +296,10 @@ export function OneOfRender({
 const useStyles = makeStyles((theme) => ({
   rowWrap: {
     display: 'flex',
+
+    '&:not($isFocused)': {
+      opacity: 0.3,
+    },
   },
   allowHover: {
     '&:hover $row': {
@@ -302,7 +312,5 @@ const useStyles = makeStyles((theme) => ({
     alignItems: 'flex-start',
     minHeight: 17,
   },
-  focused: {
-    borderBottom: '1px solid black',
-  },
+  isFocused: {},
 }));

--- a/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
@@ -376,17 +376,8 @@ export const EndpointRootPage: FC<
                     >
                       {(shapes, fields) => (
                         <HighlightController>
-                          {(
-                            selectedFieldId,
-                            setSelectedFieldId,
-                            rootElementRef
-                          ) => (
-                            <div
-                              className={classes.bodyDetails}
-                              ref={
-                                rootElementRef as React.RefObject<HTMLDivElement>
-                              }
-                            >
+                          {(selectedFieldId, setSelectedFieldId) => (
+                            <div className={classes.bodyDetails}>
                               <div>
                                 {process.env.REACT_APP_FF_FIELD_LEVEL_EDITS !==
                                   'true' || !isEditing ? (
@@ -489,17 +480,8 @@ export const EndpointRootPage: FC<
                       >
                         {(shapes, fields) => (
                           <HighlightController>
-                            {(
-                              selectedFieldId,
-                              setSelectedFieldId,
-                              rootElementRef
-                            ) => (
-                              <div
-                                className={classes.bodyDetails}
-                                ref={
-                                  rootElementRef as React.RefObject<HTMLDivElement>
-                                }
-                              >
+                            {(selectedFieldId, setSelectedFieldId) => (
+                              <div className={classes.bodyDetails}>
                                 <div>
                                   {process.env
                                     .REACT_APP_FF_FIELD_LEVEL_EDITS !==

--- a/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
@@ -529,7 +529,7 @@ export const EndpointRootPage: FC<
                                           shapes={shapes}
                                           location={response.body!.contentType}
                                           selectedFieldId={selectedFieldId}
-                                          selectableFields={true}
+                                          fieldsAreSelectable={true}
                                           setSelectedField={setSelectedFieldId}
                                         />
                                       )}

--- a/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
@@ -376,8 +376,17 @@ export const EndpointRootPage: FC<
                     >
                       {(shapes, fields) => (
                         <HighlightController>
-                          {(selectedFieldId, setSelectedFieldId) => (
-                            <div className={classes.bodyDetails}>
+                          {(
+                            selectedFieldId,
+                            setSelectedFieldId,
+                            rootElementRef
+                          ) => (
+                            <div
+                              className={classes.bodyDetails}
+                              ref={
+                                rootElementRef as React.RefObject<HTMLDivElement>
+                              }
+                            >
                               <div>
                                 {process.env.REACT_APP_FF_FIELD_LEVEL_EDITS !==
                                   'true' || !isEditing ? (
@@ -480,8 +489,17 @@ export const EndpointRootPage: FC<
                       >
                         {(shapes, fields) => (
                           <HighlightController>
-                            {(selectedFieldId, setSelectedFieldId) => (
-                              <div className={classes.bodyDetails}>
+                            {(
+                              selectedFieldId,
+                              setSelectedFieldId,
+                              rootElementRef
+                            ) => (
+                              <div
+                                className={classes.bodyDetails}
+                                ref={
+                                  rootElementRef as React.RefObject<HTMLDivElement>
+                                }
+                              >
                                 <div>
                                   {process.env
                                     .REACT_APP_FF_FIELD_LEVEL_EDITS !==

--- a/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
@@ -529,6 +529,8 @@ export const EndpointRootPage: FC<
                                           shapes={shapes}
                                           location={response.body!.contentType}
                                           selectedFieldId={selectedFieldId}
+                                          selectableFields={true}
+                                          setSelectedField={setSelectedFieldId}
                                         />
                                       )}
                                     </SimulatedBody>


### PR DESCRIPTION
## Why
We want there to be a strong link between the shape editor and preview in documentation edit mode, making field level editing as discoverable and easy to access as possible.

## What
The currently edited field is highlighted. Fields are selectable from the preview while in edit mode.

![Kapture 2021-08-12 at 13 43 10](https://user-images.githubusercontent.com/857549/129191138-725e735f-bb65-4aeb-a064-e76d1a16d415.gif)

## Validation
* [ ] CI passes
