### PR TITLE
Typo fix in 'remember'

### DIFF
--- a/website/docs/document/parameters.mdx
+++ b/website/docs/document/parameters.mdx
@@ -55,7 +55,7 @@ Optic has collected all of the traffic observed to every path that matches the p
 - Name the endpoint
 - Click the **Add Endpoint** button
 
-The learned endpoint is now on the right, highlighted in green: rmember, this means Optic has learned this endpoint and has staged it be committed to the documentation.
+The learned endpoint is now on the right, highlighted in green: remember, this means Optic has learned this endpoint and has staged it be committed to the documentation.
 
 ## Document related endpoints with the same path parameters
 


### PR DESCRIPTION
## Why
Reading the documentation as a new user and stopped a typo

## What
Missing letter in 'remember'.

## Validation
Re-read after the change.
