### PR TITLE
chore(ci): update workflow_call references to not use ref

### DIFF
--- a/.github/workflows/release-container-image.yml
+++ b/.github/workflows/release-container-image.yml
@@ -17,15 +17,6 @@ on:
         description: >
           The Optic version to package in the image. Any NPM dist tag or published semver version is technically
           supported, but this value is also used as the image tag, so avoid using 'latest'.
-    secrets:
-      BUILD_BOT_SLACK_WEBHOOK_URL_RELEASES:
-        required: true
-      DOCKER_HUB_USERNAME:
-        required: true
-      DOCKER_HUB_TOKEN:
-        required: true
-      AWS_REGION:
-        required: true
 
 permissions:
   id-token: write # This is required for requesting the JWT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,11 +155,7 @@ jobs:
   publish-container-image:
     needs: release
     if: github.event.release.prerelease == false
-    uses: opticdev/optic/.github/workflows/release-container-image.yml@main
+    uses: .github/workflows/release-container-image.yml
     with:
       optic_version: ${{ needs.release.outputs.optic_version }}
-    secrets:
-      BUILD_BOT_SLACK_WEBHOOK_URL_RELEASES: ${{ secrets.BUILD_BOT_SLACK_WEBHOOK_URL_RELEASES }}
-      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-      DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
-      AWS_REGION: ${{ secrets.AWS_REGION }}
+    secrets: inherit


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

- updates the workflow call to use the newer ref-less syntax. i suspect it may be related to the issue here, https://github.com/opticdev/optic/actions/runs/3894406958/workflow.

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
