### PR TITLE
Query parameter field editing with shapeviewer

### DIFF
--- a/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
@@ -356,81 +356,87 @@ export const EndpointRootPage: FC<
               endpointId={endpointId}
             >
               {(shapes, fields) => (
-                <div className={classes.bodyDetails}>
-                  <div>
-                    {process.env.REACT_APP_FF_FIELD_LEVEL_EDITS !== 'true' ||
-                    !isEditing ? (
-                      <ContributionsList
-                        renderField={(field) => {
-                          // TODO apply this to the shapeEditor component
-                          let isArray = field.shapes.findIndex(
-                            (choice) => choice.jsonType === JsonType.ARRAY
-                          );
+                <HighlightController>
+                  {(selectedFieldId, setSelectedFieldId) => (
+                    <div className={classes.bodyDetails}>
+                      <div>
+                        {process.env.REACT_APP_FF_FIELD_LEVEL_EDITS !==
+                          'true' || !isEditing ? (
+                          <ContributionsList
+                            renderField={(field) => {
+                              // TODO apply this to the shapeEditor component
+                              let isArray = field.shapes.findIndex(
+                                (choice) => choice.jsonType === JsonType.ARRAY
+                              );
 
-                          if (isArray > -1) {
-                            if (field.shapes.length > 1) {
-                              field.shapes.splice(isArray, 1);
-                            } else {
-                              field.shapes = field.shapes[
-                                isArray
-                              ].asArray!.shapeChoices;
-                            }
-                          }
-
-                          return (
-                            <DocsFieldOrParameterContribution
-                              key={
-                                field.contribution.id +
-                                field.contribution.contributionKey
+                              if (isArray > -1) {
+                                if (field.shapes.length > 1) {
+                                  field.shapes.splice(isArray, 1);
+                                } else {
+                                  field.shapes = field.shapes[
+                                    isArray
+                                  ].asArray!.shapeChoices;
+                                }
                               }
-                              endpoint={{
-                                pathId,
-                                method,
-                              }}
-                              name={field.name}
-                              shapes={field.shapes}
-                              depth={field.depth}
-                              id={field.contribution.id}
-                              initialValue={field.contribution.value}
-                              required={field.required}
-                            />
-                          );
-                        }}
-                        fieldDetails={fields}
-                      />
-                    ) : (
-                      <ShapeEditor
-                        fields={fields}
-                        onChangeDescription={onFieldDescriptionChanged}
-                        onChangeFieldType={onChangeFieldType}
-                        isFieldRemoved={isFieldRemoved}
-                        onToggleRemove={onToggleRemovedField}
-                      />
-                    )}
-                  </div>
-                  <div className={classes.panel}>
-                    {isEditing ? (
-                      <SimulatedBody
-                        rootShapeId={visibleQueryParameters.rootShapeId}
-                        endpointId={endpointId}
-                      >
-                        {(shapes) => (
+
+                              return (
+                                <DocsFieldOrParameterContribution
+                                  key={
+                                    field.contribution.id +
+                                    field.contribution.contributionKey
+                                  }
+                                  endpoint={{
+                                    pathId,
+                                    method,
+                                  }}
+                                  name={field.name}
+                                  shapes={field.shapes}
+                                  depth={field.depth}
+                                  id={field.contribution.id}
+                                  initialValue={field.contribution.value}
+                                  required={field.required}
+                                />
+                              );
+                            }}
+                            fieldDetails={fields}
+                          />
+                        ) : (
+                          <ShapeEditor
+                            fields={fields}
+                            selectedFieldId={selectedFieldId}
+                            setSelectedField={setSelectedFieldId}
+                            onChangeDescription={onFieldDescriptionChanged}
+                            onChangeFieldType={onChangeFieldType}
+                            isFieldRemoved={isFieldRemoved}
+                            onToggleRemove={onToggleRemovedField}
+                          />
+                        )}
+                      </div>
+                      <div className={classes.panel}>
+                        {isEditing ? (
+                          <SimulatedBody
+                            rootShapeId={visibleQueryParameters.rootShapeId}
+                            endpointId={endpointId}
+                          >
+                            {(shapes) => (
+                              <QueryParametersPanel
+                                parameters={selectors.convertShapeToQueryParameters(
+                                  shapes
+                                )}
+                              />
+                            )}
+                          </SimulatedBody>
+                        ) : (
                           <QueryParametersPanel
                             parameters={selectors.convertShapeToQueryParameters(
                               shapes
                             )}
                           />
                         )}
-                      </SimulatedBody>
-                    ) : (
-                      <QueryParametersPanel
-                        parameters={selectors.convertShapeToQueryParameters(
-                          shapes
-                        )}
-                      />
-                    )}
-                  </div>
-                </div>
+                      </div>
+                    </div>
+                  )}
+                </HighlightController>
               )}
             </ShapeFetcher>
           </div>

--- a/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
@@ -405,6 +405,7 @@ export const EndpointRootPage: FC<
                             fields={fields}
                             selectedFieldId={selectedFieldId}
                             setSelectedField={setSelectedFieldId}
+                            nonEditableTypes={new Set([JsonType.NULL])}
                             onChangeDescription={onFieldDescriptionChanged}
                             onChangeFieldType={onChangeFieldType}
                             isFieldRemoved={isFieldRemoved}

--- a/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
@@ -364,37 +364,29 @@ export const EndpointRootPage: FC<
                           'true' || !isEditing ? (
                           <ContributionsList
                             renderField={(field) => {
-                              // TODO apply this to the shapeEditor component
-                              let isArray = field.shapes.findIndex(
-                                (choice) => choice.jsonType === JsonType.ARRAY
+                              const fieldWithoutArrayShape = selectors.removeArrayShapeFromField(
+                                field
                               );
-
-                              if (isArray > -1) {
-                                if (field.shapes.length > 1) {
-                                  field.shapes.splice(isArray, 1);
-                                } else {
-                                  field.shapes = field.shapes[
-                                    isArray
-                                  ].asArray!.shapeChoices;
-                                }
-                              }
 
                               return (
                                 <DocsFieldOrParameterContribution
                                   key={
-                                    field.contribution.id +
-                                    field.contribution.contributionKey
+                                    fieldWithoutArrayShape.contribution.id +
+                                    fieldWithoutArrayShape.contribution
+                                      .contributionKey
                                   }
                                   endpoint={{
                                     pathId,
                                     method,
                                   }}
-                                  name={field.name}
-                                  shapes={field.shapes}
-                                  depth={field.depth}
-                                  id={field.contribution.id}
-                                  initialValue={field.contribution.value}
-                                  required={field.required}
+                                  name={fieldWithoutArrayShape.name}
+                                  shapes={fieldWithoutArrayShape.shapes}
+                                  depth={fieldWithoutArrayShape.depth}
+                                  id={fieldWithoutArrayShape.contribution.id}
+                                  initialValue={
+                                    fieldWithoutArrayShape.contribution.value
+                                  }
+                                  required={fieldWithoutArrayShape.required}
                                 />
                               );
                             }}
@@ -402,7 +394,9 @@ export const EndpointRootPage: FC<
                           />
                         ) : (
                           <ShapeEditor
-                            fields={fields}
+                            fields={fields.map(
+                              selectors.removeArrayShapeFromField
+                            )}
                             selectedFieldId={selectedFieldId}
                             setSelectedField={setSelectedFieldId}
                             nonEditableTypes={new Set([JsonType.NULL])}

--- a/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
@@ -256,6 +256,7 @@ const FieldEditor: FC<{
 
         {fieldNonEditableTypes.map((jsonType) => (
           <Button
+            key={jsonType}
             color="primary"
             variant="contained"
             disabled

--- a/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
@@ -21,7 +21,7 @@ import {
 import ClassNames from 'classnames';
 import Color from 'color';
 
-import { setEquals } from '<src>/lib/set-ops';
+import { setEquals, setDifference } from '<src>/lib/set-ops';
 import { IFieldDetails, IShapeRenderer } from '<src>/types';
 import { JsonType } from '@useoptic/optic-domain';
 import * as Theme from '<src>/styles/theme';
@@ -30,9 +30,10 @@ type FieldRemovedStatus = 'removed' | 'root_removed' | 'not_removed';
 
 export const ShapeEditor: FC<{
   fields: IFieldDetails[];
+  selectedFieldId: string | null;
+  setSelectedField: (fieldId: string | null) => void;
+  nonEditableTypes?: Set<JsonType>;
   isFieldRemoved?: (fieldId: string) => FieldRemovedStatus;
-  selectedFieldId?: string | null;
-  setSelectedField?: (fieldId: string | null) => void;
   onToggleRemove?: (fieldId: string) => void;
   onChangeDescription?: (
     fieldId: string,
@@ -52,14 +53,13 @@ export const ShapeEditor: FC<{
   setSelectedField,
   onChangeDescription,
   onChangeFieldType,
+  nonEditableTypes = new Set(),
 }) => {
   const classes = useStyles();
 
   const onFieldSelect = (fieldId: string) => () => {
-    if (setSelectedField) {
-      // Deselect the field if the field is already the currently selected field
-      setSelectedField(fieldId === selectedFieldId ? null : fieldId);
-    }
+    // Deselect the field if the field is already the currently selected field
+    setSelectedField(fieldId === selectedFieldId ? null : fieldId);
   };
 
   return (
@@ -76,6 +76,7 @@ export const ShapeEditor: FC<{
                 onChangeDescription={onChangeDescription}
                 onSelect={onFieldSelect(field.fieldId)}
                 onChangeFieldType={onChangeFieldType}
+                nonEditableTypes={nonEditableTypes}
               />
             </li>
           ))}
@@ -104,6 +105,7 @@ const getInitialTypes = (fields: IFieldDetails): Set<JsonType> => {
 const Row: FC<{
   field: IFieldDetails;
   selected: boolean;
+  nonEditableTypes: Set<JsonType>;
 
   isFieldRemoved?: ComponentProps<typeof ShapeEditor>['isFieldRemoved'];
   onToggleRemove?: ComponentProps<typeof ShapeEditor>['onToggleRemove'];
@@ -120,6 +122,7 @@ const Row: FC<{
   onSelect,
   isFieldRemoved,
   onToggleRemove,
+  nonEditableTypes,
 }) {
   const classes = useStyles();
   const initialDescription = field.contribution['value'];
@@ -188,6 +191,7 @@ const Row: FC<{
           currentJsonTypes={[...jsonTypes]}
           onChangeType={onChangeTypeHandler}
           onChangeDescription={onChangeDescriptionHandler}
+          nonEditableTypes={nonEditableTypes}
         />
       </Field>
     </div>
@@ -198,6 +202,7 @@ const FieldEditor: FC<{
   field: IFieldDetails;
   description: string;
   currentJsonTypes: JsonType[];
+  nonEditableTypes: Set<JsonType>;
 
   onChangeDescription?: (description: string) => void;
   onChangeType?: (type: JsonType, enabled: boolean) => void;
@@ -205,13 +210,15 @@ const FieldEditor: FC<{
   field,
   description,
   currentJsonTypes,
+  nonEditableTypes,
   onChangeDescription,
   onChangeType,
 }) {
   const classes = useStyles();
-  const nonEditableTypes = field.shapes
+  const fieldEditableTypes = setDifference(editableTypes, nonEditableTypes);
+  const fieldNonEditableTypes = field.shapes
     .map((shape) => shape.jsonType)
-    .filter((jsonType) => !editableTypes.has(jsonType));
+    .filter((jsonType) => !fieldEditableTypes.has(jsonType));
 
   let onClickTypeButton = useCallback(
     (type: JsonType) => (e: React.MouseEvent) => {
@@ -231,7 +238,7 @@ const FieldEditor: FC<{
   return (
     <div className={classes.editor}>
       <ButtonGroup className={classes.typeSelector}>
-        {[...editableTypes].map((editableType) => (
+        {[...fieldEditableTypes].map((editableType) => (
           <Button
             key={editableType}
             disableElevation
@@ -247,7 +254,7 @@ const FieldEditor: FC<{
           </Button>
         ))}
 
-        {nonEditableTypes.map((jsonType) => (
+        {fieldNonEditableTypes.map((jsonType) => (
           <Button
             color="primary"
             variant="contained"

--- a/workspaces/ui-v2/src/store/selectors/shapeSelectors.ts
+++ b/workspaces/ui-v2/src/store/selectors/shapeSelectors.ts
@@ -127,6 +127,23 @@ export function createFlatList(
   return fieldDetails;
 }
 
+export const removeArrayShapeFromField = (
+  field: IFieldDetails
+): IFieldDetails => {
+  const isArray = !!field.shapes.find(
+    (choice) => choice.jsonType === JsonType.ARRAY
+  );
+  const hasMultipleShapes = field.shapes.length > 1;
+
+  return {
+    ...field,
+    shapes:
+      isArray && hasMultipleShapes
+        ? field.shapes.filter((choice) => choice.jsonType === JsonType.ARRAY)
+        : field.shapes,
+  };
+};
+
 export const convertShapeToQueryParameters = (
   shapes: IShapeRenderer[]
 ): QueryParameters => {


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

## What
What's changing? Anything of note to call out?

- Changed `selectedFieldId` and `setSelectedFieldId` to be non-optional as it powers the functionality of the shape editor
- Moved out array splicing logic into a selector to use in both the old and new versions
- Connected up the query parameter edit field
- Removed the ability to make a query parameter nullable from the shape editor

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
