### PR TITLE
fix(ci): shell syntax issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Publish
         run: |
-          if [ "$SKIP_PUBLISH" = "false"]
+          if [ "$SKIP_PUBLISH" = "false" ]
           then
             echo "Publishing $VERSION to the "$RELEASE_CHANNEL" channel"
             task publish -- --tag $RELEASE_CHANNEL


### PR DESCRIPTION
fixes,

> /home/runner/work/_temp/4885077c-2e55-4e13-b76e-937ed0f5322d.sh: line 1: [: missing `]'