### PR TITLE
Connect redux actions to shape editor

### DIFF
--- a/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState } from 'react';
+import React, { FC, useCallback, useEffect, useState } from 'react';
 import { Redirect, RouteComponentProps } from 'react-router-dom';
 import { Button, LinearProgress, makeStyles } from '@material-ui/core';
 import { Alert } from '@material-ui/lab';
@@ -104,6 +104,22 @@ export const EndpointRootPage: FC<
 
   const unremoveEndpoint = () =>
     dispatch(documentationEditActions.unremoveEndpoint({ method, pathId }));
+
+  const onFieldDescriptionChanged = useCallback(
+    (fieldId: string, description: string, isDescriptionDifferent: boolean) => {
+      if (isDescriptionDifferent) {
+        dispatch(
+          documentationEditActions.addContribution({
+            id: fieldId,
+            contributionKey: 'description',
+            value: description,
+            endpointId: endpointId,
+          })
+        );
+      }
+    },
+    [endpointId, dispatch]
+  );
 
   const classes = useStyles();
 
@@ -314,7 +330,10 @@ export const EndpointRootPage: FC<
                             required={field.required}
                           />
                         ) : (
-                          <ShapeEditor fields={fields} />
+                          <ShapeEditor
+                            fields={fields}
+                            onChangeDescription={onFieldDescriptionChanged}
+                          />
                         );
                       }}
                       fieldDetails={fields}
@@ -408,6 +427,9 @@ export const EndpointRootPage: FC<
                                     fields={fields}
                                     selectedFieldId={selectedFieldId}
                                     setSelectedField={setSelectedFieldId}
+                                    onChangeDescription={
+                                      onFieldDescriptionChanged
+                                    }
                                   />
                                 )}
                               </div>
@@ -515,6 +537,9 @@ export const EndpointRootPage: FC<
                                       fields={fields}
                                       selectedFieldId={selectedFieldId}
                                       setSelectedField={setSelectedFieldId}
+                                      onChangeDescription={
+                                        onFieldDescriptionChanged
+                                      }
                                     />
                                   )}
                                 </div>

--- a/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
@@ -116,6 +116,13 @@ export const EndpointRootPage: FC<
             endpointId: endpointId,
           })
         );
+      } else {
+        dispatch(
+          documentationEditActions.removeContribution({
+            id: fieldId,
+            contributionKey: 'description',
+          })
+        );
       }
     },
     [endpointId, dispatch]

--- a/workspaces/ui-v2/src/pages/docs/components/Contributions.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/Contributions.tsx
@@ -72,15 +72,15 @@ export function DocsFieldOrParameterContribution({
             })
           );
         } else {
+          dispatch(
+            documentationEditActions.addContribution({
+              id,
+              contributionKey,
+              value,
+              endpointId,
+            })
+          );
         }
-        dispatch(
-          documentationEditActions.addContribution({
-            id,
-            contributionKey,
-            value,
-            endpointId,
-          })
-        );
       }}
       isEditing={isEditable}
       required={required}
@@ -223,15 +223,15 @@ export function EndpointNameMiniContribution({
             })
           );
         } else {
+          dispatch(
+            documentationEditActions.addContribution({
+              id,
+              contributionKey,
+              value,
+              endpointId,
+            })
+          );
         }
-        dispatch(
-          documentationEditActions.addContribution({
-            id,
-            contributionKey,
-            value,
-            endpointId,
-          })
-        );
       }}
       defaultText={defaultText}
       variant={TextFieldVariant.SMALL}

