### PR TITLE
Allow cli config to extend a cloud ruleset

### DIFF
--- a/projects/optic-ci/src/cli/clients/optic-client.ts
+++ b/projects/optic-ci/src/cli/clients/optic-client.ts
@@ -15,6 +15,16 @@ type Session = {
   metadata?: any;
 };
 
+export type RulesetConfig = {
+  config: {
+    ruleset: { name: string; config: unknown }[];
+  };
+  organization_id: string;
+  ruleset_id: string;
+  created_at: string;
+  updated_at: string;
+};
+
 export enum UploadSlot {
   FromFile = 'FromFile',
   ToFile = 'ToFile',
@@ -180,13 +190,24 @@ export class OpticBackendClient extends JsonHttpClient {
 
   public async getManyRulesetsByName(rulesets: string[]): Promise<{
     rulesets: ({
-      name: string
-      url: string
-      uploaded_at: string
-    } | null)[]
+      name: string;
+      url: string;
+      uploaded_at: string;
+    } | null)[];
   }> {
-    const encodedRulesets = rulesets.map(r => encodeURIComponent(r)).join(',')
+    const encodedRulesets = rulesets
+      .map((r) => encodeURIComponent(r))
+      .join(',');
     return this.getJson(`/api/rulesets?rulesets=${encodedRulesets}`);
+  }
+
+  public async getRuleConfig(
+    rulesetConfigIdentifier: string
+  ): Promise<RulesetConfig> {
+    const encodedIdentifier = encodeURIComponent(rulesetConfigIdentifier)
+    return this.getJson(
+      `/api/ruleset-configs/${encodedIdentifier}`
+    );
   }
 }
 

