### PR TITLE
Implement `optic ruleset publish` command

### DIFF
--- a/projects/optic/src/__tests__/integration/__snapshots__/ruleset-publish.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/ruleset-publish.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`optic ruleset publish can publish a ruleset 1`] = `
+"Successfully published the ruleset
+"
+`;
+
+exports[`optic ruleset publish exits if ruleset file shape is not valid 1`] = `
+"Rule file is invalid:
+data/default must have required property 'rules'
+Rules file does not match expected format. Expected ruleset file to have a default export with the shape
+{
+  name: string;
+  rules: (Ruleset | Rule)[]
+}
+"
+`;

--- a/projects/optic/src/__tests__/integration/ruleset-publish.test.ts
+++ b/projects/optic/src/__tests__/integration/ruleset-publish.test.ts
@@ -1,0 +1,31 @@
+import { runOptic, setupWorkspace, normalizeWorkspace } from './integration';
+
+jest.setTimeout(30000);
+// TODO replace this with real mocks when connected to backend
+jest.mock('node-fetch');
+
+describe('optic ruleset publish', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('can publish a ruleset', async () => {
+    const workspace = await setupWorkspace('ruleset-publish/valid-js-file');
+    const { combined, code } = await runOptic(
+      workspace,
+      'ruleset publish ./rules.js --token atoken'
+    );
+    expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
+    expect(code).toBe(0);
+  });
+
+  test('exits if ruleset file shape is not valid', async () => {
+    const workspace = await setupWorkspace('ruleset-publish/invalid-js-file');
+    const { combined, code } = await runOptic(
+      workspace,
+      'ruleset publish ./rules.js --token atoken'
+    );
+    expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
+    expect(code).toBe(1);
+  });
+});

