### PR TITLE
Create `PropertyRule` for `rulesets-base`

### DIFF
--- a/projects/rulesets-base/docs/DataShapes.md
+++ b/projects/rulesets-base/docs/DataShapes.md
@@ -123,14 +123,14 @@ type ResponseBody = {
 };
 ```
 
-## Field
+## Property
 
-The field object describes a [body property](https://swagger.io/specification/#schema-object) and has the following data structure
+The property object describes a [body property](https://swagger.io/specification/#schema-object) and has the following data structure
 
-[OpenApiFieldFact details can be found here](../../openapi-utilities/src/openapi3/sdk/types/index.ts)
+[PropertyFact details can be found here](../../openapi-utilities/src/openapi3/sdk/types/index.ts)
 
 ```javascript
-type Field = {
+type Property = {
   value: OpenApiFieldFact,
   raw: any, // The original operation object from the OpenAPI Spec
 };

--- a/projects/rulesets-base/docs/OperationRule.md
+++ b/projects/rulesets-base/docs/OperationRule.md
@@ -45,9 +45,9 @@ const has201StatusCode = new OperationRule({
 
 ## operationAssertions
 
-operationAssertions is used to define operation rules. There are [4 lifecycle triggers](./Reference.md#assertions) for registering rules which defines when they are triggered. A rule can be defined by passing in a condition (`string`), and an assertion, which is a function that receives an [`Operation` object](./DataShapes.md#operation). Throwing a `RuleError` represents a failure, RuleError [details below](./Reference.md#rule-error).
+operationAssertions is used to define operation rules. There are [4 lifecycle triggers](./Reference.md#assertions) for registering rules which defines when they are triggered. A rule can be defined by passing in an assertion, which is a function that receives an [`Operation` object](./DataShapes.md#operation). Throwing a `RuleError` represents a failure, RuleError [details below](./Reference.md#rule-error).
 
-`operationAssertions[lifecycle](condition, assertion)`
+`operationAssertions[lifecycle](assertion)`
 
 ```javascript
 new OperationRule({
@@ -242,9 +242,9 @@ new OperationRule({
 
 ## operationAssertions.queryParameter
 
-operationAssertions.queryParameter is used to define query parameter rules. There are [4 lifecycle triggers](./Reference.md#assertions) for registering rules which defines when they are triggered. A rule can be defined by passing in a condition (`string`), and an assertion, which is a function that receives an [`QueryParameter` object](./DataShapes.md#queryparameter--pathparameter--headerparameter--cookieparameter). Throwing a `RuleError` represents a failure, RuleError [details below](./Reference.md#rule-error).
+operationAssertions.queryParameter is used to define query parameter rules. There are [4 lifecycle triggers](./Reference.md#assertions) for registering rules which defines when they are triggered. A rule can be defined by passing in an assertion, which is a function that receives an [`QueryParameter` object](./DataShapes.md#queryparameter--pathparameter--headerparameter--cookieparameter). Throwing a `RuleError` represents a failure, RuleError [details below](./Reference.md#rule-error).
 
-`operationAssertions.queryParameter[lifecycle](condition, assertion)`
+`operationAssertions.queryParameter[lifecycle](assertion)`
 
 ```javascript
 new OperationRule({
@@ -264,9 +264,9 @@ new OperationRule({
 
 ## operationAssertions.pathParameter
 
-operationAssertions.pathParameter is used to define path parameter rules. There are [4 lifecycle triggers](./Reference.md#assertions) for registering rules which defines when they are triggered. A rule can be defined by passing in a condition (`string`), and an assertion, which is a function that receives an [`PathParameter` object](./DataShapes.md#queryparameter--pathparameter--headerparameter--cookieparameter). Throwing a `RuleError` represents a failure, RuleError [details below](./Reference.md#rule-error).
+operationAssertions.pathParameter is used to define path parameter rules. There are [4 lifecycle triggers](./Reference.md#assertions) for registering rules which defines when they are triggered. A rule can be defined by passing in an assertion, which is a function that receives an [`PathParameter` object](./DataShapes.md#queryparameter--pathparameter--headerparameter--cookieparameter). Throwing a `RuleError` represents a failure, RuleError [details below](./Reference.md#rule-error).
 
-`operationAssertions.pathParameter[lifecycle](condition, assertion)`
+`operationAssertions.pathParameter[lifecycle](assertion)`
 
 ```javascript
 new OperationRule({
@@ -286,9 +286,9 @@ new OperationRule({
 
 ## operationAssertions.headerParameter
 
-operationAssertions.headerParameter is used to define header parameter rules. There are [4 lifecycle triggers](./Reference.md#assertions) for registering rules which defines when they are triggered. A rule can be defined by passing in a condition (`string`), and an assertion, which is a function that receives an [`HeaderParameter` object](./DataShapes.md#queryparameter--pathparameter--headerparameter--cookieparameter). Throwing a `RuleError` represents a failure, RuleError [details below](./Reference.md#rule-error).
+operationAssertions.headerParameter is used to define header parameter rules. There are [4 lifecycle triggers](./Reference.md#assertions) for registering rules which defines when they are triggered. A rule can be defined by passing in an assertion, which is a function that receives an [`HeaderParameter` object](./DataShapes.md#queryparameter--pathparameter--headerparameter--cookieparameter). Throwing a `RuleError` represents a failure, RuleError [details below](./Reference.md#rule-error).
 
-`operationAssertions.headerParameter[lifecycle](condition, assertion)`
+`operationAssertions.headerParameter[lifecycle](assertion)`
 
 ```javascript
 new OperationRule({
@@ -308,9 +308,9 @@ new OperationRule({
 
 ## operationAssertions.cookieParameter
 
-operationAssertions.cookieParameter is used to define cookie parameter rules. There are [4 lifecycle triggers](./Reference.md#assertions) for registering rules which defines when they are triggered. A rule can be defined by passing in a condition (`string`), and an assertion, which is a function that receives an [`CookieParameter` object](./DataShapes.md#queryparameter--pathparameter--headerparameter--cookieparameter). Throwing a `RuleError` represents a failure, RuleError [details below](./Reference.md#rule-error).
+operationAssertions.cookieParameter is used to define cookie parameter rules. There are [4 lifecycle triggers](./Reference.md#assertions) for registering rules which defines when they are triggered. A rule can be defined by passing in an assertion, which is a function that receives an [`CookieParameter` object](./DataShapes.md#queryparameter--pathparameter--headerparameter--cookieparameter). Throwing a `RuleError` represents a failure, RuleError [details below](./Reference.md#rule-error).
 
-`operationAssertions.cookieParameter[lifecycle](condition, assertion)`
+`operationAssertions.cookieParameter[lifecycle](assertion)`
 
 ```javascript
 new OperationRule({

--- a/projects/rulesets-base/docs/PropertyRule.md
+++ b/projects/rulesets-base/docs/PropertyRule.md
@@ -1,0 +1,64 @@
+# PropertyRule
+
+Creates an PropertyRule. An PropertyRule allows you to write assertions around the root open api metadata in your API Specification.
+
+```javascript
+new PropertyRule({
+  name: 'require x-stability',
+  rule: (propertyAssertions) => {
+    propertyAssertions.removed('not remove request', () => {
+      throw new RuleError({
+        message: 'cannot remove an request',
+      });
+    });
+  },
+});
+```
+
+`new PropertyRule(options)`
+
+The following table describes the options object.
+
+| property | description                                                                                                                                                                                               | required | type                                                                   |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ---------------------------------------------------------------------- |
+| name     | the name of the rule                                                                                                                                                                                      | yes      | `string`                                                               |
+| matches  | A function used to determine when this Rule should be applied. Return true to indicate this Rule should run.                                                                                              | no       | `(property: Property, ruleContext: RuleContext) => boolean`              |
+| docsLink | A link to the documentation for this ruleset. This will be used to show the user on a rule error. If there is a more specific docsLink (e.g. on a nested Rule), the more specific docsLink will be shown) | no       | `string`                                                               |
+| rule     | A function to define assertions for a property.                                                                                                                                                      | yes      | `(propertyAssertions: PropertyAssertions, ruleContext: RuleContext) => void` |
+
+## matches
+
+`matches` is invoked with a `Property` and `RuleContext` objects. The `Property` object shape is [described here](./DataShapes.md#property). The [RuleContext object](./DataShapes.md#rulecontext) contains details about the location, and any [custom context](./Reference.md#custom-context). Return a boolean to indicate whether this rule should be run on the `Property` provided.
+
+Example:
+
+```javascript
+new PropertyRule({
+  ...,
+  // only runs on properties that have type 'number'
+  matches: (property, ruleContext) => property.value.flatSchema.type === 'number',
+  ...
+});
+```
+
+## propertyAssertions
+
+propertyAssertions is used to define property rules. There are [4 lifecycle triggers](./Reference.md#assertions) for registering rules which defines when they are triggered. A rule can be defined by an assertion, which is a function that receives a [`Property` object](./DataShapes.md#property). Throwing a `RuleError` represents a failure, RuleError [details below](./Reference.md#rule-error).
+
+`propertyAssertions[lifecycle](assertion)`
+
+```javascript
+new PropertyRule({
+  ...,
+  rule: (propertyAssertions) => {
+    // lifecycle rules that are available are added, changed, addedOrChanged, requirement and removed
+    propertyAssertions.added('contains a description', (property) => {
+      if (!property.value.description) {
+        throw new RuleError({
+          message: 'properties must contain a description',
+        });
+      }
+    });
+  },
+});
+```

--- a/projects/rulesets-base/docs/Reference.md
+++ b/projects/rulesets-base/docs/Reference.md
@@ -1,11 +1,12 @@
 # Rules
 
-There are 5 different rules you can use to enforce API Changes. These are:
+There are 6 different rules you can use to enforce API Changes. These are:
 
 - [OperationRule](./OperationRule.md)
 - [RequestRule]('./RequestRule.md')
 - [ResponseRule]('./ResponseRule.md)
 - [ResponseBodyRule]('./ResponseBodyRule.md)
+- [PropertyRule]('./PropertyRule.md)
 - [SpecificationRule]('./SpecificationRule.md')
 
 Rules can be grouped together into a [Ruleset](./Ruleset.md).

--- a/projects/rulesets-base/docs/RequestRule.md
+++ b/projects/rulesets-base/docs/RequestRule.md
@@ -43,9 +43,9 @@ new RequestRule({
 
 ## requestAssertions.body
 
-requestAssertions.body is used to define request rules. There are [4 lifecycle triggers](./Reference.md#assertions) for registering rules which defines when they are triggered. A rule can be defined by passing in a condition (`string`), and an assertion, which is a function that receives a [`RequestBody` object](./DataShapes.md#requestbody). Throwing a `RuleError` represents a failure, RuleError [details below](./Reference.md#rule-error).
+requestAssertions.body is used to define request rules. There are [4 lifecycle triggers](./Reference.md#assertions) for registering rules which defines when they are triggered. A rule can be defined by passing in an assertion, which is a function that receives a [`RequestBody` object](./DataShapes.md#requestbody). Throwing a `RuleError` represents a failure, RuleError [details below](./Reference.md#rule-error).
 
-`requestAssertions.body[lifecycle](condition, assertion)`
+`requestAssertions.body[lifecycle](assertion)`
 
 ```javascript
 new RequestRule({
@@ -115,9 +115,9 @@ new RequestRule({
 
 ## requestAssertions.property
 
-requestAssertions.property is used to define request body property rules. There are [4 lifecycle triggers](./Reference.md#assertions) for registering rules which defines when they are triggered. A rule can be defined by passing in a condition (`string`), and an assertion, which is a function that receives a [`Field` object](./DataShapes.md#field). Throwing a `RuleError` represents a failure, RuleError [details below](./Reference.md#rule-error).
+requestAssertions.property is used to define request body property rules. There are [4 lifecycle triggers](./Reference.md#assertions) for registering rules which defines when they are triggered. A rule can be defined by passing in an assertion, which is a function that receives a [`Field` object](./DataShapes.md#field). Throwing a `RuleError` represents a failure, RuleError [details below](./Reference.md#rule-error).
 
-`requestAssertions.property[lifecycle](condition, assertion)`
+`requestAssertions.property[lifecycle](assertion)`
 
 ```javascript
 new RequestRule({

--- a/projects/rulesets-base/docs/ResponseBodyRule.md
+++ b/projects/rulesets-base/docs/ResponseBodyRule.md
@@ -47,9 +47,9 @@ new ResponseBodyRule({
 
 ## responseBodyAssertions.body
 
-responseBodyAssertions.body is used to define response rules. There are [4 lifecycle triggers](./Reference.md#assertions) for registering rules which defines when they are triggered. A rule can be defined by passing in a condition (`string`), and an assertion, which is a function that receives a [`ResponseBody` object](./DataShapes.md#responsebody). Throwing a `RuleError` represents a failure, RuleError [details below](./Reference.md#rule-error).
+responseBodyAssertions.body is used to define response rules. There are [4 lifecycle triggers](./Reference.md#assertions) for registering rules which defines when they are triggered. A rule can be defined by passing in an assertion, which is a function that receives a [`ResponseBody` object](./DataShapes.md#responsebody). Throwing a `RuleError` represents a failure, RuleError [details below](./Reference.md#rule-error).
 
-`responseBodyAssertions.body[lifecycle](condition, assertion)`
+`responseBodyAssertions.body[lifecycle](assertion)`
 
 ```javascript
 new ResponseBodyRule({
@@ -119,9 +119,9 @@ new ResponseBodyRule({
 
 ## responseBodyAssertions.property
 
-responseBodyAssertions.property is used to define response body property rules. There are [4 lifecycle triggers](./Reference.md#assertions) for registering rules which defines when they are triggered. A rule can be defined by passing in a condition (`string`), and an assertion, which is a function that receives a [`Field` object](./DataShapes.md#field). Throwing a `RuleError` represents a failure, RuleError [details below](./Reference.md#rule-error).
+responseBodyAssertions.property is used to define response body property rules. There are [4 lifecycle triggers](./Reference.md#assertions) for registering rules which defines when they are triggered. A rule can be defined by passing in an assertion, which is a function that receives a [`Field` object](./DataShapes.md#field). Throwing a `RuleError` represents a failure, RuleError [details below](./Reference.md#rule-error).
 
-`responseBodyAssertions.property[lifecycle](condition, assertion)`
+`responseBodyAssertions.property[lifecycle](assertion)`
 
 ```javascript
 new ResponseBodyRule({

--- a/projects/rulesets-base/docs/ResponseRule.md
+++ b/projects/rulesets-base/docs/ResponseRule.md
@@ -46,9 +46,9 @@ new ResponseRule({
 
 ## responseAssertions
 
-responseAssertions is used to define response rules. There are [4 lifecycle triggers](./Reference.md#assertions) for registering rules which defines when they are triggered. A rule can be defined by passing in a condition (`string`), and an assertion, which is a function that receives a [`Response` object](./DataShapes.md#response). Throwing a `RuleError` represents a failure, RuleError [details below](./Reference.md#rule-error).
+responseAssertions is used to define response rules. There are [4 lifecycle triggers](./Reference.md#assertions) for registering rules which defines when they are triggered. A rule can be defined by passing in an assertion, which is a function that receives a [`Response` object](./DataShapes.md#response). Throwing a `RuleError` represents a failure, RuleError [details below](./Reference.md#rule-error).
 
-`responseAssertions[lifecycle](condition, assertion)`
+`responseAssertions[lifecycle](assertion)`
 
 ```javascript
 new ResponseRule({
@@ -97,9 +97,9 @@ new ResponseRule({
 
 ## responseAssertions.header
 
-responseAssertions.header is used to define response header rules. There are [4 lifecycle triggers](./Reference.md#assertions) for registering rules which defines when they are triggered. A rule can be defined by passing in a condition (`string`), and an assertion, which is a function that receives a [`Response Header` object](./DataShapes.md#responseheader). Throwing a `RuleError` represents a failure, RuleError [details below](./Reference.md#rule-error).
+responseAssertions.header is used to define response header rules. There are [4 lifecycle triggers](./Reference.md#assertions) for registering rules which defines when they are triggered. A rule can be defined by passing in an assertion, which is a function that receives a [`Response Header` object](./DataShapes.md#responseheader). Throwing a `RuleError` represents a failure, RuleError [details below](./Reference.md#rule-error).
 
-`responseAssertions.header[lifecycle](condition, assertion)`
+`responseAssertions.header[lifecycle](assertion)`
 
 ```javascript
 new ResponseRule({

--- a/projects/rulesets-base/docs/SpecificationRule.md
+++ b/projects/rulesets-base/docs/SpecificationRule.md
@@ -43,9 +43,9 @@ new SpecificationRule({
 
 ## specificationAssertions
 
-specificationAssertions is used to define specification rules. There are [4 lifecycle triggers](./Reference.md#assertions) for registering rules which defines when they are triggered. A rule can be defined by passing in a condition (`string`), and an assertion, which is a function that receives a [`Specification` object](./DataShapes.md#specification). Throwing a `RuleError` represents a failure, RuleError [details below](./Reference.md#rule-error).
+specificationAssertions is used to define specification rules. There are [4 lifecycle triggers](./Reference.md#assertions) for registering rules which defines when they are triggered. A rule can be defined by passing in an assertion, which is a function that receives a [`Specification` object](./DataShapes.md#specification). Throwing a `RuleError` represents a failure, RuleError [details below](./Reference.md#rule-error).
 
-`specificationAssertions[lifecycle](condition, assertion)`
+`specificationAssertions[lifecycle](assertion)`
 
 ```javascript
 new SpecificationRule({

--- a/projects/rulesets-base/src/__tests__/__snapshots__/operation-rules.test.ts.snap
+++ b/projects/rulesets-base/src/__tests__/__snapshots__/operation-rules.test.ts.snap
@@ -3032,7 +3032,7 @@ Object {
     },
   },
   "specification": Object {
-    "change": "changed",
+    "change": "removed",
     "location": Object {
       "conceptualLocation": Object {},
       "conceptualPath": Array [],

--- a/projects/rulesets-base/src/__tests__/__snapshots__/property-rules.test.ts.snap
+++ b/projects/rulesets-base/src/__tests__/__snapshots__/property-rules.test.ts.snap
@@ -1,0 +1,854 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PropertyRule assertions added failing assertion 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "added": Object {
+        "flatSchema": Object {},
+        "key": "hello",
+        "required": false,
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": Array [
+            "hello",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "application/json",
+          "hello",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/requestBody/content/application~1json/schema/properties/hello",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": "field does not have \`type\`",
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "property",
+    "passed": false,
+    "received": undefined,
+    "type": "added",
+    "where": "GET /api/users request body: application/json property: hello",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "flatSchema": Object {},
+        "key": "goodthings",
+        "required": false,
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": Array [
+            "goodthings",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "goodthings",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200/content/application~1json/schema/properties/goodthings",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": "field does not have \`type\`",
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "property",
+    "passed": false,
+    "received": undefined,
+    "type": "added",
+    "where": "GET /api/users response 200 response body: application/json property goodthings",
+  },
+]
+`;
+
+exports[`PropertyRule assertions added passing assertion 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "added": Object {
+        "flatSchema": Object {
+          "type": "string",
+        },
+        "key": "hello",
+        "required": false,
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": Array [
+            "hello",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "application/json",
+          "hello",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/requestBody/content/application~1json/schema/properties/hello",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "property",
+    "passed": true,
+    "received": undefined,
+    "type": "added",
+    "where": "GET /api/users request body: application/json property: hello",
+  },
+  Object {
+    "change": Object {
+      "added": Object {
+        "flatSchema": Object {
+          "type": "string",
+        },
+        "key": "goodthings",
+        "required": false,
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": Array [
+            "goodthings",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "goodthings",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200/content/application~1json/schema/properties/goodthings",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "property",
+    "passed": true,
+    "received": undefined,
+    "type": "added",
+    "where": "GET /api/users response 200 response body: application/json property goodthings",
+  },
+]
+`;
+
+exports[`PropertyRule assertions addedOrChanged failing assertion 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "added": Object {
+        "flatSchema": Object {},
+        "key": "hello",
+        "required": false,
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": Array [
+            "hello",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "application/json",
+          "hello",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/requestBody/content/application~1json/schema/properties/hello",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": "field does not have \`type\`",
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "property",
+    "passed": false,
+    "received": undefined,
+    "type": "added",
+    "where": "GET /api/users request body: application/json property: hello",
+  },
+  Object {
+    "change": Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "flatSchema": Object {
+            "description": "blah",
+          },
+          "key": "goodthings",
+          "required": false,
+        },
+        "before": Object {
+          "flatSchema": Object {},
+          "key": "goodthings",
+          "required": false,
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": Array [
+            "goodthings",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "goodthings",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200/content/application~1json/schema/properties/goodthings",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": "field does not have \`type\`",
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "property",
+    "passed": false,
+    "received": undefined,
+    "type": "changed",
+    "where": "GET /api/users response 200 response body: application/json property goodthings",
+  },
+]
+`;
+
+exports[`PropertyRule assertions addedOrChanged passing assertion 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "added": Object {
+        "flatSchema": Object {
+          "type": "string",
+        },
+        "key": "hello",
+        "required": false,
+      },
+      "changeType": "added",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": Array [
+            "hello",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "application/json",
+          "hello",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/requestBody/content/application~1json/schema/properties/hello",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "property",
+    "passed": true,
+    "received": undefined,
+    "type": "added",
+    "where": "GET /api/users request body: application/json property: hello",
+  },
+  Object {
+    "change": Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "flatSchema": Object {
+            "description": "blah",
+            "type": "string",
+          },
+          "key": "goodthings",
+          "required": false,
+        },
+        "before": Object {
+          "flatSchema": Object {
+            "type": "string",
+          },
+          "key": "goodthings",
+          "required": false,
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": Array [
+            "goodthings",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "goodthings",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200/content/application~1json/schema/properties/goodthings",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "property",
+    "passed": true,
+    "received": undefined,
+    "type": "changed",
+    "where": "GET /api/users response 200 response body: application/json property goodthings",
+  },
+]
+`;
+
+exports[`PropertyRule assertions changed failing assertion 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "flatSchema": Object {
+            "description": "blah",
+            "type": "number",
+          },
+          "key": "goodthings",
+          "required": false,
+        },
+        "before": Object {
+          "flatSchema": Object {
+            "type": "string",
+          },
+          "key": "goodthings",
+          "required": false,
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": Array [
+            "goodthings",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "goodthings",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200/content/application~1json/schema/properties/goodthings",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": "field \`type\` is changed",
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "property",
+    "passed": false,
+    "received": undefined,
+    "type": "changed",
+    "where": "GET /api/users response 200 response body: application/json property goodthings",
+  },
+]
+`;
+
+exports[`PropertyRule assertions changed passing assertion 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "changeType": "changed",
+      "changed": Object {
+        "after": Object {
+          "flatSchema": Object {
+            "description": "blah",
+            "type": "string",
+          },
+          "key": "goodthings",
+          "required": false,
+        },
+        "before": Object {
+          "flatSchema": Object {
+            "type": "string",
+          },
+          "key": "goodthings",
+          "required": false,
+        },
+      },
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": Array [
+            "goodthings",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "goodthings",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200/content/application~1json/schema/properties/goodthings",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "property",
+    "passed": true,
+    "received": undefined,
+    "type": "changed",
+    "where": "GET /api/users response 200 response body: application/json property goodthings",
+  },
+]
+`;
+
+exports[`PropertyRule assertions removed failing assertion 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "changeType": "removed",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": Array [
+            "goodthings",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "goodthings",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200/content/application~1json/schema/properties/goodthings",
+        "kind": "field",
+      },
+      "removed": Object {
+        "before": Object {
+          "flatSchema": Object {
+            "type": "number",
+          },
+          "key": "goodthings",
+          "required": false,
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": "cannot remove fields with type: number",
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "property",
+    "passed": false,
+    "received": undefined,
+    "type": "removed",
+    "where": "GET /api/users response 200 response body: application/json property goodthings",
+  },
+]
+`;
+
+exports[`PropertyRule assertions removed passing assertion 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "changeType": "removed",
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": Array [
+            "goodthings",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "goodthings",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200/content/application~1json/schema/properties/goodthings",
+        "kind": "field",
+      },
+      "removed": Object {
+        "before": Object {
+          "flatSchema": Object {
+            "type": "string",
+          },
+          "key": "goodthings",
+          "required": false,
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "property",
+    "passed": true,
+    "received": undefined,
+    "type": "removed",
+    "where": "GET /api/users response 200 response body: application/json property goodthings",
+  },
+]
+`;
+
+exports[`PropertyRule assertions requirement failing assertion 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": Array [
+            "hello",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "application/json",
+          "hello",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/requestBody/content/application~1json/schema/properties/hello",
+        "kind": "field",
+      },
+      "value": Object {
+        "flatSchema": Object {},
+        "key": "hello",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": "field does not have \`type\`",
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "property",
+    "passed": false,
+    "received": undefined,
+    "type": "requirement",
+    "where": "GET /api/users request body: application/json property: hello",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": Array [
+            "goodthings",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "goodthings",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200/content/application~1json/schema/properties/goodthings",
+        "kind": "field",
+      },
+      "value": Object {
+        "flatSchema": Object {},
+        "key": "goodthings",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": "field does not have \`type\`",
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "property",
+    "passed": false,
+    "received": undefined,
+    "type": "requirement",
+    "where": "GET /api/users response 200 response body: application/json property goodthings",
+  },
+]
+`;
+
+exports[`PropertyRule assertions requirement passing assertion 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": Array [
+            "hello",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "application/json",
+          "hello",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/requestBody/content/application~1json/schema/properties/hello",
+        "kind": "field",
+      },
+      "value": Object {
+        "flatSchema": Object {
+          "type": "string",
+        },
+        "key": "hello",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "property",
+    "passed": true,
+    "received": undefined,
+    "type": "requirement",
+    "where": "GET /api/users request body: application/json property: hello",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": Array [
+            "goodthings",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "goodthings",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200/content/application~1json/schema/properties/goodthings",
+        "kind": "field",
+      },
+      "value": Object {
+        "flatSchema": Object {
+          "type": "string",
+        },
+        "key": "goodthings",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "property",
+    "passed": true,
+    "received": undefined,
+    "type": "requirement",
+    "where": "GET /api/users response 200 response body: application/json property goodthings",
+  },
+]
+`;

--- a/projects/rulesets-base/src/__tests__/__snapshots__/specification-rules.test.ts.snap
+++ b/projects/rulesets-base/src/__tests__/__snapshots__/specification-rules.test.ts.snap
@@ -325,7 +325,19 @@ Object {
         "version": "0.0.0",
       },
       "openapi": "3.1.0",
-      "paths": Object {},
+      "paths": Object {
+        "/api/users": Object {
+          "get": Object {
+            "description": "hello",
+            "responses": Object {},
+          },
+        },
+      },
+      "servers": Array [
+        Object {
+          "url": "http://optic.com",
+        },
+      ],
     },
     "value": Object {
       "info": Object {
@@ -333,6 +345,11 @@ Object {
         "version": "0.0.0",
       },
       "openapi": "3.1.0",
+      "servers": Array [
+        Object {
+          "url": "http://optic.com",
+        },
+      ],
     },
   },
 }
@@ -443,7 +460,7 @@ Object {
     },
   },
   "specification": Object {
-    "change": "changed",
+    "change": "removed",
     "location": Object {
       "conceptualLocation": Object {},
       "conceptualPath": Array [],
@@ -530,8 +547,19 @@ Object {
         "version": "0.0.0",
       },
       "openapi": "3.1.0",
-      "paths": Object {},
-      "x-optic-ci-empty-spec": true,
+      "paths": Object {
+        "/api/users": Object {
+          "get": Object {
+            "description": "hello",
+            "responses": Object {},
+          },
+        },
+      },
+      "servers": Array [
+        Object {
+          "url": "http://optic.com",
+        },
+      ],
     },
     "value": Object {
       "info": Object {
@@ -539,7 +567,11 @@ Object {
         "version": "0.0.0",
       },
       "openapi": "3.1.0",
-      "x-optic-ci-empty-spec": true,
+      "servers": Array [
+        Object {
+          "url": "http://optic.com",
+        },
+      ],
     },
   },
 }

--- a/projects/rulesets-base/src/__tests__/operation-rules.test.ts
+++ b/projects/rulesets-base/src/__tests__/operation-rules.test.ts
@@ -52,6 +52,10 @@ describe('OperationRule', () => {
   });
 
   describe('rulesContext', () => {
+    const emptySpec = {
+      ...defaultEmptySpec,
+      ['x-optic-ci-empty-spec']: true
+    } as any
     const json: OpenAPIV3.Document = {
       ...defaultEmptySpec,
       servers: [{ url: 'http://optic.com' }],
@@ -73,7 +77,7 @@ describe('OperationRule', () => {
         }),
       ]);
 
-      ruleRunner.runRulesWithFacts(createRuleInputs(json, defaultEmptySpec));
+      ruleRunner.runRulesWithFacts(createRuleInputs(json, emptySpec));
 
       expect(mockFn.mock.calls.length > 0).toBe(true);
       const ruleContext = mockFn.mock.calls[0][1];

--- a/projects/rulesets-base/src/__tests__/property-rules.test.ts
+++ b/projects/rulesets-base/src/__tests__/property-rules.test.ts
@@ -1,0 +1,714 @@
+import { defaultEmptySpec, OpenAPIV3 } from '@useoptic/openapi-utilities';
+import { RuleError } from '../errors';
+import { RuleRunner } from '../rule-runner';
+import { PropertyRule } from '../rules';
+import { createRuleInputs } from '../test-helpers';
+
+describe('PropertyRule', () => {
+  describe('matches', () => {
+    const json: OpenAPIV3.Document = {
+      ...defaultEmptySpec,
+      paths: {
+        '/api/users': {
+          get: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      goodbye: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            responses: {},
+          },
+        },
+        '/api/users/{userId}': {
+          get: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      hello: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            responses: {},
+          },
+        },
+      },
+    };
+
+    test('matches property', () => {
+      const mockFn = jest.fn();
+      const ruleRunner = new RuleRunner([
+        new PropertyRule({
+          name: 'property',
+          matches: (_, ruleContext) =>
+            ruleContext.operation.method === 'get' &&
+            ruleContext.operation.path === '/api/users/{userId}',
+          rule: (propertyAssertions) => {
+            propertyAssertions.requirement(mockFn);
+          },
+        }),
+      ]);
+      ruleRunner.runRulesWithFacts(createRuleInputs(json, json));
+
+      expect(mockFn.mock.calls.length).toBe(1);
+      const propertyFromCallArg = mockFn.mock.calls[0][0];
+      expect(propertyFromCallArg.value.key).toBe('hello');
+    });
+  });
+
+  describe('assertions', () => {
+    describe('requirement', () => {
+      const ruleRunner = new RuleRunner([
+        new PropertyRule({
+          name: 'property',
+          rule: (propertyAssertions) => {
+            propertyAssertions.requirement((property) => {
+              if (!property.value.flatSchema.type) {
+                throw new RuleError({
+                  message: 'field does not have `type`',
+                });
+              }
+            });
+          },
+        }),
+      ]);
+
+      test('passing assertion', () => {
+        const json: OpenAPIV3.Document = {
+          ...defaultEmptySpec,
+          paths: {
+            '/api/users': {
+              get: {
+                requestBody: {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'object',
+                        properties: {
+                          hello: {
+                            type: 'string',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+                responses: {
+                  '200': {
+                    description: 'hello',
+                    content: {
+                      'application/json': {
+                        schema: {
+                          type: 'object',
+                          properties: {
+                            goodthings: {
+                              type: 'string',
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        };
+        const results = ruleRunner.runRulesWithFacts(
+          createRuleInputs(json, json)
+        );
+        expect(results).toMatchSnapshot();
+        expect(results.length > 0).toBe(true);
+        for (const result of results) {
+          expect(result.passed).toBe(true);
+        }
+      });
+
+      test('failing assertion', () => {
+        const json: OpenAPIV3.Document = {
+          ...defaultEmptySpec,
+          paths: {
+            '/api/users': {
+              get: {
+                requestBody: {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'object',
+                        properties: {
+                          hello: {},
+                        },
+                      },
+                    },
+                  },
+                },
+                responses: {
+                  '200': {
+                    description: 'hello',
+                    content: {
+                      'application/json': {
+                        schema: {
+                          type: 'object',
+                          properties: {
+                            goodthings: {},
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        };
+        const results = ruleRunner.runRulesWithFacts(
+          createRuleInputs(json, json)
+        );
+        expect(results).toMatchSnapshot();
+        expect(results.length > 0).toBe(true);
+        for (const result of results) {
+          expect(result.passed).toBe(false);
+        }
+      });
+    });
+
+    describe('added', () => {
+      const ruleRunner = new RuleRunner([
+        new PropertyRule({
+          name: 'property',
+          rule: (propertyAssertions) => {
+            propertyAssertions.added((property) => {
+              if (!property.value.flatSchema.type) {
+                throw new RuleError({
+                  message: 'field does not have `type`',
+                });
+              }
+            });
+          },
+        }),
+      ]);
+
+      test('passing assertion', () => {
+        const json: OpenAPIV3.Document = {
+          ...defaultEmptySpec,
+          paths: {
+            '/api/users': {
+              get: {
+                requestBody: {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'object',
+                        properties: {
+                          hello: {
+                            type: 'string',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+                responses: {
+                  '200': {
+                    description: 'hello',
+                    content: {
+                      'application/json': {
+                        schema: {
+                          type: 'object',
+                          properties: {
+                            goodthings: {
+                              type: 'string',
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        };
+        const results = ruleRunner.runRulesWithFacts(
+          createRuleInputs(defaultEmptySpec, json)
+        );
+        expect(results).toMatchSnapshot();
+        expect(results.length > 0).toBe(true);
+        for (const result of results) {
+          expect(result.passed).toBe(true);
+        }
+      });
+
+      test('failing assertion', () => {
+        const json: OpenAPIV3.Document = {
+          ...defaultEmptySpec,
+          paths: {
+            '/api/users': {
+              get: {
+                requestBody: {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'object',
+                        properties: {
+                          hello: {},
+                        },
+                      },
+                    },
+                  },
+                },
+                responses: {
+                  '200': {
+                    description: 'hello',
+                    content: {
+                      'application/json': {
+                        schema: {
+                          type: 'object',
+                          properties: {
+                            goodthings: {},
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        };
+        const results = ruleRunner.runRulesWithFacts(
+          createRuleInputs(defaultEmptySpec, json)
+        );
+        expect(results).toMatchSnapshot();
+        expect(results.length > 0).toBe(true);
+        for (const result of results) {
+          expect(result.passed).toBe(false);
+        }
+      });
+    });
+
+    describe('addedOrChanged', () => {
+      const ruleRunner = new RuleRunner([
+        new PropertyRule({
+          name: 'property',
+          rule: (propertyAssertions) => {
+            propertyAssertions.addedOrChanged((property) => {
+              if (!property.value.flatSchema.type) {
+                throw new RuleError({
+                  message: 'field does not have `type`',
+                });
+              }
+            });
+          },
+        }),
+      ]);
+
+      test('passing assertion', () => {
+        const beforeJson: OpenAPIV3.Document = {
+          ...defaultEmptySpec,
+          paths: {
+            '/api/users': {
+              get: {
+                responses: {
+                  '200': {
+                    description: 'hello',
+                    content: {
+                      'application/json': {
+                        schema: {
+                          type: 'object',
+                          properties: {
+                            goodthings: {
+                              type: 'string',
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        };
+        const afterJson: OpenAPIV3.Document = {
+          ...defaultEmptySpec,
+          paths: {
+            '/api/users': {
+              get: {
+                requestBody: {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'object',
+                        properties: {
+                          hello: {
+                            type: 'string',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+                responses: {
+                  '200': {
+                    description: 'hello',
+                    content: {
+                      'application/json': {
+                        schema: {
+                          type: 'object',
+                          properties: {
+                            goodthings: {
+                              type: 'string',
+                              description: 'blah',
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        };
+        const results = ruleRunner.runRulesWithFacts(
+          createRuleInputs(beforeJson, afterJson)
+        );
+        expect(results).toMatchSnapshot();
+        expect(results.length > 0).toBe(true);
+        for (const result of results) {
+          expect(result.passed).toBe(true);
+        }
+      });
+
+      test('failing assertion', () => {
+        const beforeJson: OpenAPIV3.Document = {
+          ...defaultEmptySpec,
+          paths: {
+            '/api/users': {
+              get: {
+                responses: {
+                  '200': {
+                    description: 'hello',
+                    content: {
+                      'application/json': {
+                        schema: {
+                          type: 'object',
+                          properties: {
+                            goodthings: {},
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        };
+        const afterJson: OpenAPIV3.Document = {
+          ...defaultEmptySpec,
+          paths: {
+            '/api/users': {
+              get: {
+                requestBody: {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'object',
+                        properties: {
+                          hello: {},
+                        },
+                      },
+                    },
+                  },
+                },
+                responses: {
+                  '200': {
+                    description: 'hello',
+                    content: {
+                      'application/json': {
+                        schema: {
+                          type: 'object',
+                          properties: {
+                            goodthings: {
+                              description: 'blah',
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        };
+        const results = ruleRunner.runRulesWithFacts(
+          createRuleInputs(beforeJson, afterJson)
+        );
+        expect(results).toMatchSnapshot();
+        expect(results.length > 0).toBe(true);
+        for (const result of results) {
+          expect(result.passed).toBe(false);
+        }
+      });
+    });
+
+    describe('changed', () => {
+      const ruleRunner = new RuleRunner([
+        new PropertyRule({
+          name: 'property',
+          rule: (propertyAssertions) => {
+            propertyAssertions.changed(
+              'must not change type',
+              (before, after) => {
+                if (
+                  before.value.flatSchema.type !== after.value.flatSchema.type
+                ) {
+                  throw new RuleError({
+                    message: 'field `type` is changed',
+                  });
+                }
+              }
+            );
+          },
+        }),
+      ]);
+
+      test('passing assertion', () => {
+        const beforeJson: OpenAPIV3.Document = {
+          ...defaultEmptySpec,
+          paths: {
+            '/api/users': {
+              get: {
+                responses: {
+                  '200': {
+                    description: 'hello',
+                    content: {
+                      'application/json': {
+                        schema: {
+                          type: 'object',
+                          properties: {
+                            goodthings: {
+                              type: 'string',
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        };
+        const afterJson: OpenAPIV3.Document = {
+          ...defaultEmptySpec,
+          paths: {
+            '/api/users': {
+              get: {
+                responses: {
+                  '200': {
+                    description: 'hello',
+                    content: {
+                      'application/json': {
+                        schema: {
+                          type: 'object',
+                          properties: {
+                            goodthings: {
+                              type: 'string',
+                              description: 'blah',
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        };
+        const results = ruleRunner.runRulesWithFacts(
+          createRuleInputs(beforeJson, afterJson)
+        );
+        expect(results).toMatchSnapshot();
+        expect(results.length > 0).toBe(true);
+        for (const result of results) {
+          expect(result.passed).toBe(true);
+        }
+      });
+
+      test('failing assertion', () => {
+        const beforeJson: OpenAPIV3.Document = {
+          ...defaultEmptySpec,
+          paths: {
+            '/api/users': {
+              get: {
+                responses: {
+                  '200': {
+                    description: 'hello',
+                    content: {
+                      'application/json': {
+                        schema: {
+                          type: 'object',
+                          properties: {
+                            goodthings: {
+                              type: 'string',
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        };
+        const afterJson: OpenAPIV3.Document = {
+          ...defaultEmptySpec,
+          paths: {
+            '/api/users': {
+              get: {
+                responses: {
+                  '200': {
+                    description: 'hello',
+                    content: {
+                      'application/json': {
+                        schema: {
+                          type: 'object',
+                          properties: {
+                            goodthings: {
+                              type: 'number',
+                              description: 'blah',
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        };
+        const results = ruleRunner.runRulesWithFacts(
+          createRuleInputs(beforeJson, afterJson)
+        );
+        expect(results).toMatchSnapshot();
+        expect(results.length > 0).toBe(true);
+        for (const result of results) {
+          expect(result.passed).toBe(false);
+        }
+      });
+    });
+
+    describe('removed', () => {
+      const ruleRunner = new RuleRunner([
+        new PropertyRule({
+          name: 'property',
+          rule: (propertyAssertions) => {
+            propertyAssertions.removed((property) => {
+              if (property.value.flatSchema.type === 'number') {
+                throw new RuleError({
+                  message: 'cannot remove fields with type: number',
+                });
+              }
+            });
+          },
+        }),
+      ]);
+
+      test('passing assertion', () => {
+        const json: OpenAPIV3.Document = {
+          ...defaultEmptySpec,
+          paths: {
+            '/api/users': {
+              get: {
+                responses: {
+                  '200': {
+                    description: 'hello',
+                    content: {
+                      'application/json': {
+                        schema: {
+                          type: 'object',
+                          properties: {
+                            goodthings: {
+                              type: 'string',
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        };
+        const results = ruleRunner.runRulesWithFacts(
+          createRuleInputs(json, defaultEmptySpec)
+        );
+        expect(results).toMatchSnapshot();
+        expect(results.length > 0).toBe(true);
+        for (const result of results) {
+          expect(result.passed).toBe(true);
+        }
+      });
+
+      test('failing assertion', () => {
+        const json: OpenAPIV3.Document = {
+          ...defaultEmptySpec,
+          paths: {
+            '/api/users': {
+              get: {
+                responses: {
+                  '200': {
+                    description: 'hello',
+                    content: {
+                      'application/json': {
+                        schema: {
+                          type: 'object',
+                          properties: {
+                            goodthings: {
+                              type: 'number',
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        };
+        const results = ruleRunner.runRulesWithFacts(
+          createRuleInputs(json, defaultEmptySpec)
+        );
+        expect(results).toMatchSnapshot();
+        expect(results.length > 0).toBe(true);
+        for (const result of results) {
+          expect(result.passed).toBe(false);
+        }
+      });
+    });
+  });
+});

--- a/projects/rulesets-base/src/__tests__/specification-rules.test.ts
+++ b/projects/rulesets-base/src/__tests__/specification-rules.test.ts
@@ -31,7 +31,7 @@ describe('SpecificationRule', () => {
         }),
       ]);
 
-      ruleRunner.runRulesWithFacts(createRuleInputs(json, defaultEmptySpec));
+      ruleRunner.runRulesWithFacts(createRuleInputs(json, emptySpec));
 
       expect(mockFn.mock.calls.length > 0).toBe(true);
       const ruleContext = mockFn.mock.calls[0][1];

--- a/projects/rulesets-base/src/rule-runner/assertions.ts
+++ b/projects/rulesets-base/src/rule-runner/assertions.ts
@@ -381,3 +381,8 @@ export const createResponseBodyAssertions =
 
     return responseBodyAssertions as ResponseBodyAssertionsRunner;
   };
+
+export const createPropertyAssertions =
+  (): AssertionRunner<'property'> => {
+    return new AssertionRunner('property');
+  };

--- a/projects/rulesets-base/src/rule-runner/operation.ts
+++ b/projects/rulesets-base/src/rule-runner/operation.ts
@@ -1,9 +1,7 @@
 import { OpenApiKind, OpenAPIV3, Result } from '@useoptic/openapi-utilities';
 import { createOperation, createSpecification } from './data-constructors';
-import { RulesetData, EndpointNode, NodeDetail } from './rule-runner-types';
+import { EndpointNode, NodeDetail } from './rule-runner-types';
 import {
-  createRulesetMatcher,
-  getRuleAliases,
   createRuleContext,
   isExempted,
 } from './utils';
@@ -11,38 +9,7 @@ import {
 import { Rule, Ruleset, OperationRule } from '../rules';
 import { createOperationAssertions, AssertionResult } from './assertions';
 import { Operation } from '../types';
-
-const getOperationRules = (
-  rules: (Ruleset | Rule)[]
-): (OperationRule & RulesetData)[] => {
-  const operationRules: (OperationRule & RulesetData)[] = [];
-  for (const ruleOrRuleset of rules) {
-    if (OperationRule.isInstance(ruleOrRuleset)) {
-      operationRules.push({
-        ...ruleOrRuleset,
-        aliases: [],
-      });
-    }
-
-    if (Ruleset.isInstance(ruleOrRuleset)) {
-      for (const rule of ruleOrRuleset.rules) {
-        if (OperationRule.isInstance(rule)) {
-          operationRules.push({
-            ...rule,
-            matches: createRulesetMatcher({
-              ruleMatcher: rule.matches,
-              rulesetMatcher: ruleOrRuleset.matches,
-            }),
-            aliases: getRuleAliases(ruleOrRuleset.name, rule.name),
-            docsLink: rule.docsLink || ruleOrRuleset.docsLink,
-          });
-        }
-      }
-    }
-  }
-
-  return operationRules;
-};
+import { getOperationRules } from './rule-filters';
 
 const createOperationResult = (
   assertionResult: AssertionResult,

--- a/projects/rulesets-base/src/rule-runner/operation.ts
+++ b/projects/rulesets-base/src/rule-runner/operation.ts
@@ -2,7 +2,7 @@ import { OpenApiKind, OpenAPIV3, Result } from '@useoptic/openapi-utilities';
 import { createOperation, createSpecification } from './data-constructors';
 import { EndpointNode, NodeDetail } from './rule-runner-types';
 import {
-  createRuleContext,
+  createRuleContextWithOperation,
   isExempted,
 } from './utils';
 
@@ -105,13 +105,19 @@ export const runOperationRules = ({
   // - if yes, run the user's defined `rule`. for operations, this runs against the operation, headerParameters, queryParameters, pathParameters and cookie parameters
   for (const operationRule of operationRules) {
     if (beforeOperation && beforeSpecification) {
-      const ruleContext = createRuleContext({
-        operation: beforeOperation,
-        custom: customRuleContext,
-        operationChangeType: operationNode.change?.changeType || null,
-        specification: beforeSpecification,
-        specificationNode: specificationNode,
-      });
+      const ruleContext = createRuleContextWithOperation(
+        {
+          node: specificationNode,
+          before: beforeSpecification,
+          after: afterSpecification,
+        },
+        {
+          node: operationNode,
+          before: beforeOperation,
+          after: afterOperation,
+        },
+        customRuleContext
+      );
 
       const matches =
         !operationRule.matches ||
@@ -244,13 +250,19 @@ export const runOperationRules = ({
     }
 
     if (afterOperation && afterSpecification) {
-      const ruleContext = createRuleContext({
-        operation: afterOperation,
-        custom: customRuleContext,
-        operationChangeType: operationNode.change?.changeType || null,
-        specification: afterSpecification,
-        specificationNode: specificationNode,
-      });
+      const ruleContext = createRuleContextWithOperation(
+        {
+          node: specificationNode,
+          before: beforeSpecification,
+          after: afterSpecification,
+        },
+        {
+          node: operationNode,
+          before: beforeOperation,
+          after: afterOperation,
+        },
+        customRuleContext
+      );
 
       const matches =
         !operationRule.matches ||

--- a/projects/rulesets-base/src/rule-runner/request.ts
+++ b/projects/rulesets-base/src/rule-runner/request.ts
@@ -6,14 +6,11 @@ import {
   createSpecification,
 } from './data-constructors';
 import {
-  RulesetData,
   EndpointNode,
   RequestNode,
   NodeDetail,
 } from './rule-runner-types';
 import {
-  createRulesetMatcher,
-  getRuleAliases,
   createRuleContext,
   isExempted,
 } from './utils';
@@ -21,38 +18,7 @@ import {
 import { Rule, Ruleset, RequestRule } from '../rules';
 import { AssertionResult, createRequestAssertions } from './assertions';
 import { Field, Operation, RequestBody } from '../types';
-
-const getRequestRules = (
-  rules: (Ruleset | Rule)[]
-): (RequestRule & RulesetData)[] => {
-  const requestRules: (RequestRule & RulesetData)[] = [];
-  for (const ruleOrRuleset of rules) {
-    if (RequestRule.isInstance(ruleOrRuleset)) {
-      requestRules.push({
-        ...ruleOrRuleset,
-        aliases: [],
-      });
-    }
-
-    if (Ruleset.isInstance(ruleOrRuleset)) {
-      for (const rule of ruleOrRuleset.rules) {
-        if (RequestRule.isInstance(rule)) {
-          requestRules.push({
-            ...rule,
-            matches: createRulesetMatcher({
-              ruleMatcher: rule.matches,
-              rulesetMatcher: ruleOrRuleset.matches,
-            }),
-            aliases: getRuleAliases(ruleOrRuleset.name, rule.name),
-            docsLink: rule.docsLink || ruleOrRuleset.docsLink,
-          });
-        }
-      }
-    }
-  }
-
-  return requestRules;
-};
+import { getRequestRules } from './rule-filters';
 
 const createRequestBodyResult = (
   assertionResult: AssertionResult,

--- a/projects/rulesets-base/src/rule-runner/request.ts
+++ b/projects/rulesets-base/src/rule-runner/request.ts
@@ -11,7 +11,7 @@ import {
   NodeDetail,
 } from './rule-runner-types';
 import {
-  createRuleContext,
+  createRuleContextWithOperation,
   isExempted,
 } from './utils';
 
@@ -113,22 +113,19 @@ export const runRequestRules = ({
   // - if yes, run the user's defined `rule`. for requests, this runs against the request body and request properties
   for (const requestRule of requestRules) {
     if (beforeOperation && beforeSpecification) {
-      const ruleContext =
-        afterSpecification && afterOperation
-          ? createRuleContext({
-              operation: afterOperation,
-              custom: customRuleContext,
-              operationChangeType: operationNode.change?.changeType || null,
-              specification: afterSpecification,
-              specificationNode: specificationNode,
-            })
-          : createRuleContext({
-              operation: beforeOperation,
-              custom: customRuleContext,
-              operationChangeType: operationNode.change?.changeType || null,
-              specification: beforeSpecification,
-              specificationNode: specificationNode,
-            });
+      const ruleContext =createRuleContextWithOperation(
+        {
+          node: specificationNode,
+          before: beforeSpecification,
+          after: afterSpecification,
+        },
+        {
+          node: operationNode,
+          before: beforeOperation,
+          after: afterOperation,
+        },
+        customRuleContext
+      );
       const requestAssertions = createRequestAssertions();
       // Register the user's rule definition, this is collected in the requestAssertions object
       requestRule.rule(requestAssertions, ruleContext);
@@ -192,13 +189,19 @@ export const runRequestRules = ({
     }
 
     if (afterOperation && afterSpecification) {
-      const ruleContext = createRuleContext({
-        operation: afterOperation,
-        custom: customRuleContext,
-        operationChangeType: operationNode.change?.changeType || null,
-        specification: afterSpecification,
-        specificationNode: specificationNode,
-      });
+      const ruleContext = createRuleContextWithOperation(
+        {
+          node: specificationNode,
+          before: beforeSpecification,
+          after: afterSpecification,
+        },
+        {
+          node: operationNode,
+          before: beforeOperation,
+          after: afterOperation,
+        },
+        customRuleContext
+      );
       const requestAssertions = createRequestAssertions();
       // Register the user's rule definition, this is collected in the requestAssertions object
       requestRule.rule(requestAssertions, ruleContext);

--- a/projects/rulesets-base/src/rule-runner/request.ts
+++ b/projects/rulesets-base/src/rule-runner/request.ts
@@ -5,20 +5,17 @@ import {
   createRequest,
   createSpecification,
 } from './data-constructors';
-import {
-  EndpointNode,
-  RequestNode,
-  NodeDetail,
-} from './rule-runner-types';
-import {
-  createRuleContextWithOperation,
-  isExempted,
-} from './utils';
+import { EndpointNode, RequestNode, NodeDetail } from './rule-runner-types';
+import { createRuleContextWithOperation, isExempted } from './utils';
 
-import { Rule, Ruleset, RequestRule } from '../rules';
-import { AssertionResult, createRequestAssertions } from './assertions';
+import { Rule, Ruleset, RequestRule, PropertyRule } from '../rules';
+import {
+  AssertionResult,
+  createPropertyAssertions,
+  createRequestAssertions,
+} from './assertions';
 import { Field, Operation, RequestBody } from '../types';
-import { getRequestRules } from './rule-filters';
+import { getPropertyRules, getRequestRules } from './rule-filters';
 
 const createRequestBodyResult = (
   assertionResult: AssertionResult,
@@ -48,7 +45,7 @@ const createRequestPropertyResult = (
   property: Field,
   request: RequestBody,
   operation: Operation,
-  rule: RequestRule
+  rule: RequestRule | PropertyRule
 ): Result => ({
   type: assertionResult.type,
   where: `${operation.method.toUpperCase()} ${operation.path} request body: ${
@@ -87,6 +84,7 @@ export const runRequestRules = ({
 }) => {
   const results: Result[] = [];
   const requestRules = getRequestRules(rules);
+  const propertyRules = getPropertyRules(rules);
   const beforeSpecification = createSpecification(
     specificationNode,
     'before',
@@ -113,7 +111,7 @@ export const runRequestRules = ({
   // - if yes, run the user's defined `rule`. for requests, this runs against the request body and request properties
   for (const requestRule of requestRules) {
     if (beforeOperation && beforeSpecification) {
-      const ruleContext =createRuleContextWithOperation(
+      const ruleContext = createRuleContextWithOperation(
         {
           node: specificationNode,
           before: beforeSpecification,
@@ -268,6 +266,133 @@ export const runRequestRules = ({
                       afterRequest,
                       afterOperation,
                       requestRule
+                    )
+                  )
+              );
+            }
+          }
+        }
+      }
+    }
+  }
+
+  for (const propertyRule of propertyRules) {
+    if (beforeOperation && beforeSpecification) {
+      const ruleContext = createRuleContextWithOperation(
+        {
+          node: specificationNode,
+          before: beforeSpecification,
+          after: afterSpecification,
+        },
+        {
+          node: operationNode,
+          before: beforeOperation,
+          after: afterOperation,
+        },
+        customRuleContext
+      );
+      const propertyAssertions = createPropertyAssertions();
+      // // Register the user's rule definition, this is collected in the propertyAssertions object
+      propertyRule.rule(propertyAssertions, ruleContext);
+
+      for (const contentType of requestNode.bodies.keys()) {
+        const beforeRequest = createRequest(
+          requestNode,
+          contentType,
+          'before',
+          beforeApiSpec
+        );
+        if (beforeRequest) {
+          for (const [key, property] of beforeRequest.properties.entries()) {
+            const propertyChange =
+              requestNode.bodies.get(contentType)?.fields.get(key)?.change ||
+              null;
+            const matches =
+              !propertyRule.matches ||
+              propertyRule.matches(property, ruleContext);
+
+            const exempted = isExempted(property.raw, propertyRule.name);
+            if (matches) {
+              results.push(
+                ...propertyAssertions
+                  .runBefore(property, propertyChange, exempted)
+                  .map((assertionResult) =>
+                    createRequestPropertyResult(
+                      assertionResult,
+                      property,
+                      beforeRequest,
+                      beforeOperation,
+                      propertyRule
+                    )
+                  )
+              );
+            }
+          }
+        }
+      }
+    }
+
+    if (afterOperation && afterSpecification) {
+      const ruleContext = createRuleContextWithOperation(
+        {
+          node: specificationNode,
+          before: beforeSpecification,
+          after: afterSpecification,
+        },
+        {
+          node: operationNode,
+          before: beforeOperation,
+          after: afterOperation,
+        },
+        customRuleContext
+      );
+      // Register the user's rule definition, this is collected in the propertyAssertions object
+      const propertyAssertions = createPropertyAssertions();
+      // Run the user's rules that have been stored in propertyAssertions
+      propertyRule.rule(propertyAssertions, ruleContext);
+      for (const contentType of requestNode.bodies.keys()) {
+        const maybeBeforeRequest = createRequest(
+          requestNode,
+          contentType,
+          'before',
+          beforeApiSpec
+        );
+        const afterRequest = createRequest(
+          requestNode,
+          contentType,
+          'after',
+          afterApiSpec
+        );
+        if (afterRequest) {
+          for (const [key, property] of afterRequest.properties.entries()) {
+            const maybeBeforeProperty =
+              maybeBeforeRequest?.properties.get(key) || null;
+
+            const propertyChange =
+              requestNode.bodies.get(afterRequest.contentType)?.fields.get(key)
+                ?.change || null;
+            const matches =
+              !propertyRule.matches ||
+              propertyRule.matches(property, ruleContext);
+
+            const exempted = isExempted(property.raw, propertyRule.name);
+            if (matches) {
+              // Run the user's rules that have been stored in propertyAssertions for property
+              results.push(
+                ...propertyAssertions
+                  .runAfter(
+                    maybeBeforeProperty,
+                    property,
+                    propertyChange,
+                    exempted
+                  )
+                  .map((assertionResult) =>
+                    createRequestPropertyResult(
+                      assertionResult,
+                      property,
+                      afterRequest,
+                      afterOperation,
+                      propertyRule
                     )
                   )
               );

--- a/projects/rulesets-base/src/rule-runner/response-body.ts
+++ b/projects/rulesets-base/src/rule-runner/response-body.ts
@@ -6,53 +6,19 @@ import {
   createSpecification,
 } from './data-constructors';
 import {
-  RulesetData,
   EndpointNode,
   ResponseNode,
   NodeDetail,
 } from './rule-runner-types';
 import {
   createRuleContext,
-  createRulesetMatcher,
-  getRuleAliases,
   isExempted,
 } from './utils';
 
 import { Rule, Ruleset, ResponseBodyRule } from '../rules';
 import { AssertionResult, createResponseBodyAssertions } from './assertions';
 import { Field, Operation, ResponseBody } from '../types';
-
-const getResponseBodyRules = (
-  rules: (Ruleset | Rule)[]
-): (ResponseBodyRule & RulesetData)[] => {
-  const responseRule: (ResponseBodyRule & RulesetData)[] = [];
-  for (const ruleOrRuleset of rules) {
-    if (ResponseBodyRule.isInstance(ruleOrRuleset)) {
-      responseRule.push({
-        ...ruleOrRuleset,
-        aliases: [],
-      });
-    }
-
-    if (Ruleset.isInstance(ruleOrRuleset)) {
-      for (const rule of ruleOrRuleset.rules) {
-        if (ResponseBodyRule.isInstance(rule)) {
-          responseRule.push({
-            ...rule,
-            matches: createRulesetMatcher({
-              ruleMatcher: rule.matches,
-              rulesetMatcher: ruleOrRuleset.matches,
-            }),
-            aliases: getRuleAliases(ruleOrRuleset.name, rule.name),
-            docsLink: rule.docsLink || ruleOrRuleset.docsLink,
-          });
-        }
-      }
-    }
-  }
-
-  return responseRule;
-};
+import { getPropertyRules, getResponseBodyRules } from './rule-filters';
 
 const createResponseBodyResult = (
   assertionResult: AssertionResult,
@@ -122,6 +88,7 @@ export const runResponseBodyRules = ({
 }) => {
   const results: Result[] = [];
   const responseRules = getResponseBodyRules(rules);
+  const propertyRules = getPropertyRules(rules)
   const beforeSpecification = createSpecification(
     specificationNode,
     'before',
@@ -310,6 +277,10 @@ export const runResponseBodyRules = ({
         }
       }
     }
+  }
+
+  for (const propertyRule of propertyRules) {
+
   }
 
   return results;

--- a/projects/rulesets-base/src/rule-runner/response-body.ts
+++ b/projects/rulesets-base/src/rule-runner/response-body.ts
@@ -5,13 +5,9 @@ import {
   createResponse,
   createSpecification,
 } from './data-constructors';
+import { EndpointNode, ResponseNode, NodeDetail } from './rule-runner-types';
 import {
-  EndpointNode,
-  ResponseNode,
-  NodeDetail,
-} from './rule-runner-types';
-import {
-  createRuleContext,
+  createRuleContextWithOperation,
   isExempted,
 } from './utils';
 
@@ -88,7 +84,7 @@ export const runResponseBodyRules = ({
 }) => {
   const results: Result[] = [];
   const responseRules = getResponseBodyRules(rules);
-  const propertyRules = getPropertyRules(rules)
+  const propertyRules = getPropertyRules(rules);
   const beforeSpecification = createSpecification(
     specificationNode,
     'before',
@@ -116,22 +112,20 @@ export const runResponseBodyRules = ({
   for (const responseRule of responseRules) {
     if (beforeOperation && beforeSpecification) {
       // Default to after rule context if available
-      const ruleContext =
-        afterSpecification && afterOperation
-          ? createRuleContext({
-              operation: afterOperation,
-              custom: customRuleContext,
-              operationChangeType: operationNode.change?.changeType || null,
-              specification: afterSpecification,
-              specificationNode: specificationNode,
-            })
-          : createRuleContext({
-              operation: beforeOperation,
-              custom: customRuleContext,
-              operationChangeType: operationNode.change?.changeType || null,
-              specification: beforeSpecification,
-              specificationNode: specificationNode,
-            });
+      const ruleContext = createRuleContextWithOperation(
+        {
+          node: specificationNode,
+          before: beforeSpecification,
+          after: afterSpecification,
+        },
+        {
+          node: operationNode,
+          before: beforeOperation,
+          after: afterOperation,
+        },
+        customRuleContext
+      );
+
       const responseAssertions = createResponseBodyAssertions();
       // Register the user's rule definition, this is collected in the responseAssertions object
       responseRule.rule(responseAssertions, ruleContext);
@@ -193,13 +187,19 @@ export const runResponseBodyRules = ({
     }
 
     if (afterOperation && afterSpecification) {
-      const ruleContext = createRuleContext({
-        operation: afterOperation,
-        custom: customRuleContext,
-        operationChangeType: operationNode.change?.changeType || null,
-        specification: afterSpecification,
-        specificationNode: specificationNode,
-      });
+      const ruleContext = createRuleContextWithOperation(
+        {
+          node: specificationNode,
+          before: beforeSpecification,
+          after: afterSpecification,
+        },
+        {
+          node: operationNode,
+          before: beforeOperation,
+          after: afterOperation,
+        },
+        customRuleContext
+      );
       // Register the user's rule definition, this is collected in the responseAssertions object
       const responseAssertions = createResponseBodyAssertions();
       // Run the user's rules that have been stored in responseAssertions
@@ -280,7 +280,33 @@ export const runResponseBodyRules = ({
   }
 
   for (const propertyRule of propertyRules) {
+    if (beforeOperation && beforeSpecification) {
+      // Default to after rule context if available
+      // const ruleContext =createRuleContextWithOperation(
+      //   {
+      //     node: specificationNode,
+      //     before: beforeSpecification,
+      //     after: afterSpecification,
+      //   },
+      //   {
+      //     node: operationNode,
+      //     before: beforeOperation,
+      //     after: afterOperation,
+      //   },
+      //   customRuleContext
+      // );
+      // const responseAssertions = createResponseBodyAssertions();
+      // // Register the user's rule definition, this is collected in the responseAssertions object
+      // responseRule.rule(responseAssertions, ruleContext);
+      // const beforeResponse = createResponse(
+      //   responseNode,
+      //   'before',
+      //   beforeApiSpec
+      // );
+    }
 
+    if (afterOperation && afterSpecification) {
+    }
   }
 
   return results;

--- a/projects/rulesets-base/src/rule-runner/response.ts
+++ b/projects/rulesets-base/src/rule-runner/response.ts
@@ -6,53 +6,19 @@ import {
   createSpecification,
 } from './data-constructors';
 import {
-  RulesetData,
   EndpointNode,
   ResponseNode,
   NodeDetail,
 } from './rule-runner-types';
 import {
   createRuleContext,
-  createRulesetMatcher,
-  getRuleAliases,
   isExempted,
 } from './utils';
 
 import { Rule, Ruleset, ResponseRule } from '../rules';
 import { AssertionResult, createResponseAssertions } from './assertions';
 import { Operation, Response } from '../types';
-
-const getResponseRules = (
-  rules: (Ruleset | Rule)[]
-): (ResponseRule & RulesetData)[] => {
-  const responseRule: (ResponseRule & RulesetData)[] = [];
-  for (const ruleOrRuleset of rules) {
-    if (ResponseRule.isInstance(ruleOrRuleset)) {
-      responseRule.push({
-        ...ruleOrRuleset,
-        aliases: [],
-      });
-    }
-
-    if (Ruleset.isInstance(ruleOrRuleset)) {
-      for (const rule of ruleOrRuleset.rules) {
-        if (ResponseRule.isInstance(rule)) {
-          responseRule.push({
-            ...rule,
-            matches: createRulesetMatcher({
-              ruleMatcher: rule.matches,
-              rulesetMatcher: ruleOrRuleset.matches,
-            }),
-            aliases: getRuleAliases(ruleOrRuleset.name, rule.name),
-            docsLink: rule.docsLink || ruleOrRuleset.docsLink,
-          });
-        }
-      }
-    }
-  }
-
-  return responseRule;
-};
+import { getResponseRules } from './rule-filters';
 
 const createResponseResult = (
   assertionResult: AssertionResult,

--- a/projects/rulesets-base/src/rule-runner/response.ts
+++ b/projects/rulesets-base/src/rule-runner/response.ts
@@ -11,7 +11,7 @@ import {
   NodeDetail,
 } from './rule-runner-types';
 import {
-  createRuleContext,
+  createRuleContextWithOperation,
   isExempted,
 } from './utils';
 
@@ -113,22 +113,19 @@ export const runResponseRules = ({
   // - if yes, run the user's defined `rule`. for responses, this runs against the response and response headers
   for (const responseRule of responseRules) {
     if (beforeOperation && beforeSpecification) {
-      const ruleContext =
-        afterSpecification && afterOperation
-          ? createRuleContext({
-              operation: afterOperation,
-              custom: customRuleContext,
-              operationChangeType: operationNode.change?.changeType || null,
-              specification: afterSpecification,
-              specificationNode: specificationNode,
-            })
-          : createRuleContext({
-              operation: beforeOperation,
-              custom: customRuleContext,
-              operationChangeType: operationNode.change?.changeType || null,
-              specification: beforeSpecification,
-              specificationNode: specificationNode,
-            });
+      const ruleContext =createRuleContextWithOperation(
+        {
+          node: specificationNode,
+          before: beforeSpecification,
+          after: afterSpecification,
+        },
+        {
+          node: operationNode,
+          before: beforeOperation,
+          after: afterOperation,
+        },
+        customRuleContext
+      );
       const beforeResponse = createResponse(
         responseNode,
         'before',
@@ -182,13 +179,19 @@ export const runResponseRules = ({
     }
 
     if (afterOperation && afterSpecification) {
-      const ruleContext = createRuleContext({
-        operation: afterOperation,
-        custom: customRuleContext,
-        operationChangeType: operationNode.change?.changeType || null,
-        specification: afterSpecification,
-        specificationNode: specificationNode,
-      });
+      const ruleContext = createRuleContextWithOperation(
+        {
+          node: specificationNode,
+          before: beforeSpecification,
+          after: afterSpecification,
+        },
+        {
+          node: operationNode,
+          before: beforeOperation,
+          after: afterOperation,
+        },
+        customRuleContext
+      );
       const maybeBeforeResponse = createResponse(
         responseNode,
         'before',

--- a/projects/rulesets-base/src/rule-runner/rule-filters.ts
+++ b/projects/rulesets-base/src/rule-runner/rule-filters.ts
@@ -1,0 +1,229 @@
+import {
+  Rule,
+  Ruleset,
+  SpecificationRule,
+  OperationRule,
+  RequestRule,
+  ResponseBodyRule,
+  ResponseRule,
+} from '../rules';
+import { RuleContext } from '../types';
+
+type RulesetData = {
+  aliases: string[];
+};
+
+const getRulesetRuleId = (rulesetName: string, ruleName: string) =>
+  `${rulesetName}:${ruleName}`;
+
+const createRulesetMatcher =
+  <T>({
+    ruleMatcher: maybeRuleMatcher,
+    rulesetMatcher: maybeRulesetMatcher,
+  }: {
+    ruleMatcher?: (item: T, ruleContext: RuleContext) => boolean;
+    rulesetMatcher?: (ruleContext: RuleContext) => boolean;
+  }) =>
+  (item: T, ruleContext: RuleContext): boolean => {
+    const ruleMatcher = maybeRuleMatcher || (() => true);
+    const rulesetMatcher = maybeRulesetMatcher || (() => true);
+
+    return ruleMatcher(item, ruleContext) && rulesetMatcher(ruleContext);
+  };
+
+const getRuleAliases = (rulesetName: string, ruleName: string): string[] => [
+  getRulesetRuleId(rulesetName, ruleName),
+  rulesetName,
+];
+
+export const getSpecificationRules = (
+  rules: (Ruleset | Rule)[]
+): (SpecificationRule & RulesetData)[] => {
+  const specificationRules: (SpecificationRule & RulesetData)[] = [];
+  for (const ruleOrRuleset of rules) {
+    if (SpecificationRule.isInstance(ruleOrRuleset)) {
+      specificationRules.push({
+        ...ruleOrRuleset,
+        aliases: [],
+      });
+    }
+
+    if (Ruleset.isInstance(ruleOrRuleset)) {
+      for (const rule of ruleOrRuleset.rules) {
+        if (SpecificationRule.isInstance(rule)) {
+          specificationRules.push({
+            ...rule,
+            matches: createRulesetMatcher({
+              ruleMatcher: rule.matches,
+              rulesetMatcher: ruleOrRuleset.matches,
+            }),
+            aliases: getRuleAliases(ruleOrRuleset.name, rule.name),
+            docsLink: rule.docsLink || ruleOrRuleset.docsLink,
+          });
+        }
+      }
+    }
+  }
+
+  return specificationRules;
+};
+
+export const getOperationRules = (
+  rules: (Ruleset | Rule)[]
+): (OperationRule & RulesetData)[] => {
+  const operationRules: (OperationRule & RulesetData)[] = [];
+  for (const ruleOrRuleset of rules) {
+    if (OperationRule.isInstance(ruleOrRuleset)) {
+      operationRules.push({
+        ...ruleOrRuleset,
+        aliases: [],
+      });
+    }
+
+    if (Ruleset.isInstance(ruleOrRuleset)) {
+      for (const rule of ruleOrRuleset.rules) {
+        if (OperationRule.isInstance(rule)) {
+          operationRules.push({
+            ...rule,
+            matches: createRulesetMatcher({
+              ruleMatcher: rule.matches,
+              rulesetMatcher: ruleOrRuleset.matches,
+            }),
+            aliases: getRuleAliases(ruleOrRuleset.name, rule.name),
+            docsLink: rule.docsLink || ruleOrRuleset.docsLink,
+          });
+        }
+      }
+    }
+  }
+
+  return operationRules;
+};
+
+export const getRequestRules = (
+  rules: (Ruleset | Rule)[]
+): (RequestRule & RulesetData)[] => {
+  const requestRules: (RequestRule & RulesetData)[] = [];
+  for (const ruleOrRuleset of rules) {
+    if (RequestRule.isInstance(ruleOrRuleset)) {
+      requestRules.push({
+        ...ruleOrRuleset,
+        aliases: [],
+      });
+    }
+
+    if (Ruleset.isInstance(ruleOrRuleset)) {
+      for (const rule of ruleOrRuleset.rules) {
+        if (RequestRule.isInstance(rule)) {
+          requestRules.push({
+            ...rule,
+            matches: createRulesetMatcher({
+              ruleMatcher: rule.matches,
+              rulesetMatcher: ruleOrRuleset.matches,
+            }),
+            aliases: getRuleAliases(ruleOrRuleset.name, rule.name),
+            docsLink: rule.docsLink || ruleOrRuleset.docsLink,
+          });
+        }
+      }
+    }
+  }
+
+  return requestRules;
+};
+
+export const getResponseRules = (
+  rules: (Ruleset | Rule)[]
+): (ResponseRule & RulesetData)[] => {
+  const responseRule: (ResponseRule & RulesetData)[] = [];
+  for (const ruleOrRuleset of rules) {
+    if (ResponseRule.isInstance(ruleOrRuleset)) {
+      responseRule.push({
+        ...ruleOrRuleset,
+        aliases: [],
+      });
+    }
+
+    if (Ruleset.isInstance(ruleOrRuleset)) {
+      for (const rule of ruleOrRuleset.rules) {
+        if (ResponseRule.isInstance(rule)) {
+          responseRule.push({
+            ...rule,
+            matches: createRulesetMatcher({
+              ruleMatcher: rule.matches,
+              rulesetMatcher: ruleOrRuleset.matches,
+            }),
+            aliases: getRuleAliases(ruleOrRuleset.name, rule.name),
+            docsLink: rule.docsLink || ruleOrRuleset.docsLink,
+          });
+        }
+      }
+    }
+  }
+
+  return responseRule;
+};
+
+export const getResponseBodyRules = (
+  rules: (Ruleset | Rule)[]
+): (ResponseBodyRule & RulesetData)[] => {
+  const responseRule: (ResponseBodyRule & RulesetData)[] = [];
+  for (const ruleOrRuleset of rules) {
+    if (ResponseBodyRule.isInstance(ruleOrRuleset)) {
+      responseRule.push({
+        ...ruleOrRuleset,
+        aliases: [],
+      });
+    }
+
+    if (Ruleset.isInstance(ruleOrRuleset)) {
+      for (const rule of ruleOrRuleset.rules) {
+        if (ResponseBodyRule.isInstance(rule)) {
+          responseRule.push({
+            ...rule,
+            matches: createRulesetMatcher({
+              ruleMatcher: rule.matches,
+              rulesetMatcher: ruleOrRuleset.matches,
+            }),
+            aliases: getRuleAliases(ruleOrRuleset.name, rule.name),
+            docsLink: rule.docsLink || ruleOrRuleset.docsLink,
+          });
+        }
+      }
+    }
+  }
+
+  return responseRule;
+};
+
+export const getPropertyRules = (
+  rules: (Ruleset | Rule)[]
+): (ResponseBodyRule & RulesetData)[] => {
+  const responseRule: (ResponseBodyRule & RulesetData)[] = [];
+  for (const ruleOrRuleset of rules) {
+    if (ResponseBodyRule.isInstance(ruleOrRuleset)) {
+      responseRule.push({
+        ...ruleOrRuleset,
+        aliases: [],
+      });
+    }
+
+    if (Ruleset.isInstance(ruleOrRuleset)) {
+      for (const rule of ruleOrRuleset.rules) {
+        if (ResponseBodyRule.isInstance(rule)) {
+          responseRule.push({
+            ...rule,
+            matches: createRulesetMatcher({
+              ruleMatcher: rule.matches,
+              rulesetMatcher: ruleOrRuleset.matches,
+            }),
+            aliases: getRuleAliases(ruleOrRuleset.name, rule.name),
+            docsLink: rule.docsLink || ruleOrRuleset.docsLink,
+          });
+        }
+      }
+    }
+  }
+
+  return responseRule;
+};

--- a/projects/rulesets-base/src/rule-runner/rule-filters.ts
+++ b/projects/rulesets-base/src/rule-runner/rule-filters.ts
@@ -6,6 +6,7 @@ import {
   RequestRule,
   ResponseBodyRule,
   ResponseRule,
+  PropertyRule,
 } from '../rules';
 import { RuleContext } from '../types';
 
@@ -198,11 +199,11 @@ export const getResponseBodyRules = (
 
 export const getPropertyRules = (
   rules: (Ruleset | Rule)[]
-): (ResponseBodyRule & RulesetData)[] => {
-  const responseRule: (ResponseBodyRule & RulesetData)[] = [];
+): (PropertyRule & RulesetData)[] => {
+  const propertyRules: (PropertyRule & RulesetData)[] = [];
   for (const ruleOrRuleset of rules) {
-    if (ResponseBodyRule.isInstance(ruleOrRuleset)) {
-      responseRule.push({
+    if (PropertyRule.isInstance(ruleOrRuleset)) {
+      propertyRules.push({
         ...ruleOrRuleset,
         aliases: [],
       });
@@ -210,8 +211,8 @@ export const getPropertyRules = (
 
     if (Ruleset.isInstance(ruleOrRuleset)) {
       for (const rule of ruleOrRuleset.rules) {
-        if (ResponseBodyRule.isInstance(rule)) {
-          responseRule.push({
+        if (PropertyRule.isInstance(rule)) {
+          propertyRules.push({
             ...rule,
             matches: createRulesetMatcher({
               ruleMatcher: rule.matches,
@@ -225,5 +226,5 @@ export const getPropertyRules = (
     }
   }
 
-  return responseRule;
+  return propertyRules;
 };

--- a/projects/rulesets-base/src/rule-runner/rule-runner-types.ts
+++ b/projects/rulesets-base/src/rule-runner/rule-runner-types.ts
@@ -3,11 +3,6 @@ import {
   FactVariant,
   OpenApiKind,
 } from '@useoptic/openapi-utilities';
-import { Assertion, ChangedAssertion, AssertionType } from '../types';
-
-export type RulesetData = {
-  aliases: string[];
-};
 
 export type NodeDetail<T extends OpenApiKind> = {
   before: FactVariant<T> | null;

--- a/projects/rulesets-base/src/rule-runner/specification.ts
+++ b/projects/rulesets-base/src/rule-runner/specification.ts
@@ -1,48 +1,12 @@
 import { OpenApiKind, OpenAPIV3, Result } from '@useoptic/openapi-utilities';
 
 import { createSpecification } from './data-constructors';
-import { RulesetData, NodeDetail } from './rule-runner-types';
-import {
-  createRulesetMatcher,
-  getRuleAliases,
-  createRuleContext,
-  isExempted,
-} from './utils';
+import { NodeDetail } from './rule-runner-types';
+import { createRuleContext, isExempted } from './utils';
 
 import { Rule, Ruleset, SpecificationRule } from '../rules';
 import { createSpecificationAssertions, AssertionResult } from './assertions';
-
-const getSpecificationRules = (
-  rules: (Ruleset | Rule)[]
-): (SpecificationRule & RulesetData)[] => {
-  const specificationRules: (SpecificationRule & RulesetData)[] = [];
-  for (const ruleOrRuleset of rules) {
-    if (SpecificationRule.isInstance(ruleOrRuleset)) {
-      specificationRules.push({
-        ...ruleOrRuleset,
-        aliases: [],
-      });
-    }
-
-    if (Ruleset.isInstance(ruleOrRuleset)) {
-      for (const rule of ruleOrRuleset.rules) {
-        if (SpecificationRule.isInstance(rule)) {
-          specificationRules.push({
-            ...rule,
-            matches: createRulesetMatcher({
-              ruleMatcher: rule.matches,
-              rulesetMatcher: ruleOrRuleset.matches,
-            }),
-            aliases: getRuleAliases(ruleOrRuleset.name, rule.name),
-            docsLink: rule.docsLink || ruleOrRuleset.docsLink,
-          });
-        }
-      }
-    }
-  }
-
-  return specificationRules;
-};
+import { getSpecificationRules } from './rule-filters';
 
 const createSpecificationResult = (
   assertionResult: AssertionResult,

--- a/projects/rulesets-base/src/rule-runner/specification.ts
+++ b/projects/rulesets-base/src/rule-runner/specification.ts
@@ -2,7 +2,7 @@ import { OpenApiKind, OpenAPIV3, Result } from '@useoptic/openapi-utilities';
 
 import { createSpecification } from './data-constructors';
 import { NodeDetail } from './rule-runner-types';
-import { createRuleContext, isExempted } from './utils';
+import { createRuleContextWithoutOperation, isExempted } from './utils';
 
 import { Rule, Ruleset, SpecificationRule } from '../rules';
 import { createSpecificationAssertions, AssertionResult } from './assertions';
@@ -57,11 +57,14 @@ export const runSpecificationRules = ({
   for (const specificationRule of specificationRules) {
     // rules that are triggered and use the data from the `before` specification are: `removed`
     if (beforeSpecification) {
-      const rulesContext = createRuleContext({
-        specification: beforeSpecification,
-        specificationNode: specificationNode,
-        custom: customRuleContext,
-      });
+      const rulesContext = createRuleContextWithoutOperation(
+        {
+          before: beforeSpecification,
+          after: afterSpecification,
+          node: specificationNode,
+        },
+        customRuleContext
+      );
 
       const matches =
         !specificationRule.matches ||
@@ -89,11 +92,14 @@ export const runSpecificationRules = ({
     }
 
     if (afterSpecification) {
-      const rulesContext = createRuleContext({
-        specification: afterSpecification,
-        specificationNode: specificationNode,
-        custom: customRuleContext,
-      });
+      const rulesContext = createRuleContextWithoutOperation(
+        {
+          before: beforeSpecification,
+          after: afterSpecification,
+          node: specificationNode,
+        },
+        customRuleContext
+      );
 
       const matches =
         !specificationRule.matches ||

--- a/projects/rulesets-base/src/rule-runner/utils.ts
+++ b/projects/rulesets-base/src/rule-runner/utils.ts
@@ -21,11 +21,13 @@ export const createRuleContextWithoutOperation = (
   ),
   custom: any
 ): RuleContext => {
+  const specificationChange = getSpecificationChange(specification.node)
+
   return {
     custom,
     specification: {
-      ...(specification.after ? specification.after : specification.before),
-      change: getSpecificationChange(specification.node),
+      ...(specificationChange === 'removed' ? specification.before! : specification.after!),
+      change: specificationChange,
     },
     operation: {
       location: {
@@ -66,11 +68,6 @@ export const createRuleContextWithOperation = (
         | { before: Operation | null; after: Operation }
         | { before: Operation; after: null }
       ),
-  // inputs: {
-  //   specificationNode: ;
-  //   operationNode: NodeDetail<OpenApiKind.Operation>;
-  // }
-  // ),
   custom: any
 ): RuleContext => {
   return {

--- a/projects/rulesets-base/src/rule-runner/utils.ts
+++ b/projects/rulesets-base/src/rule-runner/utils.ts
@@ -70,17 +70,33 @@ export const createRuleContextWithOperation = (
       ),
   custom: any
 ): RuleContext => {
-  return {
-    custom,
-    specification: {
-      ...(specification.after ? specification.after : specification.before),
-      change: getSpecificationChange(specification.node),
-    },
-    operation: {
-      ...(operation.after ? operation.after : operation.before),
-      change:operation.node.change?.changeType || null
-    },
-  };
+  const specificationChange = getSpecificationChange(specification.node)
+
+  if (specificationChange === 'removed') {
+    return {
+      custom,
+      specification: {
+        ...specification.before!,
+        change: specificationChange,
+      },
+      operation: {
+        ...operation.before!,
+        change: specificationChange
+      },
+    }
+  } else {
+    return {
+      custom,
+      specification: {
+        ...specification.after!,
+        change: specificationChange
+      },
+      operation: {
+        ...(operation.after ? operation.after : operation.before),
+        change:operation.node.change?.changeType || null
+      },
+    };
+  }
 };
 
 export const isExempted = (raw: object, ruleName: string) => {

--- a/projects/rulesets-base/src/rule-runner/utils.ts
+++ b/projects/rulesets-base/src/rule-runner/utils.ts
@@ -1,29 +1,6 @@
-import { OpenApiKind, OpenAPIV3 } from '@useoptic/openapi-utilities';
+import { OpenApiKind } from '@useoptic/openapi-utilities';
 import { Operation, RuleContext, Specification } from '../types';
 import { NodeDetail } from './rule-runner-types';
-
-export const getRulesetRuleId = (rulesetName: string, ruleName: string) =>
-  `${rulesetName}:${ruleName}`;
-
-export const createRulesetMatcher =
-  <T>({
-    ruleMatcher: maybeRuleMatcher,
-    rulesetMatcher: maybeRulesetMatcher,
-  }: {
-    ruleMatcher?: (item: T, ruleContext: RuleContext) => boolean;
-    rulesetMatcher?: (ruleContext: RuleContext) => boolean;
-  }) =>
-  (item: T, ruleContext: RuleContext): boolean => {
-    const ruleMatcher = maybeRuleMatcher || (() => true);
-    const rulesetMatcher = maybeRulesetMatcher || (() => true);
-
-    return ruleMatcher(item, ruleContext) && rulesetMatcher(ruleContext);
-  };
-
-export const getRuleAliases = (
-  rulesetName: string,
-  ruleName: string
-): string[] => [getRulesetRuleId(rulesetName, ruleName), rulesetName];
 
 const getSpecificationChange = (
   specificationNode: NodeDetail<OpenApiKind.Specification>
@@ -95,6 +72,7 @@ export const createRuleContext = ({
     };
   }
 };
+
 
 export const isExempted = (raw: object, ruleName: string) => {
   const exemptions = raw['x-optic-exemptions'];

--- a/projects/rulesets-base/src/rule-runner/utils.ts
+++ b/projects/rulesets-base/src/rule-runner/utils.ts
@@ -12,67 +12,79 @@ const getSpecificationChange = (
     : specificationNode.change?.changeType || null;
 };
 
-export const createRuleContext = ({
-  specification,
-  specificationNode,
-  custom,
-  operation,
-  operationChangeType,
-}: {
-  specification: Specification;
-  specificationNode: NodeDetail<OpenApiKind.Specification>;
-  custom: any;
-} & (
-  | { operation?: undefined; operationChangeType?: undefined }
-  | {
-      operation: Operation;
-      operationChangeType: RuleContext['operation']['change'];
-    }
-)): RuleContext => {
-  if (operation && operationChangeType !== undefined) {
-    return {
-      custom,
-      specification: {
-        ...specification,
-        change: getSpecificationChange(specificationNode),
+export const createRuleContextWithoutOperation = (
+  specification: {
+    node: NodeDetail<OpenApiKind.Specification>;
+  } & (
+    | { before: Specification | null; after: Specification }
+    | { before: Specification; after: null }
+  ),
+  custom: any
+): RuleContext => {
+  return {
+    custom,
+    specification: {
+      ...(specification.after ? specification.after : specification.before),
+      change: getSpecificationChange(specification.node),
+    },
+    operation: {
+      location: {
+        jsonPath: '',
+        conceptualLocation: { path: '', method: '' },
+        conceptualPath: [],
+        kind: OpenApiKind.Operation,
       },
-      operation: {
-        ...operation,
-        change: operationChangeType,
+      value: { pathPattern: '', method: '' },
+      path: '',
+      method: '',
+      raw: {
+        responses: {},
       },
-    };
-  } else {
-    return {
-      custom,
-      specification: {
-        ...specification,
-        change: getSpecificationChange(specificationNode),
-      },
-      operation: {
-        location: {
-          jsonPath: '',
-          conceptualLocation: { path: '', method: '' },
-          conceptualPath: [],
-          kind: OpenApiKind.Operation,
-        },
-        value: { pathPattern: '', method: '' },
-        path: '',
-        method: '',
-        raw: {
-          responses: {},
-        },
-        change: null,
-        queryParameters: new Map(),
-        pathParameters: new Map(),
-        headerParameters: new Map(),
-        cookieParameters: new Map(),
-        requests: [],
-        responses: new Map(),
-      },
-    };
-  }
+      change: null,
+      queryParameters: new Map(),
+      pathParameters: new Map(),
+      headerParameters: new Map(),
+      cookieParameters: new Map(),
+      requests: [],
+      responses: new Map(),
+    },
+  };
 };
 
+export const createRuleContextWithOperation = (
+  specification: {
+    node: NodeDetail<OpenApiKind.Specification>
+  }
+    & (
+      | { before: Specification | null; after: Specification }
+      | { before: Specification; after: null }
+    ),
+    operation: {
+      node: NodeDetail<OpenApiKind.Operation>
+    }
+      & (
+        | { before: Operation | null; after: Operation }
+        | { before: Operation; after: null }
+      ),
+  // inputs: {
+  //   specificationNode: ;
+  //   operationNode: NodeDetail<OpenApiKind.Operation>;
+  // }
+  // ),
+  custom: any
+): RuleContext => {
+  return {
+    custom,
+    specification: {
+      ...(specification.after ? specification.after : specification.before),
+      change: getSpecificationChange(specification.node),
+    },
+    operation: {
+      ...(operation.after ? operation.after : operation.before),
+      change:operation.node.change?.changeType || null
+    },
+  };
+};
 
 export const isExempted = (raw: object, ruleName: string) => {
   const exemptions = raw['x-optic-exemptions'];

--- a/projects/rulesets-base/src/rules/index.ts
+++ b/projects/rulesets-base/src/rules/index.ts
@@ -4,3 +4,4 @@ export * from './specification-rule';
 export * from './request-rule';
 export * from './response-rule';
 export * from './response-body-rule';
+export * from './property-rule';

--- a/projects/rulesets-base/src/rules/property-rule.ts
+++ b/projects/rulesets-base/src/rules/property-rule.ts
@@ -1,0 +1,35 @@
+import { Property, PropertyAssertions, RuleContext } from '../types';
+
+type PropertyRuleConfig<RuleName extends string> = {
+  name: RuleName;
+  docsLink?: string;
+  matches?: PropertyRule['matches'];
+  rule: PropertyRule['rule'];
+};
+
+export class PropertyRule<RuleName extends string = string> {
+  public type: 'property-rule';
+  public name: RuleName;
+  public docsLink?: string;
+  public matches?: (operation: Property, context: RuleContext) => boolean;
+  public rule: (operation: PropertyAssertions, context: RuleContext) => void;
+
+  constructor(config: PropertyRuleConfig<RuleName>) {
+    // this could be invoked via javascript so we still to check
+    if (!config.name) {
+      throw new Error('Expected a name in PropertyRule');
+    }
+    if (!config.rule) {
+      throw new Error('Expected a rule definition in PropertyRule');
+    }
+    this.name = config.name;
+    this.docsLink = config.docsLink;
+    this.matches = config.matches;
+    this.rule = config.rule;
+    this.type = 'property-rule';
+  }
+
+  static isInstance(v: any): v is PropertyRule {
+    return v?.type === 'property-rule';
+  }
+}

--- a/projects/rulesets-base/src/rules/property-rule.ts
+++ b/projects/rulesets-base/src/rules/property-rule.ts
@@ -11,8 +11,8 @@ export class PropertyRule<RuleName extends string = string> {
   public type: 'property-rule';
   public name: RuleName;
   public docsLink?: string;
-  public matches?: (operation: Property, context: RuleContext) => boolean;
-  public rule: (operation: PropertyAssertions, context: RuleContext) => void;
+  public matches?: (property: Property, context: RuleContext) => boolean;
+  public rule: (property: PropertyAssertions, context: RuleContext) => void;
 
   constructor(config: PropertyRuleConfig<RuleName>) {
     // this could be invoked via javascript so we still to check

--- a/projects/rulesets-base/src/rules/ruleset.ts
+++ b/projects/rulesets-base/src/rules/ruleset.ts
@@ -3,6 +3,7 @@ import { RequestRule } from './request-rule';
 import { ResponseRule } from './response-rule';
 import { ResponseBodyRule } from './response-body-rule';
 import { SpecificationRule } from './specification-rule';
+import { PropertyRule } from './property-rule';
 import { RuleContext } from '../types';
 
 export type Rule =
@@ -10,7 +11,8 @@ export type Rule =
   | OperationRule
   | RequestRule
   | ResponseRule
-  | ResponseBodyRule;
+  | ResponseBodyRule
+  | PropertyRule;
 
 export type RuleNames<R extends Rule[]> = R[number]['name'];
 

--- a/projects/rulesets-base/src/types.ts
+++ b/projects/rulesets-base/src/types.ts
@@ -50,12 +50,14 @@ export type CookieParameter = FactVariant<OpenApiKind.CookieParameter> & {
 export type RequestBody = FactVariant<OpenApiKind.Body> & {
   raw: OpenAPIV3.RequestBodyObject;
   contentType: string;
-  properties: Map<string, Field>;
+  properties: Map<string, Property>;
 };
 
-export type Field = FactVariant<OpenApiKind.Field> & {
+export type Property = FactVariant<OpenApiKind.Field> & {
   raw: OpenAPIV3.SchemaObject;
 };
+
+export type Field = Property;
 
 export type ResponseHeader = FactVariant<OpenApiKind.ResponseHeader> & {
   raw: OpenAPIV3.HeaderObject;
@@ -231,3 +233,5 @@ export type ResponseBodyAssertions = {
   body: Assertions<'response-body'>;
   property: Assertions<'property'>;
 };
+
+export type PropertyAssertions = Assertions<'property'>


### PR DESCRIPTION
based off https://github.com/opticdev/optic/pull/1327

Addresses: https://github.com/opticdev/optic/issues/1321

Adds a propertyRule as well as some refactoring for the rulesets-base package. Example rules:

```javascript
new PropertyRule({
...
  matches: (property, ruleContext) => ...
  rule: (propertyAssertions) => ...
})
```