--- a/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
@@ -257,3 +257,59 @@ Configure check rulesets in your local optic.dev.yml file.
 [34mRerun this command with the --web flag to view the detailed changes in your browser[39m
 "
 `;
+
+exports[`diff with mock server extends 1`] = `
+"Extending ruleset from @test-org/ruleset-id
+
+[1mGET[22m /example: 
+  - operationId [33mchanged[39m
+
+[1mPATCH[22m /example: 
+  - operationId [33mchanged[39m
+  - response [1m200[22m: [32madded[39m
+    - description [32madded[39m
+    - body [1mapplication/json[22m: [32madded[39m
+      - type [32madded[39m
+      - example [32madded[39m
+        - value [32madded[39m
+
+[1mPOST[22m /example: [31mremoved[39m
+[1mPUT[22m /example: 
+  - operationId [33mchanged[39m
+
+[1mGET[22m /invalid_name: [32madded[39m
+  - operationId [32madded[39m
+
+Checks
+
+  [1m[42m[37m PASS [39m[49m[22m [1mGET[22m /example
+
+
+  [1m[42m[37m PASS [39m[49m[22m [1mPATCH[22m /example
+
+
+  [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /example
+    removed rule: prevent operation removal
+      [31m[31mx[39m[31m cannot remove an operation. This is a breaking change.[39m
+      at [4m$workspace$/example-api-v0.json:9:150[24m
+
+
+
+  [1m[42m[37m PASS [39m[49m[22m [1mPUT[22m /example
+
+
+  [1m[41m[37m FAIL [39m[49m[22m [1mGET[22m /invalid_name
+    requirement rule: operation path component naming check
+      [31m[31mx[39m[31m invalid_name is not camelCase[39m
+      at [4m$workspace$/example-api-v1.json:31:632[24m
+
+
+
+1 operation added, 3 changed, 1 removed
+[32m[1m3 checks passed[22m[39m
+[31m[1m2 checks failed[22m[39m
+
+Configure check rulesets in your local optic.dev.yml file.
+[34mRerun this command with the --web flag to view the detailed changes in your browser[39m
+"
+`;

--- a/projects/optic/src/__tests__/integration/diff.test.ts
+++ b/projects/optic/src/__tests__/integration/diff.test.ts
@@ -44,13 +44,39 @@ describe('diff', () => {
           ],
         });
       } else if (method === 'GET' && /download-url/.test(url)) {
-        return fs.readFile(path.resolve(__dirname, './workspaces/diff/custom-rules/rules/cloud-mock.js'));
+        return fs.readFile(
+          path.resolve(
+            __dirname,
+            './workspaces/diff/custom-rules/rules/cloud-mock.js'
+          )
+        );
+      } else if (method === 'GET' && /\/api\/ruleset-configs\//) {
+        return JSON.stringify({
+          organization_id: 'abc',
+          config: {
+            ruleset: [{ name: 'breaking-changes', config: {} }],
+          },
+          ruleset_id: 'abc',
+          created_at: '2022-11-02T17:55:48.078Z',
+          updated_at: '2022-11-02T17:55:48.078Z',
+        });
       }
       return JSON.stringify({});
     });
 
     test('custom rules', async () => {
       const workspace = await setupWorkspace('diff/custom-rules');
+      const { combined, code } = await runOptic(
+        workspace,
+        'diff example-api-v0.json example-api-v1.json --check'
+      );
+
+      expect(code).toBe(1);
+      expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
+    });
+
+    test('extends', async () => {
+      const workspace = await setupWorkspace('diff/extends');
       const { combined, code } = await runOptic(
         workspace,
         'diff example-api-v0.json example-api-v1.json --check'

--- a/projects/optic/src/__tests__/integration/workspaces/diff/extends/example-api-v0.json
+++ b/projects/optic/src/__tests__/integration/workspaces/diff/extends/example-api-v0.json
@@ -1,0 +1,27 @@
+{
+  "openapi": "3.0.1",
+  "paths": {
+    "/example": {
+      "get": {
+        "operationId": "my-op-original",
+        "responses": {}
+      },
+      "post": {
+        "operationId": "postOriginal",
+        "responses": {}
+      },
+      "put": {
+        "operationId": "putOriginal",
+        "responses": {}
+      },
+      "patch": {
+        "operationId": "putOriginal",
+        "responses": {}
+      }
+    }
+  },
+  "info": {
+    "version": "0.0.0",
+    "title": "Empty"
+  }
+}

--- a/projects/optic/src/__tests__/integration/workspaces/diff/extends/example-api-v1.json
+++ b/projects/optic/src/__tests__/integration/workspaces/diff/extends/example-api-v1.json
@@ -1,0 +1,41 @@
+{
+  "openapi": "3.0.1",
+  "paths": {
+    "/example": {
+      "get": {
+        "operationId": "my-op",
+        "responses": {}
+      },
+      "put": {
+        "operationId": "putOriginalaa",
+        "responses": {}
+      },
+      "patch": {
+        "operationId": "putOriginaaal",
+        "responses": {
+          "200": {
+            "description": "hello",
+            "content": {
+              "application/json": {
+                "example": "hello",
+                "schema": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/invalid_name": {
+      "get": {
+        "operationId": "getInvalidName",
+        "responses": {}
+      }
+    }
+  },
+  "info": {
+    "version": "0.0.0",
+    "title": "Empty"
+  }
+}

--- a/projects/optic/src/__tests__/integration/workspaces/diff/extends/optic.dev.yml
+++ b/projects/optic/src/__tests__/integration/workspaces/diff/extends/optic.dev.yml
@@ -1,0 +1,4 @@
+extends: '@test-org/ruleset-id'
+ruleset:
+  - naming:
+      pathComponents: camelCase


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Will bump version + merge this Tuesday

This PR adds the functionality to extend a ruleset from a cloud configuration. This will download the ruleset from an identifier, and apply any locally defined rules on top of the cloud ruleset.

```yml
extends: @orgslug/rulesetconfigid
ruleset:
  ...
```

TODO
- [ ] Bump version
- [x] Test out end to end

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
