### PR TITLE
refactor(optic): have init create an optic.dev.yml file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openapi-workspaces",
   "private": true,
-  "version": "0.29.0",
+  "version": "0.29.1",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/json-pointer-helpers",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-cli",
   "packageManager": "yarn@3.0.2",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/openapi-io",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/openapi-utilities",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/optic-ci",
   "packageManager": "yarn@3.0.2",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/README.md
+++ b/projects/optic/README.md
@@ -8,11 +8,11 @@ Install `optic` and `oas`:
 npm i -g @useoptic/optic
 ```
 
-Initialize an `optic.yml` config file
+Initialize an `optic.dev.yml` config file
 
 ```bash
 optic init
-# this will create an optic.yml file with references to openapi files detected in the git repo
+# this will create an optic.dev.yml file with references to openapi files detected in the git repo
 ```
 
 Run a diff between two OpenAPI files:
@@ -41,7 +41,7 @@ optic diff master:specs/openapi-spec.yml specs/openapi-spec.yml
 optic diff specs/openapi-spec.yml --base master
 ```
 
-Running a diff on a file from your `optic.yml`
+Running a diff on a file from your `optic.dev.yml`
 
 ```bash
 # runs a diff against the users-api id

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/optic",
   "packageManager": "yarn@3.0.2",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/src/__tests__/config.test.ts
+++ b/projects/optic/src/__tests__/config.test.ts
@@ -2,15 +2,25 @@ import { UserError } from '@useoptic/openapi-utilities';
 import {
   detectCliConfig,
   formatRules,
-  OpticCliConfig,
   validateConfig,
   RawYmlConfig,
 } from '../config';
 
 describe('detectConfig', () => {
+  beforeEach(() => {
+    console.warn = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   test('finds config', async () => {
     const path = await detectCliConfig('src/__tests__/');
     expect(path).toBe('src/__tests__/optic.yml');
+
+    // Expecting deprecation warning
+    expect(console.warn).toHaveBeenCalled();
   });
 
   test("doesn't find config", async () => {

--- a/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`diff \`optic diff\` compares against HEAD in repo 1`] = `
-"Deprecation warning: optic diff is deprecated, please use optic diff <file_path> --base <base> instead
+"Deprecation warning: optic.yml file is deprecated. Please rename your file to optic.dev.yml
+Deprecation warning: optic diff is deprecated, please use optic diff <file_path> --base <base> instead
 example-api-1:
 
 [1mGET[22m /example: 
@@ -49,7 +50,8 @@ example-api-2:
 `;
 
 exports[`diff basic rules config 1`] = `
-"
+"Deprecation warning: optic.yml file is deprecated. Please rename your file to optic.dev.yml
+
 [1mGET[22m /example: 
   - operationId [33mchanged[39m
 
@@ -159,7 +161,8 @@ Configure check rulesets in your local optic.dev.yml file.
 `;
 
 exports[`diff breaking changes exclusion 1`] = `
-"
+"Deprecation warning: optic.yml file is deprecated. Please rename your file to optic.dev.yml
+
 [1mGET[22m /example: 
   - x-optic-ignore-breaking-changes [32madded[39m
   - operationId [33mchanged[39m

--- a/projects/optic/src/__tests__/integration/__snapshots__/init.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/init.test.ts.snap
@@ -43,7 +43,8 @@ More details at: https://github.com/opticdev/github-action/
 `;
 
 exports[`init init with \`--ci-only github-action\` option 1`] = `
-"Initializing Optic...
+"Deprecation warning: optic.yml file is deprecated. Please rename your file to optic.dev.yml
+Initializing Optic...
 
 Setting up CI:
 - Github action file written to $workspace$/.github/workflows/optic-ci.yml
@@ -54,6 +55,7 @@ More details at: https://github.com/opticdev/github-action/
 `;
 
 exports[`init init with existing optic.init.yml 1`] = `
-"Error: a configuration file already exists at $workspace$/optic.yml.
+"Deprecation warning: optic.yml file is deprecated. Please rename your file to optic.dev.yml
+Error: a configuration file already exists at $workspace$/optic.yml.
 "
 `;

--- a/projects/optic/src/__tests__/integration/__snapshots__/init.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/init.test.ts.snap
@@ -14,7 +14,7 @@ Adding ruleset:
 - breaking-changes
 
 File IDs are stable identifiers for your API specifications that will appear in Optic.
