### PR TITLE
Allow opt-out of telemetry

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.34.2",
+  "version": "0.34.3",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
-  "version": "0.34.2",
+  "version": "0.34.3",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-cli",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.34.2",
+  "version": "0.34.3",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-io",
   "license": "MIT",
-  "version": "0.34.2",
+  "version": "0.34.3",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
-  "version": "0.34.2",
+  "version": "0.34.3",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-utilities/src/utilities/segment.ts
+++ b/projects/openapi-utilities/src/utilities/segment.ts
@@ -4,7 +4,8 @@ const packageJson = require('../../package.json');
 let analytics: Analytics | null = null;
 
 export const initSegment = (key: string | undefined) => {
-  if (key) {
+  const isSegmentDisabled = process.env.TELEMETRY_LEVEL === 'off' || process.env.TELEMETRY_LEVEL === 'error';
+  if (key && !isSegmentDisabled) {
     analytics = new Analytics(key);
   }
 };

--- a/projects/openapi-utilities/src/utilities/segment.ts
+++ b/projects/openapi-utilities/src/utilities/segment.ts
@@ -4,7 +4,7 @@ const packageJson = require('../../package.json');
 let analytics: Analytics | null = null;
 
 export const initSegment = (key: string | undefined) => {
-  const isSegmentDisabled = process.env.TELEMETRY_LEVEL === 'off' || process.env.TELEMETRY_LEVEL === 'error';
+  const isSegmentDisabled = process.env.OPTIC_TELEMETRY_LEVEL === 'off' || process.env.OPTIC_TELEMETRY_LEVEL === 'error';
   if (key && !isSegmentDisabled) {
     analytics = new Analytics(key);
   }

--- a/projects/openapi-utilities/src/utilities/sentry.ts
+++ b/projects/openapi-utilities/src/utilities/sentry.ts
@@ -4,12 +4,12 @@ import { UserError } from '../errors';
 export  { Sentry as SentryClient};
 
 export const initSentry = (sentryUrl: string | undefined, version: string) => {
-  if (sentryUrl) {
+  const isSentryDisabled = process.env.TELEMETRY_LEVEL === 'off';
+  if (sentryUrl && !isSentryDisabled) {
     Sentry.init({
       dsn: sentryUrl,
       tracesSampleRate: 1.0,
       release: version,
-      
     });
   }
 };

--- a/projects/openapi-utilities/src/utilities/sentry.ts
+++ b/projects/openapi-utilities/src/utilities/sentry.ts
@@ -4,7 +4,7 @@ import { UserError } from '../errors';
 export  { Sentry as SentryClient};
 
 export const initSentry = (sentryUrl: string | undefined, version: string) => {
-  const isSentryDisabled = process.env.TELEMETRY_LEVEL === 'off';
+  const isSentryDisabled = process.env.OPTIC_TELEMETRY_LEVEL === 'off';
   if (sentryUrl && !isSentryDisabled) {
     Sentry.init({
       dsn: sentryUrl,

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.34.2",
+  "version": "0.34.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/README.md
+++ b/projects/optic/README.md
@@ -55,50 +55,11 @@ Additional options:
 
 ## Setup Optic in CI
 
-Optic helps you review OpenAPI specs and enforce API standards. Sign up on [app.useoptic.com](https://app.useoptic.com) to get a token and get started.
+Optic helps you review OpenAPI specs and enforce API standards. Sign up on [app.useoptic.com](https://app.useoptic.com).
 
-### GitHub Actions
+### Telemetry
 
-Optic comes with a GitHub Action for easy setup and configuration. The Optic GitHub Action can be configured in your `.github/workflows/optic-ci.yml` file. An example snippet is listed below.
+Optic collects telemetry which is used to help understand how to improve the product. For example, this usage data helps to debug issues and to prioritize features and improvements based on usage. While this information does help us build a great product, we understand that not everyone wants to share their usage data. If you would like to disable telemetry you can add an environment variable that will opt out of sending usage data:
 
-```yml
-name: Optic
-
-on: [pull_request]
-
-jobs:
-  optic-run:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: optic run
-        uses: opticdev/github-action@v1
-        with:
-          token: ${{ secrets.OPTIC_TOKEN }} # You will need to connect up your secret here
-          base: ${{ github.event.pull_request.base.ref }}
-```
-
-### Other CI Providers
-
-You can manually connect up Optic using any other CI provider by calling optic directly. An example implementation in bash is listed below, where each step command can be broken out into different CI steps.
-
-```bash
-# requires nodeJS installed
-# install optic-ci in your CI runner
-npm i -g @useoptic/optic
-
-# create the context - these will differ between CI providers
-optic cloud create-manual-context \\
-  --owner <owner>  \\ # the repository owner (in github, this can be an organization or user)
-  --repo <repo>  \\ # the repository name
-  --pull_request <pull_request>  \\ # the pull request number that this run is associated with
-  --run <run>  \\ # the run number that this run is associated with
-  --commit_hash <commit_hash>  \\ # the commit hash that this run is associated with
-  --branch_name <branch_name>  \\ # the branch name that this run is associated with
-  --user <user> # the user that triggered this run
-
-# trigger the optic runner
-# base is the branch that you are comparing the OpenAPI Changes against - this defaults to 'origin/master'
-OPTIC_TOKEN=<token> optic cloud run --base <base ref>
-```
+- `TELEMETRY_LEVEL=off` - disables telemetry (both usage, and crash reporting)
+- `TELEMETRY_LEVEL=error` - disables telemetry (only usage data is sent)

--- a/projects/optic/README.md
+++ b/projects/optic/README.md
@@ -59,7 +59,7 @@ Optic helps you review OpenAPI specs and enforce API standards. Sign up on [app.
 
 ### Telemetry
 
-Optic collects telemetry which is used to help understand how to improve the product. For example, this usage data helps to debug issues and to prioritize features and improvements based on usage. While this information does help us build a great product, we understand that not everyone wants to share their usage data. If you would like to disable telemetry you can add an environment variable that will opt out of sending usage data:
+Optic collects telemetry which is used to help understand how to improve the product. For example, this usage data helps to debug issues and to prioritize features and improvements based on usage. The usage of our telemetry data falls under our [privacy policy](https://www.useoptic.com/privacy-policy). While this information does help us build a great product, we understand that not everyone wants to share their usage data. If you would like to disable telemetry you can add an environment variable that will opt out of sending usage data:
 
 - `OPTIC_TELEMETRY_LEVEL=off` - disables telemetry (both usage, and error reporting)
 - `OPTIC_TELEMETRY_LEVEL=error` - disables telemetry (only usage data is sent)

--- a/projects/optic/README.md
+++ b/projects/optic/README.md
@@ -61,5 +61,5 @@ Optic helps you review OpenAPI specs and enforce API standards. Sign up on [app.
 
 Optic collects telemetry which is used to help understand how to improve the product. For example, this usage data helps to debug issues and to prioritize features and improvements based on usage. While this information does help us build a great product, we understand that not everyone wants to share their usage data. If you would like to disable telemetry you can add an environment variable that will opt out of sending usage data:
 
-- `TELEMETRY_LEVEL=off` - disables telemetry (both usage, and error reporting)
-- `TELEMETRY_LEVEL=error` - disables telemetry (only usage data is sent)
+- `OPTIC_TELEMETRY_LEVEL=off` - disables telemetry (both usage, and error reporting)
+- `OPTIC_TELEMETRY_LEVEL=error` - disables telemetry (only usage data is sent)

--- a/projects/optic/README.md
+++ b/projects/optic/README.md
@@ -61,5 +61,5 @@ Optic helps you review OpenAPI specs and enforce API standards. Sign up on [app.
 
 Optic collects telemetry which is used to help understand how to improve the product. For example, this usage data helps to debug issues and to prioritize features and improvements based on usage. While this information does help us build a great product, we understand that not everyone wants to share their usage data. If you would like to disable telemetry you can add an environment variable that will opt out of sending usage data:
 
-- `TELEMETRY_LEVEL=off` - disables telemetry (both usage, and crash reporting)
+- `TELEMETRY_LEVEL=off` - disables telemetry (both usage, and error reporting)
 - `TELEMETRY_LEVEL=error` - disables telemetry (only usage data is sent)

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.34.2",
+  "version": "0.34.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.34.2",
+  "version": "0.34.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.34.2",
+  "version": "0.34.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Adds in the following ways to turn off telemetry:
- `TELEMETRY_LEVEL=off` turns off sentry + segment
- `TELEMETRY_LEVEL=error` turns off segment

TODO
- [x] Bump + publish a new version

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._
https://github.com/opticdev/optic/issues/1381

## 👹 QA
_How can other humans verify that this PR is correct?_