--- a/projects/optic/src/__tests__/integration/ruleset-publish.test.ts
+++ b/projects/optic/src/__tests__/integration/ruleset-publish.test.ts
@@ -5,15 +5,22 @@ jest.setTimeout(30000);
 jest.mock('node-fetch');
 
 describe('optic ruleset publish', () => {
+  let oldEnv: any;
+  beforeEach(() => {
+    oldEnv = {...process.env}
+  })
+
   afterEach(() => {
     jest.resetAllMocks();
+    process.env = {...oldEnv}
   });
 
   test('can publish a ruleset', async () => {
     const workspace = await setupWorkspace('ruleset-publish/valid-js-file');
+    process.env.OPTIC_TOKEN = '123'
     const { combined, code } = await runOptic(
       workspace,
-      'OPTIC_TOKEN=atoken ruleset publish ./rules.js'
+      'ruleset publish ./rules.js'
     );
     expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
     expect(code).toBe(0);
@@ -21,9 +28,10 @@ describe('optic ruleset publish', () => {
 
   test('exits if ruleset file shape is not valid', async () => {
     const workspace = await setupWorkspace('ruleset-publish/invalid-js-file');
+    process.env.OPTIC_TOKEN = '123'
     const { combined, code } = await runOptic(
       workspace,
-      'OPTIC_TOKEN=atoken ruleset publish ./rules.js'
+      'ruleset publish ./rules.js'
     );
     expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
     expect(code).toBe(1);

--- a/projects/optic/src/__tests__/integration/ruleset-publish.test.ts
+++ b/projects/optic/src/__tests__/integration/ruleset-publish.test.ts
@@ -13,7 +13,7 @@ describe('optic ruleset publish', () => {
     const workspace = await setupWorkspace('ruleset-publish/valid-js-file');
     const { combined, code } = await runOptic(
       workspace,
-      'ruleset publish ./rules.js --token atoken'
+      'OPTIC_TOKEN=atoken ruleset publish ./rules.js'
     );
     expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
     expect(code).toBe(0);
@@ -23,7 +23,7 @@ describe('optic ruleset publish', () => {
     const workspace = await setupWorkspace('ruleset-publish/invalid-js-file');
     const { combined, code } = await runOptic(
       workspace,
-      'ruleset publish ./rules.js --token atoken'
+      'OPTIC_TOKEN=atoken ruleset publish ./rules.js'
     );
     expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
     expect(code).toBe(1);

--- a/projects/optic/src/__tests__/integration/workspaces/ruleset-publish/invalid-js-file/rules.js
+++ b/projects/optic/src/__tests__/integration/workspaces/ruleset-publish/invalid-js-file/rules.js
@@ -1,3 +1,3 @@
 module.exports = {
-  name: 'no-rules',
+  name: 'asdasdasdasdasdasd - no rules', // this name is so that this is compressable
 }

--- a/projects/optic/src/__tests__/integration/workspaces/ruleset-publish/invalid-js-file/rules.js
+++ b/projects/optic/src/__tests__/integration/workspaces/ruleset-publish/invalid-js-file/rules.js
@@ -1,0 +1,3 @@
+module.exports = {
+  name: 'no-rules',
+}

--- a/projects/optic/src/__tests__/integration/workspaces/ruleset-publish/invalid-js-file/rules.js
+++ b/projects/optic/src/__tests__/integration/workspaces/ruleset-publish/invalid-js-file/rules.js
@@ -1,3 +1,3 @@
 module.exports = {
-  name: 'asdasdasdasdasdasd - no rules', // this name is so that this is compressable
+  name: 'asdasdasdasdasdasd-no-rules', // this name is so that this is compressable
 }

--- a/projects/optic/src/__tests__/integration/workspaces/ruleset-publish/valid-js-file/rules.js
+++ b/projects/optic/src/__tests__/integration/workspaces/ruleset-publish/valid-js-file/rules.js
@@ -1,4 +1,4 @@
 module.exports = {
-  name: 'the-best-ruleset',
+  name: 'asdasdasdasdasdasd - the best ruleset', // this name is so that this is compressable
   rules: []
 }

--- a/projects/optic/src/__tests__/integration/workspaces/ruleset-publish/valid-js-file/rules.js
+++ b/projects/optic/src/__tests__/integration/workspaces/ruleset-publish/valid-js-file/rules.js
@@ -1,4 +1,4 @@
 module.exports = {
-  name: 'asdasdasdasdasdasd - the best ruleset', // this name is so that this is compressable
+  name: 'asdasdasdasdasdasd-the-best-ruleset', // this name is so that this is compressable
   rules: []
 }

--- a/projects/optic/src/__tests__/integration/workspaces/ruleset-publish/valid-js-file/rules.js
+++ b/projects/optic/src/__tests__/integration/workspaces/ruleset-publish/valid-js-file/rules.js
@@ -1,0 +1,4 @@
+module.exports = {
+  name: 'the-best-ruleset',
+  rules: []
+}

--- a/projects/optic/src/commands/ruleset/publish.ts
+++ b/projects/optic/src/commands/ruleset/publish.ts
@@ -1,24 +1,91 @@
+import fs from 'node:fs/promises';
 import { Command } from 'commander';
-import { OpticCliConfig, VCS } from '../../config';
+import fetch from 'node-fetch';
+
 import { wrapActionHandlerWithSentry } from '@useoptic/openapi-utilities/build/utilities/sentry';
+import { UserError } from '@useoptic/openapi-utilities';
 
-import chalk from 'chalk';
+import { OpticCliConfig } from '../../config';
 
-export const registerRulesetPublish = (cli: Command, config: OpticCliConfig) => {
+const uploadFileToS3 = async (signedUrl: string, file: Buffer) => {
+  await fetch(signedUrl, {
+    method: 'PUT',
+    headers: {
+      'x-amz-server-side-encryption': 'AES256',
+    },
+    body: file,
+  });
+};
+
+// TODO help text
+// TODO description1
+// TODO usage
+// TODO write tests
+const expectedFileShape = `Expected ruleset file to have a default export with the shape
+{
+  name: string;
+  rules: (Ruleset | Rule)[]
+}`
+/**
+ * Expected shape
+ * {
+ *  name: string,
+ *  rules: Rulesets
+ * }
+ */
+
+export const registerRulesetPublish = (
+  cli: Command,
+  config: OpticCliConfig
+) => {
   cli
     .command('publish', {
-      hidden: true,
+      hidden: true, // TODO unhide this
     })
     // .configureHelp({
     //   commandUsage: usage,
     // })
     // .addHelpText('after', helpText)
     // .description(description)
-    
-    // TODO add args
-
-
-    .action(wrapActionHandlerWithSentry(getPublishAction(config)));
+    .argument('<path_to_ruleset>', 'the path to the ruleset to publish')
+    .requiredOption(
+      '--token <token>',
+      'the optic token used to authenticate uploading a ruleset. generate an optic token at https://app.useoptic.com'
+    )
+    .action(wrapActionHandlerWithSentry(getPublishAction()));
 };
 
-const getPublishAction = (config: OpticCliConfig) => async () => {}
+const getPublishAction =
+  () =>
+  async ({ path, token }: { path: string; token: string }) => {
+    const userRuleFile = await import(path).catch((e) => {
+      console.error(e);
+      throw new UserError();
+    });
+
+    if (!fileIsValid(userRuleFile)) {
+      throw new UserError(`Rules file does not match expected format. ${expectedFileShape}`)
+    }
+
+    const name = userRuleFile.default.name
+
+    const fileBuffer = await fs.readFile(path);
+    const rulesetUpload: {
+      id: string,
+      uploadUrl: string
+    } = await (async (name: any, token: string) => ({id: '', uploadUrl: ''}))(name, token) // TODO
+    await uploadFileToS3(rulesetUpload.uploadUrl,fileBuffer);
+    await (async(id: string) => {})(rulesetUpload.id); // TODO
+
+    console.log('Successfully published the ruleset')
+  };
+
+const fileIsValid = (file: any): file is {
+  default: {
+    name: string;
+    rules: any[]
+  }
+} => {
+  // TODO validate with ajv
+  return true
+}

--- a/projects/optic/src/commands/ruleset/publish.ts
+++ b/projects/optic/src/commands/ruleset/publish.ts
@@ -1,9 +1,9 @@
+import brotli from 'brotli';
 import fs from 'node:fs/promises';
 import path from 'path';
 import { Command } from 'commander';
 import fetch from 'node-fetch';
 import Ajv from 'ajv';
-import brotli from 'brotli';
 
 import { wrapActionHandlerWithSentry } from '@useoptic/openapi-utilities/build/utilities/sentry';
 import { UserError } from '@useoptic/openapi-utilities';
@@ -72,7 +72,9 @@ const getPublishAction = () => async (filePath: string) => {
   const name = userRuleFile.default.name;
 
   const fileBuffer = await fs.readFile(absolutePath);
-  const compressedFileBuffer = Buffer.from(brotli.compress(fileBuffer));
+  const compressed = brotli.compress(fileBuffer);
+
+  const compressedFileBuffer = Buffer.from(compressed);
   const rulesetUpload: {
     id: string;
     upload_url: string;

--- a/projects/optic/src/commands/ruleset/publish.ts
+++ b/projects/optic/src/commands/ruleset/publish.ts
@@ -1,0 +1,24 @@
+import { Command } from 'commander';
+import { OpticCliConfig, VCS } from '../../config';
+import { wrapActionHandlerWithSentry } from '@useoptic/openapi-utilities/build/utilities/sentry';
+
+import chalk from 'chalk';
+
+export const registerRulesetPublish = (cli: Command, config: OpticCliConfig) => {
+  cli
+    .command('publish', {
+      hidden: true,
+    })
+    // .configureHelp({
+    //   commandUsage: usage,
+    // })
+    // .addHelpText('after', helpText)
+    // .description(description)
+    
+    // TODO add args
+
+
+    .action(wrapActionHandlerWithSentry(getPublishAction(config)));
+};
+
+const getPublishAction = (config: OpticCliConfig) => async () => {}

--- a/projects/optic/src/commands/ruleset/publish.ts
+++ b/projects/optic/src/commands/ruleset/publish.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { Command } from 'commander';
 import fetch from 'node-fetch';
 import Ajv from 'ajv';
+import brotli from 'brotli';
 
 import { wrapActionHandlerWithSentry } from '@useoptic/openapi-utilities/build/utilities/sentry';
 import { UserError } from '@useoptic/openapi-utilities';
@@ -71,6 +72,7 @@ const getPublishAction = () => async (filePath: string) => {
   const name = userRuleFile.default.name;
 
   const fileBuffer = await fs.readFile(absolutePath);
+  const compressedFileBuffer = Buffer.from(brotli.compress(fileBuffer));
   const rulesetUpload: {
     id: string;
     upload_url: string;
@@ -78,7 +80,7 @@ const getPublishAction = () => async (filePath: string) => {
     id: '',
     upload_url: 'https://example.com/placeholder',
   }))(name, maybeToken); // TODO connect up to BWTS
-  await uploadFileToS3(rulesetUpload.upload_url, fileBuffer);
+  await uploadFileToS3(rulesetUpload.upload_url, compressedFileBuffer);
   await (async (id: string) => {})(rulesetUpload.id); // TODO connect up to BWTS
 
   console.log('Successfully published the ruleset');

--- a/projects/optic/src/init.ts
+++ b/projects/optic/src/init.ts
@@ -26,7 +26,7 @@ export const initCli = async () => {
   initSentry(process.env.SENTRY_URL, packageJson.version);
   initSegment(process.env.SEGMENT_KEY);
   cli.hook('preAction', async (command) => {
-    const subcommands = ['cloud'];
+    const subcommands = ['ruleset'];
     try {
       let commandName: string;
       let args: string[];

--- a/projects/optic/src/init.ts
+++ b/projects/optic/src/init.ts
@@ -6,10 +6,10 @@ import {
   trackEvent,
 } from '@useoptic/openapi-utilities/build/utilities/segment';
 
-import { registerCreateGithubContext } from '@useoptic/optic-ci/build/cli/commands/create-context/create-github-context';
-import { registerCreateManualContext } from '@useoptic/optic-ci/build/cli/commands/create-context/create-manual-context';
 import { registerInit } from './commands/init/register-init';
 import { registerDiff } from './commands/diff/diff';
+import { registerRulesetPublish } from './commands/ruleset/publish';
+
 import {
   VCS,
   DefaultOpticCliConfig,
@@ -63,14 +63,13 @@ export const initCli = async () => {
   registerInit(cli, cliConfig);
   registerDiff(cli, cliConfig);
 
-  const cloudSubcommands = cli
-    .command('cloud')
+  const rulesetSubcommands = cli
+    .command('ruleset')
     .description(
-      'Commands to interact with Optic Cloud. See `optic cloud --help`'
+      'Commands to build your own optic rulesets. See `optic ruleset --help`'
     )
     .addHelpCommand(false);
-  registerCreateGithubContext(cloudSubcommands, true);
-  registerCreateManualContext(cloudSubcommands);
+  registerRulesetPublish(rulesetSubcommands, cliConfig);
 
   return cli;
 };


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

This PR implements the optic ruleset publish command. It's currently hidden, will be shown when we've finished implementing the custom rules flow. 

I'm intending usage to look something like: `optic ruleset publish file_path --token <token>`. The name of the ruleset can be included in the JS file. This allows us to be agnostic of the wider environment (e.g. want to set up and publish multiple rules in different repos, we aren't tied to any repo level construct).

In follow up PRs:
- Will connect up this command to backend endpoints

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
