### PR TITLE
Include src files in npm bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openapi-workspaces",
   "private": true,
-  "version": "0.32.2",
+  "version": "0.32.3-0",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",
@@ -15,5 +15,6 @@
   "scripts": {
     "release": "gh release create --target=$(git branch --show-current) v$(node -e \"process.stdout.write(require('./package.json').version)\")",
     "version": "yarn workspaces foreach -v version"
-  }
+  },
+  "stableVersion": "0.32.2"
 }

--- a/projects/json-pointer-helpers/.npmignore
+++ b/projects/json-pointer-helpers/.npmignore
@@ -1,0 +1,2 @@
+*.test.ts
+*.test.ts.snap

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/json-pointer-helpers",
-  "version": "0.32.2",
+  "version": "0.32.3-0",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -37,5 +37,6 @@
   },
   "dependencies": {
     "jsonpointer": "^5.0.1"
-  }
+  },
+  "stableVersion": "0.32.2"
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -5,7 +5,8 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
-    "/build"
+    "/build",
+    "/src"
   ],
   "scripts": {
     "dev:test": "jest --colors",

--- a/projects/openapi-cli/.npmignore
+++ b/projects/openapi-cli/.npmignore
@@ -1,0 +1,2 @@
+*.test.ts
+*.test.ts.snap

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-cli",
   "packageManager": "yarn@3.0.2",
-  "version": "0.32.2",
+  "version": "0.32.3-0",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [
@@ -107,5 +107,6 @@
         "<rootDir>../../../../node_modules/csv-parse/dist/cjs/sync.cjs"
       ]
     }
-  }
+  },
+  "stableVersion": "0.32.2"
 }

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -5,7 +5,8 @@
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [
-    "/build"
+    "/build",
+    "/src"
   ],
   "bin": {
     "oas": "build/index.js"

--- a/projects/openapi-io/.npmignore
+++ b/projects/openapi-io/.npmignore
@@ -1,0 +1,2 @@
+*.test.ts
+*.test.ts.snap

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/openapi-io",
-  "version": "0.32.2",
+  "version": "0.32.3-0",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -73,5 +73,6 @@
     "testPathIgnorePatterns": [
       "build"
     ]
-  }
+  },
+  "stableVersion": "0.32.2"
 }

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -5,7 +5,8 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
-    "/build"
+    "/build",
+    "/src"
   ],
   "scripts": {
     "dev:test": "jest --colors",

--- a/projects/openapi-utilities/.npmignore
+++ b/projects/openapi-utilities/.npmignore
@@ -1,0 +1,2 @@
+*.test.ts
+*.test.ts.snap

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/openapi-utilities",
-  "version": "0.32.2",
+  "version": "0.32.3-0",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -67,5 +67,6 @@
     "testPathIgnorePatterns": [
       "build"
     ]
-  }
+  },
+  "stableVersion": "0.32.2"
 }

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -5,7 +5,8 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
-    "/build"
+    "/build",
+    "/src"
   ],
   "scripts": {
     "dev:test": "jest --colors",

--- a/projects/optic-ci/.npmignore
+++ b/projects/optic-ci/.npmignore
@@ -1,0 +1,2 @@
+*.test.ts
+*.test.ts.snap

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/optic-ci",
   "packageManager": "yarn@3.0.2",
-  "version": "0.32.2",
+  "version": "0.32.3-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -85,5 +85,6 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  }
+  },
+  "stableVersion": "0.32.2"
 }

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -5,7 +5,8 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
-    "/build"
+    "/build",
+    "/src"
   ],
   "bin": "build/index.js",
   "scripts": {

--- a/projects/optic/.npmignore
+++ b/projects/optic/.npmignore
@@ -1,0 +1,2 @@
+*.test.ts
+*.test.ts.snap

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/optic",
   "packageManager": "yarn@3.0.2",
-  "version": "0.32.2",
+  "version": "0.32.3-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -90,5 +90,6 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  }
+  },
+  "stableVersion": "0.32.2"
 }

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -5,7 +5,8 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
-    "/build"
+    "/build",
+    "/src"
   ],
   "bin": {
     "oas": "build/oas.js",

--- a/projects/rulesets-base/.npmignore
+++ b/projects/rulesets-base/.npmignore
@@ -1,0 +1,2 @@
+*.test.ts
+*.test.ts.snap

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/rulesets-base",
   "packageManager": "yarn@3.0.2",
-  "version": "0.32.2",
+  "version": "0.32.3-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -59,5 +59,6 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  }
+  },
+  "stableVersion": "0.32.2"
 }

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -5,7 +5,8 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
-    "/build"
+    "/build",
+    "/src"
   ],
   "bin": "build/index.js",
   "scripts": {

--- a/projects/standard-rulesets/.npmignore
+++ b/projects/standard-rulesets/.npmignore
@@ -1,0 +1,2 @@
+*.test.ts
+*.test.ts.snap

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/standard-rulesets",
   "packageManager": "yarn@3.0.2",
-  "version": "0.32.2",
+  "version": "0.32.3-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -57,5 +57,6 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  }
+  },
+  "stableVersion": "0.32.2"
 }

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -5,7 +5,8 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
-    "/build"
+    "/build",
+    "/src"
   ],
   "bin": "build/index.js",
   "scripts": {


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

I realize our optic packages sourcemaps aren't included in downstream builds. This is because:
- our sourcemap files refer to `../src/**`
- we don't upload ..src

We have three options here:
- Include src in the published packages
- Update tsconfig settings so that we inline sources https://www.typescriptlang.org/tsconfig#inlineSources
- Remove generating sourcemaps for our packages

I decided to go with the first option but I don't really mind which way if there's strong opinions

TODO
- [ ] Test on a prerelease build

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
