### PR TITLE
chore: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    allow:
+      - dependency-type: production
+    schedule:
+      interval: monthly
+    rebase-strategy: auto
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: sunday
+    assignees:
+      - opticdev/infra
+    rebase-strategy: auto


### PR DESCRIPTION
adds the equivalent dependabot config from monorail