### PR TITLE
Fix daemon version mismatch

### DIFF
--- a/workspaces/ui-v2/src/entry-points/local/EnsureDaemonRunning.tsx
+++ b/workspaces/ui-v2/src/entry-points/local/EnsureDaemonRunning.tsx
@@ -9,6 +9,10 @@ import * as SupportLinks from '<src>/constants/SupportLinks';
 const packageJson = require('../../../package.json');
 const uiPackageVersion = packageJson.version;
 
+// TODO remove this and make sure the UI gets the latest side channel version attached when being built
+const trimPrereleaseVersions = (version: string): string =>
+  version.split('-')[0];
+
 export const EnsureDaemonRunning: FC = ({ children }) => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
@@ -19,12 +23,17 @@ export const EnsureDaemonRunning: FC = ({ children }) => {
       const cliClient = new Client('/api');
       try {
         const { version } = await cliClient.daemonStatus();
-        if (version !== uiPackageVersion) {
+        if (
+          trimPrereleaseVersions(version) !==
+          trimPrereleaseVersions(uiPackageVersion)
+        ) {
           Sentry.captureEvent({
             message: 'Mismatched UI and daemon versions',
             extra: {
               uiVersion: uiPackageVersion,
               daemonVersion: version,
+              trimmedUiVersion: trimPrereleaseVersions(uiPackageVersion),
+              trimmedDaemonVersion: trimPrereleaseVersions(version),
             },
           });
           setHasMismatchedVersions(true);


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

In side channel builds:
```
Request URL: http://localhost:34444/api/daemon/status > {isRunning: true, version: "10.2.4-alpha.b223"}

Looks like this will always fail on side-channel/beta/etc. builds. ui-v2 workspace package.json:

"version": "10.2.4",

and it looks like EnsureDaemonRunning.ts is loading the package.json file and using that for version.
```

## What
What's changing? Anything of note to call out?

Ideally we inject the side channel version into the UI - but for making the side channel work, this is the quickest solution

Side channel action to test this:
https://github.com/opticdev/optic/actions/runs/1124601725


## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
