### PR TITLE
Simplify hasGit to just run git -v

### DIFF
--- a/projects/optic/src/utils/git-utils.ts
+++ b/projects/optic/src/utils/git-utils.ts
@@ -6,7 +6,7 @@ export const hasGit = async (): Promise<boolean> =>
       if (err || stderr || !stdout) resolve(false);
       resolve(true);
     };
-    const command = `which git`;
+    const command = `git -v`;
     exec(command, cb);
   });
 


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Right now we run `which git` which requires `which` to work, which is less than ideal. This just tries running `git -v` instead.

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

See #1391

## 👹 QA
_How can other humans verify that this PR is correct?_
