### PR TITLE
fix: skip spectral rules when --to spec is empty

### DIFF
--- a/projects/optic-ci/src/cli/commands/utils/generateSpecResults.ts
+++ b/projects/optic-ci/src/cli/commands/utils/generateSpecResults.ts
@@ -62,12 +62,12 @@ export const generateSpecResults = async (
   );
 
   const spectralResults =
-    spectralConfig && checkService.runSpectralRules
+    !to.isEmptySpec && spectralConfig && checkService.runSpectralRules
       ? await checkService.runSpectralRules({
-          ruleset: spectralConfig,
-          nextJsonLike: toJsonLike,
-          nextFacts: nextFacts,
-        })
+        ruleset: spectralConfig,
+        nextJsonLike: toJsonLike,
+        nextFacts: nextFacts,
+      })
       : [];
 
   const ruleResults = checkService.runRulesWithFacts({


### PR DESCRIPTION
When the --to spec is empty, Spectral will fail on some required OpenAPI
3 top-level document properties missing. This skips the spectral rules
in that condition.