### PR TITLE
Add deprecation warnings to old diff + cloud commands

### DIFF
--- a/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`diff \`optic diff\` compares against HEAD in repo 1`] = `
-"example-api-1:
+"Deprecation warning: optic diff is deprecated, please use optic diff <file_path> --base <base> instead
+example-api-1:
 
 [1mGET[22m /example: 
   - operationId [33mchanged[39m

--- a/projects/optic/src/commands/cloud-compare/cloud-compare.ts
+++ b/projects/optic/src/commands/cloud-compare/cloud-compare.ts
@@ -41,6 +41,7 @@ export const registerCloudCompare = (
     .action(
       wrapActionHandlerWithSentry(
         async ({ base, verbose }: { base: string; verbose: boolean }) => {
+          console.warn('optic cloud run is deprecated, please migrate to our new flow by installing our github application. Follow the instructions at https://app.useoptic.com.')
           const token = process.env.OPTIC_TOKEN;
           if (!token) {
             throw new UserError(

--- a/projects/optic/src/commands/diff/diff.ts
+++ b/projects/optic/src/commands/diff/diff.ts
@@ -30,27 +30,12 @@ import { getAnonId } from '../../utils/anonymous-id';
 const description = `run a diff between two API specs`;
 
 const usage = () => `
-  optic diff
-  optic diff --base <base>
-  optic diff --id user-api --base <base>
   optic diff <file_path> --base <base>
   optic diff <file_path> <file_to_compare_against>
   optic diff <file_path> <file_to_compare_against> --check`;
 
 const helpText = `
 Example usage:
-  Diff all API specs files defined in your \`optic.yml\` config file against HEAD
-  $ optic diff
-
-  Diff all API specs files defined in your \`optic.yml\` config file against master
-  $ optic diff --base master
-
-  Diff a single \`user-api\` spec defined in your \`optic.yml\` config file against HEAD
-  $ optic diff --id user-api
-
-  Diff the single \`user-api\` spec from your \`optic.yml\` config file against master
-  $ optic diff --id user-api --base master
-
   Diff \`specs/openapi-spec.yml\` against master
   $ optic diff openapi-spec.yml --base master
 
@@ -308,6 +293,7 @@ const getDiffAction =
       );
       await runDiff(files, parsedFiles, config, options);
     } else if (options.id) {
+      console.warn('Deprecation warning: optic diff --id <id> is deprecated, please use optic diff <file_path> --base <base> instead');
       const commandVariant = `optic diff --id <id> --base <ref>`;
       if (config.vcs !== VCS.Git) {
         console.error(
@@ -346,6 +332,7 @@ const getDiffAction =
       );
       await runDiff(files, parsedFiles, config, options);
     } else {
+      console.warn('Deprecation warning: optic diff is deprecated, please use optic diff <file_path> --base <base> instead');
       if (!config.configPath) {
         console.error(
           'Error: no `optic.yml` config file was found. Run `optic init` to generate a config file.'


### PR DESCRIPTION
Adds deprecation warnings to:
- `optic diff` (default command) (all files in optic.yml)
- `optic diff --id <id>` (file id from optic.yml)
- `optic cloud run`