### PR TITLE
Flat OAS Types

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.35.5-2",
+  "version": "0.35.5",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",
@@ -16,6 +16,5 @@
   "scripts": {
     "release": "gh release create --target=$(git branch --show-current) v$(node -e \"process.stdout.write(require('./package.json').version)\")",
     "version": "yarn workspaces foreach -v version"
-  },
-  "stableVersion": "0.35.4"
+  }
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
-  "version": "0.35.5-2",
+  "version": "0.35.5",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -38,6 +38,5 @@
   },
   "dependencies": {
     "jsonpointer": "^5.0.1"
-  },
-  "stableVersion": "0.35.4"
+  }
 }

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-cli",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.5-2",
+  "version": "0.35.5",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [
@@ -108,6 +108,5 @@
         "<rootDir>../../../../node_modules/csv-parse/dist/cjs/sync.cjs"
       ]
     }
-  },
-  "stableVersion": "0.35.4"
+  }
 }

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -45,7 +45,8 @@
     "micro-cors": "^0.1.1",
     "prettier": "^2.4.1",
     "ts-node": "^10.3.1",
-    "typescript": "^4.4.4"
+    "typescript": "^4.4.4",
+    "upath": "^2.0.1"
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^9.0.9",

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-io",
   "license": "MIT",
-  "version": "0.35.5-2",
+  "version": "0.35.5",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -77,6 +77,5 @@
     "testPathIgnorePatterns": [
       "build"
     ]
-  },
-  "stableVersion": "0.35.4"
+  }
 }

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
-  "version": "0.35.5-2",
+  "version": "0.35.5",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -68,6 +68,5 @@
     "testPathIgnorePatterns": [
       "build"
     ]
-  },
-  "stableVersion": "0.35.4"
+  }
 }