-You can change them now before you check in the optic.yml file.
+You can change them now before you check in the optic.dev.yml file.
 "
 `;
 
@@ -32,7 +32,7 @@ Adding ruleset:
 - breaking-changes
 
 File IDs are stable identifiers for your API specifications that will appear in Optic.
-You can change them now before you check in the optic.yml file.
+You can change them now before you check in the optic.dev.yml file.
 
 Setting up CI:
 - Github action file written to $workspace$/.github/workflows/optic-ci.yml
@@ -53,7 +53,7 @@ More details at: https://github.com/opticdev/github-action/
 "
 `;
 
-exports[`init init with existing optic.yml 1`] = `
+exports[`init init with existing optic.init.yml 1`] = `
 "Error: a configuration file already exists at $workspace$/optic.yml.
 "
 `;

--- a/projects/optic/src/__tests__/integration/init.test.ts
+++ b/projects/optic/src/__tests__/integration/init.test.ts
@@ -5,6 +5,7 @@ import {
   normalizeWorkspace,
 } from './integration';
 import path from 'node:path';
+import { OPTIC_DEV_YML_NAME } from '../../config';
 
 jest.setTimeout(30000);
 
@@ -12,9 +13,13 @@ describe('init', () => {
   test('basic init', async () => {
     const workspace = await setupWorkspace('init/basic');
 
-    expect(await fileExists(path.join(workspace, 'optic.yml'))).toBe(false);
+    expect(await fileExists(path.join(workspace, OPTIC_DEV_YML_NAME))).toBe(
+      false
+    );
     const { combined, code } = await runOptic(workspace, 'init');
-    expect(await fileExists(path.join(workspace, 'optic.yml'))).toBe(true);
+    expect(await fileExists(path.join(workspace, OPTIC_DEV_YML_NAME))).toBe(
+      true
+    );
     expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
     expect(code).toBe(0);
   });

--- a/projects/optic/src/__tests__/integration/init.test.ts
+++ b/projects/optic/src/__tests__/integration/init.test.ts
@@ -24,7 +24,7 @@ describe('init', () => {
     expect(code).toBe(0);
   });
 
-  test('init with existing optic.yml', async () => {
+  test('init with existing optic.init.yml', async () => {
     const workspace = await setupWorkspace('init/existing');
 
     const { combined, code } = await runOptic(workspace, 'init');

--- a/projects/optic/src/commands/cloud-compare/cloud-compare.ts
+++ b/projects/optic/src/commands/cloud-compare/cloud-compare.ts
@@ -69,7 +69,7 @@ const cloudCompare = async (
 ) => {
   if (!cliConfig.configPath) {
     throw new UserError(
-      'Could not find an optic.yml at the root of the repo. Create an optic.yml file with a list of files to run optic against. Run `npx @useoptic/optic@latest init` to generate a file.'
+      'Could not find an optic.dev.yml at the root of the repo. Create an optic.dev.yml file with a list of files to run optic against. Run `npx @useoptic/optic@latest init` to generate a file.'
     );
   }
 

--- a/projects/optic/src/commands/diff/diff.ts
+++ b/projects/optic/src/commands/diff/diff.ts
@@ -45,7 +45,7 @@ Example usage:
   Run a diff and view changes in the Optic web view
   $ optic diff --id user-api --base master --web
 
-  Run a diff and check the changes against the rulesets configured in your \`optic.yml\` config file:
+  Run a diff and check the changes against the rulesets configured in your \`optic.dev.yml\` config file:
   $ optic diff openapi-spec-v0.yml openapi-spec-v1.yml --check
   `;
 
@@ -74,7 +74,7 @@ export const registerDiff = (cli: Command, config: OpticCliConfig) => {
     )
     .option(
       '--id <id>',
-      'the id of the spec to run against in defined in the `optic.yml` file'
+      'the id of the spec to run against in defined in the `optic.dev.yml` file'
     )
     .option('--check', 'enable checks', false)
     .option('--web', 'view the diff in the optic changelog web view', false)
@@ -304,19 +304,21 @@ const getDiffAction =
       }
       if (!config.configPath) {
         console.error(
-          `Error: no optic.yml config file was found. optic.yml must be included for ${commandVariant}`
+          `Error: no optic.dev.yml config file was found. optic.dev.yml must be included for ${commandVariant}`
         );
         process.exitCode = 1;
         return;
       }
 
