### PR TITLE
chore: disable container image building for now

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,9 +152,9 @@ jobs:
         with:
           args: '{{ GITHUB_ACTOR }}: 🚫 optic v{{ VERSION }} failed to publish.'
 
-  publish-container-image:
-    needs: release
-    if: github.event.release.prerelease == 'false'
-    uses: opticdev/optic/.github/workflows/release-container-image.yml@main
-    with:
-      optic_version: ${{ needs.release.outputs.optic_version }}
+#  publish-container-image:
+#    needs: release
+#    if: github.event.release.prerelease == 'false'
+#    uses: opticdev/optic/.github/workflows/release-container-image.yml@main
+#    with:
+#      optic_version: ${{ needs.release.outputs.optic_version }}


### PR DESCRIPTION
after merging the container image building workflow, i was able to kick off some manual runs. ...and something goofy is going on, 

```
#13 [linux/amd64 4/4] RUN npm install -g @useoptic/optic@0.29.1
#13 CANCELED

#14 [linux/arm64 4/4] RUN npm install -g @useoptic/optic@0.29.1
#0 0.086 Error while loading /usr/local/sbin/node: No such file or directory
#14 ERROR: process "/dev/.buildkit_qemu_emulator /bin/sh -c npm install -g @useoptic/optic@$OPTIC_CLI_VERSION" did not complete successfully: exit code: 1
------
 > [linux/arm64 4/4] RUN npm install -g @useoptic/optic@0.29.1:
#0 0.086 Error while loading /usr/local/sbin/node: No such file or directory
------
Dockerfile:7
--------------------
   5 |     RUN apk add git
   6 |     RUN echo "optic-docker" > /etc/machine-id
   7 | >>> RUN npm install -g @useoptic/optic@$OPTIC_CLI_VERSION
   8 |     
   9 |     ENTRYPOINT ["/usr/local/bin/optic"]
--------------------
ERROR: failed to solve: process "/dev/.buildkit_qemu_emulator /bin/sh -c npm install -g @useoptic/optic@$OPTIC_CLI_VERSION" did not complete successfully: exit code: 1
task: Failed to run task "docker:build:release": exit status 1
Error: Process completed with exit code 1.
```

not sure what thats about, so while i investigate im disabling these builds.