### PR TITLE
fix: prevent HAR entries from being skipped for bracketed ipv6 values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openapi-workspaces",
   "private": true,
-  "version": "0.30.1",
+  "version": "0.30.2",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/json-pointer-helpers",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-cli",
   "packageManager": "yarn@3.0.2",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/openapi-io",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/openapi-utilities",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/optic-ci",
   "packageManager": "yarn@3.0.2",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/optic",
   "packageManager": "yarn@3.0.2",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/rulesets-base",
   "packageManager": "yarn@3.0.2",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/standard-rulesets",
   "packageManager": "yarn@3.0.2",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
We've had reports of HAR entries being skipped due to `serverIPAddress` not passing validation as ipv4 or ipv6. Upon closer investigation it seems that some tools include brackets around their IPv6 addresses. That's _probably_ because it was extracted from the URI, in which IPv6 are wrapped in brackets to be compatible with `:port` (see [rfc 2732](https://www.rfc-editor.org/rfc/rfc2732#ref-URL)). 

With this PR we're unwrapping any IPv6 addresses that have been bracketed, allowing it to pass validation and be used further.