### PR TITLE
docker hub readme

### DIFF
--- a/docs/dockerhub-readme.md
+++ b/docs/dockerhub-readme.md
@@ -22,6 +22,6 @@ For example, to run `optic diff` your command would look something like this:
 docker run --rm -it \
   --volume=$HOME/code/optic-test:/repo \
   --workdir /repo \
-  docker.io/useoptic/optic:0.29.1 \
+  docker.io/useoptic/optic:<optic-version> \
   diff ./petstore.yml
 ```

--- a/docs/dockerhub-readme.md
+++ b/docs/dockerhub-readme.md
@@ -1,0 +1,27 @@
+![Optic Logo](https://www.useoptic.com/img/optic-logo.png)
+
+# Quick Reference
+
+Maintained by:
+[The Optic team](https://github.com/useoptic/optic)
+
+Where to file issues:
+[github.com/useoptic/optic/issues](https://github.com/useoptic/optic/issues)
+
+# What is Optic?
+
+Optic makes it easy to Track and Review all your API changes before they get released. Start working API-first and ship better APIs, faster.
+
+# How to use this image
+
+This image is a thin wrapper around the Optic CLI. It supports the same functions and commands as the [NPM package](https://www.npmjs.com/package/@useoptic/optic). For commands that interact with your files locally, you'll need to mount your Git repo to the container.
+
+For example, to run `optic diff` your command would look something like this:
+
+```
+docker run --rm -it \
+  --volume=$HOME/code/optic-test:/repo \
+  --workdir /repo \
+  docker.io/useoptic/optic:0.29.1 \
+  diff ./petstore.yml
+```

--- a/docs/dockerhub-readme.md
+++ b/docs/dockerhub-readme.md
@@ -3,10 +3,10 @@
 # Quick Reference
 
 Maintained by:
-[The Optic team](https://github.com/useoptic/optic)
+[The Optic team](https://github.com/opticdev/optic)
 
 Where to file issues:
-[github.com/useoptic/optic/issues](https://github.com/useoptic/optic/issues)
+[github.com/useoptic/optic/issues](https://github.com/opticdev/optic/issues)
 
 # What is Optic?
 


### PR DESCRIPTION
this adds a doc that is intended to be the copy use for the description of the Optic docker repo.

<img width="1399" alt="image" src="https://user-images.githubusercontent.com/672246/187704898-700dae2c-a098-4a80-abf1-805827b06eaf.png">
