### PR TITLE
fix fs-extra dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.36.1-0",
+  "version": "0.36.1",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",
@@ -28,6 +28,5 @@
     "**/*.+(js|jsx|ts|tsx|json|css)": [
       "yarn prettier --write"
     ]
-  },
-  "stableVersion": "0.36.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.36.0",
+  "version": "0.36.1-0",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",
@@ -28,5 +28,6 @@
     "**/*.+(js|jsx|ts|tsx|json|css)": [
       "yarn prettier --write"
     ]
-  }
+  },
+  "stableVersion": "0.36.0"
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
-  "version": "0.36.0",
+  "version": "0.36.1-0",
   "packageManager": "yarn@3.3.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -34,5 +34,6 @@
   },
   "dependencies": {
     "jsonpointer": "^5.0.1"
-  }
+  },
+  "stableVersion": "0.36.0"
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
-  "version": "0.36.1-0",
+  "version": "0.36.1",
   "packageManager": "yarn@3.3.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -34,6 +34,5 @@
   },
   "dependencies": {
     "jsonpointer": "^5.0.1"
-  },
-  "stableVersion": "0.36.0"
+  }
 }

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-cli",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.36.0",
+  "version": "0.36.1-0",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [
@@ -96,5 +96,6 @@
     "ts-results": "^3.3.0",
     "update-notifier": "^6.0.2",
     "whatwg-mimetype": "^3.0.0"
-  }
+  },
+  "stableVersion": "0.36.0"
 }

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-cli",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.36.1-0",
+  "version": "0.36.1",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [
@@ -96,6 +96,5 @@
     "ts-results": "^3.3.0",
     "update-notifier": "^6.0.2",
     "whatwg-mimetype": "^3.0.0"
-  },
-  "stableVersion": "0.36.0"
+  }
 }

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-io",
   "license": "MIT",
-  "version": "0.36.0",
+  "version": "0.36.1-0",
   "packageManager": "yarn@3.3.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -74,5 +74,6 @@
     "upath": "^2.0.1",
     "yaml": "^2.2.0",
     "yaml-ast-parser": "^0.0.43"
-  }
+  },
+  "stableVersion": "0.36.0"
 }

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-io",
   "license": "MIT",
-  "version": "0.36.1-0",
+  "version": "0.36.1",
   "packageManager": "yarn@3.3.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -74,6 +74,5 @@
     "upath": "^2.0.1",
     "yaml": "^2.2.0",
     "yaml-ast-parser": "^0.0.43"
-  },
-  "stableVersion": "0.36.0"
+  }
 }

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
-  "version": "0.36.0",
+  "version": "0.36.1-0",
   "packageManager": "yarn@3.3.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -63,5 +63,6 @@
     "openapi-types": "^12.0.2",
     "ts-invariant": "^0.9.3",
     "yaml-ast-parser": "^0.0.43"
-  }
+  },
+  "stableVersion": "0.36.0"
 }

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
-  "version": "0.36.1-0",
+  "version": "0.36.1",
   "packageManager": "yarn@3.3.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -63,6 +63,5 @@
     "openapi-types": "^12.0.2",
     "ts-invariant": "^0.9.3",
     "yaml-ast-parser": "^0.0.43"
-  },
-  "stableVersion": "0.36.0"
+  }
 }

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.36.0",
+  "version": "0.36.1-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -66,5 +66,6 @@
     "picomatch": "^2.3.1",
     "url-join": "^4.0.1",
     "uuid": "^9.0.0"
-  }
+  },
+  "stableVersion": "0.36.0"
 }

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.36.1-0",
+  "version": "0.36.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -66,6 +66,5 @@
     "picomatch": "^2.3.1",
     "url-join": "^4.0.1",
     "uuid": "^9.0.0"
-  },
-  "stableVersion": "0.36.0"
+  }
 }

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.36.1-0",
+  "version": "0.36.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -75,6 +75,5 @@
     "tar": "^6.1.11",
     "url-join": "^4.0.1",
     "uuid": "^9.0.0"
-  },
-  "stableVersion": "0.36.0"
+  }
 }

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.36.0",
+  "version": "0.36.1-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -75,5 +75,6 @@
     "tar": "^6.1.11",
     "url-join": "^4.0.1",
     "uuid": "^9.0.0"
-  }
+  },
+  "stableVersion": "0.36.0"
 }

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.36.0",
+  "version": "0.36.1-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -42,5 +42,6 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.4.0",
     "typescript": "^4.4.4"
-  }
+  },
+  "stableVersion": "0.36.0"
 }

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.36.1-0",
+  "version": "0.36.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -42,6 +42,5 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.4.0",
     "typescript": "^4.4.4"
-  },
-  "stableVersion": "0.36.0"
+  }
 }

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.36.0",
+  "version": "0.36.1-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -47,5 +47,6 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.4.0",
     "typescript": "^4.4.4"
-  }
+  },
+  "stableVersion": "0.36.0"
 }

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.36.1-0",
+  "version": "0.36.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -47,6 +47,5 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.4.0",
     "typescript": "^4.4.4"
-  },
-  "stableVersion": "0.36.0"
+  }
 }

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -26,6 +26,7 @@
     "@useoptic/rulesets-base": "workspace:*",
     "ajv": "^8.6.0",
     "ajv-formats": "~2.1.0",
+    "fs-extra": "^11.1.0",
     "whatwg-mimetype": "^3.0.0"
   },
   "devDependencies": {
@@ -36,6 +37,7 @@
     "@babel/preset-typescript": "^7.17.0",
     "@types/babel__core": "^7",
     "@types/babel__preset-env": "^7",
+    "@types/fs-extra": "^11.0.0",
     "@types/json-stable-stringify": "^1.0.33",
     "@types/lodash.pick": "^4",
     "@types/node": "^18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4305,6 +4305,7 @@ __metadata:
     "@stoplight/spectral-rulesets": ^1.14.1
     "@types/babel__core": ^7
     "@types/babel__preset-env": ^7
+    "@types/fs-extra": ^11.0.0
     "@types/json-stable-stringify": ^1.0.33
     "@types/lodash.pick": ^4
     "@types/node": ^18.0.0
@@ -4313,6 +4314,7 @@ __metadata:
     ajv: ^8.6.0
     ajv-formats: ~2.1.0
     babel-jest: ^29.3.1
+    fs-extra: ^11.1.0
     jest: ^29.3.1
     prettier: ^2.4.1
     ts-jest: ^29.0.3


### PR DESCRIPTION
## 🍗 Description
**0.36.0** had an issue with fs-extra dep not being imported for spectral plus rules that was reported by a user. 

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
