### PR TITLE
feat: improve warnings for HAR entries that can't be parsed or validated

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openapi-workspaces",
   "private": true,
-  "version": "0.28.1",
+  "version": "0.28.2",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/json-pointer-helpers",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-cli",
   "packageManager": "yarn@3.0.2",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [

--- a/projects/openapi-cli/src/captures/interaction.test.ts
+++ b/projects/openapi-cli/src/captures/interaction.test.ts
@@ -2,7 +2,7 @@ import { CapturedInteraction } from './interaction';
 import { CapturedBody } from './body';
 import { HarEntries, HttpArchive } from './streams/sources/har';
 import { ProxyInteractions, ProxySource } from './streams/sources/proxy';
-import { collect } from '../lib/async-tools';
+import { collect, unwrap } from '../lib/async-tools';
 import fs from 'fs';
 import Path from 'path';
 import { Readable } from 'stream';
@@ -15,7 +15,7 @@ describe('CapturedIntearction.fromHarEntry', () => {
       Path.join(__dirname, '../tests/inputs/petstore.swagger.io.har')
     );
 
-    testEntries = await collect(HarEntries.fromReadable(source));
+    testEntries = await collect(unwrap(HarEntries.fromReadable(source)));
   });
 
   it('can create a CapturedInteraction from a HttpArchive.Entry', () => {

--- a/projects/openapi-cli/src/captures/streams/sources/har.test.ts
+++ b/projects/openapi-cli/src/captures/streams/sources/har.test.ts
@@ -1,7 +1,7 @@
 import { HarEntries, HttpArchive } from './har';
 import fs from 'fs';
 import Path from 'path';
-import { collect, take } from '../../../lib/async-tools';
+import { collect, take, unwrap } from '../../../lib/async-tools';
 
 describe('HarEntries', () => {
   it('can be constructed from a readable', async () => {
@@ -55,7 +55,9 @@ describe('HarEntries', () => {
       Path.join(__dirname, '../../../tests/inputs/petstore.swagger.io.har')
     );
 
-    let entries = take<HttpArchive.Entry>(2)(HarEntries.fromReadable(source));
+    let entries = take<HttpArchive.Entry>(2)(
+      unwrap(HarEntries.fromReadable(source))
+    );
 
     let jsonStream = HarEntries.toHarJSON(entries);
 

--- a/projects/openapi-cli/src/captures/streams/sources/har.ts
+++ b/projects/openapi-cli/src/captures/streams/sources/har.ts
@@ -209,7 +209,7 @@ export class HarEntryValidationError extends Error {
       (description) => `  - ${description}\n`
     )}`;
     if (url) {
-      message += `\n Request url: ${url}`;
+      message += `\nRequest url: ${url}`;
     }
 
     super(message);

--- a/projects/openapi-cli/src/commands/add.ts
+++ b/projects/openapi-cli/src/commands/add.ts
@@ -84,7 +84,10 @@ export async function addCommand(): Promise<Command> {
           );
         }
         let harFile = fs.createReadStream(absoluteHarPath);
-        let harEntries = HarEntries.fromReadable(harFile);
+        let harEntryResults = HarEntries.fromReadable(harFile);
+        let harEntries = AT.unwrapOr(harEntryResults, (err) => {
+          console.warn(err.message); // just warn , skip and keep going
+        });
         sources.push(CapturedInteractions.fromHarEntries(harEntries));
       }
 

--- a/projects/openapi-cli/src/commands/add.ts
+++ b/projects/openapi-cli/src/commands/add.ts
@@ -7,6 +7,7 @@ import readline from 'readline';
 
 import { createCommandFeedback, InputErrors } from './reporters/feedback';
 import { trackCompletion } from '../segment';
+import { trackWarning } from '../sentry';
 import * as AT from '../lib/async-tools';
 import {
   CapturedInteraction,
@@ -86,7 +87,9 @@ export async function addCommand(): Promise<Command> {
         let harFile = fs.createReadStream(absoluteHarPath);
         let harEntryResults = HarEntries.fromReadable(harFile);
         let harEntries = AT.unwrapOr(harEntryResults, (err) => {
-          console.warn(err.message); // just warn , skip and keep going
+          let message = `HAR entry skipped: ${err.message}`;
+          console.warn(message); // warn, skip and keep going
+          trackWarning(message, err);
         });
         sources.push(CapturedInteractions.fromHarEntries(harEntries));
       }

--- a/projects/openapi-cli/src/commands/capture.ts
+++ b/projects/openapi-cli/src/commands/capture.ts
@@ -50,7 +50,10 @@ export async function captureCommand(): Promise<Command> {
           );
         }
         let harFile = fs.createReadStream(absoluteHarPath);
-        let harEntries = HarEntries.fromReadable(harFile);
+        let harEntryResults = HarEntries.fromReadable(harFile);
+        let harEntries = AT.unwrapOr(harEntryResults, (err) => {
+          console.warn(err.message); // just warn , skip and keep going
+        });
         sources.push(harEntries);
       }
 

--- a/projects/openapi-cli/src/commands/capture.ts
+++ b/projects/openapi-cli/src/commands/capture.ts
@@ -8,6 +8,7 @@ import exitHook from 'async-exit-hook';
 import * as AT from '../lib/async-tools';
 import { createCommandFeedback, InputErrors } from './reporters/feedback';
 import { trackCompletion } from '../segment';
+import { trackWarning } from '../sentry';
 
 import {
   CapturedInteraction,
@@ -52,7 +53,9 @@ export async function captureCommand(): Promise<Command> {
         let harFile = fs.createReadStream(absoluteHarPath);
         let harEntryResults = HarEntries.fromReadable(harFile);
         let harEntries = AT.unwrapOr(harEntryResults, (err) => {
-          console.warn(err.message); // just warn , skip and keep going
+          let message = `HAR entry skipped: ${err.message}`;
+          console.warn(message); // warn, skip and keep going
+          trackWarning(message, err);
         });
         sources.push(harEntries);
       }

--- a/projects/openapi-cli/src/commands/status.ts
+++ b/projects/openapi-cli/src/commands/status.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs-extra';
 
 import { createCommandFeedback, InputErrors } from './reporters/feedback';
 import { trackCompletion } from '../segment';
+import { trackWarning } from '../sentry';
 import * as AT from '../lib/async-tools';
 import { ComponentSchemaExampleFacts, readDeferencedSpec } from '../specs';
 import {
@@ -60,7 +61,9 @@ export async function statusCommand({
         let harFile = fs.createReadStream(absoluteHarPath);
         let harEntryResults = HarEntries.fromReadable(harFile);
         let harEntries = AT.unwrapOr(harEntryResults, (err) => {
-          console.warn(err.message); // just warn , skip and keep going
+          let message = `HAR entry skipped: ${err.message}`;
+          console.warn(message); // warn, skip and keep going
+          trackWarning(message, err);
         });
         sources.push(CapturedInteractions.fromHarEntries(harEntries));
       }

--- a/projects/openapi-cli/src/commands/status.ts
+++ b/projects/openapi-cli/src/commands/status.ts
@@ -58,10 +58,10 @@ export async function statusCommand({
           );
         }
         let harFile = fs.createReadStream(absoluteHarPath);
-        let harEntries = AT.tap(
-          (entry: any) => {}
-          // console.log('har entry', entry)
-        )(HarEntries.fromReadable(harFile));
+        let harEntryResults = HarEntries.fromReadable(harFile);
+        let harEntries = AT.unwrapOr(harEntryResults, (err) => {
+          console.warn(err.message); // just warn , skip and keep going
+        });
         sources.push(CapturedInteractions.fromHarEntries(harEntries));
       }
 

--- a/projects/openapi-cli/src/commands/update.ts
+++ b/projects/openapi-cli/src/commands/update.ts
@@ -23,6 +23,7 @@ import {
 } from '../specs';
 
 import { trackCompletion, trackEvent } from '../segment';
+import { trackWarning } from '../sentry';
 import {
   CapturedInteraction,
   CapturedInteractions,
@@ -72,7 +73,9 @@ export async function updateCommand(): Promise<Command> {
         let harFile = fs.createReadStream(absoluteHarPath);
         let harEntryResults = HarEntries.fromReadable(harFile);
         let harEntries = AT.unwrapOr(harEntryResults, (err) => {
-          console.warn(err.message); // just warn , skip and keep going
+          let message = `HAR entry skipped: ${err.message}`;
+          console.warn(message); // warn, skip and keep going
+          trackWarning(message, err);
         });
         sources.push(CapturedInteractions.fromHarEntries(harEntries));
       }

--- a/projects/openapi-cli/src/commands/update.ts
+++ b/projects/openapi-cli/src/commands/update.ts
@@ -6,6 +6,7 @@ import { updateReporter } from './reporters/update';
 import { createCommandFeedback, InputErrors } from './reporters/feedback';
 
 import { tap, forkable, merge, Subject } from '../lib/async-tools';
+import * as AT from '../lib/async-tools';
 import {
   SpecFile,
   SpecFileOperation,
@@ -69,7 +70,10 @@ export async function updateCommand(): Promise<Command> {
           );
         }
         let harFile = fs.createReadStream(absoluteHarPath);
-        let harEntries = HarEntries.fromReadable(harFile);
+        let harEntryResults = HarEntries.fromReadable(harFile);
+        let harEntries = AT.unwrapOr(harEntryResults, (err) => {
+          console.warn(err.message); // just warn , skip and keep going
+        });
         sources.push(CapturedInteractions.fromHarEntries(harEntries));
       }
 

--- a/projects/openapi-cli/src/lib/async-tools.ts
+++ b/projects/openapi-cli/src/lib/async-tools.ts
@@ -1,5 +1,7 @@
 export * from 'axax/esnext';
 
+import { Result } from 'ts-results';
+
 // Fork an async iterable and share the backpressure (preventing memory bloat, but
 // reading at rate of slowest consumer).
 // Won't allow new forks once consumption has started through `forkable.start()`.
@@ -137,4 +139,25 @@ export async function collect<T>(source: AsyncIterable<T>): Promise<T[]> {
     results.push(item);
   }
   return results;
+}
+
+export async function* unwrap<T, E>(
+  source: AsyncIterable<Result<T, E>>
+): AsyncIterable<T> {
+  for await (let result of source) {
+    yield result.unwrap();
+  }
+}
+
+export async function* unwrapOr<T, E>(
+  source: AsyncIterable<Result<T, E>>,
+  handler: (error: E) => void | Promise<void>
+): AsyncIterable<T> {
+  for await (let result of source) {
+    if (result.ok) {
+      yield result.val;
+    } else {
+      await handler(result.val);
+    }
+  }
 }

--- a/projects/openapi-cli/src/sentry.ts
+++ b/projects/openapi-cli/src/sentry.ts
@@ -17,3 +17,15 @@ export const initSentry = ({
 
   Sentry.setTag('runId', runId);
 };
+
+export function trackWarning(
+  message: string,
+  context?: { [key: string]: any }
+) {
+  Sentry.withScope(function (scope) {
+    if (context) {
+      scope.setContext('warning context', context);
+    }
+    Sentry.captureMessage(message, 'warning');
+  });
+}

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/openapi-io",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/openapi-utilities",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/optic-ci",
   "packageManager": "yarn@3.0.2",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/optic",
   "packageManager": "yarn@3.0.2",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/rulesets-base",
   "packageManager": "yarn@3.0.2",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/standard-rulesets",
   "packageManager": "yarn@3.0.2",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
A lot of programs out there can generate HARs, and while there is a spec, we've come across some situations where entries could not be validated and were skipped, logging only a very generic warning. To get some more insight into _why_ validation didn't work and for _which_ entry inside the HAR, we improved the warnings and their tracking (without leaking actual request or response contents).

### QA
- [x] feed the commands that accept `--har` an invalid HAR and observe the more useful warning in console and Sentry