### PR TITLE
added an Optic CI issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/OPTIC-CI.yml
+++ b/.github/ISSUE_TEMPLATE/OPTIC-CI.yml
@@ -1,0 +1,30 @@
+name: Optic CI Issue Report
+description: File an issue or request for Optic CI
+title: "[Optic-CI]: "
+labels: ["optic-ci"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reaching out to us! Let us know how we can make Optic CI work better for you.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
+    validations:
+      required: true
+  - type: textarea
+    id: starter-fork
+    attributes:
+      label: Are you using a fork of opticdev/optic-ci-starter?
+      description: If you are using a fork of the Optic CI starter repository to customize your rules, please point us to the fork here so we can see the changes. Or, let us know the best way to reach out to you if you can't share the fork.
+      placeholder: opticdev/optic-ci-starter
+  - type: textarea
+    id: open-source-repo
+    attributes:
+      label: Open Source Repo (if present)
+      description: Are you running rules on an open source repository? If so, please tell us which one here.
+      placeholder: opticdev/optic


### PR DESCRIPTION
## Why

Adding a feedback channel for our Optic CI tooling, trying out the GitHub issue forms feature.

## What

- a new Issue form for Optic CI tooling (`opticdev/optic-ci-starter`)

## Validation

- eyeballs
