### PR TITLE
Built-in ruleset for examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openapi-workspaces",
   "private": true,
-  "version": "0.32.3-0",
+  "version": "0.33.0",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",
@@ -15,6 +15,5 @@
   "scripts": {
     "release": "gh release create --target=$(git branch --show-current) v$(node -e \"process.stdout.write(require('./package.json').version)\")",
     "version": "yarn workspaces foreach -v version"
-  },
-  "stableVersion": "0.32.2"
+  }
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/json-pointer-helpers",
-  "version": "0.32.3-0",
+  "version": "0.33.0",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -37,6 +37,5 @@
   },
   "dependencies": {
     "jsonpointer": "^5.0.1"
-  },
-  "stableVersion": "0.32.2"
+  }
 }

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-cli",
   "packageManager": "yarn@3.0.2",
-  "version": "0.32.3-0",
+  "version": "0.33.0",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [
@@ -107,6 +107,5 @@
         "<rootDir>../../../../node_modules/csv-parse/dist/cjs/sync.cjs"
       ]
     }
-  },
-  "stableVersion": "0.32.2"
+  }
 }

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/openapi-io",
-  "version": "0.32.3-0",
+  "version": "0.33.0",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -73,6 +73,5 @@
     "testPathIgnorePatterns": [
       "build"
     ]
-  },
-  "stableVersion": "0.32.2"
+  }
 }

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/openapi-utilities",
-  "version": "0.32.3-0",
+  "version": "0.33.0",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -67,6 +67,5 @@
     "testPathIgnorePatterns": [
       "build"
     ]
-  },
-  "stableVersion": "0.32.2"
+  }
 }

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/optic-ci",
   "packageManager": "yarn@3.0.2",
-  "version": "0.32.3-0",
+  "version": "0.33.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -85,6 +85,5 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  },
-  "stableVersion": "0.32.2"
+  }
 }

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/optic",
   "packageManager": "yarn@3.0.2",
-  "version": "0.32.3-0",
+  "version": "0.33.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -90,6 +90,5 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  },
-  "stableVersion": "0.32.2"
+  }
 }

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/rulesets-base",
   "packageManager": "yarn@3.0.2",
-  "version": "0.32.3-0",
+  "version": "0.33.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -59,6 +59,5 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  },
-  "stableVersion": "0.32.2"
+  }
 }

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/standard-rulesets",
   "packageManager": "yarn@3.0.2",
-  "version": "0.32.3-0",
+  "version": "0.33.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -57,6 +57,5 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  },
-  "stableVersion": "0.32.2"
+  }
 }

--- a/projects/standard-rulesets/src/examples/__tests__/__snapshots__/examples-are-required.test.ts.snap
+++ b/projects/standard-rulesets/src/examples/__tests__/__snapshots__/examples-are-required.test.ts.snap
@@ -161,7 +161,7 @@ Array [
     },
     "condition": undefined,
     "docsLink": undefined,
-    "error": "a valid example is required for every documented query parameter",
+    "error": "a valid example is required for every query parameter",
     "exempted": false,
     "expected": undefined,
     "isMust": true,

