### PR TITLE
feat(ci): publish to ecr-public as well

### DIFF
--- a/.github/workflows/release-container-image.yml
+++ b/.github/workflows/release-container-image.yml
@@ -66,7 +66,7 @@ jobs:
         env:
           SLACK_WEBHOOK: ${{ secrets.BUILD_BOT_SLACK_WEBHOOK_URL_RELEASES }}
         with:
-          args: '{{ GITHUB_ACTOR }}: ✅ useoptic/optic:${{ inputs.optic_version }} published to Docker Hub!'
+          args: '{{ GITHUB_ACTOR }}: ✅ container images `docker.io/useoptic/optic:${{ inputs.optic_version }}`, `public.ecr.aws/optic/optic:${{ inputs.optic_version }}` published!'
 
       - name: Announce failure
         uses: Ilshidur/action-slack@689ad44a9c9092315abd286d0e3a9a74d31ab78a # v2.1.0
@@ -74,4 +74,4 @@ jobs:
         env:
           SLACK_WEBHOOK: ${{ secrets.BUILD_BOT_SLACK_WEBHOOK_URL_RELEASES }}
         with:
-          args: '{{ GITHUB_ACTOR }}: 🚫 useoptic/optic:${{ inputs.optic_version }} failed to publish to Docker Hub.'
+          args: '{{ GITHUB_ACTOR }}: 🚫 container images failed to publish.'

--- a/.github/workflows/release-container-image.yml
+++ b/.github/workflows/release-container-image.yml
@@ -33,19 +33,19 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
 
       - name: Install Task
         run: curl -sL https://taskfile.dev/install.sh | sudo bash -s -- -b /usr/local/bin/
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # v2.0.0
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 #v1.7.0
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
         with:
           aws-access-key-id: ${{ secrets.OPTIC_REPO_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.OPTIC_REPO_AWS_SECRET_ACCESS_KEY }}
@@ -53,7 +53,7 @@ jobs:
 
       - name: Login to Amazon ECR Public
         id: login-ecr-public
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@9149ade017c57f86dea2f76a01f8b2d5bd06b10f # v1.5.1
         with:
           registry-type: public
 

--- a/.github/workflows/release-container-image.yml
+++ b/.github/workflows/release-container-image.yml
@@ -51,9 +51,11 @@ jobs:
           aws-secret-access-key: ${{ secrets.OPTIC_REPO_AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@9149ade017c57f86dea2f76a01f8b2d5bd06b10f #v1.5.1
+      - name: Login to Amazon ECR Public
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v1
+        with:
+          registry-type: public
 
       - name: Build and publish
         run: task docker:build:release OPTIC_CLI_VERSION="${{ inputs.optic_version }}" -- --push

--- a/.github/workflows/release-container-image.yml
+++ b/.github/workflows/release-container-image.yml
@@ -44,6 +44,17 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 #v1.7.0
+        with:
+          aws-access-key-id: ${{ secrets.OPTIC_REPO_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.OPTIC_REPO_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@9149ade017c57f86dea2f76a01f8b2d5bd06b10f #v1.5.1
+
       - name: Build and publish
         run: task docker:build:release OPTIC_CLI_VERSION="${{ inputs.optic_version }}" -- --push
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -86,8 +86,10 @@ tasks:
     cmds:
       - >
         docker buildx build {{.CLI_ARGS}}
-        --tag useoptic/optic:{{.OPTIC_CLI_VERSION}}
-        --tag useoptic/optic:latest
+        --tag docker.io/useoptic/optic:{{.OPTIC_CLI_VERSION}}
+        --tag docker.io/useoptic/optic:latest
+        --tag public.ecr.aws/optic/optic:{{.OPTIC_CLI_VERSION}}
+        --tag public.ecr.aws/optic/optic:latest
         --platform linux/amd64,linux/arm64
         --builder optic-multiplatform-builder
         --build-arg OPTIC_CLI_VERSION={{.OPTIC_CLI_VERSION}}


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

dockerhub has tight pull rate-limits, even for authenticated requests. this pr also pushes our optic image to ecr-public which does not rate limit.

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._
- closes https://github.com/opticdev/issues/issues/531

## 👹 QA
_How can other humans verify that this PR is correct?_

manual run worked, see https://gallery.ecr.aws/optic/optic