### PR TITLE
Update to not swallow uncaught exception in rule runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.35.10",
+  "version": "0.35.11",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
-  "version": "0.35.10",
+  "version": "0.35.11",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-cli",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.10",
+  "version": "0.35.11",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-io",
   "license": "MIT",
-  "version": "0.35.10",
+  "version": "0.35.11",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
-  "version": "0.35.10",
+  "version": "0.35.11",
   "packageManager": "yarn@3.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.10",
+  "version": "0.35.11",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.10",
+  "version": "0.35.11",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.10",
+  "version": "0.35.11",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/src/rule-runner/assertions.ts
+++ b/projects/rulesets-base/src/rule-runner/assertions.ts
@@ -216,8 +216,9 @@ class AssertionRunner<T extends AssertionType> implements Assertions<T> {
               type: 'removed',
             });
           } else {
-            const err = e as Error;
-            throw new UserError(err.message);
+            const err = e as UserError;
+            err.type = 'user-error';
+            throw err;
           }
         }
       }
@@ -255,8 +256,9 @@ class AssertionRunner<T extends AssertionType> implements Assertions<T> {
               type: 'requirement',
             });
           } else {
-            const err = e as Error;
-            throw new UserError(err.message);
+            const err = e as UserError;
+            err.type = 'user-error';
+            throw err;
           }
         }
       }
@@ -288,8 +290,9 @@ class AssertionRunner<T extends AssertionType> implements Assertions<T> {
               type: 'added',
             });
           } else {
-            const err = e as Error;
-            throw new UserError(err.message);
+            const err = e as UserError;
+            err.type = 'user-error';
+            throw err;
           }
         }
       }
@@ -322,8 +325,9 @@ class AssertionRunner<T extends AssertionType> implements Assertions<T> {
               type: 'changed',
             });
           } else {
-            const err = e as Error;
-            throw new UserError(err.message);
+            const err = e as UserError;
+            err.type = 'user-error';
+            throw err;
           }
         }
       }
@@ -407,7 +411,6 @@ export const createResponseBodyAssertions =
     return responseBodyAssertions as ResponseBodyAssertionsRunner;
   };
 
-export const createPropertyAssertions =
-  (): AssertionRunner<'property'> => {
-    return new AssertionRunner('property');
-  };
+export const createPropertyAssertions = (): AssertionRunner<'property'> => {
+  return new AssertionRunner('property');
+};

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.0.2",
-  "version": "0.35.10",
+  "version": "0.35.11",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

If an uncaught exception is thrown in the rules runner, we get an Error message without the original stack trace where the user's input was added. This PR maintains the thrown stack trace so that we can tell where uncaught exceptions originate from.

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
