### PR TITLE
use raw content type for fetching github file data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openapi-workspaces",
   "private": true,
-  "version": "0.28.1-0",
+  "version": "0.28.1-1",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",
@@ -15,6 +15,5 @@
   "scripts": {
     "release": "gh release create --target=$(git branch --show-current) v$(node -e \"process.stdout.write(require('./package.json').version)\")",
     "version": "yarn workspaces foreach -v version"
-  },
-  "stableVersion": "0.28.0"
+  }
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/json-pointer-helpers",
-  "version": "0.28.1-0",
+  "version": "0.28.1-1",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -36,6 +36,5 @@
   },
   "dependencies": {
     "jsonpointer": "^5.0.1"
-  },
-  "stableVersion": "0.28.0"
+  }
 }

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-cli",
   "packageManager": "yarn@3.0.2",
-  "version": "0.28.1-0",
+  "version": "0.28.1-1",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [
@@ -94,6 +94,5 @@
         "<rootDir>../../../../node_modules/csv-parse/dist/cjs/sync.cjs"
       ]
     }
-  },
-  "stableVersion": "0.28.0"
+  }
 }

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/openapi-io",
-  "version": "0.28.1-0",
+  "version": "0.28.1-1",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -69,6 +69,5 @@
     "testPathIgnorePatterns": [
       "build"
     ]
-  },
-  "stableVersion": "0.28.0"
+  }
 }

--- a/projects/openapi-io/src/parser/resolvers/github-file-resolver.ts
+++ b/projects/openapi-io/src/parser/resolvers/github-file-resolver.ts
@@ -18,20 +18,23 @@ export const createGithubFileResolver = (
     const { owner, repo, sha } = gitDetails;
     const gitPath = path.relative(process.cwd(), file.url);
     try {
-      const { data } = await octokit.request(
+      const response = await octokit.request(
         'GET /repos/{owner}/{repo}/contents/{path}',
         {
           owner,
           repo,
           path: gitPath,
           ref: sha,
+          headers: {
+            accept: 'application/vnd.github.VERSION.raw'
+          }
         }
       );
-      if ('content' in data) {
-        return Buffer.from(data.content, 'base64').toString();
+      if (typeof response.data === 'string') {
+        return response.data as string // octokit typing doesn't recognize header accept changes
       } else {
         throw new ResolverError(
-          ono(new Error('No content key from github response')),
+          ono(new Error('Expected a text response')),
           gitPath
         );
       }

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/openapi-utilities",
-  "version": "0.28.1-0",
+  "version": "0.28.1-1",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -66,6 +66,5 @@
     "testPathIgnorePatterns": [
       "build"
     ]
-  },
-  "stableVersion": "0.28.0"
+  }
 }

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/optic-ci",
   "packageManager": "yarn@3.0.2",
-  "version": "0.28.1-0",
+  "version": "0.28.1-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -84,6 +84,5 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  },
-  "stableVersion": "0.28.0"
+  }
 }

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/optic",
   "packageManager": "yarn@3.0.2",
-  "version": "0.28.1-0",
+  "version": "0.28.1-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -89,6 +89,5 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  },
-  "stableVersion": "0.28.0"
+  }
 }

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/rulesets-base",
   "packageManager": "yarn@3.0.2",
-  "version": "0.28.1-0",
+  "version": "0.28.1-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -58,6 +58,5 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  },
-  "stableVersion": "0.28.0"
+  }
 }

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/standard-rulesets",
   "packageManager": "yarn@3.0.2",
-  "version": "0.28.1-0",
+  "version": "0.28.1-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -56,6 +56,5 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  },
-  "stableVersion": "0.28.0"
+  }
 }


### PR DESCRIPTION
Uses the raw content type to fetch the raw data using the accept header `application/vnd.github.VERSION.raw` - https://docs.github.com/en/rest/repos/contents#custom-media-types-for-repository-contents - this allows us to handle files < 100mb

I tested this using a separate script for response, the octokit typing looks incorrect here since data comes back as a raw string.