### PR TITLE
Handle polymorphic nested shapes

### DIFF
--- a/workspaces/ui-v2/src/components/ShapeRenderer/OneOfTabs.tsx
+++ b/workspaces/ui-v2/src/components/ShapeRenderer/OneOfTabs.tsx
@@ -6,7 +6,7 @@ import { useShapeRenderContext } from './ShapeRenderContext';
 
 export type OneOfTabsProps = {
   choices: { label: string; id: string }[];
-  parentShapeId: string;
+  shapeId: string;
 };
 
 export function OneOfTabs(oneOfTabsProps: OneOfTabsProps) {
@@ -23,7 +23,7 @@ export function OneOfTabs(oneOfTabsProps: OneOfTabsProps) {
           {...i}
           active={current === i.id}
           setActive={() => {
-            updateChoice(oneOfTabsProps.parentShapeId, i.id);
+            updateChoice(oneOfTabsProps.shapeId, i.id);
           }}
         />
       ))}

--- a/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRenderContext.tsx
+++ b/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRenderContext.tsx
@@ -26,6 +26,8 @@ type ShapeRenderContextProps = {
   setSelectedField?: (fieldId: string) => void;
 };
 
+// Returns the choices that should be made for a field to be visible
+// This is for polymorphic shapes where it's not immediately obvious how a field is nested
 const getChoicesFromSelectedField = (
   fieldId: string,
   shapes: IShapeRenderer[]

--- a/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRenderContext.tsx
+++ b/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRenderContext.tsx
@@ -8,7 +8,7 @@ type IShapeRenderContext = {
   showExamples: boolean;
   fieldsAreSelectable: boolean;
   getChoice: (branch: OneOfTabsProps) => string;
-  updateChoice: (parentShapeId: string, branchId: string) => void;
+  updateChoice: (shapeId: string, branchId: string) => void;
   selectField: (fieldId: string) => void;
 };
 
@@ -31,24 +31,26 @@ export const ShapeRenderStore = ({
   fieldsAreSelectable,
   setSelectedField,
 }: ShapeRenderContextProps) => {
-  const [selectedOneOfChoices, updateSelectedOneOfChoices]: [
-    { [key: string]: string },
-    any
-  ] = useState({});
+  const [selectedOneOfChoices, updateSelectedOneOfChoices] = useState<{
+    [key: string]: string;
+  }>({});
+  console.log(selectedOneOfChoices);
 
   const getChoice = (branch: OneOfTabsProps) => {
-    if (selectedOneOfChoices[branch.parentShapeId]) {
-      return selectedOneOfChoices[branch.parentShapeId]!;
+    if (selectedOneOfChoices[branch.shapeId]) {
+      return selectedOneOfChoices[branch.shapeId];
     } else {
       return branch.choices[0].id;
     }
   };
 
   const updateChoice = (parentShapeId: string, branchId: string) => {
-    updateSelectedOneOfChoices((i: { [key: string]: string }) => ({
-      ...i,
-      [parentShapeId]: branchId,
-    }));
+    updateSelectedOneOfChoices(
+      (previousChoices: { [key: string]: string }) => ({
+        ...previousChoices,
+        [parentShapeId]: branchId,
+      })
+    );
   };
 
   const selectField = useCallback(

--- a/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRenderContext.tsx
+++ b/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRenderContext.tsx
@@ -1,4 +1,5 @@
-import * as React from 'react';
+import React, { useEffect } from 'react';
+import { IShapeRenderer } from '<src>/types';
 import { useContext, useState, useCallback } from 'react';
 import { DepthStore } from './DepthContext';
 import { OneOfTabsProps } from './OneOfTabs';
@@ -18,14 +19,77 @@ export const ShapeRenderContext = React.createContext<IShapeRenderContext | null
 
 type ShapeRenderContextProps = {
   children: React.ReactNode;
+  shapes: IShapeRenderer[];
   showExamples: boolean;
   selectedFieldId?: string | null;
   fieldsAreSelectable?: boolean;
   setSelectedField?: (fieldId: string) => void;
 };
 
+const getChoicesFromSelectedField = (
+  fieldId: string,
+  shapes: IShapeRenderer[]
+): {
+  shapeId: string;
+  branchId: string;
+}[] => {
+  const stack: {
+    shapeId: string;
+    shapes: IShapeRenderer[];
+    choices: {
+      shapeId: string;
+      branchId: string;
+    }[];
+  }[] = [
+    {
+      shapeId: 'root',
+      shapes: shapes,
+      choices: [],
+    },
+  ];
+
+  while (stack.length > 0) {
+    const { shapeId, shapes, choices } = stack.pop()!;
+    const hasMultipleChoices = shapes.length > 1;
+
+    for (const shape of shapes) {
+      const newChoices = hasMultipleChoices
+        ? [
+            ...choices,
+            {
+              shapeId: shapeId,
+              branchId: shape.shapeId,
+            },
+          ]
+        : [...choices];
+      if (shape.asObject) {
+        for (const field of shape.asObject.fields) {
+          if (field.fieldId === fieldId) {
+            return newChoices;
+          }
+
+          stack.push({
+            choices: newChoices,
+            shapes: field.shapeChoices,
+            shapeId: field.shapeId,
+          });
+        }
+      } else if (shape.asArray) {
+        stack.push({
+          choices: newChoices,
+          shapes: shape.asArray.shapeChoices,
+          shapeId: shape.asArray.shapeId,
+        });
+      }
+    }
+  }
+
+  return [];
+};
+
 export const ShapeRenderStore = ({
   children,
+  shapes,
   showExamples,
   selectedFieldId,
   fieldsAreSelectable,
@@ -34,7 +98,23 @@ export const ShapeRenderStore = ({
   const [selectedOneOfChoices, updateSelectedOneOfChoices] = useState<{
     [key: string]: string;
   }>({});
-  console.log(selectedOneOfChoices);
+  useEffect(() => {
+    if (selectedFieldId) {
+      const choicesForVisibleField = getChoicesFromSelectedField(
+        selectedFieldId,
+        shapes
+      );
+      updateSelectedOneOfChoices((previousChoices) => {
+        const newChoices = {
+          ...previousChoices,
+        };
+        for (const choice of choicesForVisibleField) {
+          newChoices[choice.shapeId] = choice.branchId;
+        }
+        return newChoices;
+      });
+    }
+  }, [shapes, selectedFieldId]);
 
   const getChoice = (branch: OneOfTabsProps) => {
     if (selectedOneOfChoices[branch.shapeId]) {
@@ -44,13 +124,11 @@ export const ShapeRenderStore = ({
     }
   };
 
-  const updateChoice = (parentShapeId: string, branchId: string) => {
-    updateSelectedOneOfChoices(
-      (previousChoices: { [key: string]: string }) => ({
-        ...previousChoices,
-        [parentShapeId]: branchId,
-      })
-    );
+  const updateChoice = (shapeId: string, branchId: string) => {
+    updateSelectedOneOfChoices((previousChoices) => ({
+      ...previousChoices,
+      [shapeId]: branchId,
+    }));
   };
 
   const selectField = useCallback(

--- a/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRenderer.tsx
+++ b/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRenderer.tsx
@@ -22,6 +22,7 @@ export const ShapeRenderer: FC<ShapeRendererProps> = ({
 }) => {
   return (
     <ShapeRenderStore
+      shapes={shapes}
       showExamples={showExamples}
       selectedFieldId={selectedFieldId}
       fieldsAreSelectable={fieldsAreSelectable}

--- a/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRenderer.tsx
+++ b/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRenderer.tsx
@@ -28,7 +28,7 @@ export const ShapeRenderer: FC<ShapeRendererProps> = ({
       setSelectedField={setSelectedField}
     >
       {shapes.length > 1 ? (
-        <OneOfRender shapes={shapes} parentShapeId={'root'} />
+        <OneOfRender shapes={shapes} shapeId={'root'} />
       ) : shapes.length === 1 ? (
         <RenderRootShape shape={shapes[0]} />
       ) : null}

--- a/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRowBase.tsx
+++ b/workspaces/ui-v2/src/components/ShapeRenderer/ShapeRowBase.tsx
@@ -73,10 +73,10 @@ export const RenderField = ({
   name,
   shapeChoices,
   required,
-  parentId,
+  shapeId,
   changes,
   fieldId,
-}: IFieldRenderer & { parentId: string }) => {
+}: IFieldRenderer) => {
   const sharedClasses = useSharedStyles();
   const { depth } = useDepth();
 
@@ -129,7 +129,7 @@ export const RenderField = ({
     );
   } else {
     const tabprops: OneOfTabsProps = {
-      parentShapeId: parentId,
+      shapeId,
       choices: shapeChoices.map((i) => ({
         label: i.jsonType,
         id: i.shapeId,
@@ -244,7 +244,7 @@ export const RenderFieldRowValues = ({
         <>
           {shape.asObject.fields.map((field) => (
             <Indent key={field.fieldId}>
-              <RenderField {...field} parentId={shape.shapeId} />
+              <RenderField {...field} />
             </Indent>
           ))}
           <ShapeRowBase depth={depth} focused={!selectedFieldId}>
@@ -269,7 +269,7 @@ export const RenderFieldRowValues = ({
       const inner =
         shape.asArray.shapeChoices.length > 1 ? (
           <OneOfRender
-            parentShapeId={shape.shapeId}
+            shapeId={shape.asArray.shapeId}
             shapes={shape.asArray.shapeChoices}
           />
         ) : shape.asArray.shapeChoices.length === 1 ? (
@@ -294,10 +294,10 @@ export const RenderFieldRowValues = ({
 
 export function OneOfRender({
   shapes,
-  parentShapeId,
+  shapeId,
 }: {
   shapes: IShapeRenderer[];
-  parentShapeId: string;
+  shapeId: string;
 }) {
   const { getChoice } = useShapeRenderContext();
   if (shapes.length === 1) {
@@ -311,7 +311,7 @@ export function OneOfRender({
 
   const tabProps = {
     choices,
-    parentShapeId,
+    shapeId,
   };
 
   const chosenShapeToRender = choices.find((i) => i.id === getChoice(tabProps));


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

<img width="1280" alt="Screen Shot 2021-08-13 at 2 20 37 PM" src="https://user-images.githubusercontent.com/18374483/129402468-e3b4eb74-d121-416f-a55e-b7f9d7d2dd6c.png">
In certain shapes, there are fields that aren't clear how they are nested in the shape viewer. Clicking on these fields do not highlight anything as the field is not visible.

This PR autoselects the relevant polymorphic choices when in the shapeeditor view and selecting a field

## What
What's changing? Anything of note to call out?
- Contains a fix where if there were multiple fields pointing to the same shape (i.e. an object with 2 polymorphic fields) - you could only select one.
- Select the correct choices in polymorphic shapes when selecting a field

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
