### PR TITLE
fix(ci): skipped image build workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,7 +154,7 @@ jobs:
 
   publish-container-image:
     needs: release
-    if: github.event.release.prerelease == 'false'
+    if: github.event.release.prerelease == false
     uses: opticdev/optic/.github/workflows/release-container-image.yml@main
     with:
       optic_version: ${{ needs.release.outputs.optic_version }}


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

the image build was inadvertently skipped in this run https://github.com/opticdev/optic/actions/runs/2979898869/workflow

looking at [the docs](https://docs.github.com/en/rest/releases/releases#get-a-release) the comparison on running the workflow should have been against a bool rather than a string. there's not much logging in actions to confirm specifically this was the issue, but i'm fairly certain it is because its the only condition :)

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._
closes https://github.com/opticdev/issues/issues/514

## 👹 QA
_How can other humans verify that this PR is correct?_