--- a/workspaces/ui-v2/src/pages/docs/components/Contributions.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/Contributions.tsx
@@ -112,7 +112,16 @@ export function DocsFieldOrParameterContribution({
       shapes={shapes}
       depth={depth}
       value={value}
-      setValue={(value) =>
+      setValue={(value) => {
+        if (value === initialValue) {
+          dispatch(
+            documentationEditActions.removeContribution({
+              id,
+              contributionKey,
+            })
+          );
+        } else {
+        }
         dispatch(
           documentationEditActions.addContribution({
             id,
@@ -120,8 +129,8 @@ export function DocsFieldOrParameterContribution({
             value,
             endpointId,
           })
-        )
-      }
+        );
+      }}
       isEditing={isEditable}
       required={required}
     />
@@ -186,7 +195,16 @@ export function EndpointNameContribution({
           )
         }
         value={value}
-        setValue={(value) =>
+        setValue={(value) => {
+          if (value === initialValue) {
+            dispatch(
+              documentationEditActions.removeContribution({
+                id,
+                contributionKey,
+              })
+            );
+          } else {
+          }
           dispatch(
             documentationEditActions.addContribution({
               id,
@@ -194,8 +212,8 @@ export function EndpointNameContribution({
               value,
               endpointId,
             })
-          )
-        }
+          );
+        }}
         helperText="Help consumers by naming this endpoint"
         defaultText={defaultText}
         variant={TextFieldVariant.REGULAR}
@@ -245,7 +263,16 @@ export function EndpointNameMiniContribution({
         )
       }
       value={value}
-      setValue={(value) =>
+      setValue={(value) => {
+        if (value === initialValue) {
+          dispatch(
+            documentationEditActions.removeContribution({
+              id,
+              contributionKey,
+            })
+          );
+        } else {
+        }
         dispatch(
           documentationEditActions.addContribution({
             id,
@@ -253,8 +280,8 @@ export function EndpointNameMiniContribution({
             value,
             endpointId,
           })
-        )
-      }
+        );
+      }}
       defaultText={defaultText}
       variant={TextFieldVariant.SMALL}
     />

--- a/workspaces/ui-v2/src/pages/docs/components/Contributions.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/Contributions.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { makeStyles } from '@material-ui/core';
 import { IShapeRenderer } from '<src>/types';
 import Helmet from 'react-helmet';
 import {
@@ -29,54 +28,6 @@ export type DocsFieldOrParameterContributionProps = {
   required: boolean;
   setSelectedField?: (selectedFieldId: string | null) => void;
 };
-
-export function DocFieldContribution(
-  props: DocsFieldOrParameterContributionProps
-) {
-  const { setSelectedField } = props;
-  const isEditing = useAppSelector(
-    (state) => state.documentationEdits.isEditing
-  );
-  const fieldId = props.id;
-  const classes = useStyles();
-  const isFieldRemoved = useAppSelector(selectors.isFieldRemoved(fieldId));
-  const isFieldRemovedRoot = useAppSelector(
-    selectors.isFieldRemovedRoot(props.id)
-  );
-  const dispatch = useAppDispatch();
-  const removeField = () =>
-    dispatch(documentationEditActions.removeField({ fieldId }));
-  const unremoveField = () =>
-    dispatch(documentationEditActions.unremoveField({ fieldId }));
-
-  return process.env.REACT_APP_FF_FIELD_LEVEL_EDITS === 'true' ? (
-    <div className={classes.fieldContainer}>
-      <div className={classes.contributionContainer}>
-        <DocsFieldOrParameterContribution
-          {...props}
-          onFocus={() => {
-            setSelectedField && setSelectedField(fieldId);
-          }}
-          onBlur={() => {
-            setSelectedField && setSelectedField(null);
-          }}
-        />
-      </div>
-      {isEditing &&
-        (isFieldRemoved ? (
-          isFieldRemovedRoot ? (
-            <div onClick={unremoveField}>unremove</div>
-          ) : (
-            <div>is removed</div>
-          )
-        ) : (
-          <div onClick={removeField}>remove</div>
-        ))}
-    </div>
-  ) : (
-    <DocsFieldOrParameterContribution {...props} />
-  );
-}
 
 export function DocsFieldOrParameterContribution({
   name,
@@ -287,12 +238,3 @@ export function EndpointNameMiniContribution({
     />
   );
 }
-
-const useStyles = makeStyles((theme) => ({
-  fieldContainer: {
-    display: 'flex',
-  },
-  contributionContainer: {
-    flexGrow: 1,
-  },
-}));

--- a/workspaces/ui-v2/src/pages/docs/components/MarkdownBodyContribution.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/MarkdownBodyContribution.tsx
@@ -53,14 +53,23 @@ export function MarkdownBodyContribution({
       placeholder={defaultText}
       value={value}
       onChange={({ target: { value } }: ChangeEvent<HTMLInputElement>) => {
-        dispatch(
-          documentationEditActions.addContribution({
-            id,
-            contributionKey,
-            value,
-            endpointId,
-          })
-        );
+        if (initialValue === value) {
+          dispatch(
+            documentationEditActions.removeContribution({
+              id,
+              contributionKey,
+            })
+          );
+        } else {
+          dispatch(
+            documentationEditActions.addContribution({
+              id,
+              contributionKey,
+              value,
+              endpointId,
+            })
+          );
+        }
       }}
     />
   ) : (

--- a/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
@@ -17,7 +17,6 @@ import {
   Check as CheckIcon,
   UndoOutlined as UndoOutlinedIcon,
   DeleteOutline as DeleteOutlineIcon,
-  RemoveOutlined as RemoveOutlinedIcon,
 } from '@material-ui/icons';
 import ClassNames from 'classnames';
 import Color from 'color';
@@ -183,16 +182,13 @@ const Row: FC<{
         removedState={fieldRemovedState}
         onToggleRemove={onToggleRemoveHandler}
       >
-        {/* TODO implement removed state */}
-        {selected && (
-          <FieldEditor
-            field={field}
-            description={description}
-            currentJsonTypes={[...jsonTypes]}
-            onChangeType={onChangeTypeHandler}
-            onChangeDescription={onChangeDescriptionHandler}
-          />
-        )}
+        <FieldEditor
+          field={field}
+          description={description}
+          currentJsonTypes={[...jsonTypes]}
+          onChangeType={onChangeTypeHandler}
+          onChangeDescription={onChangeDescriptionHandler}
+        />
       </Field>
     </div>
   );
@@ -342,6 +338,8 @@ const Field: FC<{
     [removedState, onToggleRemove]
   );
 
+  const isRemoved = removedState !== 'not_removed';
+
   return (
     <div
       className={ClassNames(classes.container, {
@@ -357,14 +355,18 @@ const Field: FC<{
           backgroundImage: `url("${indentsImageUrl(depth - 1)}")`,
         }}
       >
-        <div className={classes.description}>
+        <div
+          className={ClassNames(classes.description, {
+            [classes.removed]: isRemoved,
+          })}
+        >
           <div className={classes.fieldName}>{name}</div>
           <div className={classes.typesSummary}>
             {summarizeTypes(shapes, required)}
           </div>
         </div>
         <div className={classes.controls}>
-          {selected && onToggleRemove && (
+          {selected && onToggleRemove && removedState !== 'removed' && (
             <IconButton
               className={classes.removeControl}
               size="small"
@@ -372,17 +374,24 @@ const Field: FC<{
             >
               {removedState === 'not_removed' ? (
                 <DeleteOutlineIcon />
-              ) : removedState === 'root_removed' ? (
-                <UndoOutlinedIcon />
               ) : (
-                <RemoveOutlinedIcon />
+                <UndoOutlinedIcon />
               )}
             </IconButton>
           )}
         </div>
       </header>
-
-      <div className={classes.stage}>{children}</div>
+      {selected && (
+        <div className={classes.stage}>
+          {isRemoved ? (
+            <div className={classes.fieldRemovedInfo}>
+              Field is staged to be removed
+            </div>
+          ) : (
+            <>{children}</>
+          )}
+        </div>
+      )}
     </div>
   );
 };
@@ -517,6 +526,17 @@ const useFieldStyles = makeStyles((theme) => ({
         .hsl()
         .string(),
     },
+  },
+
+  removed: {
+    textDecoration: 'line-through',
+  },
+
+  fieldRemovedInfo: {
+    fontFamily: Theme.FontFamily,
+    fontSize: theme.typography.fontSize - 1,
+    fontWeight: theme.typography.fontWeightLight,
+    padding: theme.spacing(3, 2),
   },
 
   fieldName: {

--- a/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useState } from 'react';
+import React, { ComponentProps, FC, useCallback, useState } from 'react';
 import {
   makeStyles,
   lighten,
@@ -12,22 +12,32 @@ import ClassNames from 'classnames';
 import Color from 'color';
 import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
 
+import { setEquals } from '<src>/lib/set-ops';
 import { IFieldDetails, IShapeRenderer } from '<src>/types';
 import { JsonType } from '@useoptic/optic-domain';
 import * as Theme from '<src>/styles/theme';
-
-type onChangeDescription = (
-  fieldId: string,
-  description: string,
-  isDescriptionDifferent: boolean
-) => void;
 
 export const ShapeEditor: FC<{
   fields: IFieldDetails[];
   selectedFieldId?: string | null;
   setSelectedField?: (fieldId: string | null) => void;
-  onChangeDescription?: onChangeDescription;
-}> = ({ fields, selectedFieldId, setSelectedField, onChangeDescription }) => {
+  onChangeDescription?: (
+    fieldId: string,
+    description: string,
+    isDescriptionDifferent: boolean
+  ) => void;
+  onChangeFieldType?: (
+    fieldId: string,
+    requestedFieldTypes: Set<JsonType>,
+    isFieldTypeDifferent: boolean
+  ) => void;
+}> = ({
+  fields,
+  selectedFieldId,
+  setSelectedField,
+  onChangeDescription,
+  onChangeFieldType,
+}) => {
   const classes = useStyles();
 
   const onFieldSelect = (fieldId: string) => () => {
@@ -42,12 +52,13 @@ export const ShapeEditor: FC<{
       {fields.length > 0 && (
         <ul className={classes.rowsList}>
           {fields.map((field) => (
-            <li className={classes.rowListItem}>
+            <li key={field.fieldId} className={classes.rowListItem}>
               <Row
                 field={field}
                 selected={selectedFieldId === field.fieldId}
                 onChangeDescription={onChangeDescription}
                 onSelect={onFieldSelect(field.fieldId)}
+                onChangeFieldType={onChangeFieldType}
               />
             </li>
           ))}
@@ -57,28 +68,62 @@ export const ShapeEditor: FC<{
   );
 };
 
+const editableTypes: Set<JsonType> = new Set([
+  JsonType.UNDEFINED,
+  JsonType.NULL,
+]);
+const getInitialTypes = (fields: IFieldDetails): Set<JsonType> => {
+  const initialTypes: Set<JsonType> = new Set();
+  for (const type of editableTypes) {
+    if (type === JsonType.UNDEFINED && !fields.required) {
+      initialTypes.add(type);
+    } else if (fields.shapes.find((shape) => shape.jsonType === type)) {
+      initialTypes.add(type);
+    }
+  }
+  return initialTypes;
+};
+
 const Row: FC<{
   field: IFieldDetails;
   selected: boolean;
 
-  onChangeDescription?: onChangeDescription;
+  onChangeDescription?: ComponentProps<
+    typeof ShapeEditor
+  >['onChangeDescription'];
+  onChangeFieldType?: ComponentProps<typeof ShapeEditor>['onChangeFieldType'];
   onSelect?: () => void;
 }> = function ShapeEditorRow({
   field,
   selected,
   onChangeDescription,
+  onChangeFieldType,
   onSelect,
 }) {
   const classes = useStyles();
   const initialDescription = field.contribution['value'];
+  const initialFieldTypes = getInitialTypes(field);
   const [description, setDescription] = useState(initialDescription);
+  const [jsonTypes, setJsonTypes] = useState<Set<JsonType>>(initialFieldTypes);
 
-  // TODO hook this up
-  const onChangeType = useCallback(
+  const onChangeTypeHandler = useCallback(
     (type: JsonType, enabled: boolean) => {
-      console.log('changed type for field', type, enabled, field.fieldId);
+      const newJsonTypes = new Set(jsonTypes);
+      if (enabled) {
+        newJsonTypes.add(type);
+      } else {
+        newJsonTypes.delete(type);
+      }
+      setJsonTypes(newJsonTypes);
+
+      onChangeFieldType &&
+        onChangeFieldType(
+          field.fieldId,
+          newJsonTypes,
+          !setEquals(initialFieldTypes, newJsonTypes)
+        );
     },
-    [field.fieldId]
+    [field.fieldId, onChangeFieldType, initialFieldTypes, jsonTypes]
   );
 
   const onChangeDescriptionHandler = useCallback(
@@ -109,7 +154,8 @@ const Row: FC<{
           <FieldEditor
             field={field}
             description={description}
-            onChangeType={onChangeType}
+            currentJsonTypes={[...jsonTypes]}
+            onChangeType={onChangeTypeHandler}
             onChangeDescription={onChangeDescriptionHandler}
           />
         )}
@@ -121,22 +167,21 @@ const Row: FC<{
 const FieldEditor: FC<{
   field: IFieldDetails;
   description: string;
+  currentJsonTypes: JsonType[];
 
   onChangeDescription?: (description: string) => void;
   onChangeType?: (type: JsonType, enabled: boolean) => void;
 }> = function ShapeEditorFieldEditor({
   field,
   description,
+  currentJsonTypes,
   onChangeDescription,
   onChangeType,
 }) {
   const classes = useStyles();
-
-  let currentJsonTypes = field.shapes.map(({ jsonType }) => jsonType);
-  if (!field.required) currentJsonTypes.push(JsonType.UNDEFINED);
-  let nonEditableTypes = currentJsonTypes.filter(
-    (jsonType) => jsonType !== JsonType.UNDEFINED && jsonType !== JsonType.NULL
-  );
+  const nonEditableTypes = field.shapes
+    .map((shape) => shape.jsonType)
+    .filter((jsonType) => !editableTypes.has(jsonType));
 
   let onClickTypeButton = useCallback(
     (type: JsonType) => (e: React.MouseEvent) => {
@@ -156,32 +201,21 @@ const FieldEditor: FC<{
   return (
     <div className={classes.editor}>
       <ButtonGroup className={classes.typeSelector}>
-        <Button
-          disableElevation
-          variant={
-            currentJsonTypes.includes(JsonType.UNDEFINED)
-              ? 'contained'
-              : 'outlined'
-          }
-          startIcon={
-            currentJsonTypes.includes(JsonType.UNDEFINED) ? <CheckIcon /> : null
-          }
-          onClick={onClickTypeButton(JsonType.UNDEFINED)}
-        >
-          Optional
-        </Button>
-        <Button
-          disableElevation
-          variant={
-            currentJsonTypes.includes(JsonType.NULL) ? 'contained' : 'outlined'
-          }
-          startIcon={
-            currentJsonTypes.includes(JsonType.NULL) ? <CheckIcon /> : null
-          }
-          onClick={onClickTypeButton(JsonType.NULL)}
-        >
-          Null
-        </Button>
+        {[...editableTypes].map((editableType) => (
+          <Button
+            key={editableType}
+            disableElevation
+            variant={
+              currentJsonTypes.includes(editableType) ? 'contained' : 'outlined'
+            }
+            startIcon={
+              currentJsonTypes.includes(editableType) ? <CheckIcon /> : null
+            }
+            onClick={onClickTypeButton(editableType)}
+          >
+            {editableType === JsonType.UNDEFINED ? 'Optional' : editableType}
+          </Button>
+        ))}
 
         {nonEditableTypes.map((jsonType) => (
           <Button
@@ -307,7 +341,7 @@ const Field: FC<{
 function summarizeTypes(shapes: IShapeRenderer[], required: boolean) {
   const optionalText = required ? '' : ' (optional)';
   let components = shapes.map(({ jsonType }: { jsonType: JsonType }) => (
-    <span style={{ color: Theme.jsonTypeColors[jsonType] }}>
+    <span key={jsonType} style={{ color: Theme.jsonTypeColors[jsonType] }}>
       {jsonType.toString().toLowerCase()}
     </span>
   ));
@@ -322,7 +356,7 @@ function summarizeTypes(shapes: IShapeRenderer[], required: boolean) {
     return (
       <>
         {components.map((component, i) => (
-          <span key={i}>{component},</span>
+          <span key={component.key}>{component},</span>
         ))}{' '}
         or {last} {optionalText}
       </>

--- a/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
@@ -84,12 +84,13 @@ const Row: FC<{
   const onChangeDescriptionHandler = useCallback(
     (description: string) => {
       setDescription(description);
-      if (onChangeDescription)
+      if (onChangeDescription) {
         onChangeDescription(
           field.fieldId,
           description,
           description !== initialDescription
         );
+      }
     },
     [field.fieldId, onChangeDescription, initialDescription]
   );
@@ -336,7 +337,6 @@ function indentsImageUrl(depth: number = 0) {
   let range = Array(Math.max(depth, 0))
     .fill(0)
     .map((val, n) => n);
-  console.log(range);
   let width = INDENT_WIDTH * depth;
   return (
     'data:image/svg+xml,' +

--- a/workspaces/ui-v2/src/store/documentationEdit/slice.ts
+++ b/workspaces/ui-v2/src/store/documentationEdit/slice.ts
@@ -76,7 +76,6 @@ const documentationEditSlice = createSlice({
         };
       }
     },
-    // TODO FLEB connect this up to the UI
     removeContribution: (
       state,
       action: PayloadAction<{
@@ -89,7 +88,6 @@ const documentationEditSlice = createSlice({
         delete state.contributions[id][contributionKey];
       }
     },
-    // TODO FLEB connect this up to the UI
     addFieldEdit: (
       state,
       action: PayloadAction<{
@@ -103,7 +101,6 @@ const documentationEditSlice = createSlice({
       const { fieldId, options } = action.payload;
       state.fields.edited[fieldId] = options;
     },
-    // TODO FLEB connect this up to the UI
     removeFieldEdit: (
       state,
       action: PayloadAction<{

--- a/workspaces/ui-v2/src/store/selectors/documentationEditSelectors.ts
+++ b/workspaces/ui-v2/src/store/selectors/documentationEditSelectors.ts
@@ -4,7 +4,7 @@ import { IContribution } from '<src>/types';
 import { getEndpointId } from '<src>/utils';
 import { JsonType } from '@useoptic/optic-domain';
 
-const memoizedGetAllRemovedFields = createSelector<
+export const memoizedGetAllRemovedFields = createSelector<
   RootState,
   RootState['shapes'],
   string[],

--- a/workspaces/ui-v2/src/store/selectors/documentationEditSelectors.ts
+++ b/workspaces/ui-v2/src/store/selectors/documentationEditSelectors.ts
@@ -77,12 +77,15 @@ export const getValidContributions = (state: RootState): IContribution[] => {
 export const getDocumentationEditStagedCount = (state: RootState) => {
   const {
     removedEndpoints,
-    fields: { removed: removedFields },
+    fields: { edited: editedFields, removed: removedFields },
   } = state.documentationEdits;
   const validContributions = getValidContributions(state);
 
   return (
-    validContributions.length + removedEndpoints.length + removedFields.length
+    validContributions.length +
+    removedEndpoints.length +
+    removedFields.length +
+    Object.keys(editedFields).length
   );
 };
 


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

New shape editor contains a bunch of actions that needed to be hooked up. This included:
- contributions
- Removing fields
- Editing field types

## What
What's changing? Anything of note to call out?

- Connects up these components from the endpointRootPage - exposed through components + functions
- Fixed a bunch of misc react key errors
- Updates the isRemoved state (it's currently just a strikethrough - but theres likely better styling we can add in here)

Field that is the root removed field
<img width="892" alt="Screen Shot 2021-08-12 at 7 17 13 PM" src="https://user-images.githubusercontent.com/18374483/129281849-e90a7905-e0f3-4a67-b948-b03b058a57b4.png">

Field that is a child of a removed field
<img width="680" alt="Screen Shot 2021-08-12 at 7 17 15 PM" src="https://user-images.githubusercontent.com/18374483/129281863-be5468bc-6607-43f6-aab9-0da87b1f4582.png">

Things to follow this:
- Query Parameters can't be edited right now - query parameters can also only be set as optional, instead of nullable - since we can never infer nullable query parameters. 
- Add a loading indicator to the simulated body component

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
