### PR TITLE
JSON output flag for diff command

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.35.8-0",
+  "version": "0.35.8-1",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.35.8-4",
+  "version": "0.35.8-5",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.35.6",
+  "version": "0.35.7-0",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",
@@ -16,5 +16,6 @@
   "scripts": {
     "release": "gh release create --target=$(git branch --show-current) v$(node -e \"process.stdout.write(require('./package.json').version)\")",
     "version": "yarn workspaces foreach -v version"
-  }
+  },
+  "stableVersion": "0.35.6"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.35.7",
+  "version": "0.35.8-0",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",
@@ -16,5 +16,6 @@
   "scripts": {
     "release": "gh release create --target=$(git branch --show-current) v$(node -e \"process.stdout.write(require('./package.json').version)\")",
     "version": "yarn workspaces foreach -v version"
-  }
+  },
+  "stableVersion": "0.35.7"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.35.8-1",
+  "version": "0.35.8-4",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.35.7-0",
+  "version": "0.35.6",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",
@@ -16,6 +16,5 @@
   "scripts": {
     "release": "gh release create --target=$(git branch --show-current) v$(node -e \"process.stdout.write(require('./package.json').version)\")",
     "version": "yarn workspaces foreach -v version"
-  },
-  "stableVersion": "0.35.6"
+  }
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
-  "version": "0.35.6",
+  "version": "0.35.7-0",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -38,5 +38,6 @@
   },
   "dependencies": {
     "jsonpointer": "^5.0.1"
-  }
+  },
+  "stableVersion": "0.35.6"
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
-  "version": "0.35.8-4",
+  "version": "0.35.8-5",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
-  "version": "0.35.7-0",
+  "version": "0.35.6",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -38,6 +38,5 @@
   },
   "dependencies": {
     "jsonpointer": "^5.0.1"
-  },
-  "stableVersion": "0.35.6"
+  }
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
-  "version": "0.35.8-1",
+  "version": "0.35.8-4",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
-  "version": "0.35.7",
+  "version": "0.35.8-0",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -38,5 +38,6 @@
   },
   "dependencies": {
     "jsonpointer": "^5.0.1"
-  }
+  },
+  "stableVersion": "0.35.7"
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
-  "version": "0.35.8-0",
+  "version": "0.35.8-1",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-cli",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.8-1",
+  "version": "0.35.8-4",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-cli",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.8-4",
+  "version": "0.35.8-5",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-cli",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.6",
+  "version": "0.35.7-0",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [
@@ -108,5 +108,6 @@
         "<rootDir>../../../../node_modules/csv-parse/dist/cjs/sync.cjs"
       ]
     }
-  }
+  },
+  "stableVersion": "0.35.6"
 }

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-cli",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.7",
+  "version": "0.35.8-0",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [
@@ -108,5 +108,6 @@
         "<rootDir>../../../../node_modules/csv-parse/dist/cjs/sync.cjs"
       ]
     }
-  }
+  },
+  "stableVersion": "0.35.7"
 }

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-cli",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.8-0",
+  "version": "0.35.8-1",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-cli",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.7-0",
+  "version": "0.35.6",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [
@@ -108,6 +108,5 @@
         "<rootDir>../../../../node_modules/csv-parse/dist/cjs/sync.cjs"
       ]
     }
-  },
-  "stableVersion": "0.35.6"
+  }
 }

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-io",
   "license": "MIT",
-  "version": "0.35.7",
+  "version": "0.35.8-0",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -78,5 +78,6 @@
     "testPathIgnorePatterns": [
       "build"
     ]
-  }
+  },
+  "stableVersion": "0.35.7"
 }

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-io",
   "license": "MIT",
-  "version": "0.35.8-1",
+  "version": "0.35.8-4",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-io",
   "license": "MIT",
-  "version": "0.35.8-4",
+  "version": "0.35.8-5",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-io",
   "license": "MIT",
-  "version": "0.35.8-0",
+  "version": "0.35.8-1",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-io",
   "license": "MIT",
-  "version": "0.35.7-0",
+  "version": "0.35.6",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -78,6 +78,5 @@
     "testPathIgnorePatterns": [
       "build"
     ]
-  },
-  "stableVersion": "0.35.6"
+  }
 }

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-io",
   "license": "MIT",
-  "version": "0.35.6",
+  "version": "0.35.7-0",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -78,5 +78,6 @@
     "testPathIgnorePatterns": [
       "build"
     ]
-  }
+  },
+  "stableVersion": "0.35.6"
 }

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
-  "version": "0.35.7",
+  "version": "0.35.8-0",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -68,5 +68,6 @@
     "testPathIgnorePatterns": [
       "build"
     ]
-  }
+  },
+  "stableVersion": "0.35.7"
 }

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
-  "version": "0.35.8-0",
+  "version": "0.35.8-1",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
-  "version": "0.35.6",
+  "version": "0.35.7-0",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -68,5 +68,6 @@
     "testPathIgnorePatterns": [
       "build"
     ]
-  }
+  },
+  "stableVersion": "0.35.6"
 }

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
-  "version": "0.35.7-0",
+  "version": "0.35.6",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -68,6 +68,5 @@
     "testPathIgnorePatterns": [
       "build"
     ]
