### PR TITLE
Create `optic ruleset init` command

### DIFF
--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -36,6 +36,7 @@
     "@types/json-stable-stringify": "^1.0.33",
     "@types/node": "^17.0.15",
     "@types/picomatch": "^2.3.0",
+    "@types/tar": "^6",
     "@types/url-join": "^4.0.1",
     "@types/uuid": "^8.3.1",
     "babel-jest": "^27.5.1",
@@ -69,6 +70,7 @@
     "node-machine-id": "^1.1.12",
     "open": "^8.4.0",
     "picomatch": "^2.3.1",
+    "tar": "^6.1.11",
     "url-join": "^4.0.1",
     "uuid": "^8.3.2"
   },

--- a/projects/optic/src/commands/ruleset/init.ts
+++ b/projects/optic/src/commands/ruleset/init.ts
@@ -3,12 +3,13 @@ import { wrapActionHandlerWithSentry } from '@useoptic/openapi-utilities/build/u
 import { Command } from 'commander';
 import fetch from 'node-fetch';
 import { OpticCliConfig } from '../../config';
-import tar from 'tar'
+import tar from 'tar';
 import path from 'path';
 import chalk from 'chalk';
 
+const DEFAULT_INIT_FOLDER = 'optic-ruleset';
 const owner = 'opticdev';
-const repo = 'optic-ci-custom-rules-starter';
+const repo = 'optic-ci-custom-rules-starter'; // TODO update this to point at a
 const ref = 'main';
 
 export const registerRulesetInit = (cli: Command, config: OpticCliConfig) => {
@@ -17,29 +18,43 @@ export const registerRulesetInit = (cli: Command, config: OpticCliConfig) => {
       hidden: true, // TODO unhide this
     })
     .description('Initializes a new ruleset project')
-    .option('--name <name>', 'the name of the new ruleset project')
+    .argument('[name]', 'the name of the new ruleset project')
     .action(wrapActionHandlerWithSentry(getInitAction()));
 };
 
