### PR TITLE
Handle uncompressable ruleset file in optic ruleset publish

### DIFF
--- a/projects/optic/src/__tests__/integration/__snapshots__/ruleset-publish.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/ruleset-publish.test.ts.snap
@@ -5,6 +5,11 @@ exports[`optic ruleset publish can publish a ruleset 1`] = `
 "
 `;
 
+exports[`optic ruleset publish can publish uncompressable ruleset 1`] = `
+"Successfully published the ruleset
+"
+`;
+
 exports[`optic ruleset publish exits if ruleset file shape is not valid 1`] = `
 "Rule file is invalid:
 data/default must have required property 'rules'

--- a/projects/optic/src/__tests__/integration/ruleset-publish.test.ts
+++ b/projects/optic/src/__tests__/integration/ruleset-publish.test.ts
@@ -26,6 +26,17 @@ describe('optic ruleset publish', () => {
     expect(code).toBe(0);
   });
 
+  test('can publish uncompressable ruleset', async () => {
+    const workspace = await setupWorkspace('ruleset-publish/uncompressed-file');
+    process.env.OPTIC_TOKEN = '123'
+    const { combined, code } = await runOptic(
+      workspace,
+      'ruleset publish ./rules.js'
+    );
+    expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
+    expect(code).toBe(0);
+  });
+
   test('exits if ruleset file shape is not valid', async () => {
     const workspace = await setupWorkspace('ruleset-publish/invalid-js-file');
     process.env.OPTIC_TOKEN = '123'

--- a/projects/optic/src/__tests__/integration/workspaces/ruleset-publish/uncompressed-file/rules.js
+++ b/projects/optic/src/__tests__/integration/workspaces/ruleset-publish/uncompressed-file/rules.js
@@ -1,0 +1,4 @@
+module.exports = {
+  name: 'asdasdasdasdasdasd-the-best-ruleset', // this name is so that this is compressable
+  rules: []
+}

--- a/projects/optic/src/commands/diff/diff.ts
+++ b/projects/optic/src/commands/diff/diff.ts
@@ -120,10 +120,13 @@ const compressData = (
     meta,
     version: '1',
   };
-  const compressed = brotli.compress(
+  // brotli.compress returns null if the data is uncompressable. This is not something we need to worry about since
+  // we should _always_ be able to compress something in this massive blob
+  // If we optimize the data structure we send, we may need to handle the null case.
+  const compressed: Uint8Array | null = brotli.compress(
     Buffer.from(JSON.stringify(dataToCompress))
   );
-  const urlSafeString = Buffer.from(compressed).toString('base64');
+  const urlSafeString = Buffer.from(compressed!).toString('base64');
   return urlSafeString;
 };
 


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

A follow up from https://github.com/opticdev/optic/pull/1380#discussion_r999789380

After thinking about this, I don't think we need to update the CLIDiff flow, the data in that flow should _always_ be compressable (since there's two openapi specs uploaded along with results). If we optimize the changelog format such that it no longer becomes compressable, we will need to update that flow to also handle the null case.

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
