### PR TITLE
Fix for when static content is served on the same basepath as the API

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.35.12",
+  "version": "0.35.13",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
-  "version": "0.35.12",
+  "version": "0.35.13",
   "packageManager": "yarn@3.3.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-cli",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.35.12",
+  "version": "0.35.13",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [

--- a/projects/openapi-cli/src/commands/diffing/document.ts
+++ b/projects/openapi-cli/src/commands/diffing/document.ts
@@ -408,7 +408,9 @@ export function addOperations(
     // phase one: documented all undocumented operations
     let updatingSpec: AT.Subject<OpenAPIV3.Document> = new AT.Subject();
     const undocumentedOperations = UndocumentedOperations.fromPairs(
-      AT.from(requiredOperations),
+      AT.from(
+        requiredOperations.map((add) => ({ ...add, onApiBasePath: true }))
+      ),
       spec,
       updatingSpec.iterator
     );

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-io",
   "license": "MIT",
-  "version": "0.35.12",
+  "version": "0.35.13",
   "packageManager": "yarn@3.3.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
-  "version": "0.35.12",
+  "version": "0.35.13",
   "packageManager": "yarn@3.3.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.35.12",
+  "version": "0.35.13",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.35.12",
+  "version": "0.35.13",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.35.12",
+  "version": "0.35.13",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.35.12",
+  "version": "0.35.13",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
## 🍗 Description
`verify` would fail if any of the undocumented paths were not under the base path (ie /api/v1)

This was happening because the code assumed every path would be under the basepath -- which is true, unless you serve static content alongside your api from the same host. 


## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