-const getInitAction = () => async ({name}: {name?: string}) => {
-  const folderToCreate: string | undefined = name && path.join(process.cwd(), name);
-  if (folderToCreate) {
-    if (fs.existsSync(folderToCreate)){
-      console.error(chalk.red(`Cannot create a project named ${name} because a folder ${folderToCreate} already exists.`))
-      return process.exit(1);
-    }
-
-    fs.mkdirSync(folderToCreate);
+const getInitAction = () => async (name?: string) => {
+  console.log(
+    chalk.bold.blue(
+      `Initializing ${
+        name ? `project ${name}` : 'a new optic ruleset project'
+      }...`
+    )
+  );
+  const folderToCreate = path.join(process.cwd(), name ?? DEFAULT_INIT_FOLDER);
+  if (fs.existsSync(folderToCreate)) {
+    console.error(
+      chalk.red(
+        `Cannot create a project named ${name} because a folder ${folderToCreate} already exists.`
+      )
+    );
+    return process.exit(1);
   }
 
+  fs.mkdirSync(folderToCreate);
+
+  console.log();
+  console.log(`Downloading template...`);
+  console.log();
 
   const templateReadStream = await fetch(
     `https://api.github.com/repos/${owner}/${repo}/tarball/${ref}`
   ).then((res) => res.body);
-  const tarConfig = folderToCreate ? {
-    strip: 1,
-    cwd: folderToCreate
-  } : {}
+  const tarConfig = folderToCreate
+    ? {
+        strip: 1,
+        cwd: folderToCreate,
+      }
+    : {};
   const tarWriteStream = tar.extract(tarConfig);
 
   await new Promise((resolve) => {
@@ -47,6 +62,15 @@ const getInitAction = () => async ({name}: {name?: string}) => {
     tarWriteStream.on('finish', resolve);
   });
 
-  // TODO add logging output
-  console.log('done');
+  console.log(
+    chalk.green.bold(
+      `Successfully initialized your optic ruleset project!`
+    ),
+    folderToCreate
+  );
+  console.log();
+  console.log(`Your newly created project has been created at:`, folderToCreate)
+  console.log(
+    `Get started by reading the README at: ${folderToCreate}/README.md and installing the project dependencies (npm install or yarn install)`
+  );
 };

--- a/projects/optic/src/commands/ruleset/init.ts
+++ b/projects/optic/src/commands/ruleset/init.ts
@@ -9,7 +9,7 @@ import chalk from 'chalk';
 
 const DEFAULT_INIT_FOLDER = 'optic-ruleset';
 const owner = 'opticdev';
-const repo = 'optic-ci-custom-rules-starter'; // TODO update this to point at a
+const repo = 'optic-custom-rules-starter';
 const ref = 'main';
 
 export const registerRulesetInit = (cli: Command, config: OpticCliConfig) => {

--- a/projects/optic/src/commands/ruleset/init.ts
+++ b/projects/optic/src/commands/ruleset/init.ts
@@ -1,0 +1,52 @@
+import fs from 'fs';
+import { wrapActionHandlerWithSentry } from '@useoptic/openapi-utilities/build/utilities/sentry';
+import { Command } from 'commander';
+import fetch from 'node-fetch';
+import { OpticCliConfig } from '../../config';
+import tar from 'tar'
+import path from 'path';
+import chalk from 'chalk';
+
+const owner = 'opticdev';
+const repo = 'optic-ci-custom-rules-starter';
+const ref = 'main';
+
+export const registerRulesetInit = (cli: Command, config: OpticCliConfig) => {
+  cli
+    .command('init', {
+      hidden: true, // TODO unhide this
+    })
+    .description('Initializes a new ruleset project')
+    .option('--name <name>', 'the name of the new ruleset project')
+    .action(wrapActionHandlerWithSentry(getInitAction()));
+};
+
+const getInitAction = () => async ({name}: {name?: string}) => {
+  const folderToCreate: string | undefined = name && path.join(process.cwd(), name);
+  if (folderToCreate) {
+    if (fs.existsSync(folderToCreate)){
+      console.error(chalk.red(`Cannot create a project named ${name} because a folder ${folderToCreate} already exists.`))
+      return process.exit(1);
+    }
+
+    fs.mkdirSync(folderToCreate);
+  }
+
+
+  const templateReadStream = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/tarball/${ref}`
+  ).then((res) => res.body);
+  const tarConfig = folderToCreate ? {
+    strip: 1,
+    cwd: folderToCreate
+  } : {}
+  const tarWriteStream = tar.extract(tarConfig);
+
+  await new Promise((resolve) => {
+    templateReadStream.pipe(tarWriteStream);
+    tarWriteStream.on('finish', resolve);
+  });
+
+  // TODO add logging output
+  console.log('done');
+};

--- a/projects/optic/src/init.ts
+++ b/projects/optic/src/init.ts
@@ -19,6 +19,7 @@ import {
 } from './config';
 import { hasGit, isInGitRepo, getRootPath } from './utils/git-utils';
 import { getAnonId } from './utils/anonymous-id';
+import { registerRulesetInit } from './commands/ruleset/init';
 
 const packageJson = require('../package.json');
 
@@ -70,6 +71,7 @@ export const initCli = async () => {
     )
     .addHelpCommand(false);
   registerRulesetPublish(rulesetSubcommands, cliConfig);
+  registerRulesetInit(rulesetSubcommands, cliConfig);
 
   return cli;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3224,6 +3224,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/tar@npm:^6":
+  version: 6.1.3
+  resolution: "@types/tar@npm:6.1.3"
+  dependencies:
+    "@types/node": "*"
+    minipass: ^3.3.5
+  checksum: 3a221f74adfcef8555b9c4cc951907dfd567630744ffe5211da1b44caf2a4c3b02297b73c9fb02d171e93a7a7c74fb15c1826e3f0438f0e5e8f4c790db59ddcf
+  languageName: node
+  linkType: hard
+
 "@types/tunnel@npm:^0":
   version: 0.0.3
   resolution: "@types/tunnel@npm:0.0.3"
@@ -3584,6 +3594,7 @@ __metadata:
     "@types/json-stable-stringify": ^1.0.33
     "@types/node": ^17.0.15
     "@types/picomatch": ^2.3.0
+    "@types/tar": ^6
     "@types/url-join": ^4.0.1
     "@types/uuid": ^8.3.1
     "@useoptic/openapi-cli": "workspace:*"
@@ -3609,6 +3620,7 @@ __metadata:
     open: ^8.4.0
     picomatch: ^2.3.1
     prettier: ^2.4.1
+    tar: ^6.1.11
     ts-node: ^10.8.0
     typescript: ^4.7.2
     url-join: ^4.0.1
@@ -8098,6 +8110,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minipass@npm:^3.3.5":
+  version: 3.3.5
+  resolution: "minipass@npm:3.3.5"
+  dependencies:
+    yallist: ^4.0.0
+  checksum: f89f02bcaa0e0e4bb4c44ec796008e69fbca62db0aba6ead1bc57d25bdaefdf42102130f4f9ecb7d9c6b6cd35ff7b0c7b97d001d3435da8e629fb68af3aea57e
+  languageName: node
+  linkType: hard
+
 "minizlib@npm:^2.0.0, minizlib@npm:^2.1.1":
   version: 2.1.2
   resolution: "minizlib@npm:2.1.2"
@@ -9851,7 +9872,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^6.0.2, tar@npm:^6.1.2":
+"tar@npm:^6.0.2, tar@npm:^6.1.11, tar@npm:^6.1.2":
   version: 6.1.11
   resolution: "tar@npm:6.1.11"
   dependencies:


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

This PR implements the optic ruleset init command. This goes through the high level flow of:
- Downloads the tarball from github
- Extracts the tarball to a user defined location (or default named location)

I'll update the repo pointer to the correct template repo when we've got that ready to go.

Example output
```
$ yarn run local:run ruleset init my-new-project
Initializing project my-new-project...

Downloading template...

Successfully initialized your optic ruleset project! /Users/user/Desktop/repos/optic/projects/optic/my-new-project

Your newly created project has been created at: /Users/user/Desktop/repos/optic/projects/optic/my-new-project
Get started by reading the README at: /Users/user/Desktop/repos/optic/projects/optic/my-new-project/README.md and installing the project dependencies (npm install or yarn install)
```

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
