### PR TITLE
Ecs ingest fix

### DIFF
--- a/workspaces/cli-shared/src/ingest/ecs-to-sample.ts
+++ b/workspaces/cli-shared/src/ingest/ecs-to-sample.ts
@@ -8,7 +8,8 @@ export function ecsToHttpInteraction(
 ): IHttpInteraction {
   const { request, response } = ecs.http;
   const { path, domain } = ecs.url;
-
+  const lowerCasedRequestHeaders = convertObjKeysToLower(request.headers);
+  const lowerCasedResponseHeaders = convertObjKeysToLower(response.headers);
   function extractBody(message: any) {
     const content =
       message.body && message.body.content ? message.body.content : '';
@@ -45,8 +46,8 @@ export function ecsToHttpInteraction(
       },
       body: {
         contentType:
-          request.headers && request.headers['content-type']
-            ? request.headers['content-type']
+          request.headers && lowerCasedRequestHeaders['content-type']
+            ? lowerCasedRequestHeaders['content-type']
             : null,
         value: extractBody(request),
       },
@@ -60,8 +61,8 @@ export function ecsToHttpInteraction(
       },
       body: {
         contentType:
-          response.headers && response.headers['content-type']
-            ? response.headers['content-type']
+          response.headers && lowerCasedResponseHeaders['content-type']
+            ? lowerCasedResponseHeaders['content-type']
             : null,
         value: extractBody(response),
       },
@@ -77,4 +78,9 @@ function tryParseJson(json: string) {
   } catch (e) {
     return null;
   }
+}
+function convertObjKeysToLower(obj: Object) {
+  return Object.fromEntries(
+    Object.entries(obj).map(([k, v]) => [k.toLowerCase(), v])
+  );
 }

--- a/workspaces/cli-shared/src/ingest/ingest-traffic-service.ts
+++ b/workspaces/cli-shared/src/ingest/ingest-traffic-service.ts
@@ -47,7 +47,7 @@ export class IngestTrafficService {
     samples.forEach((sample: any) => {
       developerDebugLogger('saw sample', sample);
       try {
-        ecsToHttpInteraction(sample);
+        this.captureSaver.save(ecsToHttpInteraction(sample));
       } catch (e) {
         developerDebugLogger(
           'could not transform ecs sample -> interaction format',


### PR DESCRIPTION
## Why
Describe the motivation for the changes.
Fix issues with ecs to HTTP interaction converter.

## What
What's changing? Anything of note to call out?
1. Header keys are case insensitive when converting from ecs to HTTP interaction
2. Interaction is saved by optic when ecs object is sent to optic server
## Validation
* [x] CI passes
* [x] Verified in staging
* etc...
