### PR TITLE
Introduced more strict OpenAPI Validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.35.1",
+  "version": "0.35.2-0",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",
@@ -16,5 +16,6 @@
   "scripts": {
     "release": "gh release create --target=$(git branch --show-current) v$(node -e \"process.stdout.write(require('./package.json').version)\")",
     "version": "yarn workspaces foreach -v version"
-  }
+  },
+  "stableVersion": "0.35.1"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.35.2-0",
+  "version": "0.35.2",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",
@@ -16,6 +16,5 @@
   "scripts": {
     "release": "gh release create --target=$(git branch --show-current) v$(node -e \"process.stdout.write(require('./package.json').version)\")",
     "version": "yarn workspaces foreach -v version"
-  },
-  "stableVersion": "0.35.1"
+  }
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
-  "version": "0.35.2-0",
+  "version": "0.35.2",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -38,6 +38,5 @@
   },
   "dependencies": {
     "jsonpointer": "^5.0.1"
-  },
-  "stableVersion": "0.35.1"
+  }
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
-  "version": "0.35.1",
+  "version": "0.35.2-0",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -38,5 +38,6 @@
   },
   "dependencies": {
     "jsonpointer": "^5.0.1"
-  }
+  },
+  "stableVersion": "0.35.1"
 }

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-cli",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.2-0",
+  "version": "0.35.2",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [
@@ -108,6 +108,5 @@
         "<rootDir>../../../../node_modules/csv-parse/dist/cjs/sync.cjs"
       ]
     }
-  },
-  "stableVersion": "0.35.1"
+  }
 }

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-cli",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.1",
+  "version": "0.35.2-0",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [
@@ -108,5 +108,6 @@
         "<rootDir>../../../../node_modules/csv-parse/dist/cjs/sync.cjs"
       ]
     }
-  }
+  },
+  "stableVersion": "0.35.1"
 }

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-io",
   "license": "MIT",
-  "version": "0.35.2-0",
+  "version": "0.35.2",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -77,6 +77,5 @@
     "testPathIgnorePatterns": [
       "build"
     ]
-  },
-  "stableVersion": "0.35.1"
+  }
 }

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-io",
   "license": "MIT",
-  "version": "0.35.1",
+  "version": "0.35.2-0",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -77,5 +77,6 @@
     "testPathIgnorePatterns": [
       "build"
     ]
-  }
+  },
+  "stableVersion": "0.35.1"
 }

