### PR TITLE
Release `oas` cli as part of installing optic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openapi-workspaces",
   "private": true,
-  "version": "0.27.0-0",
+  "version": "0.27.0-1",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openapi-workspaces",
   "private": true,
-  "version": "0.27.0-1",
+  "version": "0.27.0",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openapi-workspaces",
   "private": true,
-  "version": "0.26.28",
+  "version": "0.27.0-0",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",
@@ -16,5 +16,6 @@
   "scripts": {
     "release": "gh release create --target=$(git branch --show-current) v$(node -e \"process.stdout.write(require('./package.json').version)\")",
     "version": "yarn workspaces foreach -v version"
-  }
+  },
+  "stableVersion": "0.26.28"
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/json-pointer-helpers",
-  "version": "0.26.28",
+  "version": "0.27.0-0",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -36,5 +36,6 @@
   },
   "dependencies": {
     "jsonpointer": "^5.0.1"
-  }
+  },
+  "stableVersion": "0.26.28"
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/json-pointer-helpers",
-  "version": "0.27.0-1",
+  "version": "0.27.0",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/json-pointer-helpers",
-  "version": "0.27.0-0",
+  "version": "0.27.0-1",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-cli",
   "packageManager": "yarn@3.0.2",
-  "version": "0.27.0-0",
+  "version": "0.27.0-1",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-cli",
   "packageManager": "yarn@3.0.2",
-  "version": "0.27.0-1",
+  "version": "0.27.0",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-cli",
   "packageManager": "yarn@3.0.2",
-  "version": "0.26.28",
+  "version": "0.27.0-0",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [
@@ -94,5 +94,6 @@
         "<rootDir>../../../../node_modules/csv-parse/dist/cjs/sync.cjs"
       ]
     }
-  }
+  },
+  "stableVersion": "0.26.28"
 }

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -7,7 +7,9 @@
   "files": [
     "/build"
   ],
-  "bin": "build/index.js",
+  "bin": {
+    "oas": "build/index.js"
+  },
   "scripts": {
     "dev:test": "jest --colors",
     "build": "yarn tsc --build --verbose && yarn babel ./build/config.js --out-dir ./build --extensions \".js\"",

--- a/projects/openapi-cli/src/cli.ts
+++ b/projects/openapi-cli/src/cli.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import { Command } from 'commander';
 import fs from 'fs-extra';
 import Path from 'path';
@@ -36,7 +34,10 @@ export async function makeCli(config: CliConfig) {
   return cli;
 }
 
-export async function runCli(packageManifest?: { name: string; version: string }) {
+export async function runCli(packageManifest?: {
+  name: string;
+  version: string;
+}) {
   const updateNotifier = (await import('update-notifier')).default;
   const config = readConfig(packageManifest);
 

--- a/projects/openapi-cli/src/index.ts
+++ b/projects/openapi-cli/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { runCli } from './cli';
 
 (async function () {

--- a/projects/openapi-diff-experiment/package.json
+++ b/projects/openapi-diff-experiment/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-diff-experiment",
   "private": true,
   "packageManager": "yarn@3.0.2",
-  "version": "0.27.0-1",
+  "version": "0.27.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-diff-experiment/package.json
+++ b/projects/openapi-diff-experiment/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-diff-experiment",
   "private": true,
   "packageManager": "yarn@3.0.2",
-  "version": "0.26.28",
+  "version": "0.27.0-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -84,5 +84,6 @@
       "/build/",
       "/node_modules/"
     ]
-  }
+  },
+  "stableVersion": "0.26.28"
 }

--- a/projects/openapi-diff-experiment/package.json
+++ b/projects/openapi-diff-experiment/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-diff-experiment",
   "private": true,
   "packageManager": "yarn@3.0.2",
-  "version": "0.27.0-0",
+  "version": "0.27.0-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/openapi-io",
-  "version": "0.27.0-1",
+  "version": "0.27.0",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/openapi-io",
-  "version": "0.27.0-0",
+  "version": "0.27.0-1",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/openapi-io",
-  "version": "0.26.28",
+  "version": "0.27.0-0",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -68,5 +68,6 @@
     "testPathIgnorePatterns": [
       "build"
     ]
-  }
+  },
+  "stableVersion": "0.26.28"
 }

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/openapi-utilities",
-  "version": "0.27.0-0",
+  "version": "0.27.0-1",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/openapi-utilities",
-  "version": "0.27.0-1",
+  "version": "0.27.0",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/openapi-utilities",
-  "version": "0.26.28",
+  "version": "0.27.0-0",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -67,5 +67,6 @@
     "testPathIgnorePatterns": [
       "build"
     ]
-  }
+  },
+  "stableVersion": "0.26.28"
 }

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/optic-ci",
   "packageManager": "yarn@3.0.2",
