### PR TITLE
fix: allow `oas capture` to be more resilient by completing HAR under various user signals

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openapi-workspaces",
   "private": true,
-  "version": "0.28.1-1",
+  "version": "0.28.1",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/json-pointer-helpers",
-  "version": "0.28.1-1",
+  "version": "0.28.1",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-cli",
   "packageManager": "yarn@3.0.2",
-  "version": "0.28.1-1",
+  "version": "0.28.1",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/openapi-io",
-  "version": "0.28.1-1",
+  "version": "0.28.1",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/openapi-utilities",
-  "version": "0.28.1-1",
+  "version": "0.28.1",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/optic-ci",
   "packageManager": "yarn@3.0.2",
-  "version": "0.28.1-1",
+  "version": "0.28.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/optic",
   "packageManager": "yarn@3.0.2",
-  "version": "0.28.1-1",
+  "version": "0.28.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/rulesets-base",
   "packageManager": "yarn@3.0.2",
-  "version": "0.28.1-1",
+  "version": "0.28.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/standard-rulesets",
   "packageManager": "yarn@3.0.2",
-  "version": "0.28.1-1",
+  "version": "0.28.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
When running `oas capture --proxy`, the user had to signal with a newline (effectively hitting Enter in a terminal) to indicate the completion of the capture. However, signaling using other common methods, like `SIGTERM`, `SIGINT` or `SIGBREAK`, caused the HAR file to never be completed and be rendered invalid.

While other commands benefit from being able to _cancel_ a command before completing it, that's not really the case for capturing. At any time we should attempt to finish the capture and produce a valid HAR file.

This PR handles various exit signals and attempts to finish up writing before the OS time-out kills the process. Unless your I/O is heavily congested, it should manage to. Using the already existing `AbortController` and accompanying `AbortSignal`,  the capture of new requests is halted and the stream closed, causing everything downstream to wrap up and exit when ready.

Bonus: `oas capture` can now only be used in non-interactive (non-tty) sessions, meaning it's easier to integrate it as part of another program.