### PR TITLE
Fix bug where fields with unknown shapes can't be edited

### DIFF
--- a/workspaces/optic-engine/src/queries/shape.rs
+++ b/workspaces/optic-engine/src/queries/shape.rs
@@ -62,7 +62,6 @@ impl<'a> ShapeQueries<'a> {
           _ => unreachable!("expected to be a core shape node"),
         };
         let trails: Vec<ChoiceOutput> = match core_shape_node.descriptor.kind {
-          // ShapeKind::UnknownKind => vec![],
           ShapeKind::NullableKind => {
             let nullable_parameter_id = core_shape_node
               .descriptor
@@ -447,8 +446,6 @@ impl<'a> ShapeQueries<'a> {
 
   pub fn resolve_shape_trail(&self, shape_id: &ShapeId) -> Option<ShapeTrail> {
     let mut next_node = self.shape_projection.get_node_by_id(shape_id);
-
-    log::debug!("{:#?}", &next_node);
 
     let mut trail_components = vec![];
     let mut root_shape_id = None;

--- a/workspaces/optic-engine/src/queries/shape.rs
+++ b/workspaces/optic-engine/src/queries/shape.rs
@@ -1031,6 +1031,11 @@ mod test {
       { "ShapeParameterShapeSet": { "shapeDescriptor": { "ProviderInShape": { "shapeId": "one_of_shape_1","providerDescriptor": {"ShapeProvider": {"shapeId": "number_shape_1"}},"consumingParameterId": "one_of_param_2" }}}},
       { "FieldAdded": { "fieldId": "field_5", "shapeId": "object_shape_1", "name": "nestedObject", "shapeDescriptor": { "FieldShapeFromShape": { "fieldId": "field_5", "shapeId": "one_of_shape_1"}} }},
 
+      // unknown nullable field
+      { "ShapeAdded": { "shapeId": "unknown_shape_1", "baseShapeId": "$string", "name": "" }},
+      { "ShapeAdded": { "shapeId": "nullable_shape_2", "baseShapeId": "$nullable", "name": "" }},
+      { "ShapeParameterShapeSet": { "shapeDescriptor": { "ProviderInShape": { "shapeId": "nullable_shape_2","providerDescriptor": {"ShapeProvider": {"shapeId": "unknown_shape_1"}},"consumingParameterId": "$nullableInner" }}}},
+      { "FieldAdded": { "fieldId": "field_6", "shapeId": "object_shape_1", "name": "unknownField", "shapeDescriptor": { "FieldShapeFromShape": { "fieldId": "field_6", "shapeId": "nullable_shape_2"}} }},
     ]))
     .expect("should be able to deserialize test events");
 
@@ -1073,6 +1078,12 @@ mod test {
     //   "can_resolve_shape_trails__one_of_trail",
     //   &one_of_trail
     // );
+
+    let unknown_nullable_trail = shape_queries.resolve_shape_trail(&"field_6".to_owned());
+    assert_debug_snapshot!(
+      "can_resolve_shape_trails__unknown_nullable_trail",
+      &unknown_nullable_trail
+    );
   }
 
   fn assert_valid_commands(

--- a/workspaces/optic-engine/src/queries/shape.rs
+++ b/workspaces/optic-engine/src/queries/shape.rs
@@ -62,7 +62,7 @@ impl<'a> ShapeQueries<'a> {
           _ => unreachable!("expected to be a core shape node"),
         };
         let trails: Vec<ChoiceOutput> = match core_shape_node.descriptor.kind {
-          ShapeKind::UnknownKind => vec![],
+          // ShapeKind::UnknownKind => vec![],
           ShapeKind::NullableKind => {
             let nullable_parameter_id = core_shape_node
               .descriptor
@@ -150,6 +150,14 @@ impl<'a> ShapeQueries<'a> {
       .flatten()
       .collect();
     result
+  }
+
+  pub fn list_known_trail_choices(&self, shape_trail: &ShapeTrail) -> Vec<ChoiceOutput> {
+    self
+      .list_trail_choices(shape_trail)
+      .into_iter()
+      .filter(|choice| !matches!(choice.core_shape_kind, ShapeKind::UnknownKind))
+      .collect()
   }
 
   pub fn resolve_to_core_shape(&self, shape_id: &ShapeId) -> &ShapeKind {

--- a/workspaces/optic-engine/src/queries/snapshots/optic_engine__queries__shape__test__can_generate_edit_shape_trail_commands_to_make_unknown_nullable_field_optional__choice_mapping.snap
+++ b/workspaces/optic-engine/src/queries/snapshots/optic_engine__queries__shape__test__can_generate_edit_shape_trail_commands_to_make_unknown_nullable_field_optional__choice_mapping.snap
@@ -1,0 +1,52 @@
+---
+source: workspaces/optic-engine/src/queries/shape.rs
+expression: choice_mapping
+---
+{
+    "nullable_shape_1": [
+        Primitive(
+            PrimitiveChoice {
+                shape_id: "nullable_shape_1",
+                json_type: Null,
+            },
+        ),
+    ],
+    "object_shape_1": [
+        Object(
+            ObjectChoice {
+                shape_id: "object_shape_1",
+                json_type: Object,
+                fields: [
+                    ObjectFieldChoice {
+                        name: "lastName",
+                        field_id: "field_1",
+                        shape_id: "shape_1095",
+                    },
+                ],
+            },
+        ),
+    ],
+    "shape_1094": [
+        Primitive(
+            PrimitiveChoice {
+                shape_id: "shape_1094",
+                json_type: Null,
+            },
+        ),
+    ],
+    "shape_1095": [
+        Primitive(
+            PrimitiveChoice {
+                shape_id: "shape_1095",
+                json_type: Undefined,
+            },
+        ),
+        Primitive(
+            PrimitiveChoice {
+                shape_id: "shape_1094",
+                json_type: Null,
+            },
+        ),
+    ],
+    "unknown_shape_1": [],
+}

--- a/workspaces/optic-engine/src/queries/snapshots/optic_engine__queries__shape__test__can_generate_edit_shape_trail_commands_to_make_unknown_nullable_field_optional__commands.snap
+++ b/workspaces/optic-engine/src/queries/snapshots/optic_engine__queries__shape__test__can_generate_edit_shape_trail_commands_to_make_unknown_nullable_field_optional__commands.snap
@@ -1,0 +1,70 @@
+---
+source: workspaces/optic-engine/src/queries/shape.rs
+expression: "&edit_shape_commands"
+---
+[
+    ShapeCommand(
+        AddShape(
+            AddShape {
+                shape_id: "shape_1094",
+                base_shape_id: "$nullable",
+                name: "",
+            },
+        ),
+    ),
+    ShapeCommand(
+        SetParameterShape(
+            SetParameterShape {
+                shape_descriptor: ProviderInShape(
+                    ProviderInShape {
+                        shape_id: "shape_1094",
+                        provider_descriptor: ShapeProvider(
+                            ShapeProvider {
+                                shape_id: "unknown_shape_1",
+                            },
+                        ),
+                        consuming_parameter_id: "$nullableInner",
+                    },
+                ),
+            },
+        ),
+    ),
+    ShapeCommand(
+        AddShape(
+            AddShape {
+                shape_id: "shape_1095",
+                base_shape_id: "$optional",
+                name: "",
+            },
+        ),
+    ),
+    ShapeCommand(
+        SetParameterShape(
+            SetParameterShape {
+                shape_descriptor: ProviderInShape(
+                    ProviderInShape {
+                        shape_id: "shape_1095",
+                        provider_descriptor: ShapeProvider(
+                            ShapeProvider {
+                                shape_id: "shape_1094",
+                            },
+                        ),
+                        consuming_parameter_id: "$optionalInner",
+                    },
+                ),
+            },
+        ),
+    ),
+    ShapeCommand(
+        SetFieldShape(
+            SetFieldShape {
+                shape_descriptor: FieldShapeFromShape(
+                    FieldShapeFromShape {
+                        field_id: "field_1",
+                        shape_id: "shape_1095",
+                    },
+                ),
+            },
+        ),
+    ),
+]

--- a/workspaces/optic-engine/src/queries/snapshots/optic_engine__queries__shape__test__can_resolve_shape_trails__unknown_nullable_trail.snap
+++ b/workspaces/optic-engine/src/queries/snapshots/optic_engine__queries__shape__test__can_resolve_shape_trails__unknown_nullable_trail.snap
@@ -1,0 +1,19 @@
+---
+source: workspaces/optic-engine/src/queries/shape.rs
+expression: "&unknown_nullable_trail"
+---
+Some(
+    ShapeTrail {
+        root_shape_id: "object_shape_1",
+        path: [
+            ObjectTrail {
+                shape_id: "object_shape_1",
+            },
+            ObjectFieldTrail {
+                field_id: "field_6",
+                field_shape_id: "nullable_shape_2",
+                parent_object_shape_id: "object_shape_1",
+            },
+        ],
+    },
+)

--- a/workspaces/optic-engine/src/queries/spectacle/spec_choices.rs
+++ b/workspaces/optic-engine/src/queries/spectacle/spec_choices.rs
@@ -92,7 +92,7 @@ impl<'a> ShapeChoiceQueries<'a> {
     &'a self,
     shape_trail: &ShapeTrail,
   ) -> impl Iterator<Item = ShapeChoice> + 'a {
-    let trail_choices = self.shape_queries.list_trail_choices(&shape_trail);
+    let trail_choices = self.shape_queries.list_known_trail_choices(&shape_trail);
     let queries = &self.shape_queries;
 
     trail_choices

--- a/workspaces/optic-engine/src/shapes/traverser.rs
+++ b/workspaces/optic-engine/src/shapes/traverser.rs
@@ -29,7 +29,7 @@ impl<'a> Traverser<'a> {
   ) {
     let body_trail = JsonTrail::empty();
     let trail_origin = ShapeTrail::new(shape_id.clone());
-    let choices: Vec<ChoiceOutput> = self.shape_queries.list_trail_choices(&trail_origin);
+    let choices: Vec<ChoiceOutput> = self.shape_queries.list_known_trail_choices(&trail_origin);
     self.traverse(body_option, body_trail, trail_origin, &choices, visitors)
   }
 
@@ -77,7 +77,7 @@ impl<'a> Traverser<'a> {
                     list_shape_id: choice.shape_id.clone(),
                     item_shape_id: item_shape_id,
                   });
-              self.shape_queries.list_trail_choices(&item_trail)
+              self.shape_queries.list_known_trail_choices(&item_trail)
             } else {
               unreachable!("should only contain items of list kind");
             }
@@ -195,7 +195,7 @@ impl<'a> Traverser<'a> {
                       field_shape_id: field_shape_id,
                       parent_object_shape_id: choice.shape_id.clone(),
                     });
-                self.shape_queries.list_trail_choices(&field_trail)
+                self.shape_queries.list_known_trail_choices(&field_trail)
               } else {
                 unreachable!("should only contain choices of object kind");
               }


### PR DESCRIPTION
## Why
The possibility exists for a field to be learned as `null` and without any information of the non-null shape. The way editing commands generation has been implemented currently, does not allow for this, not generating any commands at all.

## What
Tests have been added to verify the limitation in the command generation. 

The root of the issue stemmed from the `list_trail_choices` not returning any results for `Unknown` shapes, not giving us the `shape_id` of the shape we are trying to wrap with nullables / optionals. However, the diff and choice mapping code relies on that fact, for which an unknown choice isn't a choice at all. 

As a fix, `list_trail_choices` now returns a result for `Unknown` shapes, and a new `list_known_trail_choices` is introduced for the diffing and spec choice mapping, where unknown choices are filtered out. That allows the resolving of trail choices to remain in the single place and power all our choice related functionality.

## Validation
* [ ] CI passes
* [x] New tests pass
* [x] Validated end-to-end against test project
