### PR TITLE
Make QueryParametersData and fields public

### DIFF
--- a/workspaces/optic-engine/src/events/http_interaction.rs
+++ b/workspaces/optic-engine/src/events/http_interaction.rs
@@ -64,7 +64,7 @@ pub struct ArbitraryData {
 #[derive(Clone, Deserialize, Serialize, Debug, Default)]
 pub struct QueryParametersData {
   #[serde(flatten)]
-  data: ArbitraryData,
+  pub data: ArbitraryData,
 }
 
 impl From<&ArbitraryData> for Option<serde_json::value::Value> {

--- a/workspaces/optic-engine/src/lib.rs
+++ b/workspaces/optic-engine/src/lib.rs
@@ -17,7 +17,9 @@ pub mod streams;
 pub use commands::{CommandContext, EndpointCommand, RfcCommand, SpecCommand, SpecCommandHandler};
 pub use cqrs_core::Aggregate;
 pub use events::{
-  http_interaction::{ArbitraryData, Body, HttpInteraction, Request, Response},
+  http_interaction::{
+    ArbitraryData, Body, HttpInteraction, QueryParametersData, Request, Response,
+  },
   RfcEvent, SpecChunkEvent, SpecEvent,
 };
 pub use interactions::result::{BodyAnalysisLocation, BodyAnalysisResult, InteractionDiffResult};


### PR DESCRIPTION
EDIT: Maybe I should explain this in the commit message as well. The reason that we haven't seen this to-date is that optic-engine in Cargo.lock in monorail happens to be older. If you trigger a build where the dependencies are re-resolved (e.g. in a misconfigured dockerfile or in a new program entirely) then it uses the latest (Cargo.toml points to `develop` and not a tag).

## Why
We refactored HTTPInteraction.query to use this new data type. While it
accepts serializations following the old layout, creating HTTPInteraction
objects is impossible without access to the type, and it's one field.

## What
I'm fairly certain this changes nothing, as serde has a flatten directive on QueryParamsData.data, but it may change the output?

## Validation
* slurp & other code using HTTPInteraction from newer optic-engine versions now compile when using HTTPInteraction