--- a/projects/openapi-utilities/src/flat-openapi-types.ts
+++ b/projects/openapi-utilities/src/flat-openapi-types.ts
@@ -14,21 +14,21 @@ export enum HttpMethods {
 
 export namespace DereferencedOpenAPI {
   export type Document<T extends {} = {}> =
-    | OpenAPIV2.Document<T>
-    | OpenAPIV3.Document<T>
-    | OpenAPIV3_1.Document<T>;
+    | DereferencedOpenAPIV2.Document<T>
+    | DereferencedOpenAPIV3.Document<T>
+    | DereferencedOpenAPIV3_1.Document<T>;
   export type Operation<T extends {} = {}> =
-    | OpenAPIV2.OperationObject<T>
-    | OpenAPIV3.OperationObject<T>
-    | OpenAPIV3_1.OperationObject<T>;
+    | DereferencedOpenAPIV2.OperationObject<T>
+    | DereferencedOpenAPIV3.OperationObject<T>
+    | DereferencedOpenAPIV3_1.OperationObject<T>;
   export type Parameter =
-    | OpenAPIV3_1.ParameterObject
-    | OpenAPIV3.ParameterObject
-    | OpenAPIV2.Parameter;
+    | DereferencedOpenAPIV3_1.ParameterObject
+    | DereferencedOpenAPIV3.ParameterObject
+    | DereferencedOpenAPIV2.Parameter;
   export type Parameters =
-    | (OpenAPIV3_1.ParameterObject)[]
-    | (OpenAPIV3.ParameterObject)[]
-    | (OpenAPIV2.Parameter)[];
+    | (DereferencedOpenAPIV3_1.ParameterObject)[]
+    | (DereferencedOpenAPIV3.ParameterObject)[]
+    | (DereferencedOpenAPIV2.Parameter)[];
 
   export interface Request {
     body?: any;
@@ -38,7 +38,7 @@ export namespace DereferencedOpenAPI {
   }
 }
 
-export namespace OpenAPIV3_1 {
+export namespace DereferencedOpenAPIV3_1 {
   type Modify<T, R> = Omit<T, keyof R> & R;
 
   type PathsWebhooksComponents<T extends {} = {}> = {
@@ -48,7 +48,7 @@ export namespace OpenAPIV3_1 {
   };
 
   export type Document<T extends {} = {}> = Modify<
-    Omit<OpenAPIV3.Document<T>, 'paths' | 'components'>,
+    Omit<DereferencedOpenAPIV3.Document<T>, 'paths' | 'components'>,
     {
       info: InfoObject;
       jsonSchemaDialect?: string;
@@ -64,24 +64,24 @@ export namespace OpenAPIV3_1 {
     >;
 
   export type InfoObject = Modify<
-    OpenAPIV3.InfoObject,
+    DereferencedOpenAPIV3.InfoObject,
     {
       summary?: string;
       license?: LicenseObject;
     }
     >;
 
-  export type ContactObject = OpenAPIV3.ContactObject;
+  export type ContactObject = DereferencedOpenAPIV3.ContactObject;
 
   export type LicenseObject = Modify<
-    OpenAPIV3.LicenseObject,
+    DereferencedOpenAPIV3.LicenseObject,
     {
       identifier?: string;
     }
     >;
 
   export type ServerObject = Modify<
-    OpenAPIV3.ServerObject,
+    DereferencedOpenAPIV3.ServerObject,
     {
       url: string;
       description?: string;
@@ -90,7 +90,7 @@ export namespace OpenAPIV3_1 {
     >;
 
   export type ServerVariableObject = Modify<
-    OpenAPIV3.ServerVariableObject,
+    DereferencedOpenAPIV3.ServerVariableObject,
     {
       enum?: [string, ...string[]];
     }
@@ -103,7 +103,7 @@ export namespace OpenAPIV3_1 {
 
 
   export type PathItemObject<T extends {} = {}> = Modify<
-    OpenAPIV3.PathItemObject<T>,
+    DereferencedOpenAPIV3.PathItemObject<T>,
     {
       servers?: ServerObject[];
       parameters?: ( ParameterObject)[];
@@ -114,7 +114,7 @@ export namespace OpenAPIV3_1 {
     };
 
   export type OperationObject<T extends {} = {}> = Modify<
-    OpenAPIV3.OperationObject<T>,
+    DereferencedOpenAPIV3.OperationObject<T>,
     {
       parameters?: ( ParameterObject)[];
       requestBody?:  RequestBodyObject;
@@ -125,19 +125,19 @@ export namespace OpenAPIV3_1 {
     > &
     T;
 
-  export type ExternalDocumentationObject = OpenAPIV3.ExternalDocumentationObject;
+  export type ExternalDocumentationObject = DereferencedOpenAPIV3.ExternalDocumentationObject;
 
-  export type ParameterObject = OpenAPIV3.ParameterObject;
+  export type ParameterObject = DereferencedOpenAPIV3.ParameterObject;
 
-  export type HeaderObject = OpenAPIV3.HeaderObject;
+  export type HeaderObject = DereferencedOpenAPIV3.HeaderObject;
 
-  export type ParameterBaseObject = OpenAPIV3.ParameterBaseObject;
+  export type ParameterBaseObject = DereferencedOpenAPIV3.ParameterBaseObject;
 
   export type NonArraySchemaObjectType =
-    | OpenAPIV3.NonArraySchemaObjectType
+    | DereferencedOpenAPIV3.NonArraySchemaObjectType
     | 'null';
 
-  export type ArraySchemaObjectType = OpenAPIV3.ArraySchemaObjectType;
+  export type ArraySchemaObjectType = DereferencedOpenAPIV3.ArraySchemaObjectType;
 
   /**
    * There is no way to tell typescript to require items when type is either 'array' or array containing 'array' type
@@ -164,9 +164,9 @@ export namespace OpenAPIV3_1 {
   }
 
   export type BaseSchemaObject = Modify<
-    Omit<OpenAPIV3.BaseSchemaObject, 'nullable'>,
+    Omit<DereferencedOpenAPIV3.BaseSchemaObject, 'nullable'>,
     {
-      examples?: OpenAPIV3.BaseSchemaObject['example'][];
+      examples?: DereferencedOpenAPIV3.BaseSchemaObject['example'][];
       exclusiveMinimum?: boolean | number;
       exclusiveMaximum?: boolean | number;
       contentMediaType?: string;
@@ -186,24 +186,24 @@ export namespace OpenAPIV3_1 {
     }
     >;
 
-  export type DiscriminatorObject = OpenAPIV3.DiscriminatorObject;
+  export type DiscriminatorObject = DereferencedOpenAPIV3.DiscriminatorObject;
 
-  export type XMLObject = OpenAPIV3.XMLObject;
+  export type XMLObject = DereferencedOpenAPIV3.XMLObject;
 
-  export type ExampleObject = OpenAPIV3.ExampleObject;
+  export type ExampleObject = DereferencedOpenAPIV3.ExampleObject;
 
   export type MediaTypeObject = Modify<
-    OpenAPIV3.MediaTypeObject,
+    DereferencedOpenAPIV3.MediaTypeObject,
     {
       schema?: SchemaObject ;
       examples?: Record<string,  ExampleObject>;
     }
     >;
 
-  export type EncodingObject = OpenAPIV3.EncodingObject;
+  export type EncodingObject = DereferencedOpenAPIV3.EncodingObject;
 
   export type RequestBodyObject = Modify<
-    OpenAPIV3.RequestBodyObject,
+    DereferencedOpenAPIV3.RequestBodyObject,
     {
       content: { [media: string]: MediaTypeObject };
     }
@@ -215,7 +215,7 @@ export namespace OpenAPIV3_1 {
     >;
 
   export type ResponseObject = Modify<
-    OpenAPIV3.ResponseObject,
+    DereferencedOpenAPIV3.ResponseObject,
     {
       headers?: { [header: string]:  HeaderObject };
       content?: { [media: string]: MediaTypeObject };
@@ -224,7 +224,7 @@ export namespace OpenAPIV3_1 {
     >;
 
   export type LinkObject = Modify<
-    OpenAPIV3.LinkObject,
+    DereferencedOpenAPIV3.LinkObject,
     {
       server?: ServerObject;
     }
@@ -232,10 +232,10 @@ export namespace OpenAPIV3_1 {
 
   export type CallbackObject = Record<string, PathItemObject >;
 
-  export type SecurityRequirementObject = OpenAPIV3.SecurityRequirementObject;
+  export type SecurityRequirementObject = DereferencedOpenAPIV3.SecurityRequirementObject;
 
   export type ComponentsObject = Modify<
-    OpenAPIV3.ComponentsObject,
+    DereferencedOpenAPIV3.ComponentsObject,
     {
       schemas?: Record<string, SchemaObject>;
       responses?: Record<string,  ResponseObject>;
@@ -250,20 +250,20 @@ export namespace OpenAPIV3_1 {
     }
     >;
 
-  export type SecuritySchemeObject = OpenAPIV3.SecuritySchemeObject;
+  export type SecuritySchemeObject = DereferencedOpenAPIV3.SecuritySchemeObject;
 
-  export type HttpSecurityScheme = OpenAPIV3.HttpSecurityScheme;
+  export type HttpSecurityScheme = DereferencedOpenAPIV3.HttpSecurityScheme;
 
-  export type ApiKeySecurityScheme = OpenAPIV3.ApiKeySecurityScheme;
+  export type ApiKeySecurityScheme = DereferencedOpenAPIV3.ApiKeySecurityScheme;
 
-  export type OAuth2SecurityScheme = OpenAPIV3.OAuth2SecurityScheme;
+  export type OAuth2SecurityScheme = DereferencedOpenAPIV3.OAuth2SecurityScheme;
 
-  export type OpenIdSecurityScheme = OpenAPIV3.OpenIdSecurityScheme;
+  export type OpenIdSecurityScheme = DereferencedOpenAPIV3.OpenIdSecurityScheme;
 
-  export type TagObject = OpenAPIV3.TagObject;
+  export type TagObject = DereferencedOpenAPIV3.TagObject;
 }
 
-export namespace OpenAPIV3 {
+export namespace DereferencedOpenAPIV3 {
   export interface Document<T extends {} = {}> {
     openapi: string;
     info: InfoObject;
@@ -570,7 +570,7 @@ export namespace OpenAPIV3 {
   }
 }
 
-export namespace OpenAPIV2 {
+export namespace DereferencedOpenAPIV2 {
   export interface Document<T extends {} = {}> {
     basePath?: string;
     consumes?: MimeTypes;

--- a/projects/openapi-utilities/src/flat-openapi-types.ts
+++ b/projects/openapi-utilities/src/flat-openapi-types.ts
@@ -1,0 +1,888 @@
+/* tslint:disable:no-namespace no-empty-interface */
+
+export enum HttpMethods {
+  GET = 'get',
+  PUT = 'put',
+  POST = 'post',
+  DELETE = 'delete',
+  OPTIONS = 'options',
+  HEAD = 'head',
+  PATCH = 'patch',
+  TRACE = 'trace',
+}
+
+
+export namespace DereferencedOpenAPI {
+  export type Document<T extends {} = {}> =
+    | OpenAPIV2.Document<T>
+    | OpenAPIV3.Document<T>
+    | OpenAPIV3_1.Document<T>;
+  export type Operation<T extends {} = {}> =
+    | OpenAPIV2.OperationObject<T>
+    | OpenAPIV3.OperationObject<T>
+    | OpenAPIV3_1.OperationObject<T>;
+  export type Parameter =
+    | OpenAPIV3_1.ParameterObject
+    | OpenAPIV3.ParameterObject
+    | OpenAPIV2.Parameter;
+  export type Parameters =
+    | (OpenAPIV3_1.ParameterObject)[]
+    | (OpenAPIV3.ParameterObject)[]
+    | (OpenAPIV2.Parameter)[];
+
+  export interface Request {
+    body?: any;
+    headers?: object;
+    params?: object;
+    query?: object;
+  }
+}
+
+export namespace OpenAPIV3_1 {
+  type Modify<T, R> = Omit<T, keyof R> & R;
+
+  type PathsWebhooksComponents<T extends {} = {}> = {
+    paths: PathsObject<T>;
+    webhooks: Record<string, PathItemObject >;
+    components: ComponentsObject;
+  };
+
+  export type Document<T extends {} = {}> = Modify<
+    Omit<OpenAPIV3.Document<T>, 'paths' | 'components'>,
+    {
+      info: InfoObject;
+      jsonSchemaDialect?: string;
+      servers?: ServerObject[];
+    } & (
+    | (Pick<PathsWebhooksComponents<T>, 'paths'> &
+    Omit<Partial<PathsWebhooksComponents<T>>, 'paths'>)
+    | (Pick<PathsWebhooksComponents<T>, 'webhooks'> &
+    Omit<Partial<PathsWebhooksComponents<T>>, 'webhooks'>)
+    | (Pick<PathsWebhooksComponents<T>, 'components'> &
+    Omit<Partial<PathsWebhooksComponents<T>>, 'components'>)
+    )
+    >;
+
+  export type InfoObject = Modify<
+    OpenAPIV3.InfoObject,
+    {
+      summary?: string;
+      license?: LicenseObject;
+    }
+    >;
+
+  export type ContactObject = OpenAPIV3.ContactObject;
+
+  export type LicenseObject = Modify<
+    OpenAPIV3.LicenseObject,
+    {
+      identifier?: string;
+    }
+    >;
+
+  export type ServerObject = Modify<
+    OpenAPIV3.ServerObject,
+    {
+      url: string;
+      description?: string;
+      variables?: Record<string, ServerVariableObject>;
+    }
+    >;
+
+  export type ServerVariableObject = Modify<
+    OpenAPIV3.ServerVariableObject,
+    {
+      enum?: [string, ...string[]];
+    }
+    >;
+
+  export type PathsObject<T extends {} = {}, P extends {} = {}> = Record<
+    string,
+    (PathItemObject<T> & P) | undefined
+    >;
+
+
+  export type PathItemObject<T extends {} = {}> = Modify<
+    OpenAPIV3.PathItemObject<T>,
+    {
+      servers?: ServerObject[];
+      parameters?: ( ParameterObject)[];
+    }
+    > &
+    {
+      [method in HttpMethods]?: OperationObject<T>;
+    };
+
+  export type OperationObject<T extends {} = {}> = Modify<
+    OpenAPIV3.OperationObject<T>,
+    {
+      parameters?: ( ParameterObject)[];
+      requestBody?:  RequestBodyObject;
+      responses?: ResponsesObject;
+      callbacks?: Record<string,  CallbackObject>;
+      servers?: ServerObject[];
+    }
+    > &
+    T;
+
+  export type ExternalDocumentationObject = OpenAPIV3.ExternalDocumentationObject;
+
+  export type ParameterObject = OpenAPIV3.ParameterObject;
+
+  export type HeaderObject = OpenAPIV3.HeaderObject;
+
+  export type ParameterBaseObject = OpenAPIV3.ParameterBaseObject;
+
+  export type NonArraySchemaObjectType =
+    | OpenAPIV3.NonArraySchemaObjectType
+    | 'null';
+
+  export type ArraySchemaObjectType = OpenAPIV3.ArraySchemaObjectType;
+
+  /**
+   * There is no way to tell typescript to require items when type is either 'array' or array containing 'array' type
+   * 'items' will be always visible as optional
+   * Casting schema object to ArraySchemaObject or NonArraySchemaObject will work fine
+   */
+  export type SchemaObject =
+    | ArraySchemaObject
+    | NonArraySchemaObject
+    | MixedSchemaObject;
+
+  export interface ArraySchemaObject extends BaseSchemaObject {
+    type: ArraySchemaObjectType;
+    items:  SchemaObject;
+  }
+
+  export interface NonArraySchemaObject extends BaseSchemaObject {
+    type?: NonArraySchemaObjectType;
+  }
+
+  interface MixedSchemaObject extends BaseSchemaObject {
+    type?: (ArraySchemaObjectType | NonArraySchemaObjectType)[];
+    items?:  SchemaObject;
+  }
+
+  export type BaseSchemaObject = Modify<
+    Omit<OpenAPIV3.BaseSchemaObject, 'nullable'>,
+    {
+      examples?: OpenAPIV3.BaseSchemaObject['example'][];
+      exclusiveMinimum?: boolean | number;
+      exclusiveMaximum?: boolean | number;
+      contentMediaType?: string;
+      $schema?: string;
+      additionalProperties?: boolean  | SchemaObject;
+      properties?: {
+        [name: string]:  SchemaObject;
+      };
+      allOf?: ( SchemaObject)[];
+      oneOf?: ( SchemaObject)[];
+      anyOf?: ( SchemaObject)[];
+      not?:  SchemaObject;
+      discriminator?: DiscriminatorObject;
+      externalDocs?: ExternalDocumentationObject;
+      xml?: XMLObject;
+      const?: any;
+    }
+    >;
+
+  export type DiscriminatorObject = OpenAPIV3.DiscriminatorObject;
+
+  export type XMLObject = OpenAPIV3.XMLObject;
+
+  export type ExampleObject = OpenAPIV3.ExampleObject;
+
+  export type MediaTypeObject = Modify<
+    OpenAPIV3.MediaTypeObject,
+    {
+      schema?: SchemaObject ;
+      examples?: Record<string,  ExampleObject>;
+    }
+    >;
+
+  export type EncodingObject = OpenAPIV3.EncodingObject;
+
+  export type RequestBodyObject = Modify<
+    OpenAPIV3.RequestBodyObject,
+    {
+      content: { [media: string]: MediaTypeObject };
+    }
+    >;
+
+  export type ResponsesObject = Record<
+    string,
+     ResponseObject
+    >;
+
+  export type ResponseObject = Modify<
+    OpenAPIV3.ResponseObject,
+    {
+      headers?: { [header: string]:  HeaderObject };
+      content?: { [media: string]: MediaTypeObject };
+      links?: { [link: string]:  LinkObject };
+    }
+    >;
+
+  export type LinkObject = Modify<
+    OpenAPIV3.LinkObject,
+    {
+      server?: ServerObject;
+    }
+    >;
+
+  export type CallbackObject = Record<string, PathItemObject >;
+
+  export type SecurityRequirementObject = OpenAPIV3.SecurityRequirementObject;
+
+  export type ComponentsObject = Modify<
+    OpenAPIV3.ComponentsObject,
+    {
+      schemas?: Record<string, SchemaObject>;
+      responses?: Record<string,  ResponseObject>;
+      parameters?: Record<string,  ParameterObject>;
+      examples?: Record<string,  ExampleObject>;
+      requestBodies?: Record<string,  RequestBodyObject>;
+      headers?: Record<string,  HeaderObject>;
+      securitySchemes?: Record<string,  SecuritySchemeObject>;
+      links?: Record<string,  LinkObject>;
+      callbacks?: Record<string,  CallbackObject>;
+      pathItems?: Record<string,  PathItemObject>;
+    }
+    >;
+
+  export type SecuritySchemeObject = OpenAPIV3.SecuritySchemeObject;
+
+  export type HttpSecurityScheme = OpenAPIV3.HttpSecurityScheme;
+
+  export type ApiKeySecurityScheme = OpenAPIV3.ApiKeySecurityScheme;
+
+  export type OAuth2SecurityScheme = OpenAPIV3.OAuth2SecurityScheme;
+
+  export type OpenIdSecurityScheme = OpenAPIV3.OpenIdSecurityScheme;
+
+  export type TagObject = OpenAPIV3.TagObject;
+}
+
+export namespace OpenAPIV3 {
+  export interface Document<T extends {} = {}> {
+    openapi: string;
+    info: InfoObject;
+    servers?: ServerObject[];
+    paths: PathsObject<T>;
+    components?: ComponentsObject;
+    security?: SecurityRequirementObject[];
+    tags?: TagObject[];
+    externalDocs?: ExternalDocumentationObject;
+    'x-express-openapi-additional-middleware'?: (
+      | ((request: any, response: any, next: any) => Promise<void>)
+      | ((request: any, response: any, next: any) => void)
+      )[];
+    'x-express-openapi-validation-strict'?: boolean;
+  }
+
+  export interface InfoObject {
+    title: string;
+    description?: string;
+    termsOfService?: string;
+    contact?: ContactObject;
+    license?: LicenseObject;
+    version: string;
+  }
+
+  export interface ContactObject {
+    name?: string;
+    url?: string;
+    email?: string;
+  }
+
+  export interface LicenseObject {
+    name: string;
+    url?: string;
+  }
+
+  export interface ServerObject {
+    url: string;
+    description?: string;
+    variables?: { [variable: string]: ServerVariableObject };
+  }
+
+  export interface ServerVariableObject {
+    enum?: string[];
+    default: string;
+    description?: string;
+  }
+
+  export interface PathsObject<T extends {} = {}, P extends {} = {}> {
+    [pattern: string]: (PathItemObject<T> & P) | undefined;
+  }
+
+  // All HTTP methods allowed by OpenAPI 3 spec
+  // See https://swagger.io/specification/#path-item-object
+  // You can use keys or values from it in TypeScript code like this:
+  //     for (const method of Object.values(OpenAPIV3.HttpMethods)) { … }
+  export type PathItemObject<T extends {} = {}> = {
+    summary?: string;
+    description?: string;
+    servers?: ServerObject[];
+    parameters?: ( ParameterObject)[];
+  } & {
+    [method in HttpMethods]?: OperationObject<T>;
+  };
+
+  export type OperationObject<T extends {} = {}> = {
+    tags?: string[];
+    summary?: string;
+    description?: string;
+    externalDocs?: ExternalDocumentationObject;
+    operationId?: string;
+    parameters?: ( ParameterObject)[];
+    requestBody?:  RequestBodyObject;
+    responses: ResponsesObject;
+    callbacks?: { [callback: string]:  CallbackObject };
+    deprecated?: boolean;
+    security?: SecurityRequirementObject[];
+    servers?: ServerObject[];
+  } & T;
+
+  export interface ExternalDocumentationObject {
+    description?: string;
+    url: string;
+  }
+
+  export interface ParameterObject extends ParameterBaseObject {
+    name: string;
+    in: string;
+  }
+
+  export interface HeaderObject extends ParameterBaseObject {}
+
+  export interface ParameterBaseObject {
+    description?: string;
+    required?: boolean;
+    deprecated?: boolean;
+    allowEmptyValue?: boolean;
+    style?: string;
+    explode?: boolean;
+    allowReserved?: boolean;
+    schema?:  SchemaObject;
+    example?: any;
+    examples?: { [media: string]:  ExampleObject };
+    content?: { [media: string]: MediaTypeObject };
+  }
+  export type NonArraySchemaObjectType =
+    | 'boolean'
+    | 'object'
+    | 'number'
+    | 'string'
+    | 'integer';
+  export type ArraySchemaObjectType = 'array';
+  export type SchemaObject = ArraySchemaObject | NonArraySchemaObject;
+
+  export interface ArraySchemaObject extends BaseSchemaObject {
+    type: ArraySchemaObjectType;
+    items:  SchemaObject;
+  }
+
+  export interface NonArraySchemaObject extends BaseSchemaObject {
+    type?: NonArraySchemaObjectType;
+  }
+
+  export interface BaseSchemaObject {
+    // JSON schema allowed properties, adjusted for OpenAPI
+    title?: string;
+    description?: string;
+    format?: string;
+    default?: any;
+    multipleOf?: number;
+    maximum?: number;
+    exclusiveMaximum?: boolean;
+    minimum?: number;
+    exclusiveMinimum?: boolean;
+    maxLength?: number;
+    minLength?: number;
+    pattern?: string;
+    additionalProperties?: boolean  | SchemaObject;
+    maxItems?: number;
+    minItems?: number;
+    uniqueItems?: boolean;
+    maxProperties?: number;
+    minProperties?: number;
+    required?: string[];
+    enum?: any[];
+    properties?: {
+      [name: string]:  SchemaObject;
+    };
+    allOf?: ( SchemaObject)[];
+    oneOf?: ( SchemaObject)[];
+    anyOf?: ( SchemaObject)[];
+    not?:  SchemaObject;
+
+    // OpenAPI-specific properties
+    nullable?: boolean;
+    discriminator?: DiscriminatorObject;
+    readOnly?: boolean;
+    writeOnly?: boolean;
+    xml?: XMLObject;
+    externalDocs?: ExternalDocumentationObject;
+    example?: any;
+    deprecated?: boolean;
+  }
+
+  export interface DiscriminatorObject {
+    propertyName: string;
+    mapping?: { [value: string]: string };
+  }
+
+  export interface XMLObject {
+    name?: string;
+    namespace?: string;
+    prefix?: string;
+    attribute?: boolean;
+    wrapped?: boolean;
+  }
+
+  export interface ExampleObject {
+    summary?: string;
+    description?: string;
+    value?: any;
+    externalValue?: string;
+  }
+
+  export interface MediaTypeObject {
+    schema?:  SchemaObject;
+    example?: any;
+    examples?: { [media: string]:  ExampleObject };
+    encoding?: { [media: string]: EncodingObject };
+  }
+
+  export interface EncodingObject {
+    contentType?: string;
+    headers?: { [header: string]:  HeaderObject };
+    style?: string;
+    explode?: boolean;
+    allowReserved?: boolean;
+  }
+
+  export interface RequestBodyObject {
+    description?: string;
+    content: { [media: string]: MediaTypeObject };
+    required?: boolean;
+  }
+
+  export interface ResponsesObject {
+    [code: string]:  ResponseObject;
+  }
+
+  export interface ResponseObject {
+    description: string;
+    headers?: { [header: string]:  HeaderObject };
+    content?: { [media: string]: MediaTypeObject };
+    links?: { [link: string]:  LinkObject };
+  }
+
+  export interface LinkObject {
+    operationRef?: string;
+    operationId?: string;
+    parameters?: { [parameter: string]: any };
+    requestBody?: any;
+    description?: string;
+    server?: ServerObject;
+  }
+
+  export interface CallbackObject {
+    [url: string]: PathItemObject;
+  }
+
+  export interface SecurityRequirementObject {
+    [name: string]: string[];
+  }
+
+  export interface ComponentsObject {
+    schemas?: { [key: string]:  SchemaObject };
+    responses?: { [key: string]:  ResponseObject };
+    parameters?: { [key: string]:  ParameterObject };
+    examples?: { [key: string]:  ExampleObject };
+    requestBodies?: { [key: string]:  RequestBodyObject };
+    headers?: { [key: string]:  HeaderObject };
+    securitySchemes?: { [key: string]:  SecuritySchemeObject };
+    links?: { [key: string]:  LinkObject };
+    callbacks?: { [key: string]:  CallbackObject };
+  }
+
+  export type SecuritySchemeObject =
+    | HttpSecurityScheme
+    | ApiKeySecurityScheme
+    | OAuth2SecurityScheme
+    | OpenIdSecurityScheme;
+
+  export interface HttpSecurityScheme {
+    type: 'http';
+    description?: string;
+    scheme: string;
+    bearerFormat?: string;
+  }
+
+  export interface ApiKeySecurityScheme {
+    type: 'apiKey';
+    description?: string;
+    name: string;
+    in: string;
+  }
+
+  export interface OAuth2SecurityScheme {
+    type: 'oauth2';
+    description?: string;
+    flows: {
+      implicit?: {
+        authorizationUrl: string;
+        refreshUrl?: string;
+        scopes: { [scope: string]: string };
+      };
+      password?: {
+        tokenUrl: string;
+        refreshUrl?: string;
+        scopes: { [scope: string]: string };
+      };
+      clientCredentials?: {
+        tokenUrl: string;
+        refreshUrl?: string;
+        scopes: { [scope: string]: string };
+      };
+      authorizationCode?: {
+        authorizationUrl: string;
+        tokenUrl: string;
+        refreshUrl?: string;
+        scopes: { [scope: string]: string };
+      };
+    };
+  }
+
+  export interface OpenIdSecurityScheme {
+    type: 'openIdConnect';
+    description?: string;
+    openIdConnectUrl: string;
+  }
+
+  export interface TagObject {
+    name: string;
+    description?: string;
+    externalDocs?: ExternalDocumentationObject;
+  }
+}
+
+export namespace OpenAPIV2 {
+  export interface Document<T extends {} = {}> {
+    basePath?: string;
+    consumes?: MimeTypes;
+    definitions?: DefinitionsObject;
+    externalDocs?: ExternalDocumentationObject;
+    host?: string;
+    info: InfoObject;
+    parameters?: ParametersDefinitionsObject;
+    paths: PathsObject<T>;
+    produces?: MimeTypes;
+    responses?: ResponsesDefinitionsObject;
+    schemes?: string[];
+    security?: SecurityRequirementObject[];
+    securityDefinitions?: SecurityDefinitionsObject;
+    swagger: string;
+    tags?: TagObject[];
+    'x-express-openapi-additional-middleware'?: (
+      | ((request: any, response: any, next: any) => Promise<void>)
+      | ((request: any, response: any, next: any) => void)
+      )[];
+    'x-express-openapi-validation-strict'?: boolean;
+  }
+
+  export interface TagObject {
+    name: string;
+    description?: string;
+    externalDocs?: ExternalDocumentationObject;
+  }
+
+  export interface SecuritySchemeObjectBase {
+    type: 'basic' | 'apiKey' | 'oauth2';
+    description?: string;
+  }
+
+  export interface SecuritySchemeBasic extends SecuritySchemeObjectBase {
+    type: 'basic';
+  }
+
+  export interface SecuritySchemeApiKey extends SecuritySchemeObjectBase {
+    type: 'apiKey';
+    name: string;
+    in: string;
+  }
+
+  export type SecuritySchemeOauth2 =
+    | SecuritySchemeOauth2Implicit
+    | SecuritySchemeOauth2AccessCode
+    | SecuritySchemeOauth2Password
+    | SecuritySchemeOauth2Application;
+
+  export interface ScopesObject {
+    [index: string]: any;
+  }
+
+  export interface SecuritySchemeOauth2Base extends SecuritySchemeObjectBase {
+    type: 'oauth2';
+    flow: 'implicit' | 'password' | 'application' | 'accessCode';
+    scopes: ScopesObject;
+  }
+
+  export interface SecuritySchemeOauth2Implicit
+    extends SecuritySchemeOauth2Base {
+    flow: 'implicit';
+    authorizationUrl: string;
+  }
+
+  export interface SecuritySchemeOauth2AccessCode
+    extends SecuritySchemeOauth2Base {
+    flow: 'accessCode';
+    authorizationUrl: string;
+    tokenUrl: string;
+  }
+
+  export interface SecuritySchemeOauth2Password
+    extends SecuritySchemeOauth2Base {
+    flow: 'password';
+    tokenUrl: string;
+  }
+
+  export interface SecuritySchemeOauth2Application
+    extends SecuritySchemeOauth2Base {
+    flow: 'application';
+    tokenUrl: string;
+  }
+
+  export type SecuritySchemeObject =
+    | SecuritySchemeBasic
+    | SecuritySchemeApiKey
+    | SecuritySchemeOauth2;
+
+  export interface SecurityDefinitionsObject {
+    [index: string]: SecuritySchemeObject;
+  }
+
+  export interface SecurityRequirementObject {
+    [index: string]: string[];
+  }
+
+  export type Response = ResponseObject ;
+
+  export interface ResponsesDefinitionsObject {
+    [index: string]: ResponseObject;
+  }
+
+  export type Schema = SchemaObject ;
+
+  export interface ResponseObject {
+    description: string;
+    schema?: Schema;
+    headers?: HeadersObject;
+    examples?: ExampleObject;
+  }
+
+  export interface HeadersObject {
+    [index: string]: HeaderObject;
+  }
+
+  export interface HeaderObject extends ItemsObject {}
+
+  export interface ExampleObject {
+    [index: string]: any;
+  }
+
+  export interface ResponseObject {
+    description: string;
+    schema?: Schema;
+    headers?: HeadersObject;
+    examples?: ExampleObject;
+  }
+
+  export type OperationObject<T extends {} = {}> = {
+    tags?: string[];
+    summary?: string;
+    description?: string;
+    externalDocs?: ExternalDocumentationObject;
+    operationId?: string;
+    consumes?: MimeTypes;
+    produces?: MimeTypes;
+    parameters?: Parameters;
+    responses: ResponsesObject;
+    schemes?: string[];
+    deprecated?: boolean;
+    security?: SecurityRequirementObject[];
+  } & T;
+
+  export interface ResponsesObject {
+    [index: string]: Response | undefined;
+    default?: Response;
+  }
+
+  export type Parameters = ( Parameter)[];
+
+  export type Parameter = InBodyParameterObject | GeneralParameterObject;
+
+  export interface InBodyParameterObject extends ParameterObject {
+    schema: Schema;
+  }
+
+  export interface GeneralParameterObject extends ParameterObject, ItemsObject {
+    allowEmptyValue?: boolean;
+  }
+
+  // All HTTP methods allowed by OpenAPI 2 spec
+  // See https://swagger.io/specification/v2#path-item-object
+  // You can use keys or values from it in TypeScript code like this:
+  //     for (const method of Object.values(OpenAPIV2.HttpMethods)) { … }
+  export enum HttpMethods {
+    GET = 'get',
+    PUT = 'put',
+    POST = 'post',
+    DELETE = 'delete',
+    OPTIONS = 'options',
+    HEAD = 'head',
+    PATCH = 'patch',
+  }
+
+  export type PathItemObject<T extends {} = {}> = {
+    parameters?: Parameters;
+  } & {
+    [method in HttpMethods]?: OperationObject<T>;
+  };
+
+  export interface PathsObject<T extends {} = {}> {
+    [index: string]: PathItemObject<T>;
+  }
+
+  export interface ParametersDefinitionsObject {
+    [index: string]: ParameterObject;
+  }
+
+  export interface ParameterObject {
+    name: string;
+    in: string;
+    description?: string;
+    required?: boolean;
+    [index: string]: any;
+  }
+
+  export type MimeTypes = string[];
+
+  export interface DefinitionsObject {
+    [index: string]: SchemaObject;
+  }
+
+  export interface SchemaObject extends IJsonSchema {
+    [index: string]: any;
+    discriminator?: string;
+    readOnly?: boolean;
+    xml?: XMLObject;
+    externalDocs?: ExternalDocumentationObject;
+    example?: any;
+    default?: any;
+    items?: ItemsObject ;
+    properties?: {
+      [name: string]: SchemaObject;
+    };
+  }
+
+  export interface ExternalDocumentationObject {
+    [index: string]: any;
+    description?: string;
+    url: string;
+  }
+
+  export interface ItemsObject {
+    type: string;
+    format?: string;
+    items?: ItemsObject ;
+    collectionFormat?: string;
+    default?: any;
+    maximum?: number;
+    exclusiveMaximum?: boolean;
+    minimum?: number;
+    exclusiveMinimum?: boolean;
+    maxLength?: number;
+    minLength?: number;
+    pattern?: string;
+    maxItems?: number;
+    minItems?: number;
+    uniqueItems?: boolean;
+    enum?: any[];
+    multipleOf?: number;
+  }
+
+  export interface XMLObject {
+    [index: string]: any;
+    name?: string;
+    namespace?: string;
+    prefix?: string;
+    attribute?: boolean;
+    wrapped?: boolean;
+  }
+
+  export interface InfoObject {
+    title: string;
+    description?: string;
+    termsOfService?: string;
+    contact?: ContactObject;
+    license?: LicenseObject;
+    version: string;
+  }
+
+  export interface ContactObject {
+    name?: string;
+    url?: string;
+    email?: string;
+  }
+
+  export interface LicenseObject {
+    name: string;
+    url?: string;
+  }
+}
+
+export interface IJsonSchema {
+  id?: string;
+  $schema?: string;
+  title?: string;
+  description?: string;
+  multipleOf?: number;
+  maximum?: number;
+  exclusiveMaximum?: boolean;
+  minimum?: number;
+  exclusiveMinimum?: boolean;
+  maxLength?: number;
+  minLength?: number;
+  pattern?: string;
+  additionalItems?: boolean | IJsonSchema;
+  items?: IJsonSchema | IJsonSchema[];
+  maxItems?: number;
+  minItems?: number;
+  uniqueItems?: boolean;
+  maxProperties?: number;
+  minProperties?: number;
+  required?: string[];
+  additionalProperties?: boolean | IJsonSchema;
+  definitions?: {
+    [name: string]: IJsonSchema;
+  };
+  properties?: {
+    [name: string]: IJsonSchema;
+  };
+  patternProperties?: {
+    [name: string]: IJsonSchema;
+  };
+  dependencies?: {
+    [name: string]: IJsonSchema | string[];
+  };
+  enum?: any[];
+  type?: string | string[];
+  allOf?: IJsonSchema[];
+  anyOf?: IJsonSchema[];
+  oneOf?: IJsonSchema[];
+  not?: IJsonSchema;
+}

--- a/projects/openapi-utilities/src/flat-openapi-types.ts
+++ b/projects/openapi-utilities/src/flat-openapi-types.ts
@@ -11,24 +11,23 @@ export enum HttpMethods {
   TRACE = 'trace',
 }
 
-
-export namespace DereferencedOpenAPI {
+export namespace FlatOpenAPI {
   export type Document<T extends {} = {}> =
-    | DereferencedOpenAPIV2.Document<T>
-    | DereferencedOpenAPIV3.Document<T>
-    | DereferencedOpenAPIV3_1.Document<T>;
+    | FlatOpenAPIV2.Document<T>
+    | FlatOpenAPIV3.Document<T>
+    | FlatOpenAPIV3_1.Document<T>;
   export type Operation<T extends {} = {}> =
-    | DereferencedOpenAPIV2.OperationObject<T>
-    | DereferencedOpenAPIV3.OperationObject<T>
-    | DereferencedOpenAPIV3_1.OperationObject<T>;
+    | FlatOpenAPIV2.OperationObject<T>
+    | FlatOpenAPIV3.OperationObject<T>
+    | FlatOpenAPIV3_1.OperationObject<T>;
   export type Parameter =
-    | DereferencedOpenAPIV3_1.ParameterObject
-    | DereferencedOpenAPIV3.ParameterObject
-    | DereferencedOpenAPIV2.Parameter;
+    | FlatOpenAPIV3_1.ParameterObject
+    | FlatOpenAPIV3.ParameterObject
+    | FlatOpenAPIV2.Parameter;
   export type Parameters =
-    | (DereferencedOpenAPIV3_1.ParameterObject)[]
-    | (DereferencedOpenAPIV3.ParameterObject)[]
-    | (DereferencedOpenAPIV2.Parameter)[];
+    | FlatOpenAPIV3_1.ParameterObject[]
+    | FlatOpenAPIV3.ParameterObject[]
+    | FlatOpenAPIV2.Parameter[];
 
   export interface Request {
     body?: any;
@@ -38,106 +37,105 @@ export namespace DereferencedOpenAPI {
   }
 }
 
-export namespace DereferencedOpenAPIV3_1 {
+export namespace FlatOpenAPIV3_1 {
   type Modify<T, R> = Omit<T, keyof R> & R;
 
   type PathsWebhooksComponents<T extends {} = {}> = {
     paths: PathsObject<T>;
-    webhooks: Record<string, PathItemObject >;
+    webhooks: Record<string, PathItemObject>;
     components: ComponentsObject;
   };
 
   export type Document<T extends {} = {}> = Modify<
-    Omit<DereferencedOpenAPIV3.Document<T>, 'paths' | 'components'>,
+    Omit<FlatOpenAPIV3.Document<T>, 'paths' | 'components'>,
     {
       info: InfoObject;
       jsonSchemaDialect?: string;
       servers?: ServerObject[];
     } & (
-    | (Pick<PathsWebhooksComponents<T>, 'paths'> &
-    Omit<Partial<PathsWebhooksComponents<T>>, 'paths'>)
-    | (Pick<PathsWebhooksComponents<T>, 'webhooks'> &
-    Omit<Partial<PathsWebhooksComponents<T>>, 'webhooks'>)
-    | (Pick<PathsWebhooksComponents<T>, 'components'> &
-    Omit<Partial<PathsWebhooksComponents<T>>, 'components'>)
+      | (Pick<PathsWebhooksComponents<T>, 'paths'> &
+          Omit<Partial<PathsWebhooksComponents<T>>, 'paths'>)
+      | (Pick<PathsWebhooksComponents<T>, 'webhooks'> &
+          Omit<Partial<PathsWebhooksComponents<T>>, 'webhooks'>)
+      | (Pick<PathsWebhooksComponents<T>, 'components'> &
+          Omit<Partial<PathsWebhooksComponents<T>>, 'components'>)
     )
-    >;
+  >;
 
   export type InfoObject = Modify<
-    DereferencedOpenAPIV3.InfoObject,
+    FlatOpenAPIV3.InfoObject,
     {
       summary?: string;
       license?: LicenseObject;
     }
-    >;
+  >;
 
-  export type ContactObject = DereferencedOpenAPIV3.ContactObject;
+  export type ContactObject = FlatOpenAPIV3.ContactObject;
 
   export type LicenseObject = Modify<
-    DereferencedOpenAPIV3.LicenseObject,
+    FlatOpenAPIV3.LicenseObject,
     {
       identifier?: string;
     }
-    >;
+  >;
 
   export type ServerObject = Modify<
-    DereferencedOpenAPIV3.ServerObject,
+    FlatOpenAPIV3.ServerObject,
     {
       url: string;
       description?: string;
       variables?: Record<string, ServerVariableObject>;
     }
-    >;
+  >;
 
   export type ServerVariableObject = Modify<
-    DereferencedOpenAPIV3.ServerVariableObject,
+    FlatOpenAPIV3.ServerVariableObject,
     {
       enum?: [string, ...string[]];
     }
-    >;
+  >;
 
   export type PathsObject<T extends {} = {}, P extends {} = {}> = Record<
     string,
     (PathItemObject<T> & P) | undefined
-    >;
-
+  >;
 
   export type PathItemObject<T extends {} = {}> = Modify<
-    DereferencedOpenAPIV3.PathItemObject<T>,
+    FlatOpenAPIV3.PathItemObject<T>,
     {
       servers?: ServerObject[];
-      parameters?: ( ParameterObject)[];
+      parameters?: ParameterObject[];
     }
-    > &
-    {
-      [method in HttpMethods]?: OperationObject<T>;
-    };
+  > & {
+    [method in HttpMethods]?: OperationObject<T>;
+  };
 
   export type OperationObject<T extends {} = {}> = Modify<
-    DereferencedOpenAPIV3.OperationObject<T>,
+    FlatOpenAPIV3.OperationObject<T>,
     {
-      parameters?: ( ParameterObject)[];
-      requestBody?:  RequestBodyObject;
+      parameters?: ParameterObject[];
+      requestBody?: RequestBodyObject;
       responses?: ResponsesObject;
-      callbacks?: Record<string,  CallbackObject>;
+      callbacks?: Record<string, CallbackObject>;
       servers?: ServerObject[];
     }
-    > &
+  > &
     T;
 
-  export type ExternalDocumentationObject = DereferencedOpenAPIV3.ExternalDocumentationObject;
+  export type ExternalDocumentationObject =
+    FlatOpenAPIV3.ExternalDocumentationObject;
 
-  export type ParameterObject = DereferencedOpenAPIV3.ParameterObject;
+  export type ParameterObject = FlatOpenAPIV3.ParameterObject;
 
-  export type HeaderObject = DereferencedOpenAPIV3.HeaderObject;
+  export type HeaderObject = FlatOpenAPIV3.HeaderObject;
 
-  export type ParameterBaseObject = DereferencedOpenAPIV3.ParameterBaseObject;
+  export type ParameterBaseObject = FlatOpenAPIV3.ParameterBaseObject;
 
   export type NonArraySchemaObjectType =
-    | DereferencedOpenAPIV3.NonArraySchemaObjectType
+    | FlatOpenAPIV3.NonArraySchemaObjectType
     | 'null';
 
-  export type ArraySchemaObjectType = DereferencedOpenAPIV3.ArraySchemaObjectType;
+  export type ArraySchemaObjectType = FlatOpenAPIV3.ArraySchemaObjectType;
 
   /**
    * There is no way to tell typescript to require items when type is either 'array' or array containing 'array' type
@@ -151,7 +149,7 @@ export namespace DereferencedOpenAPIV3_1 {
 
   export interface ArraySchemaObject extends BaseSchemaObject {
     type: ArraySchemaObjectType;
-    items:  SchemaObject;
+    items: SchemaObject;
   }
 
   export interface NonArraySchemaObject extends BaseSchemaObject {
@@ -160,110 +158,108 @@ export namespace DereferencedOpenAPIV3_1 {
 
   interface MixedSchemaObject extends BaseSchemaObject {
     type?: (ArraySchemaObjectType | NonArraySchemaObjectType)[];
-    items?:  SchemaObject;
+    items?: SchemaObject;
   }
 
   export type BaseSchemaObject = Modify<
-    Omit<DereferencedOpenAPIV3.BaseSchemaObject, 'nullable'>,
+    Omit<FlatOpenAPIV3.BaseSchemaObject, 'nullable'>,
     {
-      examples?: DereferencedOpenAPIV3.BaseSchemaObject['example'][];
+      examples?: FlatOpenAPIV3.BaseSchemaObject['example'][];
       exclusiveMinimum?: boolean | number;
       exclusiveMaximum?: boolean | number;
       contentMediaType?: string;
       $schema?: string;
-      additionalProperties?: boolean  | SchemaObject;
+      additionalProperties?: boolean | SchemaObject;
       properties?: {
-        [name: string]:  SchemaObject;
+        [name: string]: SchemaObject;
       };
-      allOf?: ( SchemaObject)[];
-      oneOf?: ( SchemaObject)[];
-      anyOf?: ( SchemaObject)[];
-      not?:  SchemaObject;
+      allOf?: SchemaObject[];
+      oneOf?: SchemaObject[];
+      anyOf?: SchemaObject[];
+      not?: SchemaObject;
       discriminator?: DiscriminatorObject;
       externalDocs?: ExternalDocumentationObject;
       xml?: XMLObject;
       const?: any;
     }
-    >;
+  >;
 
-  export type DiscriminatorObject = DereferencedOpenAPIV3.DiscriminatorObject;
+  export type DiscriminatorObject = FlatOpenAPIV3.DiscriminatorObject;
 
-  export type XMLObject = DereferencedOpenAPIV3.XMLObject;
+  export type XMLObject = FlatOpenAPIV3.XMLObject;
 
-  export type ExampleObject = DereferencedOpenAPIV3.ExampleObject;
+  export type ExampleObject = FlatOpenAPIV3.ExampleObject;
 
   export type MediaTypeObject = Modify<
-    DereferencedOpenAPIV3.MediaTypeObject,
+    FlatOpenAPIV3.MediaTypeObject,
     {
-      schema?: SchemaObject ;
-      examples?: Record<string,  ExampleObject>;
+      schema?: SchemaObject;
+      examples?: Record<string, ExampleObject>;
     }
-    >;
+  >;
 
-  export type EncodingObject = DereferencedOpenAPIV3.EncodingObject;
+  export type EncodingObject = FlatOpenAPIV3.EncodingObject;
 
   export type RequestBodyObject = Modify<
-    DereferencedOpenAPIV3.RequestBodyObject,
+    FlatOpenAPIV3.RequestBodyObject,
     {
       content: { [media: string]: MediaTypeObject };
     }
-    >;
+  >;
 
-  export type ResponsesObject = Record<
-    string,
-     ResponseObject
-    >;
+  export type ResponsesObject = Record<string, ResponseObject>;
 
   export type ResponseObject = Modify<
-    DereferencedOpenAPIV3.ResponseObject,
+    FlatOpenAPIV3.ResponseObject,
     {
-      headers?: { [header: string]:  HeaderObject };
+      headers?: { [header: string]: HeaderObject };
       content?: { [media: string]: MediaTypeObject };
-      links?: { [link: string]:  LinkObject };
+      links?: { [link: string]: LinkObject };
     }
-    >;
+  >;
 
   export type LinkObject = Modify<
-    DereferencedOpenAPIV3.LinkObject,
+    FlatOpenAPIV3.LinkObject,
     {
       server?: ServerObject;
     }
-    >;
+  >;
 
-  export type CallbackObject = Record<string, PathItemObject >;
+  export type CallbackObject = Record<string, PathItemObject>;
 
-  export type SecurityRequirementObject = DereferencedOpenAPIV3.SecurityRequirementObject;
+  export type SecurityRequirementObject =
+    FlatOpenAPIV3.SecurityRequirementObject;
 
   export type ComponentsObject = Modify<
-    DereferencedOpenAPIV3.ComponentsObject,
+    FlatOpenAPIV3.ComponentsObject,
     {
       schemas?: Record<string, SchemaObject>;
-      responses?: Record<string,  ResponseObject>;
-      parameters?: Record<string,  ParameterObject>;
-      examples?: Record<string,  ExampleObject>;
-      requestBodies?: Record<string,  RequestBodyObject>;
-      headers?: Record<string,  HeaderObject>;
-      securitySchemes?: Record<string,  SecuritySchemeObject>;
-      links?: Record<string,  LinkObject>;
-      callbacks?: Record<string,  CallbackObject>;
-      pathItems?: Record<string,  PathItemObject>;
+      responses?: Record<string, ResponseObject>;
+      parameters?: Record<string, ParameterObject>;
+      examples?: Record<string, ExampleObject>;
+      requestBodies?: Record<string, RequestBodyObject>;
+      headers?: Record<string, HeaderObject>;
+      securitySchemes?: Record<string, SecuritySchemeObject>;
+      links?: Record<string, LinkObject>;
+      callbacks?: Record<string, CallbackObject>;
+      pathItems?: Record<string, PathItemObject>;
     }
-    >;
+  >;
 
-  export type SecuritySchemeObject = DereferencedOpenAPIV3.SecuritySchemeObject;
+  export type SecuritySchemeObject = FlatOpenAPIV3.SecuritySchemeObject;
 
-  export type HttpSecurityScheme = DereferencedOpenAPIV3.HttpSecurityScheme;
+  export type HttpSecurityScheme = FlatOpenAPIV3.HttpSecurityScheme;
 
-  export type ApiKeySecurityScheme = DereferencedOpenAPIV3.ApiKeySecurityScheme;
+  export type ApiKeySecurityScheme = FlatOpenAPIV3.ApiKeySecurityScheme;
 
-  export type OAuth2SecurityScheme = DereferencedOpenAPIV3.OAuth2SecurityScheme;
+  export type OAuth2SecurityScheme = FlatOpenAPIV3.OAuth2SecurityScheme;
 
-  export type OpenIdSecurityScheme = DereferencedOpenAPIV3.OpenIdSecurityScheme;
+  export type OpenIdSecurityScheme = FlatOpenAPIV3.OpenIdSecurityScheme;
 
-  export type TagObject = DereferencedOpenAPIV3.TagObject;
+  export type TagObject = FlatOpenAPIV3.TagObject;
 }
 
-export namespace DereferencedOpenAPIV3 {
+export namespace FlatOpenAPIV3 {
   export interface Document<T extends {} = {}> {
     openapi: string;
     info: InfoObject;
@@ -276,7 +272,7 @@ export namespace DereferencedOpenAPIV3 {
     'x-express-openapi-additional-middleware'?: (
       | ((request: any, response: any, next: any) => Promise<void>)
       | ((request: any, response: any, next: any) => void)
-      )[];
+    )[];
     'x-express-openapi-validation-strict'?: boolean;
   }
 
@@ -324,7 +320,7 @@ export namespace DereferencedOpenAPIV3 {
     summary?: string;
     description?: string;
     servers?: ServerObject[];
-    parameters?: ( ParameterObject)[];
+    parameters?: ParameterObject[];
   } & {
     [method in HttpMethods]?: OperationObject<T>;
   };
@@ -335,10 +331,10 @@ export namespace DereferencedOpenAPIV3 {
     description?: string;
     externalDocs?: ExternalDocumentationObject;
     operationId?: string;
-    parameters?: ( ParameterObject)[];
-    requestBody?:  RequestBodyObject;
+    parameters?: ParameterObject[];
+    requestBody?: RequestBodyObject;
     responses: ResponsesObject;
-    callbacks?: { [callback: string]:  CallbackObject };
+    callbacks?: { [callback: string]: CallbackObject };
     deprecated?: boolean;
     security?: SecurityRequirementObject[];
     servers?: ServerObject[];
@@ -364,9 +360,9 @@ export namespace DereferencedOpenAPIV3 {
     style?: string;
     explode?: boolean;
     allowReserved?: boolean;
-    schema?:  SchemaObject;
+    schema?: SchemaObject;
     example?: any;
-    examples?: { [media: string]:  ExampleObject };
+    examples?: { [media: string]: ExampleObject };
     content?: { [media: string]: MediaTypeObject };
   }
   export type NonArraySchemaObjectType =
@@ -380,7 +376,7 @@ export namespace DereferencedOpenAPIV3 {
 
   export interface ArraySchemaObject extends BaseSchemaObject {
     type: ArraySchemaObjectType;
-    items:  SchemaObject;
+    items: SchemaObject;
   }
 
   export interface NonArraySchemaObject extends BaseSchemaObject {
@@ -401,7 +397,7 @@ export namespace DereferencedOpenAPIV3 {
     maxLength?: number;
     minLength?: number;
     pattern?: string;
-    additionalProperties?: boolean  | SchemaObject;
+    additionalProperties?: boolean | SchemaObject;
     maxItems?: number;
     minItems?: number;
     uniqueItems?: boolean;
@@ -410,12 +406,12 @@ export namespace DereferencedOpenAPIV3 {
     required?: string[];
     enum?: any[];
     properties?: {
-      [name: string]:  SchemaObject;
+      [name: string]: SchemaObject;
     };
-    allOf?: ( SchemaObject)[];
-    oneOf?: ( SchemaObject)[];
-    anyOf?: ( SchemaObject)[];
-    not?:  SchemaObject;
+    allOf?: SchemaObject[];
+    oneOf?: SchemaObject[];
+    anyOf?: SchemaObject[];
+    not?: SchemaObject;
 
     // OpenAPI-specific properties
     nullable?: boolean;
@@ -449,15 +445,15 @@ export namespace DereferencedOpenAPIV3 {
   }
 
   export interface MediaTypeObject {
-    schema?:  SchemaObject;
+    schema?: SchemaObject;
     example?: any;
-    examples?: { [media: string]:  ExampleObject };
+    examples?: { [media: string]: ExampleObject };
     encoding?: { [media: string]: EncodingObject };
   }
 
   export interface EncodingObject {
     contentType?: string;
-    headers?: { [header: string]:  HeaderObject };
+    headers?: { [header: string]: HeaderObject };
     style?: string;
     explode?: boolean;
     allowReserved?: boolean;
@@ -470,14 +466,14 @@ export namespace DereferencedOpenAPIV3 {
   }
 
   export interface ResponsesObject {
-    [code: string]:  ResponseObject;
+    [code: string]: ResponseObject;
   }
 
   export interface ResponseObject {
     description: string;
-    headers?: { [header: string]:  HeaderObject };
+    headers?: { [header: string]: HeaderObject };
     content?: { [media: string]: MediaTypeObject };
-    links?: { [link: string]:  LinkObject };
+    links?: { [link: string]: LinkObject };
   }
 
   export interface LinkObject {
@@ -498,15 +494,15 @@ export namespace DereferencedOpenAPIV3 {
   }
 
   export interface ComponentsObject {
-    schemas?: { [key: string]:  SchemaObject };
-    responses?: { [key: string]:  ResponseObject };
-    parameters?: { [key: string]:  ParameterObject };
-    examples?: { [key: string]:  ExampleObject };
-    requestBodies?: { [key: string]:  RequestBodyObject };
-    headers?: { [key: string]:  HeaderObject };
-    securitySchemes?: { [key: string]:  SecuritySchemeObject };
-    links?: { [key: string]:  LinkObject };
-    callbacks?: { [key: string]:  CallbackObject };
+    schemas?: { [key: string]: SchemaObject };
+    responses?: { [key: string]: ResponseObject };
+    parameters?: { [key: string]: ParameterObject };
+    examples?: { [key: string]: ExampleObject };
+    requestBodies?: { [key: string]: RequestBodyObject };
+    headers?: { [key: string]: HeaderObject };
+    securitySchemes?: { [key: string]: SecuritySchemeObject };
+    links?: { [key: string]: LinkObject };
+    callbacks?: { [key: string]: CallbackObject };
   }
 
   export type SecuritySchemeObject =
@@ -570,7 +566,7 @@ export namespace DereferencedOpenAPIV3 {
   }
 }
 
-export namespace DereferencedOpenAPIV2 {
+export namespace FlatOpenAPIV2 {
   export interface Document<T extends {} = {}> {
     basePath?: string;
     consumes?: MimeTypes;
@@ -590,7 +586,7 @@ export namespace DereferencedOpenAPIV2 {
     'x-express-openapi-additional-middleware'?: (
       | ((request: any, response: any, next: any) => Promise<void>)
       | ((request: any, response: any, next: any) => void)
-      )[];
+    )[];
     'x-express-openapi-validation-strict'?: boolean;
   }
 
@@ -669,13 +665,13 @@ export namespace DereferencedOpenAPIV2 {
     [index: string]: string[];
   }
 
-  export type Response = ResponseObject ;
+  export type Response = ResponseObject;
 
   export interface ResponsesDefinitionsObject {
     [index: string]: ResponseObject;
   }
 
-  export type Schema = SchemaObject ;
+  export type Schema = SchemaObject;
 
   export interface ResponseObject {
     description: string;
@@ -721,7 +717,7 @@ export namespace DereferencedOpenAPIV2 {
     default?: Response;
   }
 
-  export type Parameters = ( Parameter)[];
+  export type Parameters = Parameter[];
 
   export type Parameter = InBodyParameterObject | GeneralParameterObject;
 
@@ -783,7 +779,7 @@ export namespace DereferencedOpenAPIV2 {
     externalDocs?: ExternalDocumentationObject;
     example?: any;
     default?: any;
-    items?: ItemsObject ;
+    items?: ItemsObject;
     properties?: {
       [name: string]: SchemaObject;
     };
@@ -798,7 +794,7 @@ export namespace DereferencedOpenAPIV2 {
   export interface ItemsObject {
     type: string;
     format?: string;
-    items?: ItemsObject ;
+    items?: ItemsObject;
     collectionFormat?: string;
     default?: any;
     maximum?: number;

--- a/projects/openapi-utilities/src/index.ts
+++ b/projects/openapi-utilities/src/index.ts
@@ -1,6 +1,7 @@
 import { OpenAPITraverser } from './openapi3/implementations/openapi3/openapi-traverser';
 import { OpenAPIV3 } from 'openapi-types';
 import { factsToChangelog } from './openapi3/sdk/facts-to-changelog';
+export { DereferencedOpenAPI } from './flat-openapi-types'
 import {
   ConceptualLocation,
   IChange,

--- a/projects/openapi-utilities/src/index.ts
+++ b/projects/openapi-utilities/src/index.ts
@@ -1,7 +1,8 @@
 import { OpenAPITraverser } from './openapi3/implementations/openapi3/openapi-traverser';
 import { OpenAPIV3 } from 'openapi-types';
 import { factsToChangelog } from './openapi3/sdk/facts-to-changelog';
-export { DereferencedOpenAPI } from './flat-openapi-types'
+export { DereferencedOpenAPIV2, DereferencedOpenAPIV3, DereferencedOpenAPIV3_1 } from './flat-openapi-types'
+
 import {
   ConceptualLocation,
   IChange,
@@ -43,6 +44,7 @@ import {
   isFactOrChangeVariant,
 } from './openapi3/sdk/isType';
 import { sourcemapReader } from './openapi3/implementations/openapi3/sourcemap-reader';
+import { DereferencedOpenAPIV3 } from './flat-openapi-types';
 
 export { defaultEmptySpec } from './openapi3/constants';
 export * from './ci-types';

--- a/projects/openapi-utilities/src/index.ts
+++ b/projects/openapi-utilities/src/index.ts
@@ -1,7 +1,11 @@
 import { OpenAPITraverser } from './openapi3/implementations/openapi3/openapi-traverser';
 import { OpenAPIV3 } from 'openapi-types';
 import { factsToChangelog } from './openapi3/sdk/facts-to-changelog';
-export { DereferencedOpenAPIV2, DereferencedOpenAPIV3, DereferencedOpenAPIV3_1 } from './flat-openapi-types'
+export {
+  FlatOpenAPIV2,
+  FlatOpenAPIV3,
+  FlatOpenAPIV3_1,
+} from './flat-openapi-types';
 
 import {
   ConceptualLocation,
@@ -44,7 +48,6 @@ import {
   isFactOrChangeVariant,
 } from './openapi3/sdk/isType';
 import { sourcemapReader } from './openapi3/implementations/openapi3/sourcemap-reader';
-import { DereferencedOpenAPIV3 } from './flat-openapi-types';
 
 export { defaultEmptySpec } from './openapi3/constants';
 export * from './ci-types';

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.5-2",
+  "version": "0.35.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -84,6 +84,5 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  },
-  "stableVersion": "0.35.4"
+  }
 }

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.5-2",
+  "version": "0.35.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -91,6 +91,5 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  },
-  "stableVersion": "0.35.4"
+  }
 }

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.5-2",
+  "version": "0.35.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -61,6 +61,5 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  },
-  "stableVersion": "0.35.4"
+  }
 }

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.5-2",
+  "version": "0.35.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -60,6 +60,5 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  },
-  "stableVersion": "0.35.4"
+  }
 }


### PR DESCRIPTION
## 🍗 Description
We use Kong's `openapi-types` type definitions which assume `$ref` is allowed. By the time we've parsed, validated and cast an object to one of these types it will never have `$ref`. The practical effect of this is that our code ends up being more complex -- constantly checking for $ref and casting everything unnecessarily. This affects user rule writing and our ability to ship more advanced changelogs / docs in optic. We do not need to replace every usage at once, but we should starting moving towards using these flat types and phase out the old ones. 

`DereferencedOpenAPIV3.Document`

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