-      console.log('Running diff against files from optic.yml file');
+      console.log('Running diff against files from optic.dev.yml file');
       const configFiles = config.files;
       const maybeMatchingFile = configFiles.find(
         (file) => file.id === options.id
       );
       if (!maybeMatchingFile) {
-        console.error(`id: ${options.id} was not found in the optic.yml file`);
+        console.error(
+          `id: ${options.id} was not found in the optic.dev.yml file`
+        );
         console.log(
           `valid list of file names: ${configFiles
             .map((file) => file.id)
@@ -335,13 +337,13 @@ const getDiffAction =
       console.warn('Deprecation warning: optic diff is deprecated, please use optic diff <file_path> --base <base> instead');
       if (!config.configPath) {
         console.error(
-          'Error: no `optic.yml` config file was found. Run `optic init` to generate a config file.'
+          'Error: no `optic.dev.yml` config file was found. Run `optic init` to generate a config file.'
         );
         process.exitCode = 1;
         return;
       } else if (config.files.length === 0) {
         console.error(
-          'No files were found in your `optic.yml` file. Ensure that your `optic.yml` contains at least one file'
+          'No files were found in your `optic.dev.yml` file. Ensure that your `optic.dev.yml` contains at least one file'
         );
         process.exitCode = 1;
         return;

--- a/projects/optic/src/commands/init/init.ts
+++ b/projects/optic/src/commands/init/init.ts
@@ -117,7 +117,7 @@ export const getInit =
           'File IDs are stable identifiers for your API specifications that will appear in Optic.'
         );
         console.log(
-          'You can change them now before you check in the optic.yml file.'
+          'You can change them now before you check in the optic.dev.yml file.'
         );
       } else {
         console.error(

--- a/projects/optic/src/commands/init/init.ts
+++ b/projects/optic/src/commands/init/init.ts
@@ -4,7 +4,7 @@ import { findOpenAPISpecs } from './find-openapi-specs';
 import { generateOpticConfig } from './generate-optic-config';
 import { writeOpticConfig } from './write-optic-config';
 import { hasGit, isInGitRepo, getRootPath } from '../../utils/git-utils';
-import { OPTIC_YML_NAME } from '../../config';
+import { OPTIC_DEV_YML_NAME } from '../../config';
 import { getValidSpecs } from './get-valid-specs';
 import { OpticCliConfig } from '../../config';
 import { supportedCIs, SupportedCI } from './constants';
@@ -60,7 +60,7 @@ export const getInit =
     }
 
     const gitRoot = await getRootPath();
-    const configPath = path.join(gitRoot, OPTIC_YML_NAME);
+    const configPath = path.join(gitRoot, OPTIC_DEV_YML_NAME);
 
     console.log('Initializing Optic...');
 

--- a/projects/optic/src/commands/init/register-init.ts
+++ b/projects/optic/src/commands/init/register-init.ts
@@ -7,7 +7,7 @@ import { supportedCIs } from './constants';
 const description = 'Initializes Optic. See `optic init --help`';
 
 const helpText = `
-Initializes Optic. The command searches for valid OpenAPI specification files in your project, generates a unique ID per file and stores the result in an optic.yml configuration file.
+Initializes Optic. The command searches for valid OpenAPI specification files in your project, generates a unique ID per file and stores the result in an optic.dev.yml configuration file.
 These IDs are meant to be stable, but you can change them before committing the configuration file.
 
 Use the \`--ci <ci>\` or \`--ci-only <ci>\` options to automatically setup your CI to use Optic cloud. Supported values: ${supportedCIs.join(

--- a/projects/optic/src/config.ts
+++ b/projects/optic/src/config.ts
@@ -9,7 +9,7 @@ export enum VCS {
 }
 
 export const OPTIC_YML_NAME = 'optic.yml';
-const OPTIC_DEV_YML_NAME = 'optic.dev.yml';
+export const OPTIC_DEV_YML_NAME = 'optic.dev.yml';
 
 type ConfigRuleset = { name: string; config: unknown };
 
@@ -87,8 +87,8 @@ export async function detectCliConfig(
   // test out the dev path first
   try {
     await fs.access(expectedDevYmlPath);
-    return expectedDevYmlPath
-  } catch(e) {}
+    return expectedDevYmlPath;
+  } catch (e) {}
 
   try {
     await fs.access(expectedYmlPath);

--- a/projects/optic/src/config.ts
+++ b/projects/optic/src/config.ts
@@ -96,6 +96,9 @@ export async function detectCliConfig(
     return undefined;
   }
 
+  console.warn(
+    'Deprecation warning: optic.yml file is deprecated. Please rename your file to optic.dev.yml'
+  );
   return expectedYmlPath;
 }
 

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/rulesets-base",
   "packageManager": "yarn@3.0.2",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/standard-rulesets",
   "packageManager": "yarn@3.0.2",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
- have init create an optic.dev.yml file instead of optic.yml
- use `optic.dev.yml` everywhere in doc by default
- add deprecation warning when accessing `optic.yml`