### PR TITLE
Build FieldViewer component

### DIFF
--- a/workspaces/ui-v2/src/components/FieldViewer.tsx
+++ b/workspaces/ui-v2/src/components/FieldViewer.tsx
@@ -83,6 +83,7 @@ const useStyles = makeStyles((theme) => ({
     fontFamily: Theme.FontFamilyMono,
     fontWeight: theme.typography.fontWeightLight,
     fontSize: theme.typography.fontSize - 2,
+    color: Theme.GrayText,
   },
   fieldContribution: {
     padding: theme.spacing(1, 0, 0, 1),

--- a/workspaces/ui-v2/src/components/FieldViewer.tsx
+++ b/workspaces/ui-v2/src/components/FieldViewer.tsx
@@ -1,0 +1,90 @@
+import React, { FC } from 'react';
+import { makeStyles } from '@material-ui/core';
+
+import * as Theme from '<src>/styles/theme';
+import { IFieldDetails } from '<src>/types';
+import { ShapeTypeSummary } from './ShapeTypeSummary';
+
+type FieldViewerProps = {
+  fields: IFieldDetails[];
+};
+
+export const FieldViewer: FC<FieldViewerProps> = ({ fields }) => {
+  const classes = useStyles();
+  return (
+    <div className={classes.container}>
+      {fields.length > 0 && (
+        <ul className={classes.rowsList}>
+          {fields.map((field) => (
+            <li key={field.fieldId} className={classes.rowListItem}>
+              <FieldViewerRow field={field} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+const FieldViewerRow: FC<{
+  field: IFieldDetails;
+}> = ({ field }) => {
+  const classes = useStyles();
+
+  return (
+    <div
+      className={classes.fieldRowContainer}
+      style={{
+        paddingLeft: INDENT_WIDTH * field.depth,
+      }}
+    >
+      <div className={classes.fieldSummary}>
+        <div className={classes.fieldName}>{field.name}</div>
+        <div className={classes.fieldShape}>
+          <ShapeTypeSummary shapes={field.shapes} required={field.required} />
+        </div>
+      </div>
+      {field.contribution.value !== '' && (
+        <div className={classes.fieldContribution}>
+          {field.contribution.value}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const INDENT_WIDTH = 8 * 3;
+
+const useStyles = makeStyles((theme) => ({
+  container: {},
+  rowsList: {
+    listStyleType: 'none',
+    paddingLeft: 0,
+  },
+  rowListItem: {},
+  row: {},
+
+  fieldRowContainer: {
+    borderTop: '1px solid #e4e8ed',
+    padding: theme.spacing(1, 0),
+  },
+  fieldSummary: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+  fieldName: {
+    color: '#3c4257',
+    fontFamily: Theme.FontFamily,
+    fontWeight: theme.typography.fontWeightBold,
+    fontSize: theme.typography.fontSize - 1,
+    marginRight: theme.spacing(1),
+  },
+  fieldShape: {
+    fontFamily: Theme.FontFamilyMono,
+    fontWeight: theme.typography.fontWeightLight,
+    fontSize: theme.typography.fontSize - 2,
+  },
+  fieldContribution: {
+    padding: theme.spacing(1, 0, 0, 1),
+  },
+}));

--- a/workspaces/ui-v2/src/components/ShapeTypeSummary.tsx
+++ b/workspaces/ui-v2/src/components/ShapeTypeSummary.tsx
@@ -7,10 +7,18 @@ import * as Theme from '<src>/styles/theme';
 export const ShapeTypeSummary: FC<{
   shapes: IShapeRenderer[];
   required: boolean;
-}> = ({ shapes, required }) => {
+  hasColoredFields?: boolean;
+}> = ({ shapes, required, hasColoredFields }) => {
   const optionalText = required ? '' : ' (optional)';
   const components = shapes.map(({ jsonType }: { jsonType: JsonType }) => (
-    <span key={jsonType} style={{ color: Theme.jsonTypeColors[jsonType] }}>
+    <span
+      key={jsonType}
+      style={{
+        color: hasColoredFields
+          ? Theme.jsonTypeColors[jsonType]
+          : Theme.GrayText,
+      }}
+    >
       {jsonType.toString().toLowerCase()}
     </span>
   ));

--- a/workspaces/ui-v2/src/components/ShapeTypeSummary.tsx
+++ b/workspaces/ui-v2/src/components/ShapeTypeSummary.tsx
@@ -1,0 +1,35 @@
+import React, { FC } from 'react';
+import { JsonType } from '@useoptic/optic-domain';
+
+import { IShapeRenderer } from '<src>/types';
+import * as Theme from '<src>/styles/theme';
+
+export const ShapeTypeSummary: FC<{
+  shapes: IShapeRenderer[];
+  required: boolean;
+}> = ({ shapes, required }) => {
+  const optionalText = required ? '' : ' (optional)';
+  const components = shapes.map(({ jsonType }: { jsonType: JsonType }) => (
+    <span key={jsonType} style={{ color: Theme.jsonTypeColors[jsonType] }}>
+      {jsonType.toString().toLowerCase()}
+    </span>
+  ));
+  if (shapes.length === 1) {
+    return (
+      <>
+        {components} {optionalText}
+      </>
+    );
+  } else {
+    const last = components.pop();
+    const secondToLast = components.pop();
+    return (
+      <>
+        {components.map((component) => (
+          <span key={component.key}>{component}, </span>
+        ))}
+        {secondToLast} or {last} {optionalText}
+      </>
+    );
+  }
+};

--- a/workspaces/ui-v2/src/components/index.ts
+++ b/workspaces/ui-v2/src/components/index.ts
@@ -20,3 +20,5 @@ export * from './HttpBodyPanel';
 export * from './HttpBodySelector';
 export * from './SimulatedCommandStore';
 export * from './HighlightController';
+export * from './ShapeTypeSummary';
+export * from './FieldViewer';

--- a/workspaces/ui-v2/src/pages/changelog/ChangelogEndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/changelog/ChangelogEndpointRootPage.tsx
@@ -17,6 +17,7 @@ import {
   HttpBodyPanel,
   HttpBodySelector,
   Panel,
+  FieldViewer,
 } from '<src>/components';
 import { useChangelogPages } from '<src>/components/navigation/Routes';
 import { SubtleBlueBackground, FontFamily } from '<src>/styles';
@@ -186,22 +187,26 @@ const ChangelogRootComponent: FC<
               {(shapes, fields) => (
                 <div className={classes.bodyDetails}>
                   <div>
-                    <ContributionsList
-                      renderField={(field) => (
-                        <FieldOrParameter
-                          key={
-                            field.contribution.id +
-                            field.contribution.contributionKey
-                          }
-                          name={field.name}
-                          shapes={field.shapes}
-                          depth={field.depth}
-                          value={field.contribution.value}
-                          required={field.required}
-                        />
-                      )}
-                      fieldDetails={fields}
-                    />
+                    {process.env.REACT_APP_FF_FIELD_LEVEL_EDITS !== 'true' ? (
+                      <ContributionsList
+                        renderField={(field) => (
+                          <FieldOrParameter
+                            key={
+                              field.contribution.id +
+                              field.contribution.contributionKey
+                            }
+                            name={field.name}
+                            shapes={field.shapes}
+                            depth={field.depth}
+                            value={field.contribution.value}
+                            required={field.required}
+                          />
+                        )}
+                        fieldDetails={fields}
+                      />
+                    ) : (
+                      <FieldViewer fields={fields} />
+                    )}
                   </div>
                   <div className={classes.panel}>
                     <QueryParametersPanel
@@ -245,22 +250,27 @@ const ChangelogRootComponent: FC<
                       {(shapes, fields) => (
                         <div className={classes.bodyDetails}>
                           <div>
-                            <ContributionsList
-                              renderField={(field) => (
-                                <FieldOrParameter
-                                  key={
-                                    field.contribution.id +
-                                    field.contribution.contributionKey
-                                  }
-                                  name={field.name}
-                                  shapes={field.shapes}
-                                  depth={field.depth}
-                                  value={field.contribution.value}
-                                  required={field.required}
-                                />
-                              )}
-                              fieldDetails={fields}
-                            />
+                            {process.env.REACT_APP_FF_FIELD_LEVEL_EDITS !==
+                            'true' ? (
+                              <ContributionsList
+                                renderField={(field) => (
+                                  <FieldOrParameter
+                                    key={
+                                      field.contribution.id +
+                                      field.contribution.contributionKey
+                                    }
+                                    name={field.name}
+                                    shapes={field.shapes}
+                                    depth={field.depth}
+                                    value={field.contribution.value}
+                                    required={field.required}
+                                  />
+                                )}
+                                fieldDetails={fields}
+                              />
+                            ) : (
+                              <FieldViewer fields={fields} />
+                            )}
                           </div>
                           <div className={classes.panel}>
                             <HttpBodyPanel
@@ -314,22 +324,27 @@ const ChangelogRootComponent: FC<
                           {(shapes, fields) => (
                             <>
                               <div>
-                                <ContributionsList
-                                  renderField={(field) => (
-                                    <FieldOrParameter
-                                      key={
-                                        field.contribution.id +
-                                        field.contribution.contributionKey
-                                      }
-                                      name={field.name}
-                                      shapes={field.shapes}
-                                      depth={field.depth}
-                                      value={field.contribution.value}
-                                      required={field.required}
-                                    />
-                                  )}
-                                  fieldDetails={fields}
-                                />
+                                {process.env.REACT_APP_FF_FIELD_LEVEL_EDITS !==
+                                'true' ? (
+                                  <ContributionsList
+                                    renderField={(field) => (
+                                      <FieldOrParameter
+                                        key={
+                                          field.contribution.id +
+                                          field.contribution.contributionKey
+                                        }
+                                        name={field.name}
+                                        shapes={field.shapes}
+                                        depth={field.depth}
+                                        value={field.contribution.value}
+                                        required={field.required}
+                                      />
+                                    )}
+                                    fieldDetails={fields}
+                                  />
+                                ) : (
+                                  <FieldViewer fields={fields} />
+                                )}
                               </div>
                               <div className={classes.panel}>
                                 <HttpBodyPanel

--- a/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
+++ b/workspaces/ui-v2/src/pages/docs/EndpointRootPage.tsx
@@ -17,6 +17,7 @@ import {
   HttpBodySelector,
   Panel,
   HighlightController,
+  FieldViewer,
 } from '<src>/components';
 import { useDocumentationPageLink } from '<src>/components/navigation/Routes';
 import { FontFamily, SubtleBlueBackground } from '<src>/styles';
@@ -361,7 +362,7 @@ export const EndpointRootPage: FC<
                     <div className={classes.bodyDetails}>
                       <div>
                         {process.env.REACT_APP_FF_FIELD_LEVEL_EDITS !==
-                          'true' || !isEditing ? (
+                        'true' ? (
                           <ContributionsList
                             renderField={(field) => {
                               const fieldWithoutArrayShape = selectors.removeArrayShapeFromField(
@@ -392,7 +393,7 @@ export const EndpointRootPage: FC<
                             }}
                             fieldDetails={fields}
                           />
-                        ) : (
+                        ) : isEditing ? (
                           <ShapeEditor
                             fields={fields.map(
                               selectors.removeArrayShapeFromField
@@ -405,6 +406,8 @@ export const EndpointRootPage: FC<
                             isFieldRemoved={isFieldRemoved}
                             onToggleRemove={onToggleRemovedField}
                           />
+                        ) : (
+                          <FieldViewer fields={fields} />
                         )}
                       </div>
                       <div className={classes.panel}>
@@ -469,7 +472,7 @@ export const EndpointRootPage: FC<
                             <div className={classes.bodyDetails}>
                               <div>
                                 {process.env.REACT_APP_FF_FIELD_LEVEL_EDITS !==
-                                  'true' || !isEditing ? (
+                                'true' ? (
                                   <ContributionsList
                                     renderField={(field) => (
                                       <DocsFieldOrParameterContribution
@@ -492,7 +495,7 @@ export const EndpointRootPage: FC<
                                     )}
                                     fieldDetails={fields}
                                   />
-                                ) : (
+                                ) : isEditing ? (
                                   <ShapeEditor
                                     fields={fields}
                                     selectedFieldId={selectedFieldId}
@@ -504,6 +507,8 @@ export const EndpointRootPage: FC<
                                     isFieldRemoved={isFieldRemoved}
                                     onToggleRemove={onToggleRemovedField}
                                   />
+                                ) : (
+                                  <FieldViewer fields={fields} />
                                 )}
                               </div>
                               <div className={classes.panel}>
@@ -582,7 +587,7 @@ export const EndpointRootPage: FC<
                                 <div>
                                   {process.env
                                     .REACT_APP_FF_FIELD_LEVEL_EDITS !==
-                                    'true' || !isEditing ? (
+                                  'true' ? (
                                     <ContributionsList
                                       renderField={(field) => (
                                         <DocsFieldOrParameterContribution
@@ -607,7 +612,7 @@ export const EndpointRootPage: FC<
                                       )}
                                       fieldDetails={fields}
                                     />
-                                  ) : (
+                                  ) : isEditing ? (
                                     <ShapeEditor
                                       fields={fields}
                                       selectedFieldId={selectedFieldId}
@@ -619,6 +624,8 @@ export const EndpointRootPage: FC<
                                       isFieldRemoved={isFieldRemoved}
                                       onToggleRemove={onToggleRemovedField}
                                     />
+                                  ) : (
+                                    <FieldViewer fields={fields} />
                                   )}
                                 </div>
                                 <div className={classes.panel}>

--- a/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
@@ -21,9 +21,10 @@ import {
 import ClassNames from 'classnames';
 import Color from 'color';
 
+import { JsonType } from '@useoptic/optic-domain';
+import { ShapeTypeSummary } from '<src>/components';
 import { setEquals, setDifference } from '<src>/lib/set-ops';
 import { IFieldDetails, IShapeRenderer } from '<src>/types';
-import { JsonType } from '@useoptic/optic-domain';
 import * as Theme from '<src>/styles/theme';
 
 type FieldRemovedStatus = 'removed' | 'root_removed' | 'not_removed';
@@ -370,7 +371,7 @@ const Field: FC<{
         >
           <div className={classes.fieldName}>{name}</div>
           <div className={classes.typesSummary}>
-            {summarizeTypes(shapes, required)}
+            <ShapeTypeSummary shapes={shapes} required={required} />
           </div>
         </div>
         <div className={classes.controls}>
@@ -403,32 +404,6 @@ const Field: FC<{
     </div>
   );
 };
-
-function summarizeTypes(shapes: IShapeRenderer[], required: boolean) {
-  const optionalText = required ? '' : ' (optional)';
-  let components = shapes.map(({ jsonType }: { jsonType: JsonType }) => (
-    <span key={jsonType} style={{ color: Theme.jsonTypeColors[jsonType] }}>
-      {jsonType.toString().toLowerCase()}
-    </span>
-  ));
-  if (shapes.length === 1) {
-    return (
-      <>
-        {components} {optionalText}
-      </>
-    );
-  } else {
-    const last = components.pop();
-    return (
-      <>
-        {components.map((component, i) => (
-          <span key={component.key}>{component},</span>
-        ))}{' '}
-        or {last} {optionalText}
-      </>
-    );
-  }
-}
 
 const INDENT_WIDTH = 8 * 3;
 const INDENT_MARKER_WIDTH = 1;

--- a/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
+++ b/workspaces/ui-v2/src/pages/docs/components/ShapeEditor.tsx
@@ -371,7 +371,11 @@ const Field: FC<{
         >
           <div className={classes.fieldName}>{name}</div>
           <div className={classes.typesSummary}>
-            <ShapeTypeSummary shapes={shapes} required={required} />
+            <ShapeTypeSummary
+              shapes={shapes}
+              required={required}
+              hasColoredFields
+            />
           </div>
         </div>
         <div className={classes.controls}>
@@ -530,7 +534,7 @@ const useFieldStyles = makeStyles((theme) => ({
   },
   typesSummary: {
     fontFamily: Theme.FontFamilyMono,
-    color: '#8792a2',
+    color: Theme.GrayText,
   },
 
   // Controls

--- a/workspaces/ui-v2/src/styles/theme.ts
+++ b/workspaces/ui-v2/src/styles/theme.ts
@@ -19,6 +19,7 @@ export const OpticBlueReadable = '#868da4';
 export const SubtleBlueBackground = '#F5F6FA';
 export const LightBlueBackground = '#edeff6';
 export const SubtleGreyBackground = '#eaeaea';
+export const GrayText = '#8792a2';
 export const methodColors = {
   OPTIONS: '#686868',
   GET: '#52e2a3',
@@ -41,7 +42,7 @@ export const jsonTypeColors: Record<JsonType, string> = {
   [JsonType.NUMBER]: '#e56f4a',
   [JsonType.UNDEFINED]: '#857b79',
   [JsonType.BOOLEAN]: '#067ab8',
-  [JsonType.NULL]: '#8792a2',
+  [JsonType.NULL]: GrayText,
   [JsonType.OBJECT]: 'inherit',
   [JsonType.ARRAY]: 'inherit',
 };


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

We have a ShapeEditor component - but we need a non-editable version.

After we:
- launch this feature + remove the FF
- Modify PathParameters to not use FieldOrParameter
- Modify the endpoint name, and body description components to not use FieldOrParam

We can remove all instances of FieldOrParam, EditableTextField, etc

## What
What's changing? Anything of note to call out?

- Created a FieldViewer component, which is a non-editable component that renders the field and contributions
- Moved summarizeTypes into a component file and fixed the display of 2 object items (i.e. `object, or array` now displays as `object or array`)

This is behind the `REACT_APP_FF_FIELD_LEVEL_EDITS` FF.

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
