### PR TITLE
misc fixes related to paths

### DIFF
--- a/workspaces/local-cli/package.json
+++ b/workspaces/local-cli/package.json
@@ -34,6 +34,7 @@
     "cli-table3": "^0.6.0",
     "cli-ux": "^5.4.1",
     "colors": "^1.4.0",
+    "cross-fetch": "^3.1.4",
     "deepmerge": "^4.2.2",
     "dotenv": "^8.2.0",
     "eventsource": "^1.0.7",

--- a/workspaces/local-cli/src/commands/debug/add-paths.ts
+++ b/workspaces/local-cli/src/commands/debug/add-paths.ts
@@ -1,0 +1,157 @@
+import { Command } from '@oclif/command';
+import { Client } from '@useoptic/cli-client';
+import {
+    getPathsRelativeToConfig,
+    IApiCliConfig,
+    readApiConfig,
+} from '@useoptic/cli-config';
+import { IPathMapping } from '@useoptic/cli-config';
+import { ensureDaemonStarted } from '@useoptic/cli-server';
+import { lockFilePath } from '../../shared/paths';
+import colors from 'colors';
+import {
+    cleanupAndExit,
+    developerDebugLogger,
+    fromOptic,
+    userDebugLogger,
+} from '@useoptic/cli-shared';
+import { Config } from '../../config';
+import { SpectacleInput } from '@useoptic/spectacle';
+import { v4 as uuidv4 } from 'uuid';
+import { getOrCreateAnonId } from '@useoptic/cli-config/src/opticrc/optic-rc';
+import fetch from 'cross-fetch';
+
+export default class DebugPaths extends Command {
+    static description =
+        'add a static path component to your API specification';
+    static hidden: boolean = true;
+    static args = [
+        {
+            name: 'baseUrl',
+            description: 'The part of the URL path preceding the static component you wish to add',
+            required: true,
+        },
+
+        {
+            name: 'staticComponent',
+            description: 'the new static path component you wish to add',
+            required: true,
+        },
+    ];
+
+    async run() {
+        const { args } = this.parse(DebugPaths);
+        const { staticComponent, baseUrl } = args;
+        if (staticComponent.includes('/')) {
+            this.error('staticComponent must be a single path component with no slashes')
+        }
+
+        let paths: IPathMapping;
+        let config: IApiCliConfig;
+        try {
+            paths = await getPathsRelativeToConfig();
+            config = await readApiConfig(paths.configPath);
+        } catch (e) {
+            userDebugLogger(e);
+            this.log(
+                fromOptic(
+                    `No optic.yml file found. Add Optic to your API by running ${colors.bold(
+                        'api init'
+                    )}`
+                )
+            );
+            process.exit(0);
+        }
+        const spectacleUrl = await this.helper(paths.cwd, config);
+        // 1. find parentPathId
+        let [, ...targetComponents] = baseUrl.split('/');
+        async function spectacleQuery(query: SpectacleInput<{}>) {
+            const response = await fetch(spectacleUrl, {
+                "headers": {
+                    "accept": "application/json",
+                    "content-type": "application/json",
+                },
+                "body": JSON.stringify(query),
+                "method": "POST",
+            });
+            if (response.ok) {
+                const body = await response.json();
+                return body;
+            }
+            throw new Error(`something went wrong :(`)
+        }
+        const listPathsQuery = {
+            query: `{
+              paths{
+                absolutePathPattern
+                absolutePathPatternWithParameterNames
+                isParameterized
+                parentPathId
+                pathId
+                isRemoved
+              }
+            }`,
+            variables: {}
+        }
+        const listPathsQueryResult = await spectacleQuery(listPathsQuery)
+        const documentedPaths = listPathsQueryResult.data.paths;
+        let result = documentedPaths.find((p: any) => {
+            if (p.isRemoved) {
+                return false;
+            }
+            const [, ...components] = p.absolutePathPattern
+                .split('/')
+                .map((x: string) => ({ isParameterized: x === '{}', name: x }))
+            if (components.length !== targetComponents.length) {
+                return false
+            }
+            const matches = targetComponents.map((name: string, index: number) => {
+                if (components[index].isParameterized) {
+                    return true;
+                } else {
+                    return components[index].name === name
+                }
+            });
+            return matches.every((x: boolean) => x)
+        })
+        if (!result) {
+            throw new Error(`${baseUrl} is not documented in your API yet. Please make sure you have documented every path component in this url`)
+        }
+        // 2. apply new path command
+        const commands = [{ AddPathComponent: { pathId: uuidv4(), parentPathId: result.pathId, name: staticComponent } }]
+        let addPathMutation = {
+            query: `
+    mutation X($commands: [JSON!]!, $batchCommitId: ID!, $commitMessage: String!, $clientId: ID!, $clientSessionId: ID!) {
+      applyCommands(commands: $commands, batchCommitId: $batchCommitId, commitMessage: $commitMessage, clientId: $clientId, clientSessionId: $clientSessionId) {
+        batchCommitId
+      }
+    }
+            `,
+            variables: {
+                commands: commands,
+                batchCommitId: uuidv4(),
+                commitMessage: `added the ${staticComponent} path to the spec`,
+                clientId: await getOrCreateAnonId(),
+                clientSessionId: uuidv4(),
+            },
+        }
+
+        const addPathsMutationResult = await spectacleQuery(addPathMutation)
+        this.log('done!')
+    }
+
+
+    async helper(basePath: string, config: IApiCliConfig) {
+        const daemonState = await ensureDaemonStarted(
+            lockFilePath,
+            Config.apiBaseUrl
+        );
+        const apiBaseUrl = `http://localhost:${daemonState.port}/api`;
+        developerDebugLogger(`api base url: ${apiBaseUrl}`);
+        const cliClient = new Client(apiBaseUrl);
+        const cliSession = await cliClient.findSession(basePath, null, null);
+        developerDebugLogger({ cliSession });
+        const spectacleUrl = `${apiBaseUrl}/specs/${cliSession.session.id}/spectacle`;
+        return spectacleUrl
+    }
+}

--- a/workspaces/spectacle/src/openapi/index.ts
+++ b/workspaces/spectacle/src/openapi/index.ts
@@ -5,6 +5,7 @@ export async function generateOpenApi(spectacle: any) {
   const requests = await spectacle.queryWrapper({
     query: `{
       requests {
+        isRemoved
         id
         pathId
         pathComponents {
@@ -44,6 +45,9 @@ export async function generateOpenApi(spectacle: any) {
   };
 
   for (const request of requests.data.requests) {
+    if (request.isRemoved) {
+      continue;
+    }
     const path = request.absolutePathPatternWithParameterNames;
 
     if (!(path in openapi.paths)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5893,7 +5893,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-fetch@^3.0.4:
+cross-fetch@^3.0.4, cross-fetch@^3.1.4:
   version "3.1.4"
   resolved "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz#9723f3a3a247bf8b89039f3a380a9244e8fa2f39"
   integrity sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==


### PR DESCRIPTION
This is intended for a side-channel build to unblock a user.
## Why
People using api generate:oas on specs with removed paths get unexpected results and users are blocked when they have documented a path parameter and they need a static path component at the same level. 

## What
I've added a new hidden command api debug:add-paths and tweaked api generate:oas

## Validation
* [ ] CI passes