--- a/projects/standard-rulesets/src/examples/__tests__/__snapshots__/examples-are-required.test.ts.snap
+++ b/projects/standard-rulesets/src/examples/__tests__/__snapshots__/examples-are-required.test.ts.snap
@@ -1,0 +1,532 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`examples are required ruleset parameters need examples 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "validExample",
+          },
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "parameters",
+          "query",
+          "validExample",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/parameters/0",
+        "kind": "query-parameter",
+      },
+      "value": Object {
+        "example": "123",
+        "in": "query",
+        "name": "validExample",
+        "schema": Object {
+          "type": "string",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "parameter examples must match schemas",
+    "passed": true,
+    "received": undefined,
+    "type": "requirement",
+    "where": "GET /api/users query parameter: validExample",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "notSet",
+          },
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "parameters",
+          "query",
+          "notSet",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/parameters/1",
+        "kind": "query-parameter",
+      },
+      "value": Object {
+        "in": "query",
+        "name": "notSet",
+        "schema": Object {
+          "type": "string",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "parameter examples must match schemas",
+    "passed": true,
+    "received": undefined,
+    "type": "requirement",
+    "where": "GET /api/users query parameter: notSet",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "validExample",
+          },
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "parameters",
+          "query",
+          "validExample",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/parameters/0",
+        "kind": "query-parameter",
+      },
+      "value": Object {
+        "example": "123",
+        "in": "query",
+        "name": "validExample",
+        "schema": Object {
+          "type": "string",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require parameter examples",
+    "passed": true,
+    "received": undefined,
+    "type": "requirement",
+    "where": "GET /api/users query parameter: validExample",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "notSet",
+          },
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "parameters",
+          "query",
+          "notSet",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/parameters/1",
+        "kind": "query-parameter",
+      },
+      "value": Object {
+        "in": "query",
+        "name": "notSet",
+        "schema": Object {
+          "type": "string",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": "a valid example is required for every documented query parameter",
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require parameter examples",
+    "passed": false,
+    "received": undefined,
+    "type": "requirement",
+    "where": "GET /api/users query parameter: notSet",
+  },
+]
+`;
+
+exports[`examples are required ruleset request without example errors 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+          },
+          "method": "post",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "post",
+          "application/json",
+        ],
+        "jsonPath": "/paths/~1api~1users/post/requestBody/content/application~1json",
+        "kind": "body",
+      },
+      "value": Object {
+        "contentType": "application/json",
+        "flatSchema": Object {
+          "type": "object",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request body examples must match schema",
+    "passed": true,
+    "received": undefined,
+    "type": "requirement",
+    "where": "POST /api/users request body: application/json",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+          },
+          "method": "post",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "post",
+          "application/json",
+        ],
+        "jsonPath": "/paths/~1api~1users/post/requestBody/content/application~1json",
+        "kind": "body",
+      },
+      "value": Object {
+        "contentType": "application/json",
+        "flatSchema": Object {
+          "type": "object",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": "a valid example is required for every documented request body",
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require request body examples",
+    "passed": false,
+    "received": undefined,
+    "type": "requirement",
+    "where": "POST /api/users request body: application/json",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": Array [
+            "hello",
+          ],
+          "method": "post",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "post",
+          "application/json",
+          "hello",
+        ],
+        "jsonPath": "/paths/~1api~1users/post/requestBody/content/application~1json/schema/properties/hello",
+        "kind": "field",
+      },
+      "value": Object {
+        "flatSchema": Object {
+          "type": "string",
+        },
+        "key": "hello",
+        "required": true,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require property examples match schemas",
+    "passed": true,
+    "received": undefined,
+    "type": "requirement",
+    "where": "POST /api/users request body: application/json property: hello",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": Array [
+            "world",
+          ],
+          "method": "post",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "post",
+          "application/json",
+          "world",
+        ],
+        "jsonPath": "/paths/~1api~1users/post/requestBody/content/application~1json/schema/properties/world",
+        "kind": "field",
+      },
+      "value": Object {
+        "flatSchema": Object {
+          "type": "number",
+        },
+        "key": "world",
+        "required": true,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require property examples match schemas",
+    "passed": true,
+    "received": undefined,
+    "type": "requirement",
+    "where": "POST /api/users request body: application/json property: world",
+  },
+]
+`;
+
+exports[`examples are required ruleset responses without examples error 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": Array [
+            "hello",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "hello",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200/content/application~1json/schema/properties/hello",
+        "kind": "field",
+      },
+      "value": Object {
+        "flatSchema": Object {
+          "type": "string",
+        },
+        "key": "hello",
+        "required": true,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require property examples match schemas",
+    "passed": true,
+    "received": undefined,
+    "type": "requirement",
+    "where": "GET /api/users response 200 response body: application/json property hello",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": Array [
+            "world",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "world",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200/content/application~1json/schema/properties/world",
+        "kind": "field",
+      },
+      "value": Object {
+        "flatSchema": Object {
+          "type": "number",
+        },
+        "key": "world",
+        "required": true,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require property examples match schemas",
+    "passed": true,
+    "received": undefined,
+    "type": "requirement",
+    "where": "GET /api/users response 200 response body: application/json property world",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "statusCode": "200",
+          },
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200",
+        "kind": "response",
+      },
+      "value": Object {
+        "description": "ok",
+        "statusCode": "200",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response body examples must match schemas",
+    "passed": true,
+    "received": undefined,
+    "type": "requirement",
+    "where": "GET /api/users response 200",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "statusCode": "200",
+          },
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200",
+        "kind": "response",
+      },
+      "value": Object {
+        "description": "ok",
+        "statusCode": "200",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": "a valid example is required for every documented response body",
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require response body examples",
+    "passed": false,
+    "received": undefined,
+    "type": "requirement",
+    "where": "GET /api/users response 200",
+  },
+]
+`;

--- a/projects/standard-rulesets/src/examples/__tests__/__snapshots__/examples-are-valid-rules.test.ts.snap
+++ b/projects/standard-rulesets/src/examples/__tests__/__snapshots__/examples-are-valid-rules.test.ts.snap
@@ -1,0 +1,886 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`examples ruleset invalid parameter example errors 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "invalidExample",
+          },
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "parameters",
+          "query",
+          "invalidExample",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/parameters/0",
+        "kind": "query-parameter",
+      },
+      "value": Object {
+        "example": 123,
+        "in": "query",
+        "name": "invalidExample",
+        "schema": Object {
+          "type": "string",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": "query parameter 'invalidExample' example does not match the schema. 
+- data must be string ",
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "parameter examples must match schemas",
+    "passed": false,
+    "received": undefined,
+    "type": "requirement",
+    "where": "GET /api/users query parameter: invalidExample",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "validExample",
+          },
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "parameters",
+          "query",
+          "validExample",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/parameters/1",
+        "kind": "query-parameter",
+      },
+      "value": Object {
+        "example": "123",
+        "in": "query",
+        "name": "validExample",
+        "schema": Object {
+          "type": "string",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "parameter examples must match schemas",
+    "passed": true,
+    "received": undefined,
+    "type": "requirement",
+    "where": "GET /api/users query parameter: validExample",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "query": "notSet",
+          },
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "parameters",
+          "query",
+          "notSet",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/parameters/2",
+        "kind": "query-parameter",
+      },
+      "value": Object {
+        "in": "query",
+        "name": "notSet",
+        "schema": Object {
+          "type": "string",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "parameter examples must match schemas",
+    "passed": true,
+    "received": undefined,
+    "type": "requirement",
+    "where": "GET /api/users query parameter: notSet",
+  },
+]
+`;
+
+exports[`examples ruleset invalid property example errors 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": Array [
+            "wrong",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "wrong",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200/content/application~1json/schema/properties/wrong",
+        "kind": "field",
+      },
+      "value": Object {
+        "flatSchema": Object {
+          "example": 12345,
+          "type": "string",
+        },
+        "key": "wrong",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": "'wrong' example does not match the schema. 
+- data must be string ",
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require property examples match schemas",
+    "passed": false,
+    "received": undefined,
+    "type": "requirement",
+    "where": "GET /api/users response 200 response body: application/json property wrong",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": Array [
+            "notSet",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "notSet",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200/content/application~1json/schema/properties/notSet",
+        "kind": "field",
+      },
+      "value": Object {
+        "flatSchema": Object {
+          "type": "string",
+        },
+        "key": "notSet",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require property examples match schemas",
+    "passed": true,
+    "received": undefined,
+    "type": "requirement",
+    "where": "GET /api/users response 200 response body: application/json property notSet",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": Array [
+            "setAndCorrect",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "setAndCorrect",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200/content/application~1json/schema/properties/setAndCorrect",
+        "kind": "field",
+      },
+      "value": Object {
+        "flatSchema": Object {
+          "example": "abcdefg",
+          "type": "string",
+        },
+        "key": "setAndCorrect",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require property examples match schemas",
+    "passed": true,
+    "received": undefined,
+    "type": "requirement",
+    "where": "GET /api/users response 200 response body: application/json property setAndCorrect",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "statusCode": "200",
+          },
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200",
+        "kind": "response",
+      },
+      "value": Object {
+        "description": "ok",
+        "statusCode": "200",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response body examples must match schemas",
+    "passed": true,
+    "received": undefined,
+    "type": "requirement",
+    "where": "GET /api/users response 200",
+  },
+]
+`;
+
+exports[`examples ruleset invalid request named example errors 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+          },
+          "method": "post",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "post",
+          "application/json",
+        ],
+        "jsonPath": "/paths/~1api~1users/post/requestBody/content/application~1json",
+        "kind": "body",
+      },
+      "value": Object {
+        "contentType": "application/json",
+        "flatSchema": Object {
+          "type": "object",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": "the example named 'main' does not match the schema. 
+- data must have required property 'world' ",
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request body examples must match schema",
+    "passed": false,
+    "received": undefined,
+    "type": "requirement",
+    "where": "POST /api/users request body: application/json",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": Array [
+            "hello",
+          ],
+          "method": "post",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "post",
+          "application/json",
+          "hello",
+        ],
+        "jsonPath": "/paths/~1api~1users/post/requestBody/content/application~1json/schema/properties/hello",
+        "kind": "field",
+      },
+      "value": Object {
+        "flatSchema": Object {
+          "type": "string",
+        },
+        "key": "hello",
+        "required": true,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require property examples match schemas",
+    "passed": true,
+    "received": undefined,
+    "type": "requirement",
+    "where": "POST /api/users request body: application/json property: hello",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": Array [
+            "world",
+          ],
+          "method": "post",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "post",
+          "application/json",
+          "world",
+        ],
+        "jsonPath": "/paths/~1api~1users/post/requestBody/content/application~1json/schema/properties/world",
+        "kind": "field",
+      },
+      "value": Object {
+        "flatSchema": Object {
+          "type": "number",
+        },
+        "key": "world",
+        "required": true,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require property examples match schemas",
+    "passed": true,
+    "received": undefined,
+    "type": "requirement",
+    "where": "POST /api/users request body: application/json property: world",
+  },
+]
+`;
+
+exports[`examples ruleset invalid request top level example errors 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+          },
+          "method": "post",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "post",
+          "application/json",
+        ],
+        "jsonPath": "/paths/~1api~1users/post/requestBody/content/application~1json",
+        "kind": "body",
+      },
+      "value": Object {
+        "contentType": "application/json",
+        "flatSchema": Object {
+          "type": "object",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": "the example does not match the schema. 
+- data must have required property 'world' ",
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request body examples must match schema",
+    "passed": false,
+    "received": undefined,
+    "type": "requirement",
+    "where": "POST /api/users request body: application/json",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": Array [
+            "hello",
+          ],
+          "method": "post",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "post",
+          "application/json",
+          "hello",
+        ],
+        "jsonPath": "/paths/~1api~1users/post/requestBody/content/application~1json/schema/properties/hello",
+        "kind": "field",
+      },
+      "value": Object {
+        "flatSchema": Object {
+          "type": "string",
+        },
+        "key": "hello",
+        "required": true,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require property examples match schemas",
+    "passed": true,
+    "received": undefined,
+    "type": "requirement",
+    "where": "POST /api/users request body: application/json property: hello",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inRequest": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": Array [
+            "world",
+          ],
+          "method": "post",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "post",
+          "application/json",
+          "world",
+        ],
+        "jsonPath": "/paths/~1api~1users/post/requestBody/content/application~1json/schema/properties/world",
+        "kind": "field",
+      },
+      "value": Object {
+        "flatSchema": Object {
+          "type": "number",
+        },
+        "key": "world",
+        "required": true,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require property examples match schemas",
+    "passed": true,
+    "received": undefined,
+    "type": "requirement",
+    "where": "POST /api/users request body: application/json property: world",
+  },
+]
+`;
+
+exports[`examples ruleset invalid response named example errors 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": Array [
+            "hello",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "hello",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200/content/application~1json/schema/properties/hello",
+        "kind": "field",
+      },
+      "value": Object {
+        "flatSchema": Object {
+          "type": "string",
+        },
+        "key": "hello",
+        "required": true,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require property examples match schemas",
+    "passed": true,
+    "received": undefined,
+    "type": "requirement",
+    "where": "GET /api/users response 200 response body: application/json property hello",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": Array [
+            "world",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "world",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200/content/application~1json/schema/properties/world",
+        "kind": "field",
+      },
+      "value": Object {
+        "flatSchema": Object {
+          "type": "number",
+        },
+        "key": "world",
+        "required": true,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require property examples match schemas",
+    "passed": true,
+    "received": undefined,
+    "type": "requirement",
+    "where": "GET /api/users response 200 response body: application/json property world",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "statusCode": "200",
+          },
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200",
+        "kind": "response",
+      },
+      "value": Object {
+        "description": "ok",
+        "statusCode": "200",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": "the example named 'main' does not match the schema. 
+- data must have required property 'world' ",
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response body examples must match schemas",
+    "passed": false,
+    "received": undefined,
+    "type": "requirement",
+    "where": "GET /api/users response 200",
+  },
+]
+`;
+
+exports[`examples ruleset invalid response top level example errors 1`] = `
+Array [
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": Array [
+            "hello",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "hello",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200/content/application~1json/schema/properties/hello",
+        "kind": "field",
+      },
+      "value": Object {
+        "flatSchema": Object {
+          "type": "string",
+        },
+        "key": "hello",
+        "required": true,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require property examples match schemas",
+    "passed": true,
+    "received": undefined,
+    "type": "requirement",
+    "where": "GET /api/users response 200 response body: application/json property hello",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "body": Object {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": Array [
+            "world",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "world",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200/content/application~1json/schema/properties/world",
+        "kind": "field",
+      },
+      "value": Object {
+        "flatSchema": Object {
+          "type": "number",
+        },
+        "key": "world",
+        "required": true,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require property examples match schemas",
+    "passed": true,
+    "received": undefined,
+    "type": "requirement",
+    "where": "GET /api/users response 200 response body: application/json property world",
+  },
+  Object {
+    "change": Object {
+      "location": Object {
+        "conceptualLocation": Object {
+          "inResponse": Object {
+            "statusCode": "200",
+          },
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": Array [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200",
+        "kind": "response",
+      },
+      "value": Object {
+        "description": "ok",
+        "statusCode": "200",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": "the example does not match the schema. 
+- data must have required property 'world' ",
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response body examples must match schemas",
+    "passed": false,
+    "received": undefined,
+    "type": "requirement",
+    "where": "GET /api/users response 200",
+  },
+]
+`;

--- a/projects/standard-rulesets/src/examples/__tests__/examples-are-required.test.ts
+++ b/projects/standard-rulesets/src/examples/__tests__/examples-are-required.test.ts
@@ -1,0 +1,228 @@
+import { OpenAPIV3 } from '@useoptic/openapi-utilities';
+import { TestHelpers } from '@useoptic/rulesets-base';
+import { ExamplesRuleset } from '../index';
+
+describe('fromOpticConfig', () => {
+  test('invalid configuration', () => {
+    const out = ExamplesRuleset.fromOpticConfig({
+      require_parameter_examples: 123,
+    });
+    expect(out).toEqual(
+      '- ruleset/examples/require_parameter_examples must be boolean'
+    );
+  });
+});
+
+const requireAll = new ExamplesRuleset({
+  require_parameter_examples: true,
+  require_request_examples: true,
+  require_response_examples: true,
+});
+
+describe('examples are required ruleset', () => {
+  test('parameters need examples', () => {
+    const input: OpenAPIV3.Document = {
+      ...TestHelpers.createEmptySpec(),
+      paths: {
+        '/api/users': {
+          get: {
+            parameters: [
+              {
+                in: 'query',
+                name: 'validExample',
+                schema: { type: 'string' },
+                example: '123',
+              },
+              {
+                in: 'query',
+                name: 'notSet',
+                schema: { type: 'string' },
+              },
+            ],
+            responses: {},
+          },
+        },
+      },
+    };
+    const results = TestHelpers.runRulesWithInputs([requireAll], input, input);
+    expect(results.length > 0).toBe(true);
+
+    expect(results).toMatchSnapshot();
+    expect(results.some((result) => !result.passed)).toBe(true);
+  });
+
+  const exampleSchema: OpenAPIV3.SchemaObject = {
+    type: 'object',
+    required: ['hello', 'world'],
+    properties: {
+      hello: { type: 'string' },
+      world: { type: 'number' },
+    },
+  };
+
+  const exampleInvalid = {
+    hello: 123,
+  };
+
+  const exampleValid = {
+    hello: '123',
+    world: 123,
+  };
+
+  test('responses with example top level pass', () => {
+    const input: OpenAPIV3.Document = {
+      ...TestHelpers.createEmptySpec(),
+      paths: {
+        '/api/users': {
+          get: {
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: exampleSchema,
+                    example: exampleValid,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const results = TestHelpers.runRulesWithInputs([requireAll], input, input);
+    expect(results.filter((i) => !i.passed).length === 0).toBe(true);
+  });
+  test('responses without examples error', () => {
+    const input: OpenAPIV3.Document = {
+      ...TestHelpers.createEmptySpec(),
+      paths: {
+        '/api/users': {
+          get: {
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: exampleSchema,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const results = TestHelpers.runRulesWithInputs([requireAll], input, input);
+    expect(results.length > 0).toBe(true);
+
+    expect(results).toMatchSnapshot();
+    expect(results.some((result) => !result.passed)).toBe(true);
+  });
+  test('response with examples named pass', () => {
+    const input: OpenAPIV3.Document = {
+      ...TestHelpers.createEmptySpec(),
+      paths: {
+        '/api/users': {
+          get: {
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: exampleSchema,
+                    examples: {
+                      other: {
+                        value: exampleValid,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const results = TestHelpers.runRulesWithInputs([requireAll], input, input);
+    expect(results.filter((i) => !i.passed).length === 0).toBe(true);
+  });
+
+  test('request without example errors', () => {
+    const input: OpenAPIV3.Document = {
+      ...TestHelpers.createEmptySpec(),
+      paths: {
+        '/api/users': {
+          post: {
+            responses: {},
+            requestBody: {
+              description: '',
+              content: {
+                'application/json': {
+                  schema: exampleSchema,
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const results = TestHelpers.runRulesWithInputs([requireAll], input, input);
+    expect(results.length > 0).toBe(true);
+
+    expect(results).toMatchSnapshot();
+    expect(results.some((result) => !result.passed)).toBe(true);
+  });
+
+  test('request with top level example passes', () => {
+    const input: OpenAPIV3.Document = {
+      ...TestHelpers.createEmptySpec(),
+      paths: {
+        '/api/users': {
+          post: {
+            responses: {},
+            requestBody: {
+              description: '',
+              content: {
+                'application/json': {
+                  schema: exampleSchema,
+                  example: exampleValid,
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const results = TestHelpers.runRulesWithInputs([requireAll], input, input);
+    expect(results.filter((i) => !i.passed).length === 0).toBe(true);
+  });
+
+  test('request with named examples passes', () => {
+    const input: OpenAPIV3.Document = {
+      ...TestHelpers.createEmptySpec(),
+      paths: {
+        '/api/users': {
+          post: {
+            responses: {},
+            requestBody: {
+              description: 'ok',
+              content: {
+                'application/json': {
+                  schema: exampleSchema,
+                  examples: {
+                    other: {
+                      value: exampleValid,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const results = TestHelpers.runRulesWithInputs([requireAll], input, input);
+    expect(results.filter((i) => !i.passed).length === 0).toBe(true);
+  });
+});

--- a/projects/standard-rulesets/src/examples/__tests__/examples-are-valid-rules.test.ts
+++ b/projects/standard-rulesets/src/examples/__tests__/examples-are-valid-rules.test.ts
@@ -1,0 +1,258 @@
+import { OpenAPIV3 } from '@useoptic/openapi-utilities';
+import { TestHelpers } from '@useoptic/rulesets-base';
+import { ExamplesRuleset } from '../index';
+
+describe('fromOpticConfig', () => {
+  test('invalid configuration', () => {
+    const out = ExamplesRuleset.fromOpticConfig({
+      require_parameter_examples: 123,
+    });
+    expect(out).toEqual(
+      '- ruleset/examples/require_parameter_examples must be boolean'
+    );
+  });
+});
+
+describe('examples ruleset', () => {
+  test('invalid property example errors', () => {
+    const input: OpenAPIV3.Document = {
+      ...TestHelpers.createEmptySpec(),
+      paths: {
+        '/api/users': {
+          get: {
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        wrong: {
+                          type: 'string',
+                          example: 12345,
+                        },
+                        notSet: {
+                          type: 'string',
+                        },
+                        setAndCorrect: {
+                          type: 'string',
+                          example: 'abcdefg',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const results = TestHelpers.runRulesWithInputs(
+      [new ExamplesRuleset({})],
+      input,
+      input
+    );
+    expect(results.length > 0).toBe(true);
+
+    expect(results).toMatchSnapshot();
+    expect(results.some((result) => !result.passed)).toBe(true);
+  });
+  test('invalid parameter example errors', () => {
+    const input: OpenAPIV3.Document = {
+      ...TestHelpers.createEmptySpec(),
+      paths: {
+        '/api/users': {
+          get: {
+            parameters: [
+              {
+                in: 'query',
+                name: 'invalidExample',
+                schema: { type: 'string' },
+                example: 123,
+              },
+              {
+                in: 'query',
+                name: 'validExample',
+                schema: { type: 'string' },
+                example: '123',
+              },
+              {
+                in: 'query',
+                name: 'notSet',
+                schema: { type: 'string' },
+              },
+            ],
+            responses: {},
+          },
+        },
+      },
+    };
+    const results = TestHelpers.runRulesWithInputs(
+      [new ExamplesRuleset({})],
+      input,
+      input
+    );
+    expect(results.length > 0).toBe(true);
+
+    expect(results).toMatchSnapshot();
+    expect(results.some((result) => !result.passed)).toBe(true);
+  });
+
+  const exampleSchema: OpenAPIV3.SchemaObject = {
+    type: 'object',
+    required: ['hello', 'world'],
+    properties: {
+      hello: { type: 'string' },
+      world: { type: 'number' },
+    },
+  };
+
+  const exampleInvalid = {
+    hello: 123,
+  };
+
+  const exampleValid = {
+    hello: '123',
+    world: 123,
+  };
+
+  test('invalid response top level example errors', () => {
+    const input: OpenAPIV3.Document = {
+      ...TestHelpers.createEmptySpec(),
+      paths: {
+        '/api/users': {
+          get: {
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: exampleSchema,
+                    example: exampleInvalid,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const results = TestHelpers.runRulesWithInputs(
+      [new ExamplesRuleset({})],
+      input,
+      input
+    );
+    expect(results.length > 0).toBe(true);
+
+    expect(results).toMatchSnapshot();
+    expect(results.some((result) => !result.passed)).toBe(true);
+  });
+  test('invalid response named example errors', () => {
+    const input: OpenAPIV3.Document = {
+      ...TestHelpers.createEmptySpec(),
+      paths: {
+        '/api/users': {
+          get: {
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: exampleSchema,
+                    examples: {
+                      main: {
+                        value: exampleInvalid,
+                      },
+                      other: {
+                        value: exampleValid,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const results = TestHelpers.runRulesWithInputs(
+      [new ExamplesRuleset({})],
+      input,
+      input
+    );
+    expect(results.length > 0).toBe(true);
+
+    expect(results).toMatchSnapshot();
+    expect(results.some((result) => !result.passed)).toBe(true);
+  });
+
+  test('invalid request top level example errors', () => {
+    const input: OpenAPIV3.Document = {
+      ...TestHelpers.createEmptySpec(),
+      paths: {
+        '/api/users': {
+          post: {
+            responses: {},
+            requestBody: {
+              description: '',
+              content: {
+                'application/json': {
+                  schema: exampleSchema,
+                  example: exampleInvalid,
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const results = TestHelpers.runRulesWithInputs(
+      [new ExamplesRuleset({})],
+      input,
+      input
+    );
+    expect(results.length > 0).toBe(true);
+
+    expect(results).toMatchSnapshot();
+    expect(results.some((result) => !result.passed)).toBe(true);
+  });
+  test('invalid request named example errors', () => {
+    const input: OpenAPIV3.Document = {
+      ...TestHelpers.createEmptySpec(),
+      paths: {
+        '/api/users': {
+          post: {
+            responses: {},
+            requestBody: {
+              description: 'ok',
+              content: {
+                'application/json': {
+                  schema: exampleSchema,
+                  examples: {
+                    main: {
+                      value: exampleInvalid,
+                    },
+                    other: {
+                      value: exampleValid,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const results = TestHelpers.runRulesWithInputs(
+      [new ExamplesRuleset({})],
+      input,
+      input
+    );
+    expect(results.length > 0).toBe(true);
+
+    expect(results).toMatchSnapshot();
+    expect(results.some((result) => !result.passed)).toBe(true);
+  });
+});

--- a/projects/standard-rulesets/src/examples/constants.ts
+++ b/projects/standard-rulesets/src/examples/constants.ts
@@ -1,0 +1,1 @@
+export const appliesWhen = ['addedOrChanged', 'always'] as const;

--- a/projects/standard-rulesets/src/examples/index.ts
+++ b/projects/standard-rulesets/src/examples/index.ts
@@ -1,0 +1,84 @@
+import { Rule, Ruleset } from '@useoptic/rulesets-base';
+import Ajv from 'ajv';
+import { appliesWhen } from './constants';
+import {
+  requireParameterExamples,
+  requireRequestExamples,
+  requireResponseExamples,
+} from './requireExample';
+import {
+  requirePropertyExamplesMatchSchema,
+  requireValidParameterExamples,
+  requireValidRequestExamples,
+  requireValidResponseExamples,
+} from './requireValidExamples';
+
+type YamlConfig = {
+  require_request_examples?: boolean;
+  require_response_examples?: boolean;
+  require_parameter_examples?: boolean;
+  required_on?: typeof appliesWhen[number];
+};
+
+const ajv = new Ajv();
+const configSchema = {
+  type: 'object',
+  properties: {
+    require_request_examples: {
+      type: 'boolean',
+    },
+    require_response_examples: {
+      type: 'boolean',
+    },
+    require_parameter_examples: {
+      type: 'boolean',
+    },
+    required_on: {
+      type: 'string',
+      enum: appliesWhen,
+    },
+  },
+};
+
+const validateConfigSchema = ajv.compile(configSchema);
+
+export class ExamplesRuleset extends Ruleset {
+  static fromOpticConfig(config: unknown): ExamplesRuleset | string {
+    const result = validateConfigSchema(config);
+
+    if (!result) {
+      return `- ${ajv.errorsText(validateConfigSchema.errors, {
+        separator: '\n- ',
+        dataVar: 'ruleset/examples',
+      })}`;
+    }
+
+    const validatedConfig = config as YamlConfig;
+
+    return new ExamplesRuleset(validatedConfig);
+  }
+
+  constructor(config: YamlConfig = {}) {
+    const rules: Rule[] = [
+      requireValidResponseExamples,
+      requirePropertyExamplesMatchSchema,
+      requireValidParameterExamples,
+      requireValidRequestExamples,
+    ];
+
+    if (config.require_response_examples)
+      rules.push(requireResponseExamples(config.required_on || 'always'));
+
+    if (config.require_request_examples)
+      rules.push(requireRequestExamples(config.required_on || 'always'));
+
+    if (config.require_parameter_examples)
+      rules.push(requireParameterExamples(config.required_on || 'always'));
+
+    super({
+      ...config,
+      name: 'Examples ruleset',
+      rules: rules,
+    });
+  }
+}

--- a/projects/standard-rulesets/src/examples/requireExample.ts
+++ b/projects/standard-rulesets/src/examples/requireExample.ts
@@ -1,0 +1,136 @@
+import {
+  OperationRule,
+  RequestRule,
+  ResponseBody,
+  ResponseRule,
+  RuleError,
+} from '@useoptic/rulesets-base';
+import { appliesWhen } from './constants';
+import { OpenAPIV3 } from 'openapi-types';
+
+export const requireResponseExamples = (applies: typeof appliesWhen[number]) =>
+  new ResponseRule({
+    name: 'require response body examples',
+    rule: (responseAssertions) => {
+      function responseToNumberOfExamples(body: ResponseBody) {
+        const numberOfExamples =
+          (body.raw.example ? 1 : 0) +
+          Object.keys(body.raw.examples || {}).length;
+        return numberOfExamples;
+      }
+
+      if (applies === 'always') {
+        responseAssertions.requirement((value) => {
+          value.bodies.forEach((body) => {
+            if (responseToNumberOfExamples(body) < 1) {
+              throw new RuleError({
+                message: `a valid example is required for every documented response body`,
+              });
+            }
+          });
+        });
+      }
+
+      if (applies === 'addedOrChanged') {
+        responseAssertions.addedOrChanged((value) => {
+          value.bodies.forEach((body) => {
+            if (responseToNumberOfExamples(body) < 1) {
+              throw new RuleError({
+                message: `a valid example is required for added response bodies`,
+              });
+            }
+          });
+        });
+      }
+    },
+  });
+
+export const requireRequestExamples = (applies: typeof appliesWhen[number]) =>
+  new RequestRule({
+    name: 'require request body examples',
+    rule: (requestAssertions) => {
+      function requestToNumberOfExamples(body: OpenAPIV3.MediaTypeObject) {
+        const numberOfExamples =
+          (body.example ? 1 : 0) + Object.keys(body.examples || {}).length;
+        return numberOfExamples;
+      }
+
+      if (applies === 'always') {
+        requestAssertions.body.requirement((value) => {
+          const body = value.raw as unknown as OpenAPIV3.MediaTypeObject;
+
+          if (requestToNumberOfExamples(body) < 1) {
+            throw new RuleError({
+              message: `a valid example is required for every documented request body`,
+            });
+          }
+        });
+      }
+
+      if (applies === 'addedOrChanged') {
+        requestAssertions.body.addedOrChanged((value) => {
+          const body = value.raw as unknown as OpenAPIV3.MediaTypeObject;
+
+          if (requestToNumberOfExamples(body) < 1) {
+            throw new RuleError({
+              message: `a valid example is required for added request bodies`,
+            });
+          }
+        });
+      }
+    },
+  });
+
+export const requireParameterExamples = (applies: typeof appliesWhen[number]) =>
+  new OperationRule({
+    name: 'require parameter examples',
+    rule: (operation) => {
+      if (applies === 'always') {
+        operation.headerParameter.requirement((header) => {
+          if (!header.raw.example) {
+            throw new RuleError({
+              message: `a valid example is required for every documented header`,
+            });
+          }
+        });
+        operation.queryParameter.requirement((header) => {
+          if (!header.raw.example) {
+            throw new RuleError({
+              message: `a valid example is required for every documented query parameter`,
+            });
+          }
+        });
+        operation.cookieParameter.requirement((header) => {
+          if (!header.raw.example) {
+            throw new RuleError({
+              message: `a valid example is required for every documented cookie parameter`,
+            });
+          }
+        });
+      }
+
+      if (applies === 'addedOrChanged') {
+        operation.headerParameter.addedOrChanged((header) => {
+          if (!header.raw.example) {
+            throw new RuleError({
+              message: `a valid example is required for added header`,
+            });
+          }
+        });
+        operation.queryParameter.addedOrChanged((header) => {
+          if (!header.raw.example) {
+            throw new RuleError({
+              message: `a valid example is required for added query parameter`,
+            });
+          }
+        });
+        operation.cookieParameter.addedOrChanged((header) => {
+          if (!header.raw.example) {
+            throw new RuleError({
+              message: `a valid example is required for added cookie parameter`,
+            });
+          }
+        });
+      }
+    },
+  });

--- a/projects/standard-rulesets/src/examples/requireExample.ts
+++ b/projects/standard-rulesets/src/examples/requireExample.ts
@@ -85,52 +85,28 @@ export const requireParameterExamples = (applies: typeof appliesWhen[number]) =>
   new OperationRule({
     name: 'require parameter examples',
     rule: (operation) => {
-      if (applies === 'always') {
-        operation.headerParameter.requirement((header) => {
-          if (!header.raw.example) {
-            throw new RuleError({
-              message: `a valid example is required for every documented header`,
-            });
-          }
-        });
-        operation.queryParameter.requirement((header) => {
-          if (!header.raw.example) {
-            throw new RuleError({
-              message: `a valid example is required for every documented query parameter`,
-            });
-          }
-        });
-        operation.cookieParameter.requirement((header) => {
-          if (!header.raw.example) {
-            throw new RuleError({
-              message: `a valid example is required for every documented cookie parameter`,
-            });
-          }
-        });
-      }
-
-      if (applies === 'addedOrChanged') {
-        operation.headerParameter.addedOrChanged((header) => {
-          if (!header.raw.example) {
-            throw new RuleError({
-              message: `a valid example is required for added header`,
-            });
-          }
-        });
-        operation.queryParameter.addedOrChanged((header) => {
-          if (!header.raw.example) {
-            throw new RuleError({
-              message: `a valid example is required for added query parameter`,
-            });
-          }
-        });
-        operation.cookieParameter.addedOrChanged((header) => {
-          if (!header.raw.example) {
-            throw new RuleError({
-              message: `a valid example is required for added cookie parameter`,
-            });
-          }
-        });
-      }
+      const lifecycle = applies === 'always' ? 'requirement' : 'addedOrChanged';
+      const errorMessageType = applies === 'always' ? 'every' : 'added';
+      operation.headerParameter[lifecycle]((header) => {
+        if (!header.raw.example) {
+          throw new RuleError({
+            message: `a valid example is required for ${errorMessageType} header`,
+          });
+        }
+      });
+      operation.queryParameter[lifecycle]((header) => {
+        if (!header.raw.example) {
+          throw new RuleError({
+            message: `a valid example is required for ${errorMessageType} query parameter`,
+          });
+        }
+      });
+      operation.cookieParameter[lifecycle]((header) => {
+        if (!header.raw.example) {
+          throw new RuleError({
+            message: `a valid example is required for ${errorMessageType} cookie parameter`,
+          });
+        }
+      });
     },
   });

--- a/projects/standard-rulesets/src/examples/requireValidExamples.ts
+++ b/projects/standard-rulesets/src/examples/requireValidExamples.ts
@@ -1,0 +1,165 @@
+import {
+  OperationRule,
+  PropertyRule,
+  RequestRule,
+  ResponseRule,
+  RuleError,
+} from '@useoptic/rulesets-base';
+import { OpenAPIV3 } from 'openapi-types';
+import Ajv, { SchemaObject } from 'ajv';
+
+const ajv = new Ajv({ strict: false });
+
+function validateSchema(
+  schema: SchemaObject,
+  example: unknown
+): { pass: true } | { pass: false; error: string } {
+  const schemaCompiled = ajv.compile(schema);
+
+  const result = schemaCompiled(example);
+
+  if (!result) {
+    const error = `- ${ajv.errorsText(schemaCompiled.errors, {
+      separator: '\n- ',
+    })}`;
+
+    return { pass: false, error };
+  }
+
+  return { pass: true };
+}
+
+export const requireValidRequestExamples = new RequestRule({
+  name: 'request body examples must match schema',
+  rule: (requestAssertions) => {
+    requestAssertions.body.requirement((value) => {
+      const { schema, examples, example } =
+        value.raw as OpenAPIV3.MediaTypeObject;
+
+      if (example) {
+        const result = validateSchema(schema || {}, example);
+        if (!result.pass) {
+          throw new RuleError({
+            message: `the example does not match the schema. \n${result.error} `,
+          });
+        }
+      }
+
+      if (examples) {
+        Object.entries(examples).forEach((example) => {
+          const [exampleName, exampleValue] = example as [
+            string,
+            OpenAPIV3.ExampleObject
+          ];
+          const result = validateSchema(schema || {}, exampleValue.value);
+          if (!result.pass) {
+            throw new RuleError({
+              message: `the example named '${exampleName}' does not match the schema. \n${result.error} `,
+            });
+          }
+        });
+      }
+    });
+  },
+});
+
+export const requireValidResponseExamples = new ResponseRule({
+  name: 'response body examples must match schemas',
+  rule: (responseAssertions) => {
+    responseAssertions.requirement((value) => {
+      value.bodies.forEach((body) => {
+        if (body.raw.example) {
+          const result = validateSchema(
+            body.raw.schema || {},
+            body.raw.example
+          );
+          if (!result.pass) {
+            throw new RuleError({
+              message: `the example does not match the schema. \n${result.error} `,
+            });
+          }
+        }
+
+        if (body.raw.examples) {
+          Object.entries(body.raw.examples).forEach((example) => {
+            const [exampleName, exampleValue] = example as [
+              string,
+              OpenAPIV3.ExampleObject
+            ];
+            const result = validateSchema(
+              body.raw.schema || {},
+              exampleValue.value
+            );
+            if (!result.pass) {
+              throw new RuleError({
+                message: `the example named '${exampleName}' does not match the schema. \n${result.error} `,
+              });
+            }
+          });
+        }
+      });
+    });
+  },
+});
+
+export const requireValidParameterExamples = new OperationRule({
+  name: 'parameter examples must match schemas',
+  rule: (operation) => {
+    operation.headerParameter.requirement((header) => {
+      if (header.raw.example) {
+        const result = validateSchema(
+          header.raw.schema || {},
+          header.raw.example
+        );
+        if (!result.pass) {
+          throw new RuleError({
+            message: `header '${header.value.name}' example does not match the schema. \n${result.error} `,
+          });
+        }
+      }
+    });
+    operation.queryParameter.requirement((query) => {
+      if (query.raw.example) {
+        const result = validateSchema(
+          query.raw.schema || {},
+          query.raw.example
+        );
+        if (!result.pass) {
+          throw new RuleError({
+            message: `query parameter '${query.value.name}' example does not match the schema. \n${result.error} `,
+          });
+        }
+      }
+    });
+    operation.cookieParameter.requirement((cookie) => {
+      if (cookie.raw.example) {
+        const result = validateSchema(
+          cookie.raw.schema || {},
+          cookie.raw.example
+        );
+        if (!result.pass) {
+          throw new RuleError({
+            message: `cookie '${cookie.value.name}' example does not match the schema. \n${result.error} `,
+          });
+        }
+      }
+    });
+  },
+});
+
+export const requirePropertyExamplesMatchSchema = new PropertyRule({
+  name: 'require property examples match schemas',
+  rule: (property) => {
+    property.requirement((property) => {
+      const flatSchema = property.value.flatSchema;
+      if (property.raw.example) {
+        const result = validateSchema(flatSchema, property.raw.example);
+        if (!result.pass) {
+          throw new RuleError({
+            message: `'${property.value.key}' example does not match the schema. \n${result.error} `,
+          });
+        }
+      }
+    });
+  },
+});

--- a/projects/standard-rulesets/src/index.ts
+++ b/projects/standard-rulesets/src/index.ts
@@ -1,10 +1,14 @@
 export * from './breaking-changes';
 export * from './naming-changes';
+export * from './examples';
 
 import { BreakingChangesRuleset } from './breaking-changes';
 import { NamingChangesRuleset } from './naming-changes';
+import { ExamplesRuleset } from './examples';
 
 export const StandardRulesets = {
   'breaking-changes': BreakingChangesRuleset,
   naming: NamingChangesRuleset,
+
+  examples: ExamplesRuleset,
 };


### PR DESCRIPTION
## 🍗 Description
This ruleset has been requested by several users and since it's pretty generic / useful we've decided to bring it into the built-ins. 

The `examples` built-in does two things:
- enforce a requirement that every entity in your OpenAPI spec has a valid example. You can configure this, and also set `applies: addedOrChanged` if you only want this to apply to new APIs
- enforces that each example matches its schema. This works at the property, request, response and parameter level and cannot be configured / turned off. If the example is there, it must match the schema. 


## 📚 References
Config:
```
examples: 
  require_parameter_examples: true
  require_request_examples: true
  require_response_examples: true
  applies: 'always' | 'addedOrChanged'
```

## 👹 QA
There are a lot of tests, but go ahead and give it a spin! 

My biggest concern is the `ajv` parser failing in weird ways depending on keywords you set. 
