### PR TITLE
Put security scopes in operation context

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openapi-workspaces",
   "private": true,
-  "version": "0.33.4",
+  "version": "0.34.0",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/json-pointer-helpers",
-  "version": "0.33.4",
+  "version": "0.34.0",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-cli",
   "packageManager": "yarn@3.0.2",
-  "version": "0.33.4",
+  "version": "0.34.0",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/openapi-io",
-  "version": "0.33.4",
+  "version": "0.34.0",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/openapi-utilities",
-  "version": "0.33.4",
+  "version": "0.34.0",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/optic-ci",
   "packageManager": "yarn@3.0.2",
-  "version": "0.33.4",
+  "version": "0.34.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/optic",
   "packageManager": "yarn@3.0.2",
-  "version": "0.33.4",
+  "version": "0.34.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
@@ -111,61 +111,6 @@ Configure check rulesets in your local optic.dev.yml file.
 "
 `;
 
-exports[`diff basic rules config 3`] = `
-"
-[1mGET[22m /example: 
-  - operationId [33mchanged[39m
-
-[1mPATCH[22m /example: 
-  - operationId [33mchanged[39m
-  - response [1m200[22m:
-    - description [32madded[39m
-    - body [1mapplication/json[22m: [32madded[39m
-      - type [32madded[39m
-      - example [32madded[39m
-        - value [32madded[39m
-
-[1mPOST[22m /example: [31mremoved[39m
-[1mPUT[22m /example: 
-  - operationId [33mchanged[39m
-
-[1mGET[22m /invalid_name: [32madded[39m
-  - operationId [32madded[39m
-
-Checks
-
-  [1m[42m[37m PASS [39m[49m[22m [1mGET[22m /example
-
-
-  [1m[42m[37m PASS [39m[49m[22m [1mPATCH[22m /example
-
-
-  [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /example
-    removed rule: prevent operation removal
-      [31m[31mx[39m[31m cannot remove an operation. This is a breaking change.[39m
-      at [4m$workspace$/example-api-v0.json:9:150[24m
-
-
-
-  [1m[42m[37m PASS [39m[49m[22m [1mPUT[22m /example
-
-
-  [1m[41m[37m FAIL [39m[49m[22m [1mGET[22m /invalid_name
-    requirement rule: operation path component naming check
-      [31m[31mx[39m[31m invalid_name is not camelCase[39m
-      at [4m$workspace$/example-api-v1.json:31:632[24m
-
-
-
-1 operation added, 3 changed, 1 removed
-[32m[1m3 checks passed[22m[39m
-[31m[1m2 checks failed[22m[39m
-
-Configure check rulesets in your local optic.dev.yml file.
-[34mRerun this command with the --web flag to view the detailed changes in your browser[39m
-"
-`;
-
 exports[`diff breaking changes exclusion 1`] = `
 "Deprecation warning: optic.yml file is deprecated. Please rename your file to optic.dev.yml
 

--- a/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
@@ -111,6 +111,61 @@ Configure check rulesets in your local optic.dev.yml file.
 "
 `;
 
+exports[`diff basic rules config 3`] = `
+"
+[1mGET[22m /example: 
+  - operationId [33mchanged[39m
+
+[1mPATCH[22m /example: 
+  - operationId [33mchanged[39m
+  - response [1m200[22m:
+    - description [32madded[39m
+    - body [1mapplication/json[22m: [32madded[39m
+      - type [32madded[39m
+      - example [32madded[39m
+        - value [32madded[39m
+
+[1mPOST[22m /example: [31mremoved[39m
+[1mPUT[22m /example: 
+  - operationId [33mchanged[39m
+
+[1mGET[22m /invalid_name: [32madded[39m
+  - operationId [32madded[39m
+
+Checks
+
+  [1m[42m[37m PASS [39m[49m[22m [1mGET[22m /example
+
+
+  [1m[42m[37m PASS [39m[49m[22m [1mPATCH[22m /example
+
+
+  [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /example
+    removed rule: prevent operation removal
+      [31m[31mx[39m[31m cannot remove an operation. This is a breaking change.[39m
+      at [4m$workspace$/example-api-v0.json:9:150[24m
+
+
+
+  [1m[42m[37m PASS [39m[49m[22m [1mPUT[22m /example
+
+
+  [1m[41m[37m FAIL [39m[49m[22m [1mGET[22m /invalid_name
+    requirement rule: operation path component naming check
+      [31m[31mx[39m[31m invalid_name is not camelCase[39m
+      at [4m$workspace$/example-api-v1.json:31:632[24m
+
+
+
+1 operation added, 3 changed, 1 removed
+[32m[1m3 checks passed[22m[39m
+[31m[1m2 checks failed[22m[39m
+
+Configure check rulesets in your local optic.dev.yml file.
+[34mRerun this command with the --web flag to view the detailed changes in your browser[39m
+"
+`;
+
 exports[`diff breaking changes exclusion 1`] = `
 "Deprecation warning: optic.yml file is deprecated. Please rename your file to optic.dev.yml
 

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/rulesets-base",
   "packageManager": "yarn@3.0.2",
-  "version": "0.33.4",
+  "version": "0.34.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/src/__tests__/__snapshots__/operation-rules.test.ts.snap
+++ b/projects/rulesets-base/src/__tests__/__snapshots__/operation-rules.test.ts.snap
@@ -3108,6 +3108,7 @@ Object {
     },
     "requests": Array [],
     "responses": Map {},
+    "security": null,
     "value": Object {
       "description": "hello",
       "method": "get",
@@ -3188,6 +3189,7 @@ Object {
     },
     "requests": Array [],
     "responses": Map {},
+    "security": null,
     "value": Object {
       "description": "hello",
       "method": "get",

--- a/projects/rulesets-base/src/__tests__/__snapshots__/specification-rules.test.ts.snap
+++ b/projects/rulesets-base/src/__tests__/__snapshots__/specification-rules.test.ts.snap
@@ -306,6 +306,7 @@ Object {
     },
     "requests": Array [],
     "responses": Map {},
+    "security": null,
     "value": Object {
       "method": "",
       "pathPattern": "",
@@ -380,6 +381,7 @@ Object {
     },
     "requests": Array [],
     "responses": Map {},
+    "security": null,
     "value": Object {
       "method": "",
       "pathPattern": "",
@@ -454,6 +456,7 @@ Object {
     },
     "requests": Array [],
     "responses": Map {},
+    "security": null,
     "value": Object {
       "method": "",
       "pathPattern": "",
@@ -528,6 +531,7 @@ Object {
     },
     "requests": Array [],
     "responses": Map {},
+    "security": null,
     "value": Object {
       "method": "",
       "pathPattern": "",

--- a/projects/rulesets-base/src/rule-runner/__tests__/__snapshots__/data-constructors.test.ts.snap
+++ b/projects/rulesets-base/src/rule-runner/__tests__/__snapshots__/data-constructors.test.ts.snap
@@ -1329,7 +1329,7 @@ Object {
   },
   "security": Array [
     Object {
-      "api": Array [
+      "AuthScope": Array [
         "admin",
       ],
     },
@@ -5757,7 +5757,7 @@ Object {
     },
     "security": Array [
       Object {
-        "api": Array [
+        "AuthScope": Array [
           "admin",
         ],
       },

--- a/projects/rulesets-base/src/rule-runner/__tests__/__snapshots__/data-constructors.test.ts.snap
+++ b/projects/rulesets-base/src/rule-runner/__tests__/__snapshots__/data-constructors.test.ts.snap
@@ -1327,6 +1327,13 @@ Object {
       },
     },
   },
+  "security": Array [
+    Object {
+      "api": Array [
+        "admin",
+      ],
+    },
+  ],
   "value": Object {
     "description": "For valid response try integer IDs with value >= 1 and <= 10.         Other values will generated exceptions",
     "method": "get",
@@ -2362,6 +2369,7 @@ Object {
       },
     },
   },
+  "security": null,
   "value": Object {
     "description": "For valid response try integer IDs with value >= 1 and <= 10.         Other values will generated exceptions",
     "method": "get",
@@ -5747,6 +5755,13 @@ Object {
         },
       },
     },
+    "security": Array [
+      Object {
+        "api": Array [
+          "admin",
+        ],
+      },
+    ],
     "servers": Array [
       Object {
         "url": "https://petstore.swagger.io/v2",

--- a/projects/rulesets-base/src/rule-runner/__tests__/examples/petstore-small.ts
+++ b/projects/rulesets-base/src/rule-runner/__tests__/examples/petstore-small.ts
@@ -498,6 +498,11 @@ export const afterOpenApiJson: OpenAPIV3.Document = {
     description: 'Find out more about Swagger',
     url: 'http://swagger.io',
   },
+  security: [
+    {
+      AuthScope: ['admin'],
+    },
+  ],
   servers: [
     {
       url: 'https://petstore.swagger.io/v2',

--- a/projects/rulesets-base/src/rule-runner/data-constructors.ts
+++ b/projects/rulesets-base/src/rule-runner/data-constructors.ts
@@ -167,16 +167,13 @@ export const createOperation = (
   const security: OpenAPIV3.OperationObject['security'] | null = (() => {
     const operationOverride = jsonPointerHelpers.tryGet(
       openApiSpec,
-      jsonPointerHelpers.join(operationFact.location.jsonPath, 'security')
+      jsonPointerHelpers.join(operationFact.location.jsonPath, '/security')
     );
 
     if (operationOverride.match)
       return operationOverride.value as OpenAPIV3.OperationObject['security'];
 
-    const specLevel = jsonPointerHelpers.get(
-      openApiSpec,
-      jsonPointerHelpers.join(operationFact.location.jsonPath, 'security')
-    );
+    const specLevel = jsonPointerHelpers.tryGet(openApiSpec, '/security');
 
     if (specLevel.match)
       return specLevel.value as OpenAPIV3.OperationObject['security'];

--- a/projects/rulesets-base/src/rule-runner/data-constructors.ts
+++ b/projects/rulesets-base/src/rule-runner/data-constructors.ts
@@ -164,11 +164,32 @@ export const createOperation = (
     }
   }
 
+  const security: OpenAPIV3.OperationObject['security'] | undefined = (() => {
+    const operationOverride = jsonPointerHelpers.tryGet(
+      openApiSpec,
+      jsonPointerHelpers.join(operationFact.location.jsonPath, 'security')
+    );
+
+    if (operationOverride.match)
+      return operationOverride.value as OpenAPIV3.OperationObject['security'];
+
+    const specLevel = jsonPointerHelpers.get(
+      openApiSpec,
+      jsonPointerHelpers.join(operationFact.location.jsonPath, 'security')
+    );
+
+    if (specLevel.match)
+      return specLevel.value as OpenAPIV3.OperationObject['security'];
+
+    return undefined;
+  })();
+
   return {
     ...operationFact,
     raw: jsonPointerHelpers.get(openApiSpec, operationFact.location.jsonPath),
     path: endpoint.path,
     method: endpoint.method,
+    security,
     headerParameters: createFactsWithRaw(
       endpoint.headerParameters,
       key,

--- a/projects/rulesets-base/src/rule-runner/data-constructors.ts
+++ b/projects/rulesets-base/src/rule-runner/data-constructors.ts
@@ -164,7 +164,7 @@ export const createOperation = (
     }
   }
 
-  const security: OpenAPIV3.OperationObject['security'] | undefined = (() => {
+  const security: OpenAPIV3.OperationObject['security'] | null = (() => {
     const operationOverride = jsonPointerHelpers.tryGet(
       openApiSpec,
       jsonPointerHelpers.join(operationFact.location.jsonPath, 'security')
@@ -181,7 +181,7 @@ export const createOperation = (
     if (specLevel.match)
       return specLevel.value as OpenAPIV3.OperationObject['security'];
 
-    return undefined;
+    return null;
   })();
 
   return {

--- a/projects/rulesets-base/src/rule-runner/utils.ts
+++ b/projects/rulesets-base/src/rule-runner/utils.ts
@@ -21,12 +21,14 @@ export const createRuleContextWithoutOperation = (
   ),
   custom: any
 ): RuleContext => {
-  const specificationChange = getSpecificationChange(specification.node)
+  const specificationChange = getSpecificationChange(specification.node);
 
   return {
     custom,
     specification: {
-      ...(specificationChange === 'removed' ? specification.before! : specification.after!),
+      ...(specificationChange === 'removed'
+        ? specification.before!
+        : specification.after!),
       change: specificationChange,
     },
     operation: {
@@ -42,6 +44,7 @@ export const createRuleContextWithoutOperation = (
       raw: {
         responses: {},
       },
+      security: null,
       change: null,
       queryParameters: new Map(),
       pathParameters: new Map(),
@@ -55,22 +58,20 @@ export const createRuleContextWithoutOperation = (
 
 export const createRuleContextWithOperation = (
   specification: {
-    node: NodeDetail<OpenApiKind.Specification>
-  }
-    & (
-      | { before: Specification | null; after: Specification }
-      | { before: Specification; after: null }
-    ),
-    operation: {
-      node: NodeDetail<OpenApiKind.Operation>
-    }
-      & (
-        | { before: Operation | null; after: Operation }
-        | { before: Operation; after: null }
-      ),
+    node: NodeDetail<OpenApiKind.Specification>;
+  } & (
+    | { before: Specification | null; after: Specification }
+    | { before: Specification; after: null }
+  ),
+  operation: {
+    node: NodeDetail<OpenApiKind.Operation>;
+  } & (
+    | { before: Operation | null; after: Operation }
+    | { before: Operation; after: null }
+  ),
   custom: any
 ): RuleContext => {
-  const specificationChange = getSpecificationChange(specification.node)
+  const specificationChange = getSpecificationChange(specification.node);
 
   if (specificationChange === 'removed') {
     return {
@@ -81,19 +82,19 @@ export const createRuleContextWithOperation = (
       },
       operation: {
         ...operation.before!,
-        change: specificationChange
+        change: specificationChange,
       },
-    }
+    };
   } else {
     return {
       custom,
       specification: {
         ...specification.after!,
-        change: specificationChange
+        change: specificationChange,
       },
       operation: {
         ...(operation.after ? operation.after : operation.before),
-        change:operation.node.change?.changeType || null
+        change: operation.node.change?.changeType || null,
       },
     };
   }

--- a/projects/rulesets-base/src/types.ts
+++ b/projects/rulesets-base/src/types.ts
@@ -21,7 +21,7 @@ export type Specification = FactVariant<OpenApiKind.Specification> & {
 
 export type Operation = FactVariant<OpenApiKind.Operation> & {
   raw: OpenAPIV3.OperationObject;
-  security: OpenAPIV3.OperationObject['security'] | undefined;
+  security: OpenAPIV3.OperationObject['security'] | null;
   path: string;
   method: string;
   queryParameters: Map<string, QueryParameter>;

--- a/projects/rulesets-base/src/types.ts
+++ b/projects/rulesets-base/src/types.ts
@@ -21,6 +21,7 @@ export type Specification = FactVariant<OpenApiKind.Specification> & {
 
 export type Operation = FactVariant<OpenApiKind.Operation> & {
   raw: OpenAPIV3.OperationObject;
+  security: OpenAPIV3.OperationObject['security'] | undefined;
   path: string;
   method: string;
   queryParameters: Map<string, QueryParameter>;
@@ -235,4 +236,4 @@ export type ResponseBodyAssertions = {
   property: Assertions<'property'>;
 };
 
-export type PropertyAssertions = Assertions<'property'>
+export type PropertyAssertions = Assertions<'property'>;

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/standard-rulesets",
   "packageManager": "yarn@3.0.2",
-  "version": "0.33.4",
+  "version": "0.34.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
## 🍗 Description
Enables teams to write rules about security scopes 

## 📚 References
[_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._
](https://github.com/opticdev/optic/issues/1374)

## 👹 QA
[] Tests pass
[] Write a new rule