### PR TITLE
fix oas new command version

### DIFF
--- a/projects/openapi-cli/src/commands/new.ts
+++ b/projects/openapi-cli/src/commands/new.ts
@@ -13,6 +13,8 @@ import { SpecFile, SpecFiles, SpecFileOperations, SpecPatches } from '../specs';
 
 const streamFinished = promisify(finished);
 
+const defaultOpenAPIVersion = '3.1.0';
+
 export async function newCommand(): Promise<Command> {
   const command = new Command('new');
 
@@ -28,7 +30,7 @@ export async function newCommand(): Promise<Command> {
     .option(
       '--oas-version <version-number>',
       'OpenAPI version number to be used',
-      '3.0.3'
+      defaultOpenAPIVersion
     )
     .action(async (filePath?: string) => {
       let absoluteFilePath: string;
@@ -88,7 +90,7 @@ export async function newCommand(): Promise<Command> {
           oasVersion = semver.version;
         }
       } else {
-        oasVersion = '3.0.3';
+        oasVersion = defaultOpenAPIVersion;
       }
 
       let newSpecFile = await createNewSpecFile(absoluteFilePath, oasVersion);
@@ -105,7 +107,7 @@ export async function newCommand(): Promise<Command> {
 
 async function createNewSpecFile(
   absoluteFilePath: string,
-  oasVersion: string = '3.0.3'
+  oasVersion: string = defaultOpenAPIVersion
 ): Promise<SpecFile> {
   let info = {
     title: 'Untitled service',


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_
Default version for new OpenAPI files should be `3.1.0` 

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

Nullable may not be fully supported in 3.0.0 -- we need more testing and continue checking with teams if there are any problems using 3.1 w/ the oas tool

## 👹 QA
_How can other humans verify that this PR is correct?_
