### PR TITLE
make standard rulesets configs consistent

### DIFF
--- a/projects/standard-rulesets/src/examples/constants.ts
+++ b/projects/standard-rulesets/src/examples/constants.ts
@@ -1,1 +1,1 @@
-export const appliesWhen = ['addedOrChanged', 'always'] as const;
+export const appliesWhen = ['added', 'addedOrChanged', 'always'] as const;

--- a/projects/standard-rulesets/src/naming-changes/__tests__/index.test.ts
+++ b/projects/standard-rulesets/src/naming-changes/__tests__/index.test.ts
@@ -3,7 +3,7 @@ import { NamingChangesRuleset } from '..';
 describe('fromOpticConfig', () => {
   test('valid', () => {
     const ruleset = NamingChangesRuleset.fromOpticConfig({
-      applies: 'always',
+      required_on: 'always',
       properties: 'snake_case',
     });
     expect(ruleset).toBeInstanceOf(NamingChangesRuleset);

--- a/projects/standard-rulesets/src/naming-changes/__tests__/naming-changes.test.ts
+++ b/projects/standard-rulesets/src/naming-changes/__tests__/naming-changes.test.ts
@@ -4,9 +4,9 @@ import { NamingChangesRuleset } from '../index';
 
 describe('fromOpticConfig', () => {
   test('invalid configuration', () => {
-    const out = NamingChangesRuleset.fromOpticConfig({ applies: 'invalid' });
+    const out = NamingChangesRuleset.fromOpticConfig({ required_on: 'invalid' });
     expect(out).toEqual(
-      '- ruleset/naming/applies must be equal to one of the allowed values'
+      '- ruleset/naming/required_on must be equal to one of the allowed values'
     );
   });
 });
@@ -23,12 +23,12 @@ describe('naming changes configuration', () => {
     }).toThrowErrorMatchingSnapshot();
 
     expect(() => {
-      new NamingChangesRuleset({ applies: 'not valid' } as any);
+      new NamingChangesRuleset({ required_on: 'not valid' } as any);
     }).toThrowErrorMatchingSnapshot();
 
     expect(() => {
       new NamingChangesRuleset({
-        applies: 'always',
+        required_on: 'always',
         options: {
           queryParameters: 'not a valid format' as any,
         },
@@ -42,7 +42,7 @@ describe('naming changes', () => {
     'always',
     (applies) => {
       const namingChangeRuleset = new NamingChangesRuleset({
-        applies: applies as any,
+        required_on: applies as any,
         options: {
           queryParameters: 'camelCase',
           requestHeaders: 'PascalCase',
@@ -704,7 +704,7 @@ describe('naming changes', () => {
 
       describe('pathComponents', () => {
         const namingChangeRuleset = new NamingChangesRuleset({
-          applies: applies as any,
+          required_on: applies as any,
           options: {
             pathComponents: 'param-case',
           },

--- a/projects/standard-rulesets/src/naming-changes/index.ts
+++ b/projects/standard-rulesets/src/naming-changes/index.ts
@@ -9,7 +9,7 @@ import { createPathComponentChecks } from './pathComponents';
 import Ajv from 'ajv';
 
 type RulesetConfig = {
-  applies?: typeof appliesWhen[number];
+  required_on?: typeof appliesWhen[number];
   requestHeaders?: typeof casing[number];
   queryParameters?: typeof casing[number];
   responseHeaders?: typeof casing[number];
@@ -22,7 +22,7 @@ const ajv = new Ajv();
 const configSchema = {
   type: 'object',
   properties: {
-    applies: {
+    required_on: {
       type: 'string',
       enum: appliesWhen,
     },
@@ -81,13 +81,13 @@ export class NamingChangesRuleset extends Ruleset<Rule[]> {
     }
 
     return new NamingChangesRuleset({
-      applies: validatedConfig.applies || 'always',
+      required_on: validatedConfig.required_on || 'always',
       options: namingConfig,
     });
   }
 
   constructor(config: {
-    applies: typeof appliesWhen[number];
+    required_on: typeof appliesWhen[number];
     options?: NamingConfig;
     matches?: Ruleset['matches'];
   }) {
@@ -96,8 +96,8 @@ export class NamingChangesRuleset extends Ruleset<Rule[]> {
       throw new Error('Expected config object in NamingChangesRuleset');
     }
 
-    const { applies, matches, options = {} } = config;
-    if (!applies || !appliesWhen.includes(applies)) {
+    const { required_on, matches, options = {} } = config;
+    if (!required_on || !appliesWhen.includes(required_on)) {
       // TODO silence this from sentry
       throw new Error(
         `Expected config.applies in NamingChangesRuleset to be specified and be one of ${appliesWhen.join(
@@ -120,32 +120,32 @@ export class NamingChangesRuleset extends Ruleset<Rule[]> {
     const namingChangeRules: Rule[] = [];
     if (options.properties) {
       namingChangeRules.push(
-        ...createPropertyNamingChecks(applies, options.properties)
+        ...createPropertyNamingChecks(required_on, options.properties)
       );
     }
     if (options.queryParameters) {
       namingChangeRules.push(
-        createQueryParameterChecks(applies, options.queryParameters)
+        createQueryParameterChecks(required_on, options.queryParameters)
       );
     }
     if (options.requestHeaders) {
       namingChangeRules.push(
-        createRequestHeaderParameterChecks(applies, options.requestHeaders)
+        createRequestHeaderParameterChecks(required_on, options.requestHeaders)
       );
     }
     if (options.cookieParameters) {
       namingChangeRules.push(
-        createCookieParameterChecks(applies, options.cookieParameters)
+        createCookieParameterChecks(required_on, options.cookieParameters)
       );
     }
     if (options.responseHeaders) {
       namingChangeRules.push(
-        createResponseHeaderParameterChecks(applies, options.responseHeaders)
+        createResponseHeaderParameterChecks(required_on, options.responseHeaders)
       );
     }
     if (options.pathComponents) {
       namingChangeRules.push(
-        createPathComponentChecks(applies, options.pathComponents)
+        createPathComponentChecks(required_on, options.pathComponents)
       );
     }
 


### PR DESCRIPTION
## 🍗 Description
- allow run when `added` option for examples
- renamed `applies` to `required_on` - this will be breaking, but typescript gives people nudges when building their optic rule plugins so it's ok
## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
