### PR TITLE
fix: image builds

### DIFF
--- a/.github/workflows/release-container-image.yml
+++ b/.github/workflows/release-container-image.yml
@@ -46,7 +46,7 @@ jobs:
         env:
           SLACK_WEBHOOK: ${{ secrets.BUILD_BOT_SLACK_WEBHOOK_URL_RELEASES }}
         with:
-          args: '{{ GITHUB_ACTOR }}: ✅ useoptic/optic:{{ VERSION }} published to Docker Hub!'
+          args: '{{ GITHUB_ACTOR }}: ✅ useoptic/optic:${{ inputs.optic_version }} published to Docker Hub!'
 
       - name: Announce failure
         uses: Ilshidur/action-slack@689ad44a9c9092315abd286d0e3a9a74d31ab78a # v2.1.0
@@ -54,4 +54,4 @@ jobs:
         env:
           SLACK_WEBHOOK: ${{ secrets.BUILD_BOT_SLACK_WEBHOOK_URL_RELEASES }}
         with:
-          args: '{{ GITHUB_ACTOR }}: 🚫 useoptic/optic:{{ VERSION }} failed to publish to Docker Hub.'
+          args: '{{ GITHUB_ACTOR }}: 🚫 useoptic/optic:${{ inputs.optic_version }} failed to publish to Docker Hub.'

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ ARG OPTIC_CLI_VERSION=latest
 
 RUN apk add git
 RUN echo "optic-docker" > /etc/machine-id
-RUN npm install -g @useoptic/optic@$OPTIC_CLI_VERSION
-
 RUN mkdir -p /usr/local/sbin && ln -s /usr/local/bin/node /usr/local/sbin/node
+RUN npm install -g @useoptic/optic@$OPTIC_CLI_VERSION
 
 ENTRYPOINT ["/usr/local/bin/optic"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,6 @@ RUN apk add git
 RUN echo "optic-docker" > /etc/machine-id
 RUN npm install -g @useoptic/optic@$OPTIC_CLI_VERSION
 
+RUN mkdir -p /usr/local/sbin && ln -s /usr/local/bin/node /usr/local/sbin/node
+
 ENTRYPOINT ["/usr/local/bin/optic"]


### PR DESCRIPTION
manual testing of the build workflow revealed a really strange failure that i'm not able to replicate locally.

https://github.com/opticdev/optic/actions/runs/2966970852/workflow

```
#13 [linux/amd64 4/4] RUN npm install -g @useoptic/optic@0.29.1
#13 CANCELED

#14 [linux/arm64 4/4] RUN npm install -g @useoptic/optic@0.29.1
#0 0.086 Error while loading /usr/local/sbin/node: No such file or directory
#14 ERROR: process "/dev/.buildkit_qemu_emulator /bin/sh -c npm install -g @useoptic/optic@$OPTIC_CLI_VERSION" did not complete successfully: exit code: 1
------
 > [linux/arm64 4/4] RUN npm install -g @useoptic/optic@0.29.1:
#0 0.086 Error while loading /usr/local/sbin/node: No such file or directory
------
Dockerfile:7
--------------------
   5 |     RUN apk add git
   6 |     RUN echo "optic-docker" > /etc/machine-id
   7 | >>> RUN npm install -g @useoptic/optic@$OPTIC_CLI_VERSION
   8 |     
   9 |     ENTRYPOINT ["/usr/local/bin/optic"]
--------------------
ERROR: failed to solve: process "/dev/.buildkit_qemu_emulator /bin/sh -c npm install -g @useoptic/optic@$OPTIC_CLI_VERSION" did not complete successfully: exit code: 1
task: Failed to run task "docker:build:release": exit status 1
Error: Process completed with exit code 1.
```

i'm chalking it up to environmental or version differences between my machine and CI. in any case, symlinking `/usr/local/bin/node` to `/usr/local/sbin/node` seems to take care of it. with some upcoming package changes, this is all going to become moot anyway so im comfortable with this being a little weird for now.

i was going to disable the automated workflow in https://github.com/opticdev/optic/pull/1333, but i fixed this faster than i expected.