### PR TITLE
Implement spectral built in ruleset

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.35.9",
+  "version": "0.35.10",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
-  "version": "0.35.9",
+  "version": "0.35.10",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-cli",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.9",
+  "version": "0.35.10",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-io",
   "license": "MIT",
-  "version": "0.35.9",
+  "version": "0.35.10",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
-  "version": "0.35.9",
+  "version": "0.35.10",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.9",
+  "version": "0.35.10",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.9",
+  "version": "0.35.10",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/src/commands/diff/generate-rule-runner.ts
+++ b/projects/optic/src/commands/diff/generate-rule-runner.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import { OpticCliConfig } from '../../config';
 import { StandardRulesets } from '@useoptic/standard-rulesets';
-import { RuleRunner, Ruleset, prepareRulesets } from '@useoptic/rulesets-base';
+import { RuleRunner, Ruleset, prepareRulesets, ExternalRule } from '@useoptic/rulesets-base';
 import { createOpticClient } from '@useoptic/optic-ci/build/cli/clients/optic-client';
 
 const isLocalJsFile = (name: string) => name.endsWith('.js');
@@ -12,7 +12,7 @@ export const generateRuleRunner = async (
   config: OpticCliConfig,
   checksEnabled: boolean
 ): Promise<RuleRunner> => {
-  let rulesets: Ruleset[] = [];
+  let rulesets: (Ruleset | ExternalRule)[] = [];
 
   if (checksEnabled) {
     const client = createOpticClient('');

--- a/projects/rulesets-base/README.md
+++ b/projects/rulesets-base/README.md
@@ -235,7 +235,7 @@ new ResponseBodyRule({
 
 ## Examples
 
-[Breaking Changes](../standard-rulesets//src/breaking-changes/) and [Naming rules](../standard-rulesets//src/naming-changes/) are examples of rulesets implemented using rulesets-base.
+[Breaking Changes](../standard-rulesets/src/breaking-changes/) and [Naming rules](../standard-rulesets/src/naming-changes/) are examples of rulesets implemented using rulesets-base.
 
 ## Testing rulesets
 
@@ -284,9 +284,12 @@ test('test that my rule works', async () => {
 
 ## Connecting Spectral to Optic
 
-With Optic, you can connect your Spectral rules and extend them using Optic's lifecycle (added, changed, addedOrChanged, always) and exemption features. 
+> ℹ️ If you just want to use the basic Spectral OAS rulesets, take a look at our [spectral-oas-v6 standard ruleset](../standard-rulesets/README.md#spectral)
+
+With Optic, you can connect your Spectral rules and extend them using Optic's lifecycle (added, changed, addedOrChanged, always) and exemption features.
 
 To start:
+
 ```bash
 # Create a new custom repo
 optic ruleset init spectral-rules
@@ -301,9 +304,10 @@ npm i @stoplight/spectral-rulesets # or your own custom spectral ruleset
 ```
 
 Then in the `src/main.ts` file you can connect up Spectral to Optic.
+
 ```typescript
-import { SpectralRule } from "@useoptic/rulesets-base";
-import { Spectral } from "@stoplight/spectral-core";
+import { SpectralRule } from '@useoptic/rulesets-base';
+import { Spectral } from '@stoplight/spectral-core';
 // Use the spectral built in ruleset, or import your own!
 import { oas } from '@stoplight/spectral-rulesets';
 
@@ -312,30 +316,30 @@ import { oas } from '@stoplight/spectral-rulesets';
 const spectral = new Spectral();
 spectral.setRuleset(oas);
 
-const name = "spectral-rules";
+const name = 'spectral-rules';
 export default {
   name,
-  description: "A Spectral ruleset in Optic",
+  description: 'A Spectral ruleset in Optic',
   configSchema: {},
   rulesetConstructor: () => {
     return new SpectralRule({
       spectral,
       name,
-      applies: 'added' // will only trigger on nodes that were added
+      applies: 'added', // will only trigger on nodes that were added
     });
   },
 };
 ```
 
 After setting up this file, you can build the package and start using Spectral in Optic:
+
 - `yarn run build`
 - (optional) Upload your spectral rule to Optic
   - `OPTIC_TOKEN=<token> yarn run upload`
   - (get an OPTIC_TOKEN at [app.useoptic.com](app.useoptic.com))
-- Run checks with this ruleset by adding rulesets into your [`optic.dev.yml`](../optic/README.md#quick-start-guide) file at the root of your project. 
+- Run checks with this ruleset by adding rulesets into your [`optic.dev.yml`](../optic/README.md#quick-start-guide) file at the root of your project.
   - you can refer to the uploaded ruleset (`@organization/ruleset-name`)
   - or you can use a local path `./<path_to_ruleset_project>/build/main.js`
-
 
 ## Reference details
 

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.9",
+  "version": "0.35.10",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/src/custom-rulesets/prepare-rulesets.ts
+++ b/projects/rulesets-base/src/custom-rulesets/prepare-rulesets.ts
@@ -1,4 +1,4 @@
-import { Ruleset } from '../rules/ruleset';
+import { Ruleset, ExternalRule } from '../rules/ruleset';
 import { downloadRuleset } from './download-ruleset';
 import { resolveRuleset } from './resolve-ruleset';
 
@@ -19,12 +19,12 @@ export type RulesetPayload = {
   >;
   standardRulesets: Record<
     string,
-    { fromOpticConfig: (config: unknown) => Ruleset | string }
+    { fromOpticConfig: (config: unknown) => Ruleset | ExternalRule | string }
   >;
 };
 
 export type PrepareRulesetsResult = {
-  rulesets: Ruleset[];
+  rulesets: (Ruleset | ExternalRule)[];
   warnings: string[];
 };
 
@@ -32,11 +32,11 @@ export async function prepareRulesets(
   payload: RulesetPayload
 ): Promise<PrepareRulesetsResult> {
   const StandardRulesets = payload.standardRulesets;
-  const rulesets: Ruleset[] = [];
+  const rulesets: (Ruleset | ExternalRule)[] = [];
   const warnings: string[] = [];
 
   for (const ruleset of payload.ruleset) {
-    let instanceOrErrorMsg: Ruleset | string;
+    let instanceOrErrorMsg: Ruleset | ExternalRule | string;
     if (StandardRulesets[ruleset.name as keyof typeof StandardRulesets]) {
       const RulesetClass =
         StandardRulesets[ruleset.name as keyof typeof StandardRulesets];
@@ -77,10 +77,10 @@ export async function prepareRulesets(
       warnings.push(`Ruleset ${ruleset.name} does not exist`);
       continue;
     }
-    if (Ruleset.isInstance(instanceOrErrorMsg)) {
-      rulesets.push(instanceOrErrorMsg);
-    } else {
+    if (typeof instanceOrErrorMsg === 'string') {
       warnings.push(instanceOrErrorMsg);
+    } else {
+      rulesets.push(instanceOrErrorMsg);
     }
   }
 

--- a/projects/standard-rulesets/README.md
+++ b/projects/standard-rulesets/README.md
@@ -1,35 +1,37 @@
 # Standard rulesets
 
-Installation:
+Optic includes the following rulesets:
 
-```
-npm install -D @useoptic/standard-rulesets
-```
+- breaking changes (enforces breaking changes)
+- naming (enforces casing conventions)
+- examples (requires examples to be provided and for them to match the schemas)
+- spectral oas (run spectral rules with Optic lifecycles)
 
-```
-yarn add -D @useoptic/standard-rulesets
-```
-
-Standard rules can be configured to certain endpoints by passing in a matches block. Example:
-
-```javascript
-new BreakingChangesRules({
-  matches: (ruleContext) =>
-    ruleContext.operation.method === 'get' &&
-    ruleContext.operation.path === '/api/users',
-});
-
-// or you can match custom extentions
-new BreakingChangesRules({
-  matches: (ruleContext) =>
-    ruleContext.operation.value['x-stability'] !== 'draft',
-});
-```
+Run these locally using `optic` cli or in [optic cloud](https://app.useoptic.com) which integrates with github and gitlab.
 
 ## Breaking Changes Rules
 
-```javascript
-const { BreakingChangesRuleset } = require('@useoptic/standard-rulesets');
+Turn on breaking changes by adding the breaking-changes into your `optic.dev.yml` file
+
+```yml
+ruleset:
+  - breaking-changes
+```
+
+You can also exclude certain operations in breaking changes by exempting operations with a certain extension. E.g.
+
+```yml
+ruleset:
+  - breaking-changes:
+      exclude_operations_with_extension: x-draft # if an operation has the extension x-draft, optic will not check for breaking changes
+```
+
+```yml
+paths:
+  /api/users:
+    get:
+      x-draft: true # this endpoint will not be checked for breaking changes
+      ...
 ```
 
 The rules that are enforced are:
@@ -46,39 +48,50 @@ The rules that are enforced are:
 - prevent changing response body property types
 - prevent removing a response status code
 
-Specific rules can be ignored with the `skipRules` attribute, and an accept list can be passed with `rulesOnly`:
+## Naming Changes
 
-```javascript
-new BreakingChangesRuleset({
-  // the "prevent operation removal" rule won't apply. All other rules apply.
-  skipRules: ['prevent operation removal'],
-});
+Turn on naming enforcement to ensure your OpenAPI spec is has consistent naming conventions
 
-new BreakingChangesRuleset({
-  // Only the two selected rules will apply.
-  rulesOnly: [
-    'prevent removing response property',
-    'prevent new required path parameters',
-  ],
-});
+The configuration options are:
+
+```yml
+ruleset:
+  - naming:
+      required_on: always # also available are 'added' or addedOrChanged
+      requestHeaders: camelCase #also available are Capital-Param-Case, param-case PascalCase and snake_case
+      queryParameters: camelCase
+      responseHeaders: camelCase
+      cookieParameters: camelCase
+      properties: camelCase
+      pathComponents: camelCase
 ```
 
-## Naming Change rules
+## Require Examples Ruleset
 
-```javascript
-const { NamingChangesRuleset } = require('@useoptic/standard-rulesets');
+Require an example to be present in your schemas, and ensure that they match the schema object
+
+The configuration options are:
+
+```yml
+ruleset:
+  - examples:
+      required_on: always # also available are 'added' or addedOrChanged
+      require_request_examples: true # default is false
+      require_response_examples: true # default is false
+      require_parameter_examples: true # default is false
 ```
 
-```javascript
-new NamingChangesRuleset({
-  required_on: 'always', // also available: 'added' | 'addedOrChanged'
-  options: {
-    // valid formats are: 'camelCase' | 'Capital-Param-Case' | 'param-case' | 'PascalCase' | 'snake_case'
-    properties: 'camelCase',
-    queryParameters: 'camelCase',
-    requestHeaders: 'camelCase',
-    pathComponents: 'param-case',
-    responseHeaders: 'camelCase',
-  },
-});
+## Spectral
+
+Use [spectral's oas ruleset](https://meta.stoplight.io/docs/spectral/4dec24461f3af-open-api-rules#openapi-rules) and apply Optic's lifecycle methods to control when spectral rules are triggered. Runs on spectral v6 and applies the [oas ruleset](https://meta.stoplight.io/docs/spectral/4dec24461f3af-open-api-rules#openapi-rules) provided by spectral.
+
+```yml
+ruleset:
+  - spectral-oas-v6:
+      applies: always # also available are 'added' or addedOrChanged
+      rules:
+        # turn off rules - see a full list of rules https://meta.stoplight.io/docs/spectral/4dec24461f3af-open-api-rules#openapi-rules
+        operation-operationId: false
 ```
+
+If you need to use custom spectral functions, or want to bring your own spectral ruleset, you can set this up using our [Spectral Custom Rule](../rulesets-base/README.md#connecting-spectral-to-optic)

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -19,6 +19,8 @@
     "compare": "yarn ts-node src/index.tsx compare"
   },
   "dependencies": {
+    "@stoplight/spectral-core": "^1.8.1",
+    "@stoplight/spectral-rulesets": "^1.14.1",
     "@useoptic/openapi-utilities": "workspace:*",
     "@useoptic/rulesets-base": "workspace:*",
     "ajv": "^8.6.0",

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.9",
+  "version": "0.35.10",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/src/index.ts
+++ b/projects/standard-rulesets/src/index.ts
@@ -5,10 +5,11 @@ export * from './examples';
 import { BreakingChangesRuleset } from './breaking-changes';
 import { NamingChangesRuleset } from './naming-changes';
 import { ExamplesRuleset } from './examples';
+import { SpectralOasV6Ruleset } from './spectral-oas-v6';
 
 export const StandardRulesets = {
   'breaking-changes': BreakingChangesRuleset,
   naming: NamingChangesRuleset,
-
+  'spectral-oas-v6': SpectralOasV6Ruleset,
   examples: ExamplesRuleset,
 };

--- a/projects/standard-rulesets/src/spectral-oas-v6/__tests__/__snapshots__/index.test.ts.snap
+++ b/projects/standard-rulesets/src/spectral-oas-v6/__tests__/__snapshots__/index.test.ts.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`fromOpticConfig invalid 1`] = `"- ruleset/naming/applies must be equal to one of the allowed values always,added,addedOrChanged,changed"`;
+
+exports[`fromOpticConfig invalid non-existent rule 1`] = `"Cannot extend non-existing rule: \\"operation-2xx-response\\""`;

--- a/projects/standard-rulesets/src/spectral-oas-v6/__tests__/index.test.ts
+++ b/projects/standard-rulesets/src/spectral-oas-v6/__tests__/index.test.ts
@@ -1,0 +1,38 @@
+import { SpectralOasV6Ruleset } from '..';
+
+describe('fromOpticConfig', () => {
+  test('valid', () => {
+    const ruleset = SpectralOasV6Ruleset.fromOpticConfig({
+      applies: 'always',
+      rules: {
+        'operation-operationId': false,
+        'operation-tags': false,
+      },
+    });
+    expect(ruleset).toBeInstanceOf(SpectralOasV6Ruleset);
+  });
+
+  test('default settings', () => {
+    const ruleset = SpectralOasV6Ruleset.fromOpticConfig({});
+    expect(ruleset).toBeInstanceOf(SpectralOasV6Ruleset);
+  });
+
+  test('invalid non-existent rule', () => {
+    const ruleset = SpectralOasV6Ruleset.fromOpticConfig({
+      applies: 'always',
+      rules: {
+        'operation-2xx-response': 'error',
+      },
+    });
+    expect(ruleset).not.toBeInstanceOf(SpectralOasV6Ruleset);
+    expect(ruleset).toMatchSnapshot();
+  });
+
+  test('invalid', () => {
+    const ruleset = SpectralOasV6Ruleset.fromOpticConfig({
+      applies: 'notalways',
+    });
+    expect(ruleset).not.toBeInstanceOf(SpectralOasV6Ruleset);
+    expect(ruleset).toMatchSnapshot();
+  });
+});

--- a/projects/standard-rulesets/src/spectral-oas-v6/index.ts
+++ b/projects/standard-rulesets/src/spectral-oas-v6/index.ts
@@ -1,0 +1,68 @@
+import { SpectralRule } from '@useoptic/rulesets-base';
+import {
+  Spectral,
+  RulesetDefinition as SpectralRulesetDefinition,
+} from '@stoplight/spectral-core';
+import { oas } from '@stoplight/spectral-rulesets';
+import Ajv from 'ajv';
+
+const ajv = new Ajv();
+const configSchema = {
+  type: 'object',
+  properties: {
+    applies: {
+      type: 'string',
+      enum: ['always', 'added', 'addedOrChanged', 'changed'],
+    },
+    rules: {},
+  },
+};
+const validateConfigSchema = ajv.compile(configSchema);
+
+export class SpectralOasV6Ruleset extends SpectralRule {
+  constructor(options: {
+    applies: 'added' | 'addedOrChanged' | 'changed' | 'always';
+    spectral: Spectral;
+  }) {
+    super({
+      name: 'SpectralOASV6',
+      spectral: options.spectral,
+      applies: options.applies,
+    });
+  }
+
+  static fromOpticConfig(config: unknown): SpectralOasV6Ruleset | string {
+    const result = validateConfigSchema(config);
+
+    if (!result && validateConfigSchema.errors) {
+      return validateConfigSchema.errors
+        .map((error) => {
+          const message =
+            error.keyword === 'enum'
+              ? `${error.message} ${error.params.allowedValues}`
+              : error.message;
+          return `- ruleset/naming${error.instancePath} ${message}`;
+        })
+        .join('\n- ');
+    }
+    const configValidated = config as any;
+    const applies = configValidated.applies ?? 'always';
+    const rules = configValidated.rules ?? {};
+
+    // TODO write documentation + based off the oas 6 version stuff
+    const spectral = new Spectral();
+    try {
+      spectral.setRuleset({
+        extends: [[oas as SpectralRulesetDefinition, 'all']],
+        rules,
+      });
+
+      return new SpectralOasV6Ruleset({
+        applies,
+        spectral,
+      });
+    } catch (e) {
+      return (e as Error).message;
+    }
+  }
+}

--- a/projects/standard-rulesets/src/spectral-oas-v6/index.ts
+++ b/projects/standard-rulesets/src/spectral-oas-v6/index.ts
@@ -49,7 +49,6 @@ export class SpectralOasV6Ruleset extends SpectralRule {
     const applies = configValidated.applies ?? 'always';
     const rules = configValidated.rules ?? {};
 
-    // TODO write documentation + based off the oas 6 version stuff
     const spectral = new Spectral();
     try {
       spectral.setRuleset({

--- a/yarn.lock
+++ b/yarn.lock
@@ -3673,6 +3673,8 @@ __metadata:
     "@babel/preset-env": ^7.17.0
     "@babel/preset-react": ^7.17.0
     "@babel/preset-typescript": ^7.17.0
+    "@stoplight/spectral-core": ^1.8.1
+    "@stoplight/spectral-rulesets": ^1.14.1
     "@types/babel__core": ^7
     "@types/babel__preset-env": ^7
     "@types/jest": ^26.0.24


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Implements a built in spectral ruleset that extends the oas ruleset provided in spectral https://meta.stoplight.io/docs/spectral/4dec24461f3af-open-api-rules#openapi-rules

```yml
ruleset:
  - spectral-oas-v6:
      applies: always # also available are 'added' or addedOrChanged
      rules:
        # turn off rules - see a full list of rules https://meta.stoplight.io/docs/spectral/4dec24461f3af-open-api-rules#openapi-rules
        operation-operationId: false
```

TODO
- [x] Bump version

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
