### PR TITLE
Fix commander variable mismatch.

### DIFF
--- a/projects/openapi-cli/src/commands/capture.ts
+++ b/projects/openapi-cli/src/commands/capture.ts
@@ -49,8 +49,8 @@ export async function captureCommand(): Promise<Command> {
       `output debug information (on stderr). Use LOG_LEVEL env with 'debug', 'info' to increase verbosity`
     )
     .option('-o, --output <output>', 'file name for output')
-    .action(async (filePath: string, targetUrl: string) => {
-      const [openApiExists, trafficDirectory] = await captureStorage(filePath);
+    .action(async (openapiFile: string, targetUrl: string) => {
+      const [openApiExists, trafficDirectory] = await captureStorage(openapiFile);
 
       if (!openApiExists) {
         return await feedback.inputError(


### PR DESCRIPTION
## 🍗 Description
I'm crashing when writing the captured requests to a file (on windows) and I think this might be the problem.

## 📚 References
Problem introduced in https://github.com/opticdev/optic/commit/dd009f9d7646337ef12164c5d0723cae09284746#diff-c7b311c15117fd2c9bbca870de4cc2a9425edf3aa2c5e28dbc7fc61175d6b1ae

## 👹 QA
_How can other humans verify that this PR is correct?_
Look at the mismatching variables. They should be the same.