### PR TITLE
Fix/security schema lookup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openapi-workspaces",
   "private": true,
-  "version": "0.34.0",
+  "version": "0.34.1",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/json-pointer-helpers",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-cli",
   "packageManager": "yarn@3.0.2",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/openapi-io",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/openapi-utilities",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/optic-ci",
   "packageManager": "yarn@3.0.2",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/optic",
   "packageManager": "yarn@3.0.2",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/rulesets-base",
   "packageManager": "yarn@3.0.2",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/src/rule-runner/__tests__/__snapshots__/data-constructors.test.ts.snap
+++ b/projects/rulesets-base/src/rule-runner/__tests__/__snapshots__/data-constructors.test.ts.snap
@@ -4962,6 +4962,13 @@ Object {
               "description": "succesful",
             },
           },
+          "security": Array [
+            Object {
+              "LocalAuthScope": Array [
+                "admin",
+              ],
+            },
+          ],
         },
       },
       "/pet": Object {

--- a/projects/rulesets-base/src/rule-runner/__tests__/examples/petstore-small.ts
+++ b/projects/rulesets-base/src/rule-runner/__tests__/examples/petstore-small.ts
@@ -540,6 +540,11 @@ export const afterOpenApiJson: OpenAPIV3.Document = {
     '/example': {
       get: {
         operationId: 'getExamples',
+        security: [
+          {
+            LocalAuthScope: ['admin'],
+          },
+        ],
         responses: {
           '200': {
             description: 'succesful',

--- a/projects/rulesets-base/src/rule-runner/data-constructors.ts
+++ b/projects/rulesets-base/src/rule-runner/data-constructors.ts
@@ -167,7 +167,7 @@ export const createOperation = (
   const security: OpenAPIV3.OperationObject['security'] | null = (() => {
     const operationOverride = jsonPointerHelpers.tryGet(
       openApiSpec,
-      jsonPointerHelpers.join(operationFact.location.jsonPath, '/security')
+      jsonPointerHelpers.append(operationFact.location.jsonPath, 'security')
     );
 
     if (operationOverride.match)

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/standard-rulesets",
   "packageManager": "yarn@3.0.2",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
## 🍗 Description
We were using the `join` instead of `append` helper so lookups of security schema on the operations were being missed.
## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
