### PR TITLE
Feat/openapi utilities/imple create multisessions comment body

### DIFF
--- a/projects/openapi-utilities/src/index.ts
+++ b/projects/openapi-utilities/src/index.ts
@@ -59,7 +59,10 @@ export {
   findOpticCommentId,
   OPTIC_COMMENT_SURVEY_LINK,
 } from './utilities/shared-comment';
-export { createCommentBody } from './utilities/compare-comment';
+export {
+  createCommentBody,
+  createMultiSessionsCommentBody,
+} from './utilities/compare-comment';
 export {
   logComparison,
   getComparisonLogs,

--- a/projects/openapi-utilities/src/utilities/__tests__/__snapshots__/compare-comment.ts.snap
+++ b/projects/openapi-utilities/src/utilities/__tests__/__snapshots__/compare-comment.ts.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`compareComment  1`] = `
+"<!-- DO NOT MODIFY - OPTIC IDENTIFIER: compare_hash -->
+### New changes to your OpenAPI spec test
+
+  Summary of run [#1](opticWebUrl) results (commit_hash):
+
+  💡 1 operation added
+
+  ✅ all checks passed (**1**).
+
+  For details, see [the Optic API Changelog](opticWebUrl)
+
+### New changes to your OpenAPI spec test2
+
+  Summary of run [#2](opticWebUrl2) results (commit_hash):
+
+  💡 1 operation added
+
+  ✅ all checks passed (**1**).
+
+  For details, see [the Optic API Changelog](opticWebUrl2)
+
+------
+  How can Optic be improved? Leave your feedback [here](https://forms.gle/9CgSy6ytjeLasnfWA)
+"
+`;

--- a/projects/openapi-utilities/src/utilities/__tests__/compare-comment.ts
+++ b/projects/openapi-utilities/src/utilities/__tests__/compare-comment.ts
@@ -1,0 +1,113 @@
+import { createMultiSessionsCommentBody } from '../compare-comment';
+
+const comparison = {
+  results: [
+    {
+      passed: true,
+      condition: 'have snake case keys',
+      where: 'added field: strangeness',
+      isMust: true,
+      isShould: false,
+      change: {
+        location: {
+          jsonPath:
+            '/paths/~1orgs~1{org_id}~1thing~1{thing_id}/get/responses/200/content/application~1vnd.api+json/schema/properties/data/properties/attributes/properties/strangeness',
+          conceptualPath: [
+            'operations',
+            '/orgs/{}/thing/{}',
+            'get',
+            'responses',
+            '200',
+            'application/vnd.api+json',
+            'data',
+            'attributes',
+            'strangeness',
+          ],
+          kind: 'field',
+          conceptualLocation: {
+            method: 'get',
+            path: '/orgs/{org_id}/thing/{thing_id}',
+            inResponse: {
+              statusCode: '200',
+              body: {
+                contentType: 'application/vnd.api+json',
+              },
+            },
+            jsonSchemaTrail: ['data', 'attributes', 'strangeness'],
+          },
+        },
+        added: {
+          key: 'strangeness',
+          flatSchema: {
+            type: 'number',
+            description:
+              'The amount of strangeness this thing adds or removes from the situation.',
+            example: 42,
+          },
+          required: true,
+        },
+        changeType: 'added',
+      },
+      sourcemap: {
+        filePath:
+          '/end-end-tests/api-standards/resources/thing/2021-11-10/001-ok-add-property-field.yaml',
+        startLine: 221,
+        endLine: 224,
+        preview: '',
+        startPosition: 10080,
+        endPosition: 10233,
+      },
+    },
+  ],
+  changes: [
+    {
+      location: {
+        jsonPath: '/paths/~1user~1{username}/get',
+        conceptualPath: ['operations', '/user/{}', 'get'],
+        kind: 'operation',
+        conceptualLocation: { method: 'get', path: '/user/{username}' },
+        sourcemap: {
+          filePath:
+            '/end-end-tests/api-standards/resources/thing/2021-11-10/001-ok-add-property-field.yaml',
+          startLine: 221,
+          endLine: 224,
+          preview: '',
+          startPosition: 10080,
+          endPosition: 10233,
+        },
+      },
+      added: {
+        tags: ['user'],
+        summary: 'Get user by user name',
+        operationId: 'getUserByName',
+        method: 'get',
+        pathPattern: '/user/{username}',
+      },
+      changeType: 'added',
+    },
+  ],
+} as any;
+
+describe('compareComment', () => {
+  test('', () => {
+    const output = createMultiSessionsCommentBody(
+      'commit_hash',
+      'compare_hash',
+      [
+        {
+          apiName: 'test',
+          compareFile: comparison,
+          opticWebUrl: 'opticWebUrl',
+          run: 1,
+        },
+        {
+          apiName: 'test2',
+          compareFile: comparison,
+          opticWebUrl: 'opticWebUrl2',
+          run: 2,
+        },
+      ]
+    );
+    expect(output).toMatchSnapshot();
+  });
+});

