### PR TITLE
Fix api add to handle specs in current working directory

### DIFF
--- a/projects/optic/src/commands/api/add.ts
+++ b/projects/optic/src/commands/api/add.ts
@@ -193,12 +193,9 @@ async function crawlCandidateSpecs(
     standard: string | undefined;
   }
 ) {
-  const [firstSha, ...remainingShas] = shas;
-
   let parseResult: ParseResult;
   try {
-    const identifier = config.vcs ? `${firstSha}:${path}` : path;
-    parseResult = await getFileFromFsOrGit(identifier, config, false);
+    parseResult = await getFileFromFsOrGit(path, config, false);
   } catch (e) {
     if (path === options.path_to_spec) {
       logger.info(
@@ -212,7 +209,7 @@ async function crawlCandidateSpecs(
     return;
   }
   if (parseResult.isEmptySpec) {
-    logger.info(`File ${path} does not exist in sha ${short(firstSha)}`);
+    logger.info(`File ${path} does not exist in working directory`);
     return;
   }
 
@@ -223,13 +220,7 @@ async function crawlCandidateSpecs(
     ? { id: '', url: 'todo get optic id from url' }
     : { id: '', url: 'todo make API call' };
 
-  // TODO upload spec here
-  if (firstSha) {
-    logger.info(`Uploading spec ${short(firstSha)}:${path}`);
-  }
-  // We need to upload this spec separately to handle non-VCS cases
-
-  for await (const sha of remainingShas) {
+  for await (const sha of shas) {
     let parseResult: ParseResult;
     try {
       parseResult = await getFileFromFsOrGit(`${sha}:${path}`, config, false);


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Fixes api add to handle adding specs in the current working dir

The behavior is:
- If there's api specs in the current working dir, we'll add the APIs
- if there's any history (i.e. a commit with the spec) we'll upload the spec

In a case where we have no history (i.e. a newly created API), we'll create an API row, but won't create any specs (specs will only be created when the first run occurs.

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