-  "version": "0.26.28",
+  "version": "0.27.0-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -84,5 +84,6 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  }
+  },
+  "stableVersion": "0.26.28"
 }

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/optic-ci",
   "packageManager": "yarn@3.0.2",
-  "version": "0.27.0-1",
+  "version": "0.27.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/optic-ci",
   "packageManager": "yarn@3.0.2",
-  "version": "0.27.0-0",
+  "version": "0.27.0-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/optic",
   "packageManager": "yarn@3.0.2",
-  "version": "0.27.0-1",
+  "version": "0.27.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/optic",
   "packageManager": "yarn@3.0.2",
-  "version": "0.26.28",
+  "version": "0.27.0-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -89,5 +89,6 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  }
+  },
+  "stableVersion": "0.26.28"
 }

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/optic",
   "packageManager": "yarn@3.0.2",
-  "version": "0.27.0-0",
+  "version": "0.27.0-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -7,7 +7,10 @@
   "files": [
     "/build"
   ],
-  "bin": "build/index.js",
+  "bin": {
+    "oas": "build/oas.js",
+    "optic": "build/index.js"
+  },
   "scripts": {
     "dev:test": "ENVIRONMENT=test jest --colors",
     "build": "yarn tsc --build --verbose && yarn babel ./src --out-dir ./build --extensions \".ts\",\".tsx\"",
@@ -46,6 +49,7 @@
     "@octokit/rest": "^18.12.0",
     "@sentry/node": "^7.3.1",
     "@stoplight/spectral-core": "^1.8.1",
+    "@useoptic/openapi-cli": "workspace:*",
     "@useoptic/openapi-io": "workspace:*",
     "@useoptic/openapi-utilities": "workspace:*",
     "@useoptic/optic-ci": "workspace:*",

--- a/projects/optic/src/oas.ts
+++ b/projects/optic/src/oas.ts
@@ -1,0 +1,6 @@
+import { runCli } from '@useoptic/openapi-cli/build/cli';
+const packageJson = require('../package.json');
+
+(async function () {
+  await runCli(packageJson);
+})();

--- a/projects/optic/src/oas.ts
+++ b/projects/optic/src/oas.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { runCli } from '@useoptic/openapi-cli/build/cli';
 const packageJson = require('../package.json');
 

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/rulesets-base",
   "packageManager": "yarn@3.0.2",
-  "version": "0.27.0-1",
+  "version": "0.27.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/rulesets-base",
   "packageManager": "yarn@3.0.2",
-  "version": "0.26.28",
+  "version": "0.27.0-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -58,5 +58,6 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  }
+  },
+  "stableVersion": "0.26.28"
 }

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/rulesets-base",
   "packageManager": "yarn@3.0.2",
-  "version": "0.27.0-0",
+  "version": "0.27.0-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/standard-rulesets",
   "packageManager": "yarn@3.0.2",
-  "version": "0.27.0-1",
+  "version": "0.27.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/standard-rulesets",
   "packageManager": "yarn@3.0.2",
-  "version": "0.26.28",
+  "version": "0.27.0-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -56,5 +56,6 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  }
+  },
+  "stableVersion": "0.26.28"
 }

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/standard-rulesets",
   "packageManager": "yarn@3.0.2",
-  "version": "0.27.0-0",
+  "version": "0.27.0-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3444,7 +3444,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@useoptic/openapi-cli@workspace:projects/openapi-cli":
+"@useoptic/openapi-cli@workspace:*, @useoptic/openapi-cli@workspace:projects/openapi-cli":
   version: 0.0.0-use.local
   resolution: "@useoptic/openapi-cli@workspace:projects/openapi-cli"
   dependencies:
@@ -3754,6 +3754,7 @@ __metadata:
     "@types/picomatch": ^2.3.0
     "@types/url-join": ^4.0.1
     "@types/uuid": ^8.3.1
+    "@useoptic/openapi-cli": "workspace:*"
     "@useoptic/openapi-io": "workspace:*"
     "@useoptic/openapi-utilities": "workspace:*"
     "@useoptic/optic-ci": "workspace:*"
@@ -3782,6 +3783,7 @@ __metadata:
     url-join: ^4.0.1
     uuid: ^8.3.2
   bin:
+    oas: build/oas.js
     optic: build/index.js
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -3504,7 +3504,7 @@ __metadata:
     update-notifier: ^6.0.2
     whatwg-mimetype: ^3.0.0
   bin:
-    openapi-cli: build/index.js
+    oas: build/index.js
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
A quiet little soft launch of the CLI we've been building for authoring OpenAPI specs: `oas`. For now, a separate command from the rest of `@useoptic/optic` and the `optic` command, but bundled and installed as part of it.

`@useoptic/openapi-cli` is kept around for now as the home for the code, as well as library use by some of our design partners.

### QA
- [x] run `optic` and `oas` from installing `@useoptic/openapi-cli@0.27.0-1`