--- a/projects/openapi-io/src/validation/__snapshots__/validator.test.ts.snap
+++ b/projects/openapi-io/src/validation/__snapshots__/validator.test.ts.snap
@@ -6,7 +6,9 @@ exports[`advanced validators run and append their results 1`] = `
 [31minvalid openapi: [39m[1m[31mmust NOT have fewer than 1 items[39m[22m
 /paths/~1api~1users~1{userId}/get/responses/200/content/application~1json/schema/anyOf
 [31minvalid openapi: [39m[1m[31mmust be object[39m[22m
-/paths/~1api~1users~1{userId}/get/responses/200/content/application~1json/schema/items"
+/paths/~1api~1users~1{userId}/get/responses/200/content/application~1json/schema/items
+[31minvalid openapi: [39m[1m[31mschema with type \\"object\\" cannot also include keywords: anyOf, items, oneOf[39m[22m
+/paths/~1api~1users~1{userId}/get/responses/200/content/application~1json/schema"
 `;
 
 exports[`processValidatorErrors 1`] = `

--- a/projects/openapi-io/src/validation/__snapshots__/validator.test.ts.snap
+++ b/projects/openapi-io/src/validation/__snapshots__/validator.test.ts.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`advanced validators run and append their results 1`] = `
+"[31minvalid openapi: [39m[1m[31mmust NOT have fewer than 1 items[39m[22m
+/paths/~1api~1users~1{userId}/get/responses/200/content/application~1json/schema/oneOf
+[31minvalid openapi: [39m[1m[31mmust NOT have fewer than 1 items[39m[22m
+/paths/~1api~1users~1{userId}/get/responses/200/content/application~1json/schema/anyOf
+[31minvalid openapi: [39m[1m[31mmust be object[39m[22m
+/paths/~1api~1users~1{userId}/get/responses/200/content/application~1json/schema/items"
+`;
+
 exports[`processValidatorErrors 1`] = `
 "[31minvalid openapi: [39m[1m[31mmust be object[39m[22m
 /paths/~1api~1users~1{userId}/get/responses/200/content/application~1json/schema/properties/hello/items"

--- a/projects/openapi-io/src/validation/advanced-validation.test.ts
+++ b/projects/openapi-io/src/validation/advanced-validation.test.ts
@@ -1,0 +1,44 @@
+import { validateSchema } from './advanced-validation';
+
+it('a polymorphic schema cannot have type', () => {
+  expect(() =>
+    validateSchema({ oneOf: [], type: 'string' })
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"schema with oneOf cannot also include keywords: type"`
+  );
+  expect(() =>
+    validateSchema({ anyOf: [], type: 'string' })
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"schema with anyOf cannot also include keywords: type"`
+  );
+  expect(() =>
+    validateSchema({ allOf: [], type: 'string' })
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"schema with anyOf cannot also include keywords: type"`
+  );
+});
+
+it('a polymorphic schema have overlapping keywords type', () => {
+  expect(() =>
+    validateSchema({ oneOf: [], anyOf: [], allOf: [] })
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"schema with oneOf cannot also include keywords: allOf, anyOf"`
+  );
+});
+
+it('an object schema cannot have array items', () => {
+  expect(() =>
+    // @ts-ignore
+    validateSchema({ type: 'object', items: [] })
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"schema with type \\"object\\" cannot also include keywords: items"`
+  );
+});
+it('an array schema cannot have properties or required', () => {
+  expect(() =>
+    // @ts-ignore
+    validateSchema({ type: 'array', required: [], properties: {} })
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"schema with type \\"array\\" cannot also include keywords: properties, required"`
+  );
+});

--- a/projects/openapi-io/src/validation/advanced-validation.ts
+++ b/projects/openapi-io/src/validation/advanced-validation.ts
@@ -21,11 +21,9 @@ export function attachAdvancedValidators(ajv: Ajv) {
           message: e.message,
           params: {
             keyword: 'customValidator',
-          } /*,
-      dataPath: '.maxPoints',
-      schemaPath: '#/validateMaxPoints',
-      schema: true*/,
+          },
         });
+        return false;
       }
       return true;
     },

--- a/projects/openapi-io/src/validation/advanced-validation.ts
+++ b/projects/openapi-io/src/validation/advanced-validation.ts
@@ -1,0 +1,80 @@
+import { OpenAPIV3, OpenAPIV3_1 } from 'openapi-types';
+import Ajv from 'ajv';
+
+type SchemaUnion = OpenAPIV3.SchemaObject | OpenAPIV3_1.SchemaObject;
+
+export function attachAdvancedValidators(ajv: Ajv) {
+  ajv.addKeyword({
+    keyword: 'x-custom-validator',
+    errors: true,
+    validate: function myValidation(customValidator: any, schemaFromSpec: any) {
+      // @ts-ignore
+      if (myValidation.errors === null) myValidation.errors = [];
+
+      try {
+        if (customValidator === 'validateSchema')
+          validateSchema(schemaFromSpec);
+      } catch (e: any) {
+        // @ts-ignore
+        myValidation.errors.push({
+          keyword: 'x-custom-validator',
+          message: e.message,
+          params: {
+            keyword: 'customValidator',
+          } /*,
+      dataPath: '.maxPoints',
+      schemaPath: '#/validateMaxPoints',
+      schema: true*/,
+        });
+      }
+      return true;
+    },
+  });
+}
+
+export function validateSchema(schema: SchemaUnion) {
+  if (schema.type === 'object') {
+    checkForDisallowedKeywords(
+      'schema with type "object" cannot also include keywords: ',
+      ['allOf', 'anyOf', 'oneOf', 'items'],
+      schema
+    );
+  } else if (schema.type === 'array') {
+    checkForDisallowedKeywords(
+      'schema with type "array" cannot also include keywords: ',
+      ['allOf', 'anyOf', 'oneOf', 'properties', 'required'],
+      schema
+    );
+  } else if (schema.oneOf) {
+    checkForDisallowedKeywords(
+      'schema with oneOf cannot also include keywords: ',
+      ['allOf', 'anyOf', 'type', 'items', 'properties', 'required'],
+      schema
+    );
+  } else if (schema.anyOf) {
+    checkForDisallowedKeywords(
+      'schema with anyOf cannot also include keywords: ',
+      ['allOf', 'oneOf', 'type', 'items', 'properties', 'required'],
+      schema
+    );
+  } else if (schema.allOf) {
+    checkForDisallowedKeywords(
+      'schema with anyOf cannot also include keywords: ',
+      ['anyOf', 'oneOf', 'type', 'items', 'properties', 'required'],
+      schema
+    );
+  }
+}
+
+function checkForDisallowedKeywords(
+  errorPrefix: string,
+  keywords: string[],
+  schema: SchemaUnion
+) {
+  const found = keywords.filter((keyword) =>
+    (schema as any).hasOwnProperty(keyword)
+  );
+  if (found.length) {
+    throw new Error(`${errorPrefix}${found.sort().join(', ')}`);
+  }
+}

--- a/projects/openapi-io/src/validation/validation-schemas.ts
+++ b/projects/openapi-io/src/validation/validation-schemas.ts
@@ -1,5 +1,6 @@
 const openapi3_0_schema_object = {
   type: 'object',
+  'x-custom-validator': 'validateSchema',
   description:
     'The Schema Object allows the definition of input and output data types. These types can be objects, but also primitives and arrays. This object is an extended subset of the JSON Schema Specification Wright Draft 00.  For more information about the properties, see JSON Schema Core and JSON Schema Validation. Unless stated otherwise, the property definitions follow the JSON Schema.',
   // additionalProperties: false,
@@ -154,6 +155,7 @@ const openapi3_0_schema_object = {
 
 const openapi3_1_schema_object = {
   type: 'object',
+  'x-custom-validator': 'validateSchema',
   description:
     'The Schema Object allows the definition of input and output data types. These types can be objects, but also primitives and arrays. This object is an extended subset of the JSON Schema Specification Wright Draft 00.  For more information about the properties, see JSON Schema Core and JSON Schema Validation. Unless stated otherwise, the property definitions follow the JSON Schema.',
   additionalProperties: false,

--- a/projects/openapi-io/src/validation/validator.test.ts
+++ b/projects/openapi-io/src/validation/validator.test.ts
@@ -191,12 +191,6 @@ test('advanced validators run and append their results', () => {
     },
   };
 
-  try {
-    validateOpenApiV3Document(json);
-  } catch (e) {
-    console.log(e);
-  }
-
   expect(() => {
     validateOpenApiV3Document(json);
   }).toThrowErrorMatchingSnapshot();

--- a/projects/openapi-io/src/validation/validator.test.ts
+++ b/projects/openapi-io/src/validation/validator.test.ts
@@ -164,3 +164,40 @@ test('processValidatorErrors with sourcemap', async () => {
     );
   }).toThrowErrorMatchingSnapshot();
 });
+
+test('advanced validators run and append their results', () => {
+  const json: any = {
+    ...defaultEmptySpec,
+    paths: {
+      '/api/users/{userId}': {
+        get: {
+          responses: {
+            '200': {
+              description: 'hello',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    oneOf: [],
+                    anyOf: [],
+                    items: [],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  try {
+    validateOpenApiV3Document(json);
+  } catch (e) {
+    console.log(e);
+  }
+
+  expect(() => {
+    validateOpenApiV3Document(json);
+  }).toThrowErrorMatchingSnapshot();
+});

--- a/projects/openapi-io/src/validation/validator.ts
+++ b/projects/openapi-io/src/validation/validator.ts
@@ -71,7 +71,8 @@ export const processValidatorErrors = (
     if (
       pathsWithErrors.every(
         (addedError) => !addedError.instancePath.startsWith(error.instancePath)
-      )
+      ) ||
+      error.keyword === 'x-custom-validator'
     ) {
       pathsWithErrors.push(error);
     }
@@ -114,6 +115,7 @@ export const validateOpenApiV3Document = (
   if (version === '3.0.x') results = validator.validate3_0(spec);
   if (version === '3.1.x') results = validator.validate3_1(spec);
 
+  console.log(results.errors);
   if (results && results.errors.length > 0) {
     const processedErrors = processValidatorErrors(
       spec,

--- a/projects/openapi-io/src/validation/validator.ts
+++ b/projects/openapi-io/src/validation/validator.ts
@@ -12,6 +12,7 @@ import ajvErrors from 'ajv-errors';
 import chalk from 'chalk';
 import { jsonPointerLogger } from './log-json-pointer';
 import { JsonSchemaSourcemap } from '../parser/sourcemap';
+import { attachAdvancedValidators } from './advanced-validation';
 
 export default class OpenAPISchemaValidator {
   private v3_0Validator: ValidateFunction | undefined;
@@ -24,6 +25,7 @@ export default class OpenAPISchemaValidator {
       const v = new ajv({ allErrors: true, strict: false });
       ajvErrors(v);
       addFormats(v);
+      attachAdvancedValidators(v);
       v.addSchema(openapi3_0_json_schema);
       this.v3_0Validator = v.compile(openapi3_0_json_schema);
     }
@@ -41,6 +43,7 @@ export default class OpenAPISchemaValidator {
       const v = new ajv({ allErrors: true, strict: false });
       ajvErrors(v);
       addFormats(v);
+      attachAdvancedValidators(v);
       v.addSchema(openapi3_1_json_schema);
       this.v3_1Validator = v.compile(openapi3_1_json_schema);
     }

--- a/projects/openapi-io/src/validation/validator.ts
+++ b/projects/openapi-io/src/validation/validator.ts
@@ -115,7 +115,6 @@ export const validateOpenApiV3Document = (
   if (version === '3.0.x') results = validator.validate3_0(spec);
   if (version === '3.1.x') results = validator.validate3_1(spec);
 
-  console.log(results.errors);
   if (results && results.errors.length > 0) {
     const processedErrors = processValidatorErrors(
       spec,

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
-  "version": "0.35.1",
+  "version": "0.35.2-0",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -68,5 +68,6 @@
     "testPathIgnorePatterns": [
       "build"
     ]
-  }
+  },
+  "stableVersion": "0.35.1"
 }

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
-  "version": "0.35.2-0",
+  "version": "0.35.2",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -68,6 +68,5 @@
     "testPathIgnorePatterns": [
       "build"
     ]
-  },
-  "stableVersion": "0.35.1"
+  }
 }

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.1",
+  "version": "0.35.2-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -84,5 +84,6 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  }
+  },
+  "stableVersion": "0.35.1"
 }

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.2-0",
+  "version": "0.35.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -84,6 +84,5 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  },
-  "stableVersion": "0.35.1"
+  }
 }

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.1",
+  "version": "0.35.2-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -91,5 +91,6 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  }
+  },
+  "stableVersion": "0.35.1"
 }

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.2-0",
+  "version": "0.35.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -91,6 +91,5 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  },
-  "stableVersion": "0.35.1"
+  }
 }

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.1",
+  "version": "0.35.2-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -61,5 +61,6 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  }
+  },
+  "stableVersion": "0.35.1"
 }

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.2-0",
+  "version": "0.35.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -61,6 +61,5 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  },
-  "stableVersion": "0.35.1"
+  }
 }

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.1",
+  "version": "0.35.2-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -60,5 +60,6 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  }
+  },
+  "stableVersion": "0.35.1"
 }

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.2-0",
+  "version": "0.35.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -60,6 +60,5 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  },
-  "stableVersion": "0.35.1"
+  }
 }


### PR DESCRIPTION
## 🍗 Description
OpenAPI can validate against a schema and still be incorrect -- ie certain combinations of keywords are allowed, paths must have matching path components, etc...

After a few customers reported their teams had invalid OpenAPI I surveyed Stoplight, Postman and Swagger Hub and realized the state of affairs is pretty bad. Lots of tools are lettings lots of bad OpenAPI through. 

This PR is the first of many -- it establishes a pattern for annotating our validation schemas with additional code rules that can be used to apply these more strict forms of openapi validation

This PR also sets the first rules by adding exclusive use requirements for the keywords for object, array, and oneOf, allOf, anyOf

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