--- a/projects/openapi-utilities/src/utilities/compare-comment.ts
+++ b/projects/openapi-utilities/src/utilities/compare-comment.ts
@@ -8,7 +8,7 @@ const footer = `------
 const getCommentHeader = (hash: string) =>
   `<!-- DO NOT MODIFY - OPTIC IDENTIFIER: ${hash} -->`;
 
-const getCommendBodyInner = (
+const getCommentBodyInner = (
   name: string,
   results: CompareFileJson['results'],
   changes: CompareFileJson['changes'],
@@ -64,7 +64,7 @@ export const createMultiSessionsCommentBody = (
 ) => {
   const sessionBodies = sessions
     .map((session) =>
-      getCommendBodyInner(
+      getCommentBodyInner(
         session.apiName,
         session.compareFile.results,
         session.compareFile.changes,
@@ -91,7 +91,7 @@ export const createCommentBody = (
   opticWebUrl: string
 ) => {
   return `${getCommentHeader(compareHash)}
-${getCommendBodyInner('', results, changes, commit_hash, run, opticWebUrl)}
+${getCommentBodyInner('', results, changes, commit_hash, run, opticWebUrl)}
 
 ${footer}
 `;

--- a/projects/openapi-utilities/src/utilities/compare-comment.ts
+++ b/projects/openapi-utilities/src/utilities/compare-comment.ts
@@ -2,10 +2,16 @@ import { CompareFileJson } from '../ci-types';
 import { OPTIC_COMMENT_SURVEY_LINK } from './shared-comment';
 import { getOperationsModifsLabel } from './count-changed-operations';
 
-export const createCommentBody = (
+const footer = `------
+  How can Optic be improved? Leave your feedback [here](${OPTIC_COMMENT_SURVEY_LINK})`;
+
+const getCommentHeader = (hash: string) =>
+  `<!-- DO NOT MODIFY - OPTIC IDENTIFIER: ${hash} -->`;
+
+const getCommendBodyInner = (
+  name: string,
   results: CompareFileJson['results'],
   changes: CompareFileJson['changes'],
-  compareHash: string,
   commit_hash: string,
   run: number,
   opticWebUrl: string
@@ -27,8 +33,7 @@ export const createCommentBody = (
       ? ` ${exemptedFailingChecks} would have failed but were exempted.`
       : '';
 
-  const body = `<!-- DO NOT MODIFY - OPTIC IDENTIFIER: ${compareHash} -->
-  ### New changes to your OpenAPI spec
+  const bodyInner = `### New changes to your OpenAPI spec ${name}
 
   Summary of run [#${run}](${opticWebUrl}) results (${commit_hash}):
 
@@ -42,11 +47,52 @@ export const createCommentBody = (
       : `ℹ️ No automated checks have run.`
   }
 
-  For details, see [the Optic API Changelog](${opticWebUrl})
+  For details, see [the Optic API Changelog](${opticWebUrl})`;
 
-  ------
-  How can Optic be improved? Leave your feedback [here](${OPTIC_COMMENT_SURVEY_LINK})
+  return bodyInner;
+};
+
+export const createMultiSessionsCommentBody = (
+  commit_hash: string,
+  compareHash: string,
+  sessions: {
+    apiName: string;
+    compareFile: CompareFileJson;
+    opticWebUrl: string;
+    run: number;
+  }[]
+) => {
+  const sessionBodies = sessions
+    .map((session) =>
+      getCommendBodyInner(
+        session.apiName,
+        session.compareFile.results,
+        session.compareFile.changes,
+        commit_hash,
+        session.run,
+        session.opticWebUrl
+      )
+    )
+    .join('\n\n');
+  const body = `${getCommentHeader(compareHash)}
+${sessionBodies}
+
+${footer}
 `;
-
   return body;
+};
+
+export const createCommentBody = (
+  results: CompareFileJson['results'],
+  changes: CompareFileJson['changes'],
+  compareHash: string,
+  commit_hash: string,
+  run: number,
+  opticWebUrl: string
+) => {
+  return `${getCommentHeader(compareHash)}
+${getCommendBodyInner('', results, changes, commit_hash, run, opticWebUrl)}
+
+${footer}
+`;
 };


### PR DESCRIPTION
- Implement `createMultiSessionsCommentBody` to create a single comment from multiple sessions.
The comment could be improved over time, here I'm just going to the fastest.
- Extract `publishGithubMessage` from `sendGithubMessage`: publish takes a body and a hash as args inst. of taking compare and upload outputs, which lets me post multi session comments