### PR TITLE
chore(ci): test on node 16, run tests on merge

### DIFF
--- a/.github/workflows/pr-build-and-test.yaml
+++ b/.github/workflows/pr-build-and-test.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16
           cache: yarn
 
       - name: Install libpcap

--- a/.github/workflows/pr-build-and-test.yaml
+++ b/.github/workflows/pr-build-and-test.yaml
@@ -2,6 +2,10 @@ name: Build and Test PRs
 on:
   pull_request:
   workflow_dispatch:
+  push:
+    branches:
+      - main
+
 
 jobs:
   build:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: Build and Test PRs
+name: Test
 on:
   pull_request:
   workflow_dispatch:


### PR DESCRIPTION
- i noticed we weren't running tests after merging PRs, `on:push:branches` should do that now.
- updated the node version we test against from 14 to 16.
- renamed the workflow to "test".