### PR TITLE
fix(ci): pass secrets through on workflow_call events when building docker image

### DIFF
--- a/.github/workflows/release-container-image.yml
+++ b/.github/workflows/release-container-image.yml
@@ -17,6 +17,13 @@ on:
         description: >
           The Optic version to package in the image. Any NPM dist tag or published semver version is technically
           supported, but this value is also used as the image tag, so avoid using 'latest'.
+    secrets:
+      BUILD_BOT_SLACK_WEBHOOK_URL_RELEASES:
+        required: true
+      DOCKER_HUB_USERNAME:
+        required: true
+      DOCKER_HUB_TOKEN:
+        required: true
 
 env:
   SKIP_ANNOUNCE: 'false'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,3 +158,7 @@ jobs:
     uses: opticdev/optic/.github/workflows/release-container-image.yml@main
     with:
       optic_version: ${{ needs.release.outputs.optic_version }}
+    secrets:
+      BUILD_BOT_SLACK_WEBHOOK_URL_RELEASES: ${{ secrets.BUILD_BOT_SLACK_WEBHOOK_URL_RELEASES }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

after fixing https://github.com/opticdev/optic/pull/1346, this was the next thing that broke. i'm optimistic that this is the end of the game of whack-a-mole since we already know that the workflow works correctly when triggered via workflow_dispatch.

i forgot that runs triggered by workflow_call events don't automatically have access to secrets. so this PR wires up passing them.

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
