### PR TITLE
Normalize trailing slashes in base URLs

### DIFF
--- a/projects/openapi-cli/src/operations/queries.ts
+++ b/projects/openapi-cli/src/operations/queries.ts
@@ -53,8 +53,12 @@ export class OperationQueries {
         ? baseUrls.map((url) => {
             // add absolute in case url is relative (valid in OpenAPI, ignored when absolute)
             const parsed = new Url.URL(url, 'https://example.org');
-
-            return parsed.pathname;
+            const pathName = parsed.pathname;
+            if (pathName.endsWith('/') && pathName.length > 1) {
+              return pathName.substring(0, pathName.length - 1)
+            } else {
+              return pathName
+            }
           })
         : ['/'];
 
@@ -67,6 +71,9 @@ export class OperationQueries {
         })
       ),
     ];
+
+    console.log(this.patterns)
+
     this.patternsAsComponents = this.patterns.map((pattern) => [
       pattern,
       PathComponents.fromPath(pattern),

--- a/projects/openapi-cli/src/operations/queries.ts
+++ b/projects/openapi-cli/src/operations/queries.ts
@@ -71,9 +71,7 @@ export class OperationQueries {
         })
       ),
     ];
-
-    console.log(this.patterns)
-
+    
     this.patternsAsComponents = this.patterns.map((pattern) => [
       pattern,
       PathComponents.fromPath(pattern),

--- a/projects/openapi-cli/src/operations/streams/undocumented.ts
+++ b/projects/openapi-cli/src/operations/streams/undocumented.ts
@@ -74,12 +74,18 @@ export class UndocumentedOperations {
     spec: OpenAPIV3.Document,
     specUpdates?: AsyncIterable<OpenAPIV3.Document>
   ): UndocumentedOperations {
+
     const basePaths =
       spec.servers?.map((server) => {
         // add absolute in case url is relative (valid in OpenAPI, ignored when absolute)
         const parsed = new Url.URL(server.url, 'https://example.org');
 
-        return parsed.pathname;
+        const pathName = parsed.pathname;
+        if (pathName.endsWith('/') && pathName.length > 1) {
+          return pathName.substring(0, pathName.length - 1)
+        } else {
+          return pathName
+        }
       }) || [];
 
     const operations = AT.map<CapturedInteraction, OperationPair>(


### PR DESCRIPTION
## 🍗 Description

Fixes #1406 
2 users have discovered issues with base URLs in `oas`. OpenAPI does not have a strong opinion about whether base URLs in servers should contain a trailing `/` or not. Both inputs were allowed, and would behave differently from one another. A trailing `/` would always fail. 

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
