### PR TITLE
Improve openapi validator error messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.35.8",
+  "version": "0.35.9",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
-  "version": "0.35.8",
+  "version": "0.35.9",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-cli",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.8",
+  "version": "0.35.9",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-io",
   "license": "MIT",
-  "version": "0.35.8",
+  "version": "0.35.9",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-io/src/validation/__snapshots__/validator.test.ts.snap
+++ b/projects/openapi-io/src/validation/__snapshots__/validator.test.ts.snap
@@ -1,40 +1,40 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`advanced validators run and append their results 1`] = `
-"[31minvalid openapi: [39m[1m[31mmust NOT have fewer than 1 items[39m[22m
+"[31minvalid openapi: [39m[1m[31mpaths > /api/users/{userId} > get > responses > 200 > content > application/json > schema > oneOf must NOT have fewer than 1 items[39m[22m
 /paths/~1api~1users~1{userId}/get/responses/200/content/application~1json/schema/oneOf
-[31minvalid openapi: [39m[1m[31mmust NOT have fewer than 1 items[39m[22m
+[31minvalid openapi: [39m[1m[31mpaths > /api/users/{userId} > get > responses > 200 > content > application/json > schema > anyOf must NOT have fewer than 1 items[39m[22m
 /paths/~1api~1users~1{userId}/get/responses/200/content/application~1json/schema/anyOf
-[31minvalid openapi: [39m[1m[31mmust be object[39m[22m
+[31minvalid openapi: [39m[1m[31mpaths > /api/users/{userId} > get > responses > 200 > content > application/json > schema > items must be object[39m[22m
 /paths/~1api~1users~1{userId}/get/responses/200/content/application~1json/schema/items
-[31minvalid openapi: [39m[1m[31mschema with type \\"object\\" cannot also include keywords: anyOf, items, oneOf[39m[22m
+[31minvalid openapi: [39m[1m[31mpaths > /api/users/{userId} > get > responses > 200 > content > application/json > schema schema with type \\"object\\" cannot also include keywords: anyOf, items, oneOf[39m[22m
 /paths/~1api~1users~1{userId}/get/responses/200/content/application~1json/schema"
 `;
 
 exports[`error cases with messages additional properties in invalid place 1`] = `
-"[31minvalid openapi: [39m[1m[31mmust have required property 'responses'[39m[22m
+"[31minvalid openapi: [39m[1m[31mpaths > /example > get must have required property 'responses'[39m[22m
 /paths/~1example/get
-[31minvalid openapi: [39m[1m[31mmust NOT have additional properties[39m[22m
+[31minvalid openapi: [39m[1m[31minfo must NOT have additional properties[39m[22m
 /info"
 `;
 
 exports[`error cases with messages open api doc with no description in response 1`] = `
-"[31minvalid openapi: [39m[1m[31mmust have required property 'responses'[39m[22m
+"[31minvalid openapi: [39m[1m[31mpaths > /example > get must have required property 'responses'[39m[22m
 /paths/~1example/get"
 `;
 
 exports[`error cases with messages open api doc with no path should throw an error 1`] = `
-"[31minvalid openapi: [39m[1m[31mmust have required property 'paths'[39m[22m
+"[31minvalid openapi: [39m[1m[31m must have required property 'paths'[39m[22m
 "
 `;
 
 exports[`processValidatorErrors 1`] = `
-"[31minvalid openapi: [39m[1m[31mmust be object[39m[22m
+"[31minvalid openapi: [39m[1m[31mpaths > /api/users/{userId} > get > responses > 200 > content > application/json > schema > properties > hello > items must be object[39m[22m
 /paths/~1api~1users~1{userId}/get/responses/200/content/application~1json/schema/properties/hello/items"
 `;
 
 exports[`processValidatorErrors attaches the sourcemap 1`] = `
-"[31minvalid openapi: [39m[1m[31mmust be object[39m[22m
+"[31minvalid openapi: [39m[1m[31mpaths > /api/users/{userId} > get > responses > 200 > content > application/json > schema > properties > hello > items must be object[39m[22m
 [90m18 |[39m   \\"properties\\": {
 [90m19 |[39m     \\"hello\\": {
 [90m20 |[39m       \\"type\\": \\"array\\",
@@ -42,7 +42,7 @@ exports[`processValidatorErrors attaches the sourcemap 1`] = `
 [90m22 |[39m     }
 [90m23 |[39m   }
 [90m24 |[39m }
-[31minvalid openapi: [39m[1m[31mmust be equal to one of the allowed values[39m[22m
+[31minvalid openapi: [39m[1m[31mtype must be equal to one of the allowed values string,number,integer,object,array,boolean[39m[22m
 [90m35 |[39m \\"content\\": {
 [90m36 |[39m   \\"application/json\\": {
 [90m37 |[39m     \\"schema\\": {

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
-  "version": "0.35.8",
+  "version": "0.35.9",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.8",
+  "version": "0.35.9",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.8",
+  "version": "0.35.9",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.8",
+  "version": "0.35.9",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.8",
+  "version": "0.35.9",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

This PR improves the error messages out from OpenAPI validation. There's two instances we add more information:
- We add the path of the error to the error message (it's not always clear from the error message which line is causing the error)
- For enums, the previous error message looked like: `invalid openapi: must be equal to one of the allowed values`, now shows something like `invalid openapi: type must be equal to one of the allowed values string,number,integer,object,array,boolean`

TODO
- [ ] Bump version

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
