### PR TITLE
fix(ci): install Optic with yarn during image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ ARG OPTIC_CLI_VERSION=latest
 RUN apk add git
 RUN echo "optic-docker" > /etc/machine-id
 RUN mkdir -p /usr/local/sbin && ln -s /usr/local/bin/node /usr/local/sbin/node
-RUN npm install -g @useoptic/optic@$OPTIC_CLI_VERSION
+RUN yarn global add @useoptic/optic@$OPTIC_CLI_VERSION
 
 ENTRYPOINT ["/usr/local/bin/optic"]


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

with Optic v0.31.0 CI began failing while `npm install`ing, as seen [here](https://github.com/opticdev/optic/runs/8237884687?check_suite_focus=true). the same task works locally for me, which is quite confusing. in any case, Yarn can install the package with exploding, so it wins.

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
- passing CI https://github.com/opticdev/optic/actions/runs/3015482353/workflow