### PR TITLE
Serialize sentry error objects up to a depth of 10

### DIFF
--- a/workspaces/ui-v2/src/contexts/analytics/implementations/cloudViewerAnalytics.ts
+++ b/workspaces/ui-v2/src/contexts/analytics/implementations/cloudViewerAnalytics.ts
@@ -55,6 +55,7 @@ export const initialize: AnalyticsStoreProps['initialize'] = async (
       dsn: appConfig.analytics.sentryUrl,
       release: clientId,
       logLevel: LogLevel.Debug,
+      normalizeDepth: 10,
     });
     Sentry.setUser({ id: metadata.clientAgent });
   }

--- a/workspaces/ui-v2/src/contexts/analytics/implementations/localCliAnalytics.ts
+++ b/workspaces/ui-v2/src/contexts/analytics/implementations/localCliAnalytics.ts
@@ -69,6 +69,7 @@ export const initialize: AnalyticsStoreProps['initialize'] = async (
       dsn: appConfig.analytics.sentryUrl,
       release: clientId,
       logLevel: LogLevel.Debug,
+      normalizeDepth: 10,
     });
     Sentry.setUser({ id: metadata.clientAgent });
   }

--- a/workspaces/ui-v2/src/contexts/analytics/implementations/publicExampleAnalytics.ts
+++ b/workspaces/ui-v2/src/contexts/analytics/implementations/publicExampleAnalytics.ts
@@ -75,6 +75,7 @@ export const initialize: AnalyticsStoreProps['initialize'] = async (
       dsn: appConfig.analytics.sentryUrl,
       release: clientId,
       logLevel: LogLevel.Debug,
+      normalizeDepth: 10,
     });
     Sentry.setUser({ id: metadata.clientAgent });
   }


### PR DESCRIPTION
## Why
Describe the motivation for the changes.

Previously, sentry objects were serialized to a default depth of 3 - https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/redux/#normalization-depth - updating this to 10 since we have nested data we want to use to debug.

Why 10? Well we almost always will want to send everything unless there's a hugely nested structure - debugging data is valuable but we do want a hard limit at some point.

## What
What's changing? Anything of note to call out?

## Validation
* [ ] CI passes
* [ ] Verified in staging
* etc...