-  },
-  "stableVersion": "0.35.6"
+  }
 }

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
-  "version": "0.35.8-1",
+  "version": "0.35.8-4",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
-  "version": "0.35.8-4",
+  "version": "0.35.8-5",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-utilities/src/examples/petstore-updated.ts
+++ b/projects/openapi-utilities/src/examples/petstore-updated.ts
@@ -56,7 +56,7 @@ export const openAPI: OpenAPIV3.Document = {
   paths: {
     '/example': {
       get: {
-        operationId: 'getExamples',
+        operationId: 'get_examples',
         responses: {
           '200': {
             description: 'succesful',
@@ -126,6 +126,9 @@ export const openAPI: OpenAPIV3.Document = {
                   id: {
                     type: 'integer',
                     format: 'int64',
+                  },
+                  example: {
+                    type: 'string',
                   },
                   number: {
                     type: 'string',
@@ -221,6 +224,9 @@ export const openAPI: OpenAPIV3.Document = {
                   category: {
                     type: 'object',
                     properties: {
+                      other: {
+                        type: 'string',
+                      },
                       id: {
                         type: 'integer',
                         format: 'int64',

--- a/projects/openapi-utilities/src/index.ts
+++ b/projects/openapi-utilities/src/index.ts
@@ -76,6 +76,7 @@ export {
 } from './utilities/group-changes';
 export { traverseSpec } from './utilities/traverse-spec';
 export { terminalChangelog } from './utilities/terminal-changelog';
+export { jsonChangelog } from './utilities/json-changelog';
 export { generateChangelogData } from './utilities/generate-changelog-data';
 export { compareChangesByPath } from './utilities/compare-changes-by-path';
 export {

--- a/projects/openapi-utilities/src/utilities/__tests__/__snapshots__/group-changes.test.ts.snap
+++ b/projects/openapi-utilities/src/utilities/__tests__/__snapshots__/group-changes.test.ts.snap
@@ -4,7 +4,34 @@ exports[`groupChangesAndRules diffs and groups changes between two open api file
 Object {
   "changesByEndpoint": Map {
     "/example.GET" => Object {
-      "change": null,
+      "change": Object {
+        "changeType": "changed",
+        "changed": Object {
+          "after": Object {
+            "method": "get",
+            "operationId": "get_examples",
+            "pathPattern": "/example",
+          },
+          "before": Object {
+            "method": "get",
+            "operationId": "getExamples",
+            "pathPattern": "/example",
+          },
+        },
+        "location": Object {
+          "conceptualLocation": Object {
+            "method": "get",
+            "path": "/example",
+          },
+          "conceptualPath": Array [
+            "operations",
+            "/example",
+            "get",
+          ],
+          "jsonPath": "/paths/~1example/get",
+          "kind": "operation",
+        },
+      },
       "cookieParameters": Object {
         "changes": Map {},
         "hasRules": false,
@@ -664,7 +691,69 @@ Object {
         "hasRules": false,
       },
       "request": Object {
-        "bodyChanges": Map {},
+        "bodyChanges": Map {
+          "application/json" => Object {
+            "bodyChange": null,
+            "exampleChanges": Array [],
+            "fieldChanges": Array [
+              Object {
+                "added": Object {
+                  "flatSchema": Object {
+                    "type": "string",
+                  },
+                  "key": "other",
+                  "required": false,
+                },
+                "changeType": "added",
+                "location": Object {
+                  "conceptualLocation": Object {
+                    "inRequest": Object {
+                      "body": Object {
+                        "contentType": "application/json",
+                      },
+                    },
+                    "jsonSchemaTrail": Array [
+                      "category",
+                      "other",
+                    ],
+                    "method": "post",
+                    "path": "/pet",
+                  },
+                  "conceptualPath": Array [
+                    "operations",
+                    "/pet",
+                    "post",
+                    "application/json",
+                    "category",
+                    "other",
+                  ],
+                  "jsonPath": "/paths/~1pet/post/requestBody/content/application~1json/schema/properties/category/properties/other",
+                  "kind": "field",
+                },
+              },
+            ],
+            "hasRules": false,
+            "location": Object {
+              "conceptualLocation": Object {
+                "inRequest": Object {
+                  "body": Object {
+                    "contentType": "application/json",
+                  },
+                },
+                "method": "post",
+                "path": "/pet",
+              },
+              "conceptualPath": Array [
+                "operations",
+                "/pet",
+                "post",
+                "application/json",
+              ],
+              "jsonPath": "/paths/~1pet/post/requestBody/content/application~1json",
+              "kind": "body",
+            },
+          },
+        },
         "change": null,
         "hasRules": false,
       },
@@ -697,6 +786,39 @@ Object {
             "bodyChange": null,
             "exampleChanges": Array [],
             "fieldChanges": Array [
+              Object {
+                "added": Object {
+                  "flatSchema": Object {
+                    "type": "string",
+                  },
+                  "key": "example",
+                  "required": false,
+                },
+                "changeType": "added",
+                "location": Object {
+                  "conceptualLocation": Object {
+                    "inRequest": Object {
+                      "body": Object {
+                        "contentType": "application/json",
+                      },
+                    },
+                    "jsonSchemaTrail": Array [
+                      "example",
+                    ],
+                    "method": "put",
+                    "path": "/pet",
+                  },
+                  "conceptualPath": Array [
+                    "operations",
+                    "/pet",
+                    "put",
+                    "application/json",
+                    "example",
+                  ],
+                  "jsonPath": "/paths/~1pet/put/requestBody/content/application~1json/schema/properties/example",
+                  "kind": "field",
+                },
+              },
               Object {
                 "changeType": "removed",
                 "location": Object {

--- a/projects/openapi-utilities/src/utilities/__tests__/__snapshots__/json-changelog.test.ts.snap
+++ b/projects/openapi-utilities/src/utilities/__tests__/__snapshots__/json-changelog.test.ts.snap
@@ -210,7 +210,25 @@ Object {
       "change": "changed",
       "name": "post /pet",
       "parameters": Array [],
-      "requestBody": undefined,
+      "requestBody": Object {
+        "attributes": Array [],
+        "change": "changed",
+        "contentTypes": Array [
+          Object {
+            "attributes": Array [],
+            "change": "changed",
+            "name": "application/json",
+            "schemaChanges": Array [
+              Object {
+                "attributes": Array [],
+                "change": "added",
+                "name": "category.other",
+              },
+            ],
+          },
+        ],
+        "name": "Request Body",
+      },
       "responses": Array [],
     },
     Object {
@@ -218,7 +236,92 @@ Object {
       "change": "changed",
       "name": "put /pet",
       "parameters": Array [],
-      "requestBody": undefined,
+      "requestBody": Object {
+        "attributes": Array [],
+        "change": "changed",
+        "contentTypes": Array [
+          Object {
+            "attributes": Array [],
+            "change": "changed",
+            "name": "application/json",
+            "schemaChanges": Array [
+              Object {
+                "attributes": Array [],
+                "change": "added",
+                "name": "example",
+              },
+              Object {
+                "attributes": Array [],
+                "change": "removed",
+                "name": "name",
+              },
+              Object {
+                "attributes": Array [],
+                "change": "added",
+                "name": "number",
+              },
+            ],
+          },
+          Object {
+            "attributes": Array [],
+            "change": "removed",
+            "name": "application/xml",
+            "schemaChanges": Array [
+              Object {
+                "attributes": Array [],
+                "change": "removed",
+                "name": "category",
+              },
+              Object {
+                "attributes": Array [],
+                "change": "removed",
+                "name": "category.id",
+              },
+              Object {
+                "attributes": Array [],
+                "change": "removed",
+                "name": "category.name",
+              },
+              Object {
+                "attributes": Array [],
+                "change": "removed",
+                "name": "id",
+              },
+              Object {
+                "attributes": Array [],
+                "change": "removed",
+                "name": "name",
+              },
+              Object {
+                "attributes": Array [],
+                "change": "removed",
+                "name": "photoUrls",
+              },
+              Object {
+                "attributes": Array [],
+                "change": "removed",
+                "name": "status",
+              },
+              Object {
+                "attributes": Array [],
+                "change": "removed",
+                "name": "tags",
+              },
+              Object {
+                "attributes": Array [],
+                "change": "removed",
+                "name": "tags.items.id",
+              },
+              Object {
+                "attributes": Array [],
+                "change": "removed",
+                "name": "tags.items.name",
+              },
+            ],
+          },
+        ],
+        "name": "Request Body",
+      },
       "responses": Array [
         Object {
           "attributes": Array [],
@@ -876,7 +979,44 @@ Object {
       "change": "changed",
       "name": "post /store/order",
       "parameters": Array [],
-      "requestBody": undefined,
+      "requestBody": Object {
+        "attributes": Array [],
+        "change": "changed",
+        "contentTypes": Array [
+          Object {
+            "attributes": Array [],
+            "change": "changed",
+            "name": "*/*",
+            "schemaChanges": Array [
+              Object {
+                "attributes": Array [
+                  Object {
+                    "after": Array [
+                      "placed",
+                      "delivered",
+                      "canceled",
+                    ],
+                    "before": Array [
+                      "placed",
+                      "approved",
+                      "delivered",
+                    ],
+                    "key": "enum",
+                  },
+                ],
+                "change": "changed",
+                "name": "status",
+              },
+              Object {
+                "attributes": Array [],
+                "change": "added",
+                "name": "summary",
+              },
+            ],
+          },
+        ],
+        "name": "Request Body",
+      },
       "responses": Array [
         Object {
           "attributes": Array [],
@@ -1110,7 +1250,77 @@ Object {
       "change": "changed",
       "name": "post /user",
       "parameters": Array [],
-      "requestBody": undefined,
+      "requestBody": Object {
+        "attributes": Array [],
+        "change": "changed",
+        "contentTypes": Array [
+          Object {
+            "attributes": Array [],
+            "change": "changed",
+            "name": "*/*",
+            "schemaChanges": Array [
+              Object {
+                "attributes": Array [],
+                "change": "added",
+                "name": "bio",
+              },
+              Object {
+                "attributes": Array [
+                  Object {
+                    "after": false,
+                    "before": true,
+                    "key": "required",
+                  },
+                ],
+                "change": "changed",
+                "name": "lastName",
+              },
+              Object {
+                "attributes": Array [],
+                "change": "removed",
+                "name": "phone",
+              },
+              Object {
+                "attributes": Array [
+                  Object {
+                    "after": Array [
+                      "activation-pending",
+                      "activated",
+                      "blocked",
+                    ],
+                    "before": undefined,
+                    "key": "enum",
+                  },
+                  Object {
+                    "after": undefined,
+                    "before": "int32",
+                    "key": "format",
+                  },
+                  Object {
+                    "after": "string",
+                    "before": "integer",
+                    "key": "type",
+                  },
+                ],
+                "change": "changed",
+                "name": "userStatus",
+              },
+              Object {
+                "attributes": Array [
+                  Object {
+                    "after": true,
+                    "before": false,
+                    "key": "required",
+                  },
+                ],
+                "change": "changed",
+                "name": "username",
+              },
+            ],
+          },
+        ],
+        "name": "Request Body",
+      },
       "responses": Array [],
     },
     Object {
@@ -1118,7 +1328,77 @@ Object {
       "change": "changed",
       "name": "post /user/createWithArray",
       "parameters": Array [],
-      "requestBody": undefined,
+      "requestBody": Object {
+        "attributes": Array [],
+        "change": "changed",
+        "contentTypes": Array [
+          Object {
+            "attributes": Array [],
+            "change": "changed",
+            "name": "*/*",
+            "schemaChanges": Array [
+              Object {
+                "attributes": Array [],
+                "change": "added",
+                "name": "items.bio",
+              },
+              Object {
+                "attributes": Array [
+                  Object {
+                    "after": false,
+                    "before": true,
+                    "key": "required",
+                  },
+                ],
+                "change": "changed",
+                "name": "items.lastName",
+              },
+              Object {
+                "attributes": Array [],
+                "change": "removed",
+                "name": "items.phone",
+              },
+              Object {
+                "attributes": Array [
+                  Object {
+                    "after": Array [
+                      "activation-pending",
+                      "activated",
+                      "blocked",
+                    ],
+                    "before": undefined,
+                    "key": "enum",
+                  },
+                  Object {
+                    "after": undefined,
+                    "before": "int32",
+                    "key": "format",
+                  },
+                  Object {
+                    "after": "string",
+                    "before": "integer",
+                    "key": "type",
+                  },
+                ],
+                "change": "changed",
+                "name": "items.userStatus",
+              },
+              Object {
+                "attributes": Array [
+                  Object {
+                    "after": true,
+                    "before": false,
+                    "key": "required",
+                  },
+                ],
+                "change": "changed",
+                "name": "items.username",
+              },
+            ],
+          },
+        ],
+        "name": "Request Body",
+      },
       "responses": Array [],
     },
     Object {
@@ -1126,7 +1406,77 @@ Object {
       "change": "changed",
       "name": "post /user/createWithList",
       "parameters": Array [],
-      "requestBody": undefined,
+      "requestBody": Object {
+        "attributes": Array [],
+        "change": "changed",
+        "contentTypes": Array [
+          Object {
+            "attributes": Array [],
+            "change": "changed",
+            "name": "*/*",
+            "schemaChanges": Array [
+              Object {
+                "attributes": Array [],
+                "change": "added",
+                "name": "items.bio",
+              },
+              Object {
+                "attributes": Array [
+                  Object {
+                    "after": false,
+                    "before": true,
+                    "key": "required",
+                  },
+                ],
+                "change": "changed",
+                "name": "items.lastName",
+              },
+              Object {
+                "attributes": Array [],
+                "change": "removed",
+                "name": "items.phone",
+              },
+              Object {
+                "attributes": Array [
+                  Object {
+                    "after": Array [
+                      "activation-pending",
+                      "activated",
+                      "blocked",
+                    ],
+                    "before": undefined,
+                    "key": "enum",
+                  },
+                  Object {
+                    "after": undefined,
+                    "before": "int32",
+                    "key": "format",
+                  },
+                  Object {
+                    "after": "string",
+                    "before": "integer",
+                    "key": "type",
+                  },
+                ],
+                "change": "changed",
+                "name": "items.userStatus",
+              },
+              Object {
+                "attributes": Array [
+                  Object {
+                    "after": true,
+                    "before": false,
+                    "key": "required",
+                  },
+                ],
+                "change": "changed",
+                "name": "items.username",
+              },
+            ],
+          },
+        ],
+        "name": "Request Body",
+      },
       "responses": Array [],
     },
     Object {
@@ -1322,7 +1672,77 @@ Object {
       "change": "changed",
       "name": "put /user/{username}",
       "parameters": Array [],
-      "requestBody": undefined,
+      "requestBody": Object {
+        "attributes": Array [],
+        "change": "changed",
+        "contentTypes": Array [
+          Object {
+            "attributes": Array [],
+            "change": "changed",
+            "name": "*/*",
+            "schemaChanges": Array [
+              Object {
+                "attributes": Array [],
+                "change": "added",
+                "name": "bio",
+              },
+              Object {
+                "attributes": Array [
+                  Object {
+                    "after": false,
+                    "before": true,
+                    "key": "required",
+                  },
+                ],
+                "change": "changed",
+                "name": "lastName",
+              },
+              Object {
+                "attributes": Array [],
+                "change": "removed",
+                "name": "phone",
+              },
+              Object {
+                "attributes": Array [
+                  Object {
+                    "after": Array [
+                      "activation-pending",
+                      "activated",
+                      "blocked",
+                    ],
+                    "before": undefined,
+                    "key": "enum",
+                  },
+                  Object {
+                    "after": undefined,
+                    "before": "int32",
+                    "key": "format",
+                  },
+                  Object {
+                    "after": "string",
+                    "before": "integer",
+                    "key": "type",
+                  },
+                ],
+                "change": "changed",
+                "name": "userStatus",
+              },
+              Object {
+                "attributes": Array [
+                  Object {
+                    "after": true,
+                    "before": false,
+                    "key": "required",
+                  },
+                ],
+                "change": "changed",
+                "name": "username",
+              },
+            ],
+          },
+        ],
+        "name": "Request Body",
+      },
       "responses": Array [],
     },
   ],

--- a/projects/openapi-utilities/src/utilities/__tests__/__snapshots__/json-changelog.test.ts.snap
+++ b/projects/openapi-utilities/src/utilities/__tests__/__snapshots__/json-changelog.test.ts.snap
@@ -1,0 +1,1805 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`json changelog collects changes properly: jsonChangelog 1`] = `
+Object {
+  "operations": Array [
+    Object {
+      "attributes": Array [
+        Object {
+          "after": "get_examples",
+          "before": "getExamples",
+          "key": "operationId",
+        },
+      ],
+      "change": "changed",
+      "name": "get /example",
+      "parameters": Array [],
+      "requestBody": Object {
+        "attributes": Array [],
+        "change": "changed",
+        "contentTypes": Array [],
+        "name": "Request Body",
+      },
+      "responses": Array [
+        Object {
+          "attributes": Array [],
+          "change": "changed",
+          "contentTypes": Array [
+            Object {
+              "attributes": Array [],
+              "change": "changed",
+              "name": "application/json",
+              "schemaChanges": Array [
+                Object {
+                  "attributes": Array [
+                    Object {
+                      "after": Array [
+                        Object {
+                          "properties": Object {
+                            "orderId": Object {
+                              "type": "number",
+                            },
+                          },
+                          "type": "object",
+                        },
+                        Object {
+                          "properties": Object {
+                            "fulfillmentId": Object {
+                              "type": "string",
+                            },
+                          },
+                          "type": "object",
+                        },
+                      ],
+                      "before": Array [
+                        Object {
+                          "properties": Object {
+                            "orderId": Object {
+                              "type": "string",
+                            },
+                          },
+                          "type": "object",
+                        },
+                        Object {
+                          "properties": Object {
+                            "fulfillmentId": Object {
+                              "type": "string",
+                            },
+                          },
+                          "type": "object",
+                        },
+                      ],
+                      "key": "allOf",
+                    },
+                  ],
+                  "change": "changed",
+                  "name": "composedObject",
+                },
+                Object {
+                  "attributes": Array [
+                    Object {
+                      "after": "number",
+                      "before": "string",
+                      "key": "type",
+                    },
+                  ],
+                  "change": "changed",
+                  "name": "composedObject.orderId",
+                },
+                Object {
+                  "attributes": Array [
+                    Object {
+                      "after": Array [
+                        Object {
+                          "properties": Object {
+                            "orderId": Object {
+                              "type": "string",
+                            },
+                          },
+                          "type": "object",
+                        },
+                        Object {
+                          "properties": Object {
+                            "order": Object {
+                              "properties": Object {
+                                "id": Object {
+                                  "type": "string",
+                                },
+                              },
+                              "type": "object",
+                            },
+                          },
+                          "type": "object",
+                        },
+                      ],
+                      "before": Array [
+                        Object {
+                          "properties": Object {
+                            "orderId": Object {
+                              "type": "string",
+                            },
+                          },
+                          "type": "object",
+                        },
+                      ],
+                      "key": "anyOf",
+                    },
+                  ],
+                  "change": "changed",
+                  "name": "expandableObject",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "expandableObject.order",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "expandableObject.order.id",
+                },
+                Object {
+                  "attributes": Array [
+                    Object {
+                      "after": Array [
+                        Object {
+                          "type": "string",
+                        },
+                        Object {
+                          "type": "number",
+                        },
+                      ],
+                      "before": Array [
+                        Object {
+                          "type": "string",
+                        },
+                        Object {
+                          "type": "number",
+                        },
+                        Object {
+                          "properties": Object {
+                            "orderId": Object {
+                              "type": "string",
+                            },
+                          },
+                          "type": "object",
+                        },
+                      ],
+                      "key": "oneOf",
+                    },
+                  ],
+                  "change": "changed",
+                  "name": "stringOrNumberOrObject",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "removed",
+                  "name": "stringOrNumberOrObject.orderId",
+                },
+              ],
+            },
+          ],
+          "name": "200 response",
+        },
+      ],
+    },
+    Object {
+      "attributes": Array [],
+      "change": "removed",
+      "name": "get /pet",
+      "parameters": Array [],
+      "requestBody": Object {
+        "attributes": Array [],
+        "change": "changed",
+        "contentTypes": Array [],
+        "name": "Request Body",
+      },
+      "responses": Array [
+        Object {
+          "attributes": Array [],
+          "change": "removed",
+          "contentTypes": Array [],
+          "name": "404 response",
+        },
+        Object {
+          "attributes": Array [],
+          "change": "removed",
+          "contentTypes": Array [],
+          "name": "405 response",
+        },
+      ],
+    },
+    Object {
+      "attributes": Array [
+        Object {
+          "after": "addPet-change",
+          "before": "addPet",
+          "key": "operationId",
+        },
+      ],
+      "change": "changed",
+      "name": "post /pet",
+      "parameters": Array [],
+      "requestBody": Object {
+        "attributes": Array [],
+        "change": "changed",
+        "contentTypes": Array [
+          Object {
+            "attributes": Array [],
+            "change": "changed",
+            "name": "application/json",
+            "schemaChanges": Array [
+              Object {
+                "attributes": Array [],
+                "change": "added",
+                "name": "category.other",
+              },
+            ],
+          },
+        ],
+        "name": "Request Body",
+      },
+      "responses": Array [],
+    },
+    Object {
+      "attributes": Array [],
+      "change": "changed",
+      "name": "put /pet",
+      "parameters": Array [],
+      "requestBody": Object {
+        "attributes": Array [],
+        "change": "changed",
+        "contentTypes": Array [
+          Object {
+            "attributes": Array [],
+            "change": "changed",
+            "name": "application/json",
+            "schemaChanges": Array [
+              Object {
+                "attributes": Array [],
+                "change": "added",
+                "name": "example",
+              },
+              Object {
+                "attributes": Array [],
+                "change": "removed",
+                "name": "name",
+              },
+              Object {
+                "attributes": Array [],
+                "change": "added",
+                "name": "number",
+              },
+            ],
+          },
+          Object {
+            "attributes": Array [],
+            "change": "removed",
+            "name": "application/xml",
+            "schemaChanges": Array [
+              Object {
+                "attributes": Array [],
+                "change": "removed",
+                "name": "category",
+              },
+              Object {
+                "attributes": Array [],
+                "change": "removed",
+                "name": "category.id",
+              },
+              Object {
+                "attributes": Array [],
+                "change": "removed",
+                "name": "category.name",
+              },
+              Object {
+                "attributes": Array [],
+                "change": "removed",
+                "name": "id",
+              },
+              Object {
+                "attributes": Array [],
+                "change": "removed",
+                "name": "name",
+              },
+              Object {
+                "attributes": Array [],
+                "change": "removed",
+                "name": "photoUrls",
+              },
+              Object {
+                "attributes": Array [],
+                "change": "removed",
+                "name": "status",
+              },
+              Object {
+                "attributes": Array [],
+                "change": "removed",
+                "name": "tags",
+              },
+              Object {
+                "attributes": Array [],
+                "change": "removed",
+                "name": "tags.items.id",
+              },
+              Object {
+                "attributes": Array [],
+                "change": "removed",
+                "name": "tags.items.name",
+              },
+            ],
+          },
+        ],
+        "name": "Request Body",
+      },
+      "responses": Array [
+        Object {
+          "attributes": Array [],
+          "change": "removed",
+          "contentTypes": Array [],
+          "name": "400 response",
+        },
+      ],
+    },
+    Object {
+      "attributes": Array [],
+      "change": "added",
+      "name": "get /pet/findByStatus",
+      "parameters": Array [
+        Object {
+          "attributes": Array [],
+          "change": "added",
+          "name": "query parameter 'status'",
+        },
+        Object {
+          "attributes": Array [],
+          "change": "added",
+          "name": "cookie parameter 'debug'",
+        },
+      ],
+      "requestBody": Object {
+        "attributes": Array [],
+        "change": "changed",
+        "contentTypes": Array [],
+        "name": "Request Body",
+      },
+      "responses": Array [
+        Object {
+          "attributes": Array [],
+          "change": "added",
+          "contentTypes": Array [
+            Object {
+              "attributes": Array [],
+              "change": "added",
+              "name": "application/json",
+              "schemaChanges": Array [
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.category",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.category.id",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.category.name",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.id",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.name",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.photoUrls",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.status",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.tags",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.tags.items.id",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.tags.items.name",
+                },
+              ],
+            },
+            Object {
+              "attributes": Array [],
+              "change": "added",
+              "name": "application/xml",
+              "schemaChanges": Array [
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.category",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.category.id",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.category.name",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.id",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.name",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.photoUrls",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.status",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.tags",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.tags.items.id",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.tags.items.name",
+                },
+              ],
+            },
+          ],
+          "name": "200 response",
+        },
+        Object {
+          "attributes": Array [],
+          "change": "added",
+          "contentTypes": Array [],
+          "name": "400 response",
+        },
+      ],
+    },
+    Object {
+      "attributes": Array [],
+      "change": "added",
+      "name": "get /pet/findByTags",
+      "parameters": Array [
+        Object {
+          "attributes": Array [],
+          "change": "added",
+          "name": "query parameter 'tags'",
+        },
+      ],
+      "requestBody": Object {
+        "attributes": Array [],
+        "change": "changed",
+        "contentTypes": Array [],
+        "name": "Request Body",
+      },
+      "responses": Array [
+        Object {
+          "attributes": Array [],
+          "change": "added",
+          "contentTypes": Array [
+            Object {
+              "attributes": Array [],
+              "change": "added",
+              "name": "application/json",
+              "schemaChanges": Array [
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.category",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.category.id",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.category.name",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.id",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.name",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.photoUrls",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.status",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.tags",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.tags.items.id",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.tags.items.name",
+                },
+              ],
+            },
+            Object {
+              "attributes": Array [],
+              "change": "added",
+              "name": "application/xml",
+              "schemaChanges": Array [
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.category",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.category.id",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.category.name",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.id",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.name",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.photoUrls",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.status",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.tags",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.tags.items.id",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "items.tags.items.name",
+                },
+              ],
+            },
+          ],
+          "name": "200 response",
+        },
+        Object {
+          "attributes": Array [],
+          "change": "added",
+          "contentTypes": Array [],
+          "name": "400 response",
+        },
+      ],
+    },
+    Object {
+      "attributes": Array [],
+      "change": "added",
+      "name": "delete /pet/{petId}",
+      "parameters": Array [
+        Object {
+          "attributes": Array [],
+          "change": "added",
+          "name": "path parameter 'petId'",
+        },
+        Object {
+          "attributes": Array [],
+          "change": "added",
+          "name": "header parameter 'api_key'",
+        },
+      ],
+      "requestBody": Object {
+        "attributes": Array [],
+        "change": "changed",
+        "contentTypes": Array [],
+        "name": "Request Body",
+      },
+      "responses": Array [
+        Object {
+          "attributes": Array [],
+          "change": "added",
+          "contentTypes": Array [],
+          "name": "400 response",
+        },
+        Object {
+          "attributes": Array [],
+          "change": "added",
+          "contentTypes": Array [],
+          "name": "404 response",
+        },
+      ],
+    },
+    Object {
+      "attributes": Array [],
+      "change": "added",
+      "name": "get /pet/{petId}",
+      "parameters": Array [
+        Object {
+          "attributes": Array [],
+          "change": "added",
+          "name": "path parameter 'petId'",
+        },
+      ],
+      "requestBody": Object {
+        "attributes": Array [],
+        "change": "changed",
+        "contentTypes": Array [],
+        "name": "Request Body",
+      },
+      "responses": Array [
+        Object {
+          "attributes": Array [],
+          "change": "added",
+          "contentTypes": Array [
+            Object {
+              "attributes": Array [],
+              "change": "added",
+              "name": "application/json",
+              "schemaChanges": Array [
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "category",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "category.id",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "category.name",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "id",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "name",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "photoUrls",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "status",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "tags",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "tags.items.id",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "tags.items.name",
+                },
+              ],
+            },
+            Object {
+              "attributes": Array [],
+              "change": "added",
+              "name": "application/xml",
+              "schemaChanges": Array [
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "category",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "category.id",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "category.name",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "id",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "name",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "photoUrls",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "status",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "tags",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "tags.items.id",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "tags.items.name",
+                },
+              ],
+            },
+          ],
+          "name": "200 response",
+        },
+        Object {
+          "attributes": Array [],
+          "change": "added",
+          "contentTypes": Array [],
+          "name": "400 response",
+        },
+        Object {
+          "attributes": Array [],
+          "change": "added",
+          "contentTypes": Array [],
+          "name": "404 response",
+        },
+      ],
+    },
+    Object {
+      "attributes": Array [],
+      "change": "added",
+      "name": "post /pet/{petId}",
+      "parameters": Array [
+        Object {
+          "attributes": Array [],
+          "change": "added",
+          "name": "path parameter 'petId'",
+        },
+      ],
+      "requestBody": Object {
+        "attributes": Array [],
+        "change": "added",
+        "contentTypes": Array [
+          Object {
+            "attributes": Array [],
+            "change": "added",
+            "name": "application/x-www-form-urlencoded",
+            "schemaChanges": Array [],
+          },
+        ],
+        "name": "Request Body",
+      },
+      "responses": Array [
+        Object {
+          "attributes": Array [],
+          "change": "added",
+          "contentTypes": Array [],
+          "name": "405 response",
+        },
+      ],
+    },
+    Object {
+      "attributes": Array [],
+      "change": "changed",
+      "name": "post /pet/{petId}/uploadImage",
+      "parameters": Array [
+        Object {
+          "attributes": Array [
+            Object {
+              "after": Object {
+                "enum": Array [
+                  0,
+                  1,
+                ],
+                "type": "integer",
+              },
+              "before": Object {
+                "type": "integer",
+              },
+              "key": "schema",
+            },
+          ],
+          "change": "changed",
+          "name": "cookie parameter 'debug'",
+        },
+      ],
+      "requestBody": Object {
+        "attributes": Array [],
+        "change": "changed",
+        "contentTypes": Array [],
+        "name": "Request Body",
+      },
+      "responses": Array [
+        Object {
+          "attributes": Array [],
+          "change": "removed",
+          "contentTypes": Array [
+            Object {
+              "attributes": Array [],
+              "change": "removed",
+              "name": "application/json",
+              "schemaChanges": Array [
+                Object {
+                  "attributes": Array [],
+                  "change": "removed",
+                  "name": "code",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "removed",
+                  "name": "message",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "removed",
+                  "name": "type",
+                },
+              ],
+            },
+          ],
+          "name": "200 response",
+        },
+        Object {
+          "attributes": Array [],
+          "change": "added",
+          "contentTypes": Array [
+            Object {
+              "attributes": Array [],
+              "change": "added",
+              "name": "application/json",
+              "schemaChanges": Array [
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "code",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "message",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "type",
+                },
+              ],
+            },
+          ],
+          "name": "201 response",
+        },
+        Object {
+          "attributes": Array [],
+          "change": "added",
+          "contentTypes": Array [
+            Object {
+              "attributes": Array [],
+              "change": "added",
+              "name": "application/json",
+              "schemaChanges": Array [
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "code",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "message",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "type",
+                },
+              ],
+            },
+          ],
+          "name": "404 response",
+        },
+        Object {
+          "attributes": Array [],
+          "change": "changed",
+          "contentTypes": Array [
+            Object {
+              "attributes": Array [],
+              "change": "changed",
+              "name": "application/json",
+              "schemaChanges": Array [
+                Object {
+                  "attributes": Array [
+                    Object {
+                      "after": "integer",
+                      "before": "string",
+                      "key": "type",
+                    },
+                  ],
+                  "change": "changed",
+                  "name": "type",
+                },
+              ],
+            },
+          ],
+          "name": "default response",
+        },
+      ],
+    },
+    Object {
+      "attributes": Array [],
+      "change": "changed",
+      "name": "post /store/order",
+      "parameters": Array [],
+      "requestBody": Object {
+        "attributes": Array [],
+        "change": "changed",
+        "contentTypes": Array [
+          Object {
+            "attributes": Array [],
+            "change": "changed",
+            "name": "*/*",
+            "schemaChanges": Array [
+              Object {
+                "attributes": Array [
+                  Object {
+                    "after": Array [
+                      "placed",
+                      "delivered",
+                      "canceled",
+                    ],
+                    "before": Array [
+                      "placed",
+                      "approved",
+                      "delivered",
+                    ],
+                    "key": "enum",
+                  },
+                ],
+                "change": "changed",
+                "name": "status",
+              },
+              Object {
+                "attributes": Array [],
+                "change": "added",
+                "name": "summary",
+              },
+            ],
+          },
+        ],
+        "name": "Request Body",
+      },
+      "responses": Array [
+        Object {
+          "attributes": Array [],
+          "change": "changed",
+          "contentTypes": Array [
+            Object {
+              "attributes": Array [],
+              "change": "changed",
+              "name": "application/json",
+              "schemaChanges": Array [
+                Object {
+                  "attributes": Array [
+                    Object {
+                      "after": Array [
+                        "placed",
+                        "delivered",
+                        "canceled",
+                      ],
+                      "before": Array [
+                        "placed",
+                        "approved",
+                        "delivered",
+                      ],
+                      "key": "enum",
+                    },
+                  ],
+                  "change": "changed",
+                  "name": "status",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "summary",
+                },
+              ],
+            },
+            Object {
+              "attributes": Array [],
+              "change": "changed",
+              "name": "application/xml",
+              "schemaChanges": Array [
+                Object {
+                  "attributes": Array [
+                    Object {
+                      "after": Array [
+                        "placed",
+                        "delivered",
+                        "canceled",
+                      ],
+                      "before": Array [
+                        "placed",
+                        "approved",
+                        "delivered",
+                      ],
+                      "key": "enum",
+                    },
+                  ],
+                  "change": "changed",
+                  "name": "status",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "summary",
+                },
+              ],
+            },
+          ],
+          "name": "200 response",
+        },
+      ],
+    },
+    Object {
+      "attributes": Array [],
+      "change": "changed",
+      "name": "delete /store/order/{orderId}",
+      "parameters": Array [],
+      "requestBody": Object {
+        "attributes": Array [],
+        "change": "changed",
+        "contentTypes": Array [],
+        "name": "Request Body",
+      },
+      "responses": Array [
+        Object {
+          "attributes": Array [],
+          "change": "changed",
+          "contentTypes": Array [
+            Object {
+              "attributes": Array [],
+              "change": "added",
+              "name": "application/json",
+              "schemaChanges": Array [
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "code",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "message",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "type",
+                },
+              ],
+            },
+          ],
+          "name": "404 response",
+        },
+      ],
+    },
+    Object {
+      "attributes": Array [],
+      "change": "changed",
+      "name": "get /store/order/{orderId}",
+      "parameters": Array [],
+      "requestBody": Object {
+        "attributes": Array [],
+        "change": "changed",
+        "contentTypes": Array [],
+        "name": "Request Body",
+      },
+      "responses": Array [
+        Object {
+          "attributes": Array [],
+          "change": "changed",
+          "contentTypes": Array [
+            Object {
+              "attributes": Array [],
+              "change": "changed",
+              "name": "application/json",
+              "schemaChanges": Array [
+                Object {
+                  "attributes": Array [
+                    Object {
+                      "after": Array [
+                        "placed",
+                        "delivered",
+                        "canceled",
+                      ],
+                      "before": Array [
+                        "placed",
+                        "approved",
+                        "delivered",
+                      ],
+                      "key": "enum",
+                    },
+                  ],
+                  "change": "changed",
+                  "name": "status",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "summary",
+                },
+              ],
+            },
+            Object {
+              "attributes": Array [],
+              "change": "changed",
+              "name": "application/xml",
+              "schemaChanges": Array [
+                Object {
+                  "attributes": Array [
+                    Object {
+                      "after": false,
+                      "before": true,
+                      "key": "required",
+                    },
+                  ],
+                  "change": "changed",
+                  "name": "petId",
+                },
+                Object {
+                  "attributes": Array [
+                    Object {
+                      "after": Array [
+                        "placed",
+                        "delivered",
+                        "canceled",
+                      ],
+                      "before": Array [
+                        "placed",
+                        "approved",
+                        "delivered",
+                      ],
+                      "key": "enum",
+                    },
+                  ],
+                  "change": "changed",
+                  "name": "status",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "summary",
+                },
+              ],
+            },
+          ],
+          "name": "200 response",
+        },
+        Object {
+          "attributes": Array [],
+          "change": "changed",
+          "contentTypes": Array [
+            Object {
+              "attributes": Array [],
+              "change": "added",
+              "name": "application/json",
+              "schemaChanges": Array [
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "code",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "message",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "type",
+                },
+              ],
+            },
+          ],
+          "name": "404 response",
+        },
+      ],
+    },
+    Object {
+      "attributes": Array [],
+      "change": "changed",
+      "name": "post /user",
+      "parameters": Array [],
+      "requestBody": Object {
+        "attributes": Array [],
+        "change": "changed",
+        "contentTypes": Array [
+          Object {
+            "attributes": Array [],
+            "change": "changed",
+            "name": "*/*",
+            "schemaChanges": Array [
+              Object {
+                "attributes": Array [],
+                "change": "added",
+                "name": "bio",
+              },
+              Object {
+                "attributes": Array [
+                  Object {
+                    "after": false,
+                    "before": true,
+                    "key": "required",
+                  },
+                ],
+                "change": "changed",
+                "name": "lastName",
+              },
+              Object {
+                "attributes": Array [],
+                "change": "removed",
+                "name": "phone",
+              },
+              Object {
+                "attributes": Array [
+                  Object {
+                    "after": Array [
+                      "activation-pending",
+                      "activated",
+                      "blocked",
+                    ],
+                    "before": undefined,
+                    "key": "enum",
+                  },
+                  Object {
+                    "after": undefined,
+                    "before": "int32",
+                    "key": "format",
+                  },
+                  Object {
+                    "after": "string",
+                    "before": "integer",
+                    "key": "type",
+                  },
+                ],
+                "change": "changed",
+                "name": "userStatus",
+              },
+              Object {
+                "attributes": Array [
+                  Object {
+                    "after": true,
+                    "before": false,
+                    "key": "required",
+                  },
+                ],
+                "change": "changed",
+                "name": "username",
+              },
+            ],
+          },
+        ],
+        "name": "Request Body",
+      },
+      "responses": Array [],
+    },
+    Object {
+      "attributes": Array [],
+      "change": "changed",
+      "name": "post /user/createWithArray",
+      "parameters": Array [],
+      "requestBody": Object {
+        "attributes": Array [],
+        "change": "changed",
+        "contentTypes": Array [
+          Object {
+            "attributes": Array [],
+            "change": "changed",
+            "name": "*/*",
+            "schemaChanges": Array [
+              Object {
+                "attributes": Array [],
+                "change": "added",
+                "name": "items.bio",
+              },
+              Object {
+                "attributes": Array [
+                  Object {
+                    "after": false,
+                    "before": true,
+                    "key": "required",
+                  },
+                ],
+                "change": "changed",
+                "name": "items.lastName",
+              },
+              Object {
+                "attributes": Array [],
+                "change": "removed",
+                "name": "items.phone",
+              },
+              Object {
+                "attributes": Array [
+                  Object {
+                    "after": Array [
+                      "activation-pending",
+                      "activated",
+                      "blocked",
+                    ],
+                    "before": undefined,
+                    "key": "enum",
+                  },
+                  Object {
+                    "after": undefined,
+                    "before": "int32",
+                    "key": "format",
+                  },
+                  Object {
+                    "after": "string",
+                    "before": "integer",
+                    "key": "type",
+                  },
+                ],
+                "change": "changed",
+                "name": "items.userStatus",
+              },
+              Object {
+                "attributes": Array [
+                  Object {
+                    "after": true,
+                    "before": false,
+                    "key": "required",
+                  },
+                ],
+                "change": "changed",
+                "name": "items.username",
+              },
+            ],
+          },
+        ],
+        "name": "Request Body",
+      },
+      "responses": Array [],
+    },
+    Object {
+      "attributes": Array [],
+      "change": "changed",
+      "name": "post /user/createWithList",
+      "parameters": Array [],
+      "requestBody": Object {
+        "attributes": Array [],
+        "change": "changed",
+        "contentTypes": Array [
+          Object {
+            "attributes": Array [],
+            "change": "changed",
+            "name": "*/*",
+            "schemaChanges": Array [
+              Object {
+                "attributes": Array [],
+                "change": "added",
+                "name": "items.bio",
+              },
+              Object {
+                "attributes": Array [
+                  Object {
+                    "after": false,
+                    "before": true,
+                    "key": "required",
+                  },
+                ],
+                "change": "changed",
+                "name": "items.lastName",
+              },
+              Object {
+                "attributes": Array [],
+                "change": "removed",
+                "name": "items.phone",
+              },
+              Object {
+                "attributes": Array [
+                  Object {
+                    "after": Array [
+                      "activation-pending",
+                      "activated",
+                      "blocked",
+                    ],
+                    "before": undefined,
+                    "key": "enum",
+                  },
+                  Object {
+                    "after": undefined,
+                    "before": "int32",
+                    "key": "format",
+                  },
+                  Object {
+                    "after": "string",
+                    "before": "integer",
+                    "key": "type",
+                  },
+                ],
+                "change": "changed",
+                "name": "items.userStatus",
+              },
+              Object {
+                "attributes": Array [
+                  Object {
+                    "after": true,
+                    "before": false,
+                    "key": "required",
+                  },
+                ],
+                "change": "changed",
+                "name": "items.username",
+              },
+            ],
+          },
+        ],
+        "name": "Request Body",
+      },
+      "responses": Array [],
+    },
+    Object {
+      "attributes": Array [],
+      "change": "changed",
+      "name": "get /user/login",
+      "parameters": Array [],
+      "requestBody": Object {
+        "attributes": Array [],
+        "change": "changed",
+        "contentTypes": Array [],
+        "name": "Request Body",
+      },
+      "responses": Array [
+        Object {
+          "attributes": Array [],
+          "change": "changed",
+          "contentTypes": Array [],
+          "name": "200 response",
+        },
+      ],
+    },
+    Object {
+      "attributes": Array [],
+      "change": "changed",
+      "name": "get /user/{username}",
+      "parameters": Array [],
+      "requestBody": Object {
+        "attributes": Array [],
+        "change": "changed",
+        "contentTypes": Array [],
+        "name": "Request Body",
+      },
+      "responses": Array [
+        Object {
+          "attributes": Array [],
+          "change": "changed",
+          "contentTypes": Array [
+            Object {
+              "attributes": Array [],
+              "change": "changed",
+              "name": "application/json",
+              "schemaChanges": Array [
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "bio",
+                },
+                Object {
+                  "attributes": Array [
+                    Object {
+                      "after": false,
+                      "before": true,
+                      "key": "required",
+                    },
+                  ],
+                  "change": "changed",
+                  "name": "lastName",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "removed",
+                  "name": "phone",
+                },
+                Object {
+                  "attributes": Array [
+                    Object {
+                      "after": Array [
+                        "activation-pending",
+                        "activated",
+                        "blocked",
+                      ],
+                      "before": undefined,
+                      "key": "enum",
+                    },
+                    Object {
+                      "after": undefined,
+                      "before": "int32",
+                      "key": "format",
+                    },
+                    Object {
+                      "after": "string",
+                      "before": "integer",
+                      "key": "type",
+                    },
+                  ],
+                  "change": "changed",
+                  "name": "userStatus",
+                },
+                Object {
+                  "attributes": Array [
+                    Object {
+                      "after": true,
+                      "before": false,
+                      "key": "required",
+                    },
+                  ],
+                  "change": "changed",
+                  "name": "username",
+                },
+              ],
+            },
+            Object {
+              "attributes": Array [],
+              "change": "changed",
+              "name": "application/xml",
+              "schemaChanges": Array [
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "bio",
+                },
+                Object {
+                  "attributes": Array [
+                    Object {
+                      "after": false,
+                      "before": true,
+                      "key": "required",
+                    },
+                  ],
+                  "change": "changed",
+                  "name": "lastName",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "removed",
+                  "name": "phone",
+                },
+                Object {
+                  "attributes": Array [
+                    Object {
+                      "after": Array [
+                        "activation-pending",
+                        "activated",
+                        "blocked",
+                      ],
+                      "before": undefined,
+                      "key": "enum",
+                    },
+                    Object {
+                      "after": undefined,
+                      "before": "int32",
+                      "key": "format",
+                    },
+                    Object {
+                      "after": "string",
+                      "before": "integer",
+                      "key": "type",
+                    },
+                  ],
+                  "change": "changed",
+                  "name": "userStatus",
+                },
+                Object {
+                  "attributes": Array [
+                    Object {
+                      "after": true,
+                      "before": false,
+                      "key": "required",
+                    },
+                  ],
+                  "change": "changed",
+                  "name": "username",
+                },
+              ],
+            },
+          ],
+          "name": "200 response",
+        },
+        Object {
+          "attributes": Array [],
+          "change": "changed",
+          "contentTypes": Array [
+            Object {
+              "attributes": Array [],
+              "change": "added",
+              "name": "application/json",
+              "schemaChanges": Array [
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "code",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "message",
+                },
+                Object {
+                  "attributes": Array [],
+                  "change": "added",
+                  "name": "type",
+                },
+              ],
+            },
+          ],
+          "name": "404 response",
+        },
+      ],
+    },
+    Object {
+      "attributes": Array [],
+      "change": "changed",
+      "name": "put /user/{username}",
+      "parameters": Array [],
+      "requestBody": Object {
+        "attributes": Array [],
+        "change": "changed",
+        "contentTypes": Array [
+          Object {
+            "attributes": Array [],
+            "change": "changed",
+            "name": "*/*",
+            "schemaChanges": Array [
+              Object {
+                "attributes": Array [],
+                "change": "added",
+                "name": "bio",
+              },
+              Object {
+                "attributes": Array [
+                  Object {
+                    "after": false,
+                    "before": true,
+                    "key": "required",
+                  },
+                ],
+                "change": "changed",
+                "name": "lastName",
+              },
+              Object {
+                "attributes": Array [],
+                "change": "removed",
+                "name": "phone",
+              },
+              Object {
+                "attributes": Array [
+                  Object {
+                    "after": Array [
+                      "activation-pending",
+                      "activated",
+                      "blocked",
+                    ],
+                    "before": undefined,
+                    "key": "enum",
+                  },
+                  Object {
+                    "after": undefined,
+                    "before": "int32",
+                    "key": "format",
+                  },
+                  Object {
+                    "after": "string",
+                    "before": "integer",
+                    "key": "type",
+                  },
+                ],
+                "change": "changed",
+                "name": "userStatus",
+              },
+              Object {
+                "attributes": Array [
+                  Object {
+                    "after": true,
+                    "before": false,
+                    "key": "required",
+                  },
+                ],
+                "change": "changed",
+                "name": "username",
+              },
+            ],
+          },
+        ],
+        "name": "Request Body",
+      },
+      "responses": Array [],
+    },
+  ],
+}
+`;

--- a/projects/openapi-utilities/src/utilities/__tests__/__snapshots__/json-changelog.test.ts.snap
+++ b/projects/openapi-utilities/src/utilities/__tests__/__snapshots__/json-changelog.test.ts.snap
@@ -14,12 +14,7 @@ Object {
       "change": "changed",
       "name": "get /example",
       "parameters": Array [],
-      "requestBody": Object {
-        "attributes": Array [],
-        "change": "changed",
-        "contentTypes": Array [],
-        "name": "Request Body",
-      },
+      "requestBody": undefined,
       "responses": Array [
         Object {
           "attributes": Array [],
@@ -188,12 +183,7 @@ Object {
       "change": "removed",
       "name": "get /pet",
       "parameters": Array [],
-      "requestBody": Object {
-        "attributes": Array [],
-        "change": "changed",
-        "contentTypes": Array [],
-        "name": "Request Body",
-      },
+      "requestBody": undefined,
       "responses": Array [
         Object {
           "attributes": Array [],
@@ -220,25 +210,7 @@ Object {
       "change": "changed",
       "name": "post /pet",
       "parameters": Array [],
-      "requestBody": Object {
-        "attributes": Array [],
-        "change": "changed",
-        "contentTypes": Array [
-          Object {
-            "attributes": Array [],
-            "change": "changed",
-            "name": "application/json",
-            "schemaChanges": Array [
-              Object {
-                "attributes": Array [],
-                "change": "added",
-                "name": "category.other",
-              },
-            ],
-          },
-        ],
-        "name": "Request Body",
-      },
+      "requestBody": undefined,
       "responses": Array [],
     },
     Object {
@@ -246,92 +218,7 @@ Object {
       "change": "changed",
       "name": "put /pet",
       "parameters": Array [],
-      "requestBody": Object {
-        "attributes": Array [],
-        "change": "changed",
-        "contentTypes": Array [
-          Object {
-            "attributes": Array [],
-            "change": "changed",
-            "name": "application/json",
-            "schemaChanges": Array [
-              Object {
-                "attributes": Array [],
-                "change": "added",
-                "name": "example",
-              },
-              Object {
-                "attributes": Array [],
-                "change": "removed",
-                "name": "name",
-              },
-              Object {
-                "attributes": Array [],
-                "change": "added",
-                "name": "number",
-              },
-            ],
-          },
-          Object {
-            "attributes": Array [],
-            "change": "removed",
-            "name": "application/xml",
-            "schemaChanges": Array [
-              Object {
-                "attributes": Array [],
-                "change": "removed",
-                "name": "category",
-              },
-              Object {
-                "attributes": Array [],
-                "change": "removed",
-                "name": "category.id",
-              },
-              Object {
-                "attributes": Array [],
-                "change": "removed",
-                "name": "category.name",
-              },
-              Object {
-                "attributes": Array [],
-                "change": "removed",
-                "name": "id",
-              },
-              Object {
-                "attributes": Array [],
-                "change": "removed",
-                "name": "name",
-              },
-              Object {
-                "attributes": Array [],
-                "change": "removed",
-                "name": "photoUrls",
-              },
-              Object {
-                "attributes": Array [],
-                "change": "removed",
-                "name": "status",
-              },
-              Object {
-                "attributes": Array [],
-                "change": "removed",
-                "name": "tags",
-              },
-              Object {
-                "attributes": Array [],
-                "change": "removed",
-                "name": "tags.items.id",
-              },
-              Object {
-                "attributes": Array [],
-                "change": "removed",
-                "name": "tags.items.name",
-              },
-            ],
-          },
-        ],
-        "name": "Request Body",
-      },
+      "requestBody": undefined,
       "responses": Array [
         Object {
           "attributes": Array [],
@@ -357,12 +244,7 @@ Object {
           "name": "cookie parameter 'debug'",
         },
       ],
-      "requestBody": Object {
-        "attributes": Array [],
-        "change": "changed",
-        "contentTypes": Array [],
-        "name": "Request Body",
-      },
+      "requestBody": undefined,
       "responses": Array [
         Object {
           "attributes": Array [],
@@ -504,12 +386,7 @@ Object {
           "name": "query parameter 'tags'",
         },
       ],
-      "requestBody": Object {
-        "attributes": Array [],
-        "change": "changed",
-        "contentTypes": Array [],
-        "name": "Request Body",
-      },
+      "requestBody": undefined,
       "responses": Array [
         Object {
           "attributes": Array [],
@@ -656,12 +533,7 @@ Object {
           "name": "header parameter 'api_key'",
         },
       ],
-      "requestBody": Object {
-        "attributes": Array [],
-        "change": "changed",
-        "contentTypes": Array [],
-        "name": "Request Body",
-      },
+      "requestBody": undefined,
       "responses": Array [
         Object {
           "attributes": Array [],
@@ -688,12 +560,7 @@ Object {
           "name": "path parameter 'petId'",
         },
       ],
-      "requestBody": Object {
-        "attributes": Array [],
-        "change": "changed",
-        "contentTypes": Array [],
-        "name": "Request Body",
-      },
+      "requestBody": undefined,
       "responses": Array [
         Object {
           "attributes": Array [],
@@ -888,12 +755,7 @@ Object {
           "name": "cookie parameter 'debug'",
         },
       ],
-      "requestBody": Object {
-        "attributes": Array [],
-        "change": "changed",
-        "contentTypes": Array [],
-        "name": "Request Body",
-      },
+      "requestBody": undefined,
       "responses": Array [
         Object {
           "attributes": Array [],
@@ -1014,44 +876,7 @@ Object {
       "change": "changed",
       "name": "post /store/order",
       "parameters": Array [],
-      "requestBody": Object {
-        "attributes": Array [],
-        "change": "changed",
-        "contentTypes": Array [
-          Object {
-            "attributes": Array [],
-            "change": "changed",
-            "name": "*/*",
-            "schemaChanges": Array [
-              Object {
-                "attributes": Array [
-                  Object {
-                    "after": Array [
-                      "placed",
-                      "delivered",
-                      "canceled",
-                    ],
-                    "before": Array [
-                      "placed",
-                      "approved",
-                      "delivered",
-                    ],
-                    "key": "enum",
-                  },
-                ],
-                "change": "changed",
-                "name": "status",
-              },
-              Object {
-                "attributes": Array [],
-                "change": "added",
-                "name": "summary",
-              },
-            ],
-          },
-        ],
-        "name": "Request Body",
-      },
+      "requestBody": undefined,
       "responses": Array [
         Object {
           "attributes": Array [],
@@ -1129,12 +954,7 @@ Object {
       "change": "changed",
       "name": "delete /store/order/{orderId}",
       "parameters": Array [],
-      "requestBody": Object {
-        "attributes": Array [],
-        "change": "changed",
-        "contentTypes": Array [],
-        "name": "Request Body",
-      },
+      "requestBody": undefined,
       "responses": Array [
         Object {
           "attributes": Array [],
@@ -1172,12 +992,7 @@ Object {
       "change": "changed",
       "name": "get /store/order/{orderId}",
       "parameters": Array [],
-      "requestBody": Object {
-        "attributes": Array [],
-        "change": "changed",
-        "contentTypes": Array [],
-        "name": "Request Body",
-      },
+      "requestBody": undefined,
       "responses": Array [
         Object {
           "attributes": Array [],
@@ -1295,77 +1110,7 @@ Object {
       "change": "changed",
       "name": "post /user",
       "parameters": Array [],
-      "requestBody": Object {
-        "attributes": Array [],
-        "change": "changed",
-        "contentTypes": Array [
-          Object {
-            "attributes": Array [],
-            "change": "changed",
-            "name": "*/*",
-            "schemaChanges": Array [
-              Object {
-                "attributes": Array [],
-                "change": "added",
-                "name": "bio",
-              },
-              Object {
-                "attributes": Array [
-                  Object {
-                    "after": false,
-                    "before": true,
-                    "key": "required",
-                  },
-                ],
-                "change": "changed",
-                "name": "lastName",
-              },
-              Object {
-                "attributes": Array [],
-                "change": "removed",
-                "name": "phone",
-              },
-              Object {
-                "attributes": Array [
-                  Object {
-                    "after": Array [
-                      "activation-pending",
-                      "activated",
-                      "blocked",
-                    ],
-                    "before": undefined,
-                    "key": "enum",
-                  },
-                  Object {
-                    "after": undefined,
-                    "before": "int32",
-                    "key": "format",
-                  },
-                  Object {
-                    "after": "string",
-                    "before": "integer",
-                    "key": "type",
-                  },
-                ],
-                "change": "changed",
-                "name": "userStatus",
-              },
-              Object {
-                "attributes": Array [
-                  Object {
-                    "after": true,
-                    "before": false,
-                    "key": "required",
-                  },
-                ],
-                "change": "changed",
-                "name": "username",
-              },
-            ],
-          },
-        ],
-        "name": "Request Body",
-      },
+      "requestBody": undefined,
       "responses": Array [],
     },
     Object {
@@ -1373,77 +1118,7 @@ Object {
       "change": "changed",
       "name": "post /user/createWithArray",
       "parameters": Array [],
-      "requestBody": Object {
-        "attributes": Array [],
-        "change": "changed",
-        "contentTypes": Array [
-          Object {
-            "attributes": Array [],
-            "change": "changed",
-            "name": "*/*",
-            "schemaChanges": Array [
-              Object {
-                "attributes": Array [],
-                "change": "added",
-                "name": "items.bio",
-              },
-              Object {
-                "attributes": Array [
-                  Object {
-                    "after": false,
-                    "before": true,
-                    "key": "required",
-                  },
-                ],
-                "change": "changed",
-                "name": "items.lastName",
-              },
-              Object {
-                "attributes": Array [],
-                "change": "removed",
-                "name": "items.phone",
-              },
-              Object {
-                "attributes": Array [
-                  Object {
-                    "after": Array [
-                      "activation-pending",
-                      "activated",
-                      "blocked",
-                    ],
-                    "before": undefined,
-                    "key": "enum",
-                  },
-                  Object {
-                    "after": undefined,
-                    "before": "int32",
-                    "key": "format",
-                  },
-                  Object {
-                    "after": "string",
-                    "before": "integer",
-                    "key": "type",
-                  },
-                ],
-                "change": "changed",
-                "name": "items.userStatus",
-              },
-              Object {
-                "attributes": Array [
-                  Object {
-                    "after": true,
-                    "before": false,
-                    "key": "required",
-                  },
-                ],
-                "change": "changed",
-                "name": "items.username",
-              },
-            ],
-          },
-        ],
-        "name": "Request Body",
-      },
+      "requestBody": undefined,
       "responses": Array [],
     },
     Object {
@@ -1451,77 +1126,7 @@ Object {
       "change": "changed",
       "name": "post /user/createWithList",
       "parameters": Array [],
-      "requestBody": Object {
-        "attributes": Array [],
-        "change": "changed",
-        "contentTypes": Array [
-          Object {
-            "attributes": Array [],
-            "change": "changed",
-            "name": "*/*",
-            "schemaChanges": Array [
-              Object {
-                "attributes": Array [],
-                "change": "added",
-                "name": "items.bio",
-              },
-              Object {
-                "attributes": Array [
-                  Object {
-                    "after": false,
-                    "before": true,
-                    "key": "required",
-                  },
-                ],
-                "change": "changed",
-                "name": "items.lastName",
-              },
-              Object {
-                "attributes": Array [],
-                "change": "removed",
-                "name": "items.phone",
-              },
-              Object {
-                "attributes": Array [
-                  Object {
-                    "after": Array [
-                      "activation-pending",
-                      "activated",
-                      "blocked",
-                    ],
-                    "before": undefined,
-                    "key": "enum",
-                  },
-                  Object {
-                    "after": undefined,
-                    "before": "int32",
-                    "key": "format",
-                  },
-                  Object {
-                    "after": "string",
-                    "before": "integer",
-                    "key": "type",
-                  },
-                ],
-                "change": "changed",
-                "name": "items.userStatus",
-              },
-              Object {
-                "attributes": Array [
-                  Object {
-                    "after": true,
-                    "before": false,
-                    "key": "required",
-                  },
-                ],
-                "change": "changed",
-                "name": "items.username",
-              },
-            ],
-          },
-        ],
-        "name": "Request Body",
-      },
+      "requestBody": undefined,
       "responses": Array [],
     },
     Object {
@@ -1529,12 +1134,7 @@ Object {
       "change": "changed",
       "name": "get /user/login",
       "parameters": Array [],
-      "requestBody": Object {
-        "attributes": Array [],
-        "change": "changed",
-        "contentTypes": Array [],
-        "name": "Request Body",
-      },
+      "requestBody": undefined,
       "responses": Array [
         Object {
           "attributes": Array [],
@@ -1549,12 +1149,7 @@ Object {
       "change": "changed",
       "name": "get /user/{username}",
       "parameters": Array [],
-      "requestBody": Object {
-        "attributes": Array [],
-        "change": "changed",
-        "contentTypes": Array [],
-        "name": "Request Body",
-      },
+      "requestBody": undefined,
       "responses": Array [
         Object {
           "attributes": Array [],
@@ -1727,77 +1322,7 @@ Object {
       "change": "changed",
       "name": "put /user/{username}",
       "parameters": Array [],
-      "requestBody": Object {
-        "attributes": Array [],
-        "change": "changed",
-        "contentTypes": Array [
-          Object {
-            "attributes": Array [],
-            "change": "changed",
-            "name": "*/*",
-            "schemaChanges": Array [
-              Object {
-                "attributes": Array [],
-                "change": "added",
-                "name": "bio",
-              },
-              Object {
-                "attributes": Array [
-                  Object {
-                    "after": false,
-                    "before": true,
-                    "key": "required",
-                  },
-                ],
-                "change": "changed",
-                "name": "lastName",
-              },
-              Object {
-                "attributes": Array [],
-                "change": "removed",
-                "name": "phone",
-              },
-              Object {
-                "attributes": Array [
-                  Object {
-                    "after": Array [
-                      "activation-pending",
-                      "activated",
-                      "blocked",
-                    ],
-                    "before": undefined,
-                    "key": "enum",
-                  },
-                  Object {
-                    "after": undefined,
-                    "before": "int32",
-                    "key": "format",
-                  },
-                  Object {
-                    "after": "string",
-                    "before": "integer",
-                    "key": "type",
-                  },
-                ],
-                "change": "changed",
-                "name": "userStatus",
-              },
-              Object {
-                "attributes": Array [
-                  Object {
-                    "after": true,
-                    "before": false,
-                    "key": "required",
-                  },
-                ],
-                "change": "changed",
-                "name": "username",
-              },
-            ],
-          },
-        ],
-        "name": "Request Body",
-      },
+      "requestBody": undefined,
       "responses": Array [],
     },
   ],

--- a/projects/openapi-utilities/src/utilities/__tests__/json-changelog.test.ts
+++ b/projects/openapi-utilities/src/utilities/__tests__/json-changelog.test.ts
@@ -1,0 +1,29 @@
+import {
+  factsToChangelog,
+  OpenAPITraverser,
+  groupChangesAndRules,
+} from '../../index';
+import { openAPI as petStoreBase } from '../../examples/petstore-base';
+import { openAPI as petStoreUpdated } from '../../examples/petstore-updated';
+import { jsonChangelog } from '../json-changelog';
+
+test('json changelog collects changes properly', () => {
+  const baseTraverser = new OpenAPITraverser();
+  baseTraverser.traverse(petStoreBase);
+
+  const targetTraverser = new OpenAPITraverser();
+  targetTraverser.traverse(petStoreUpdated);
+
+  const baseFacts = [...baseTraverser.facts()];
+  const targetFacts = [...targetTraverser.facts()];
+
+  const output = jsonChangelog(
+    groupChangesAndRules({
+      toFacts: targetFacts,
+      changes: factsToChangelog(baseFacts, targetFacts),
+      rules: [],
+    })
+  );
+
+  expect(output).toMatchSnapshot('jsonChangelog');
+});

--- a/projects/openapi-utilities/src/utilities/json-changelog.ts
+++ b/projects/openapi-utilities/src/utilities/json-changelog.ts
@@ -193,6 +193,7 @@ function getEndpointLogs(
     responseChanges.push(getResponseChangeLogs(response, key));
   }
 
+  const requestChangelogs = getRequestChangeLogs(request);
   return {
     name: `${method} ${path}`,
     change: getChange(change),
@@ -203,46 +204,12 @@ function getEndpointLogs(
       : [],
     parameters: parameterChanges,
     requestBody:
-      request.change?.added ||
-      request.change?.removed ||
-      request.change?.changed
-        ? getRequestChangeLogs(request)
+      requestChangelogs.attributes.length ||
+      requestChangelogs.contentTypes.length
+        ? requestChangelogs
         : undefined,
     responses: responseChanges,
   };
-
-  // yield`${chalk.bold(method.toUpperCase())} ${path}: ${
-  //   change ? getAddedOrRemovedLabel(change) : ''
-  // }`;
-  //
-  // if (change?.removed) {
-  //   return;
-  // }
-  //
-  // if (change) {
-  //   yield *
-  //     indent(getDetailLogs(change, { excludeKeys: ['pathPattern', 'method'] }));
-  // }
-  //
-  // for (const [name, parameterChange] of queryParameters.changes) {
-  //   yield * indent(getParameterLogs('query', name, parameterChange));
-  // }
-  //
-  // for (const [name, parameterChange] of cookieParameters.changes) {
-  //   yield * indent(getParameterLogs('cookie', name, parameterChange));
-  // }
-  //
-  // for (const [name, parameterChange] of pathParameters.changes) {
-  //   yield * indent(getParameterLogs('path', name, parameterChange));
-  // }
-  //
-  // for (const [name, parameterChange] of headers.changes) {
-  //   yield * indent(getParameterLogs('header', name, parameterChange));
-  // }
-  //
-  //
-  //
-  // yield '';
 }
 
 function getResponseChangeLogs(

--- a/projects/openapi-utilities/src/utilities/json-changelog.ts
+++ b/projects/openapi-utilities/src/utilities/json-changelog.ts
@@ -1,0 +1,334 @@
+import {
+  groupChangesAndRules,
+  OpenApiEndpointChange,
+  RequestChange,
+  ResponseChange,
+  BodyChange,
+} from './group-changes';
+import { ChangeVariant, OpenApiKind, OpenApiFact } from '../openapi3/sdk/types';
+import isEqual from 'lodash.isequal';
+import omit from 'lodash.omit';
+
+const getChange = (
+  change: ChangeVariant<any> | null
+): 'added' | 'removed' | 'changed' =>
+  change?.added ? 'added' : change?.removed ? 'removed' : 'changed';
+
+const getDiff = (before: object, after: object) => {
+  const output = {
+    added: <{ key: string; value: any }[]>[],
+    changed: <{ key: string; before: any; after: any }[]>[],
+    removed: <{ key: string; value: any }[]>[],
+  };
+
+  const beforeKeys = new Set(Object.keys(before));
+  const afterKeys = new Set(Object.keys(after));
+
+  for (const key of beforeKeys) {
+    if (!afterKeys.has(key))
+      output.removed.push({ key, value: (before as any)[key] });
+    else if (!isEqual((before as any)[key], (after as any)[key]))
+      output.changed.push({
+        key,
+        before: (before as any)[key],
+        after: (after as any)[key],
+      });
+  }
+
+  for (const key of afterKeys) {
+    if (!beforeKeys.has(key))
+      output.added.push({ key, value: (after as any)[key] });
+  }
+
+  return output;
+};
+
+const getDetailsDiff = (
+  change: ChangeVariant<any>,
+  excludedKeys: string[] = []
+) => {
+  const excludeKeys = (fact: OpenApiFact) => omit(fact, excludedKeys);
+
+  const mergeFlatSchema = (fact: OpenApiFact) => {
+    if ('flatSchema' in fact) {
+      const { flatSchema, ...factRest } = fact;
+      return {
+        ...factRest,
+        ...flatSchema,
+      };
+    } else return fact;
+  };
+
+  const before = excludeKeys(
+    mergeFlatSchema(
+      change.added
+        ? {}
+        : change.removed
+        ? change.removed
+        : change.changed
+        ? change.changed.before
+        : {}
+    )
+  );
+
+  const after = excludeKeys(
+    mergeFlatSchema(
+      change.added
+        ? change.added
+        : change.removed
+        ? {}
+        : change.changed
+        ? change.changed.after
+        : {}
+    )
+  );
+
+  return getDiff(before, after);
+};
+
+function getDetailLogs(
+  change: ChangeVariant<any>,
+  options: { label?: string; excludeKeys?: string[] } = {}
+): ChangedNode['attributes'] {
+  const { label, excludeKeys } = options;
+  const diff = getDetailsDiff(change, excludeKeys);
+
+  const diffCount =
+    diff.changed.length + diff.removed.length + diff.added.length;
+
+  if (!diffCount) return [];
+
+  const results: ChangedNode['attributes'] = [];
+
+  // don't show children as added
+  if (!change.added) {
+    diff.added.forEach((added) =>
+      results.push({ key: added.key, after: added.value, before: undefined })
+    );
+  }
+  // don't show children as removed
+  if (!change.removed) {
+    diff.removed.forEach((removed) =>
+      results.push({
+        key: removed.key,
+        before: removed.value,
+        after: undefined,
+      })
+    );
+  }
+  diff.changed.forEach((changed) =>
+    results.push({
+      key: changed.key,
+      before: changed.before,
+      after: changed.after,
+    })
+  );
+
+  return results;
+}
+
+type ChangedNode = {
+  name: string;
+  change: 'added' | 'removed' | 'changed';
+  attributes: { key: string; before: any; after: any }[];
+};
+
+type OperationChangelog = ChangedNode & {
+  parameters: ChangedNode[];
+  requestBody: ChangedNode;
+  responses: ChangedNode[];
+};
+
+type JsonChangelog = {
+  operations: OperationChangelog[];
+};
+
+export function jsonChangelog(
+  groupedChanges: ReturnType<typeof groupChangesAndRules>
+): JsonChangelog {
+  const results: JsonChangelog = { operations: [] };
+
+  const { changesByEndpoint, specification } = groupedChanges;
+  // for (const specificationChange of specification.changes) {
+  //   // yield* getDetailLogs(specificationChange, {
+  //   //   label: 'specification details:',
+  //   // });
+  //   // yield '';
+  // }
+  for (const [_, endpointChange] of changesByEndpoint) {
+    results.operations.push(getEndpointLogs(endpointChange));
+  }
+
+  return results;
+}
+
+function getEndpointLogs(
+  endpointChange: OpenApiEndpointChange
+): OperationChangelog {
+  const {
+    method,
+    path,
+    request,
+    responses,
+    cookieParameters,
+    change,
+    headers,
+    pathParameters,
+    queryParameters,
+  } = endpointChange;
+
+  const parameterChanges = [];
+  for (const [name, parameterChange] of queryParameters.changes) {
+    parameterChanges.push(getParameterLogs('query', name, parameterChange));
+  }
+
+  for (const [name, parameterChange] of cookieParameters.changes) {
+    parameterChanges.push(getParameterLogs('cookie', name, parameterChange));
+  }
+
+  for (const [name, parameterChange] of pathParameters.changes) {
+    parameterChanges.push(getParameterLogs('path', name, parameterChange));
+  }
+
+  for (const [name, parameterChange] of headers.changes) {
+    parameterChanges.push(getParameterLogs('header', name, parameterChange));
+  }
+
+  const responseChanges: ChangedNode[] = [];
+  for (const [key, response] of responses) {
+    responseChanges.push(getResponseChangeLogs(response, key));
+  }
+
+  return {
+    name: `${method} ${path}`,
+    change: getChange(change),
+    attributes: change
+      ? getDetailLogs(change, {
+          excludeKeys: ['pathPattern', 'method'],
+        })
+      : [],
+    parameters: parameterChanges,
+    requestBody: getRequestChangeLogs(request),
+    responses: responseChanges,
+  };
+
+  // yield`${chalk.bold(method.toUpperCase())} ${path}: ${
+  //   change ? getAddedOrRemovedLabel(change) : ''
+  // }`;
+  //
+  // if (change?.removed) {
+  //   return;
+  // }
+  //
+  // if (change) {
+  //   yield *
+  //     indent(getDetailLogs(change, { excludeKeys: ['pathPattern', 'method'] }));
+  // }
+  //
+  // for (const [name, parameterChange] of queryParameters.changes) {
+  //   yield * indent(getParameterLogs('query', name, parameterChange));
+  // }
+  //
+  // for (const [name, parameterChange] of cookieParameters.changes) {
+  //   yield * indent(getParameterLogs('cookie', name, parameterChange));
+  // }
+  //
+  // for (const [name, parameterChange] of pathParameters.changes) {
+  //   yield * indent(getParameterLogs('path', name, parameterChange));
+  // }
+  //
+  // for (const [name, parameterChange] of headers.changes) {
+  //   yield * indent(getParameterLogs('header', name, parameterChange));
+  // }
+  //
+  //
+  //
+  // yield '';
+}
+
+function getResponseChangeLogs(
+  { change, headers, contentTypes }: ResponseChange,
+  key: string
+): ChangedNode & {
+  contentTypes: (ChangedNode & { schemaChanges: ChangedNode[] })[];
+} {
+  const contentTypeChanges: (ChangedNode & { schemaChanges: ChangedNode[] })[] =
+    [];
+
+  for (const [key, contentType] of contentTypes) {
+    contentTypeChanges.push(getBodyChangeLogs(contentType, key));
+  }
+
+  return {
+    name: `${key} response`,
+    change: getChange(change),
+    attributes: change
+      ? getDetailLogs(change, { excludeKeys: ['statusCode'] })
+      : [],
+    contentTypes: contentTypeChanges,
+  };
+}
+
+function getRequestChangeLogs({
+  change,
+  bodyChanges,
+}: RequestChange): ChangedNode & {
+  contentTypes: (ChangedNode & { schemaChanges: ChangedNode[] })[];
+} {
+  const contentTypes: (ChangedNode & { schemaChanges: ChangedNode[] })[] = [];
+  for (const [key, bodyChange] of bodyChanges) {
+    contentTypes.push(getBodyChangeLogs(bodyChange, key));
+  }
+
+  return {
+    name: `Request Body`,
+    change: getChange(change),
+    attributes: change
+      ? getDetailLogs(change, { excludeKeys: ['content'] })
+      : [],
+    contentTypes: contentTypes,
+  };
+}
+
+function getBodyChangeLogs(
+  { bodyChange, fieldChanges, exampleChanges }: BodyChange,
+  key: string
+): ChangedNode & { schemaChanges: ChangedNode[] } {
+  return {
+    name: `${key}`,
+    change: getChange(bodyChange),
+    attributes: bodyChange
+      ? getDetailLogs(bodyChange, { excludeKeys: ['contentType'] })
+      : [],
+    schemaChanges: fieldChanges.map((fieldChange) => getFieldLogs(fieldChange)),
+  };
+}
+
+function getFieldLogs(change: ChangeVariant<OpenApiKind.Field>): ChangedNode {
+  const path = change.location.conceptualLocation.jsonSchemaTrail
+    .filter((i) => i !== 'properties')
+    .join('.');
+
+  return {
+    name: path,
+    change: getChange(change),
+    attributes: change ? getDetailLogs(change, { excludeKeys: ['key'] }) : [],
+  };
+}
+
+function getParameterLogs(
+  parameterType: string,
+  parameterName: string,
+  change: ChangeVariant<
+    | OpenApiKind.QueryParameter
+    | OpenApiKind.CookieParameter
+    | OpenApiKind.PathParameter
+    | OpenApiKind.HeaderParameter
+  >
+): ChangedNode {
+  return {
+    name: `${parameterType} parameter '${parameterName}'`,
+    change: getChange(change),
+    attributes: getDetailLogs(change, { excludeKeys: ['name', 'in'] }),
+  };
+}

--- a/projects/openapi-utilities/src/utilities/json-changelog.ts
+++ b/projects/openapi-utilities/src/utilities/json-changelog.ts
@@ -135,7 +135,7 @@ type ChangedNode = {
 
 type OperationChangelog = ChangedNode & {
   parameters: ChangedNode[];
-  requestBody: ChangedNode;
+  requestBody?: ChangedNode;
   responses: ChangedNode[];
 };
 
@@ -149,12 +149,6 @@ export function jsonChangelog(
   const results: JsonChangelog = { operations: [] };
 
   const { changesByEndpoint, specification } = groupedChanges;
-  // for (const specificationChange of specification.changes) {
-  //   // yield* getDetailLogs(specificationChange, {
-  //   //   label: 'specification details:',
-  //   // });
-  //   // yield '';
-  // }
   for (const [_, endpointChange] of changesByEndpoint) {
     results.operations.push(getEndpointLogs(endpointChange));
   }
@@ -208,7 +202,12 @@ function getEndpointLogs(
         })
       : [],
     parameters: parameterChanges,
-    requestBody: getRequestChangeLogs(request),
+    requestBody:
+      request.change?.added ||
+      request.change?.removed ||
+      request.change?.changed
+        ? getRequestChangeLogs(request)
+        : undefined,
     responses: responseChanges,
   };
 

--- a/projects/openapi-utilities/src/utilities/terminal-changelog.ts
+++ b/projects/openapi-utilities/src/utilities/terminal-changelog.ts
@@ -204,7 +204,7 @@ function* getResponseChangeLogs(
   }
 
   if (change || headers.changes.size || contentTypes.size) {
-    yield label;
+    yield `${label} ${change?.added ? added : ''}`;
   }
 
   if (change) {

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.7",
+  "version": "0.35.8-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -84,5 +84,6 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  }
+  },
+  "stableVersion": "0.35.7"
 }

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.8-4",
+  "version": "0.35.8-5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.8-0",
+  "version": "0.35.8-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.8-1",
+  "version": "0.35.8-4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.6",
+  "version": "0.35.7-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -84,5 +84,6 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  }
+  },
+  "stableVersion": "0.35.6"
 }

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.7-0",
+  "version": "0.35.6",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -84,6 +84,5 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  },
-  "stableVersion": "0.35.6"
+  }
 }

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.7",
+  "version": "0.35.8-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -91,5 +91,6 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  }
+  },
+  "stableVersion": "0.35.7"
 }

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.8-0",
+  "version": "0.35.8-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.8-1",
+  "version": "0.35.8-4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.8-4",
+  "version": "0.35.8-5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.6",
+  "version": "0.35.7-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -91,5 +91,6 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  }
+  },
+  "stableVersion": "0.35.6"
 }

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.7-0",
+  "version": "0.35.6",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -91,6 +91,5 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  },
-  "stableVersion": "0.35.6"
+  }
 }

