### PR TITLE
Example validation fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.34.3",
+  "version": "0.34.4",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
-  "version": "0.34.3",
+  "version": "0.34.4",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-cli",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.34.3",
+  "version": "0.34.4",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-io",
   "license": "MIT",
-  "version": "0.34.3",
+  "version": "0.34.4",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
-  "version": "0.34.3",
+  "version": "0.34.4",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.34.3",
+  "version": "0.34.4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.34.3",
+  "version": "0.34.4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.34.3",
+  "version": "0.34.4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.34.3",
+  "version": "0.34.4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/src/examples/requireExample.ts
+++ b/projects/standard-rulesets/src/examples/requireExample.ts
@@ -87,22 +87,32 @@ export const requireParameterExamples = (applies: typeof appliesWhen[number]) =>
     rule: (operation) => {
       const lifecycle = applies === 'always' ? 'requirement' : 'addedOrChanged';
       const errorMessageType = applies === 'always' ? 'every' : 'added';
+
+      function schemaHasExample(schema: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject | undefined) {
+        if (schema) {
+          if ('example' in schema) {
+            return typeof schema.example !== 'undefined'
+          }
+        }
+        return false
+      }
+
       operation.headerParameter[lifecycle]((header) => {
-        if (!header.raw.example) {
+        if (!header.raw.example && !schemaHasExample(header.raw.schema)) {
           throw new RuleError({
             message: `a valid example is required for ${errorMessageType} header`,
           });
         }
       });
       operation.queryParameter[lifecycle]((header) => {
-        if (!header.raw.example) {
+        if (!header.raw.example && !schemaHasExample(header.raw.schema)) {
           throw new RuleError({
             message: `a valid example is required for ${errorMessageType} query parameter`,
           });
         }
       });
       operation.cookieParameter[lifecycle]((header) => {
-        if (!header.raw.example) {
+        if (!header.raw.example && !schemaHasExample(header.raw.schema)) {
           throw new RuleError({
             message: `a valid example is required for ${errorMessageType} cookie parameter`,
           });


### PR DESCRIPTION
## 🍗 Description
Our logic for parameter example required is out of sync with parameter example schemas match

One allows you to look at `schema.example` or `.example` while the other does not. This brings them into alignment so users see the behaviors they expect

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
