### PR TITLE
Fix/upath as dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.35.5",
+  "version": "0.35.6",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
-  "version": "0.35.5",
+  "version": "0.35.6",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-cli",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.5",
+  "version": "0.35.6",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -45,8 +45,7 @@
     "micro-cors": "^0.1.1",
     "prettier": "^2.4.1",
     "ts-node": "^10.3.1",
-    "typescript": "^4.4.4",
-    "upath": "^2.0.1"
+    "typescript": "^4.4.4"
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^9.0.9",
@@ -72,7 +71,8 @@
     "openapi-types": "^12.0.2",
     "semver": "^7.3.7",
     "ts-invariant": "^0.9.3",
-    "yaml-ast-parser": "^0.0.43"
+    "yaml-ast-parser": "^0.0.43",
+    "upath": "^2.0.1"
   },
   "jest": {
     "testPathIgnorePatterns": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-io",
   "license": "MIT",
-  "version": "0.35.5",
+  "version": "0.35.6",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -71,8 +71,8 @@
     "openapi-types": "^12.0.2",
     "semver": "^7.3.7",
     "ts-invariant": "^0.9.3",
-    "yaml-ast-parser": "^0.0.43",
-    "upath": "^2.0.1"
+    "upath": "^2.0.1",
+    "yaml-ast-parser": "^0.0.43"
   },
   "jest": {
     "testPathIgnorePatterns": [

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
-  "version": "0.35.5",
+  "version": "0.35.6",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.5",
+  "version": "0.35.6",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.5",
+  "version": "0.35.6",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.5",
+  "version": "0.35.6",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.5",
+  "version": "0.35.6",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
## 🍗 Description
`upath` was added Monday in a pre-release as a devDependency. It made it into the latest when https://github.com/opticdev/optic/pull/1423 landed. A user reported on a call this morning install were broken -- we realized this was the problem together. 

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