--- a/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
@@ -8,7 +8,7 @@ exports[`diff basic rules config 1`] = `
 
 [1mPATCH[22m /example: 
   - operationId [33mchanged[39m
-  - response [1m200[22m:
+  - response [1m200[22m: [32madded[39m
     - description [32madded[39m
     - body [1mapplication/json[22m: [32madded[39m
       - type [32madded[39m
@@ -63,7 +63,7 @@ exports[`diff basic rules config 2`] = `
 
 [1mPATCH[22m /example: 
   - operationId [33mchanged[39m
-  - response [1m200[22m:
+  - response [1m200[22m: [32madded[39m
     - description [32madded[39m
     - body [1mapplication/json[22m: [32madded[39m
       - type [32madded[39m
@@ -122,7 +122,7 @@ exports[`diff breaking changes exclusion 1`] = `
 
 [1mPATCH[22m /example: 
   - operationId [33mchanged[39m
-  - response [1m200[22m:
+  - response [1m200[22m: [32madded[39m
     - description [32madded[39m
     - body [1mapplication/json[22m: [32madded[39m
       - type [32madded[39m
@@ -154,7 +154,7 @@ exports[`diff breaking changes exclusion 2`] = `
 
 [1mPATCH[22m /example: 
   - operationId [33mchanged[39m
-  - response [1m200[22m:
+  - response [1m200[22m: [32madded[39m
     - description [32madded[39m
     - body [1mapplication/json[22m: [32madded[39m
       - type [32madded[39m
@@ -183,7 +183,7 @@ exports[`diff two files, no repo or config 1`] = `
 
 [1mPATCH[22m /example: 
   - operationId [33mchanged[39m
-  - response [1m200[22m:
+  - response [1m200[22m: [32madded[39m
     - description [32madded[39m
     - body [1mapplication/json[22m: [32madded[39m
       - type [32madded[39m
@@ -207,7 +207,7 @@ exports[`diff with mock server custom rules 1`] = `
 
 [1mPATCH[22m /example: 
   - operationId [33mchanged[39m
-  - response [1m200[22m:
+  - response [1m200[22m: [32madded[39m
     - description [32madded[39m
     - body [1mapplication/json[22m: [32madded[39m
       - type [32madded[39m

--- a/projects/optic/src/commands/diff/diff.ts
+++ b/projects/optic/src/commands/diff/diff.ts
@@ -10,6 +10,7 @@ import {
   OpenAPIV3,
   IChange,
   UserError,
+  jsonChangelog,
 } from '@useoptic/openapi-utilities';
 import { wrapActionHandlerWithSentry } from '@useoptic/openapi-utilities/build/utilities/sentry';
 import {
@@ -73,6 +74,7 @@ export const registerDiff = (cli: Command, config: OpticCliConfig) => {
     )
     .option('--check', 'enable checks', false)
     .option('--web', 'view the diff in the optic changelog web view', false)
+    .option('--json', 'output as json', false)
     .action(wrapActionHandlerWithSentry(getDiffAction(config)));
 };
 
@@ -162,10 +164,7 @@ const runDiff = async (
   config: OpticCliConfig,
   options: DiffActionOptions
 ): Promise<{ checks: { passed: number; failed: number; total: number } }> => {
-  const ruleRunner = await generateRuleRunner(
-    config,
-    options.check
-  );
+  const ruleRunner = await generateRuleRunner(config, options.check);
   const specResults = await generateSpecResults(
     ruleRunner,
     baseFile,
@@ -179,15 +178,6 @@ const runDiff = async (
     rules: specResults.results,
   });
 
-  if (specResults.changes.length === 0) {
-    console.log('No changes were detected');
-  } else {
-    console.log('');
-  }
-  for (const log of terminalChangelog(changelogData)) {
-    console.log(log);
-  }
-
   const diffResults = {
     checks: {
       total: specResults.results.length,
@@ -197,6 +187,21 @@ const runDiff = async (
       ).length,
     },
   };
+
+  if (specResults.changes.length === 0) {
+    console.log('No changes were detected');
+  } else {
+    console.log('');
+  }
+
+  if (options.json) {
+    console.log(JSON.stringify(jsonChangelog(changelogData)));
+    return diffResults;
+  } else {
+    for (const log of terminalChangelog(changelogData)) {
+      console.log(log);
+    }
+  }
 
   if (options.check) {
     if (specResults.results.length > 0) {
@@ -243,6 +248,7 @@ type DiffActionOptions = {
   base: string;
   check: boolean;
   web: boolean;
+  json: boolean;
 };
 
 const getDiffAction =
@@ -281,7 +287,7 @@ const getDiffAction =
       process.exitCode = 1;
       return;
     }
-    if (!options.web) {
+    if (!options.web && !options.json) {
       console.log(
         chalk.blue(
           `Rerun this command with the --web flag to view the detailed changes in your browser`

--- a/projects/optic/src/commands/diff/diff.ts
+++ b/projects/optic/src/commands/diff/diff.ts
@@ -188,16 +188,15 @@ const runDiff = async (
     },
   };
 
-  if (specResults.changes.length === 0) {
-    console.log('No changes were detected');
-  } else {
-    console.log('');
-  }
-
   if (options.json) {
     console.log(JSON.stringify(jsonChangelog(changelogData)));
     return diffResults;
   } else {
+    if (specResults.changes.length === 0) {
+      console.log('No changes were detected');
+    } else {
+      console.log('');
+    }
     for (const log of terminalChangelog(changelogData)) {
       console.log(log);
     }

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.8-0",
+  "version": "0.35.8-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.7-0",
+  "version": "0.35.6",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -61,6 +61,5 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  },
-  "stableVersion": "0.35.6"
+  }
 }

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.8-1",
+  "version": "0.35.8-4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.8-4",
+  "version": "0.35.8-5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.7",
+  "version": "0.35.8-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -61,5 +61,6 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  }
+  },
+  "stableVersion": "0.35.7"
 }

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.6",
+  "version": "0.35.7-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -61,5 +61,6 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  }
+  },
+  "stableVersion": "0.35.6"
 }

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.6",
+  "version": "0.35.7-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -60,5 +60,6 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  }
+  },
+  "stableVersion": "0.35.6"
 }

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.8-4",
+  "version": "0.35.8-5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.8-0",
+  "version": "0.35.8-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.7",
+  "version": "0.35.8-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -60,5 +60,6 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  }
+  },
+  "stableVersion": "0.35.7"
 }

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.8-1",
+  "version": "0.35.8-4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.7-0",
+  "version": "0.35.6",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -60,6 +60,5 @@
         "<rootDir>../../../../node_modules/nimma/dist/legacy/cjs/index.js"
       ]
     }
-  },
-  "stableVersion": "0.35.6"
+  }
 }


### PR DESCRIPTION
## 🍗 Description
Two customers has asked for a `--json` output to help generate their company's public changelogs. 

This PR adds a `--json` flag that serializes the terminal changelog from `optic diff`. 

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
