### PR TITLE
Make infer paths more accurate

### DIFF
--- a/projects/openapi-cli/src/commands/verify.ts
+++ b/projects/openapi-cli/src/commands/verify.ts
@@ -215,7 +215,11 @@ async function renderOperationStatus(
     for (let unmatchedPath of pathsToAdd) {
       undocumentedPaths++;
       unmatchedPath.methods.forEach((method) =>
-        renderUndocumentedPath(method.toUpperCase(), unmatchedPath.pathPattern)
+        renderUndocumentedPath(
+          method.toUpperCase(),
+          unmatchedPath.pathPattern,
+          unmatchedPath.examplePath
+        )
       );
     }
     feedback.commandInstruction('--document all', 'to document these paths');
@@ -292,10 +296,17 @@ async function getInteractions(
   return AT.merge(...sources);
 }
 
-function renderUndocumentedPath(method: string, pathPattern: string) {
+function renderUndocumentedPath(
+  method: string,
+  pathPattern: string,
+  examplePath: string
+) {
   console.log(
     `${chalk.bgYellow('  Undocumented  ')} ${method
       .toUpperCase()
-      .padStart(6, ' ')}   ${pathPattern}`
+      .padStart(6, ' ')}   ${pathPattern}\n${''.padStart(
+      22, // undocumented + method length
+      ' '
+    )}${examplePath}`
   );
 }

--- a/projects/openapi-cli/src/operations/infer-path-structure.test.ts
+++ b/projects/openapi-cli/src/operations/infer-path-structure.test.ts
@@ -1,4 +1,4 @@
-import { it,  expect } from '@jest/globals';
+import { it, expect } from '@jest/globals';
 import {
   computeInferredOperations,
   InferPathStructure,
@@ -240,6 +240,47 @@ it('can multiple top level resources ', () => {
     {
       methods: ['get'],
       pathPattern: '/users/{user}/addresses/{address}',
+    },
+  ]);
+});
+
+it('can infer multiple top level resources under the an API path', () => {
+  const pathStructure = new InferPathStructure([
+    {
+      pathPattern: '/api',
+      methods: ['get'],
+    },
+  ]);
+
+  pathStructure.includeObservedUrlPath('get', '/api/orders/3/products');
+  pathStructure.includeObservedUrlPath('get', '/api/orders/3');
+  pathStructure.includeObservedUrlPath('get', '/api/orders/3/tracking');
+  pathStructure.includeObservedUrlPath(
+    'get',
+    '/api/users/m24-3343/addresses/1'
+  );
+  pathStructure.includeObservedUrlPath('get', '/api/users/n94-3343/addresses');
+  pathStructure.includeObservedUrlPath(
+    'get',
+    '/api/users/n94-3343/addresses/4'
+  );
+  pathStructure.includeObservedUrlPath('get', '/api/health-check');
+  pathStructure.includeObservedUrlPath('get', '/api/rates/10005');
+
+  pathStructure.replaceConstantsWithVariables();
+
+  const results = pathStructure.undocumentedPaths();
+
+  expect(results).toEqual([
+    { methods: ['get'], pathPattern: '/api/orders/{order}' },
+    { methods: ['get'], pathPattern: '/api/orders/{order}/products' },
+    { methods: ['get'], pathPattern: '/api/orders/{order}/tracking' },
+    { methods: ['get'], pathPattern: '/api/health-check' },
+    { methods: ['get'], pathPattern: '/api/rates/{rate}' },
+    { methods: ['get'], pathPattern: '/api/users/{user}/addresses' },
+    {
+      methods: ['get'],
+      pathPattern: '/api/users/{user}/addresses/{address}',
     },
   ]);
 });

--- a/projects/openapi-cli/src/operations/infer-path-structure.test.ts
+++ b/projects/openapi-cli/src/operations/infer-path-structure.test.ts
@@ -53,7 +53,7 @@ it('will learn entirely new paths', () => {
   pathStructure.includeObservedUrlPath('post', '/todos');
 
   expect(pathStructure.undocumentedPaths()).toEqual([
-    { methods: ['get', 'post'], pathPattern: '/todos' },
+    { methods: ['get', 'post'], pathPattern: '/todos', examplePath: '/todos' },
   ]);
 });
 
@@ -69,6 +69,7 @@ it('can expand the structure from new patterns with obvious variables', () => {
     {
       methods: ['get'],
       pathPattern: '/organizations/{organization}/repositories/{repository}',
+      examplePath: '/organizations/648/repositories/11221',
     },
   ]);
 });
@@ -92,10 +93,12 @@ it('can expand the structure from new patterns with hints in spec variables', ()
     {
       methods: ['get'],
       pathPattern: '/organizations/{organization}/members',
+      examplePath: '/organizations/opticdev/members',
     },
     {
       methods: ['get'],
       pathPattern: '/organizations/{organization}/members/{member}',
+      examplePath: '/organizations/opticdev/members/1',
     },
   ]);
 });
@@ -135,9 +138,14 @@ it('can reduce overlapping string constants to variables', () => {
 
   pathStructure.replaceConstantsWithVariables();
   expect(pathStructure.undocumentedPaths()).toEqual([
-    { methods: ['get'], pathPattern: '/organizations/{organization}' },
     {
       methods: ['get'],
+      pathPattern: '/organizations/{organization}',
+      examplePath: '/organizations/opticdev',
+    },
+    {
+      methods: ['get'],
+      examplePath: '/organizations/opticdev/repositories/optic',
       pathPattern: '/organizations/{organization}/repositories/{repository}',
     },
   ]);
@@ -155,7 +163,11 @@ it('respects verified components', () => {
 
   pathStructure.replaceConstantsWithVariables();
   expect(pathStructure.undocumentedPaths()).toEqual([
-    { methods: ['get'], pathPattern: '/users/{username}/events/private' },
+    {
+      methods: ['get'],
+      pathPattern: '/users/{username}/events/private',
+      examplePath: '/users/name-of-a-person/events/private',
+    },
   ]);
 });
 
@@ -176,9 +188,21 @@ it('can learn a variable component with constants after', () => {
 
   pathStructure.replaceConstantsWithVariables();
   expect(pathStructure.undocumentedPaths()).toEqual([
-    { methods: ['get'], pathPattern: '/users/{user}/events' },
-    { methods: ['get'], pathPattern: '/users/{user}/repos' },
-    { methods: ['get'], pathPattern: '/users/{user}/favorites' },
+    {
+      methods: ['get'],
+      pathPattern: '/users/{user}/events',
+      examplePath: '/users/name-of-a-person/events',
+    },
+    {
+      methods: ['get'],
+      pathPattern: '/users/{user}/repos',
+      examplePath: '/users/othername-of-thing/repos',
+    },
+    {
+      methods: ['get'],
+      pathPattern: '/users/{user}/favorites',
+      examplePath: '/users/othername-of-thing/favorites',
+    },
   ]);
 });
 
@@ -209,10 +233,26 @@ it('can learn a variable component with variables after', () => {
 
   pathStructure.replaceConstantsWithVariables();
   expect(pathStructure.undocumentedPaths()).toEqual([
-    { methods: ['get'], pathPattern: '/users/{user}/events' },
-    { methods: ['get'], pathPattern: '/users/{user}/repos' },
-    { methods: ['get'], pathPattern: '/users/{user}/favorites' },
-    { methods: ['get'], pathPattern: '/users/{user}/repos/{repo}' },
+    {
+      methods: ['get'],
+      pathPattern: '/users/{user}/events',
+      examplePath: '/users/name-of-a-person/events',
+    },
+    {
+      methods: ['get'],
+      pathPattern: '/users/{user}/repos',
+      examplePath: '/users/othername-of-thing/repos',
+    },
+    {
+      methods: ['get'],
+      pathPattern: '/users/{user}/favorites',
+      examplePath: '/users/othername-of-thing/favorites',
+    },
+    {
+      methods: ['get'],
+      pathPattern: '/users/{user}/repos/{repo}',
+      examplePath: '/users/othername-of-thing/repos/abc',
+    },
   ]);
 });
 
@@ -231,15 +271,40 @@ it('can multiple top level resources ', () => {
   pathStructure.replaceConstantsWithVariables();
 
   expect(pathStructure.undocumentedPaths()).toEqual([
-    { methods: ['get'], pathPattern: '/orders/{order}' },
-    { methods: ['get'], pathPattern: '/orders/{order}/products' },
-    { methods: ['get'], pathPattern: '/orders/{order}/tracking' },
-    { methods: ['get'], pathPattern: '/health-check' },
-    { methods: ['get'], pathPattern: '/rates/{rate}' },
-    { methods: ['get'], pathPattern: '/users/{user}/addresses' },
+    {
+      methods: ['get'],
+      pathPattern: '/orders/{order}',
+      examplePath: '/orders/3',
+    },
+    {
+      methods: ['get'],
+      pathPattern: '/orders/{order}/products',
+      examplePath: '/orders/3/products',
+    },
+    {
+      methods: ['get'],
+      pathPattern: '/orders/{order}/tracking',
+      examplePath: '/orders/3/tracking',
+    },
+    {
+      methods: ['get'],
+      pathPattern: '/health-check',
+      examplePath: '/health-check',
+    },
+    {
+      methods: ['get'],
+      pathPattern: '/rates/{rate}',
+      examplePath: '/rates/10005',
+    },
+    {
+      methods: ['get'],
+      pathPattern: '/users/{user}/addresses',
+      examplePath: '/users/m24-3343/addresses',
+    },
     {
       methods: ['get'],
       pathPattern: '/users/{user}/addresses/{address}',
+      examplePath: '/users/m24-3343/addresses/1',
     },
   ]);
 });
@@ -272,15 +337,40 @@ it('can infer multiple top level resources under the an API path', () => {
   const results = pathStructure.undocumentedPaths();
 
   expect(results).toEqual([
-    { methods: ['get'], pathPattern: '/api/orders/{order}' },
-    { methods: ['get'], pathPattern: '/api/orders/{order}/products' },
-    { methods: ['get'], pathPattern: '/api/orders/{order}/tracking' },
-    { methods: ['get'], pathPattern: '/api/health-check' },
-    { methods: ['get'], pathPattern: '/api/rates/{rate}' },
-    { methods: ['get'], pathPattern: '/api/users/{user}/addresses' },
+    {
+      methods: ['get'],
+      pathPattern: '/api/orders/{order}',
+      examplePath: '/api/orders/3',
+    },
+    {
+      methods: ['get'],
+      pathPattern: '/api/orders/{order}/products',
+      examplePath: '/api/orders/3/products',
+    },
+    {
+      methods: ['get'],
+      pathPattern: '/api/orders/{order}/tracking',
+      examplePath: '/api/orders/3/tracking',
+    },
+    {
+      methods: ['get'],
+      pathPattern: '/api/health-check',
+      examplePath: '/api/health-check',
+    },
+    {
+      methods: ['get'],
+      pathPattern: '/api/rates/{rate}',
+      examplePath: '/api/rates/10005',
+    },
+    {
+      methods: ['get'],
+      examplePath: '/api/users/m24-3343/addresses',
+      pathPattern: '/api/users/{user}/addresses',
+    },
     {
       methods: ['get'],
       pathPattern: '/api/users/{user}/addresses/{address}',
+      examplePath: '/api/users/m24-3343/addresses/1',
     },
   ]);
 });
@@ -305,10 +395,11 @@ it('works with async captured interactions', async () => {
   );
 
   expect(operationsToAdd).toEqual([
-    { methods: ['get'], pathPattern: '/orders' },
+    { methods: ['get'], pathPattern: '/orders', examplePath: '/orders' },
     {
       methods: ['post', 'patch'],
       pathPattern: '/orders/{order}/products',
+      examplePath: '/orders/3/products',
     },
   ]);
 });

--- a/projects/openapi-cli/src/operations/infer-path-structure.ts
+++ b/projects/openapi-cli/src/operations/infer-path-structure.ts
@@ -162,6 +162,7 @@ export class InferPathStructure {
           if (
             children.length > 0 &&
             children[0].parent !== null &&
+            !parentIsNeverResource(children[0].parent.name) &&
             !sharedVariableParent
           ) {
             // incorporate verified from spec
@@ -401,9 +402,26 @@ function stripParamBrackets(input: string): string {
   return input.substring(1, input.length - 1);
 }
 
+const reservedPatterns = [
+  /api/,
+  /v[0-9]+/,
+  /v[0-9]+/,
+  /[0-9]+\.[0-9]+/,
+  /20[0-9][0-9]-[0-9][0-9]-[0-9][0-9]/,
+];
+
+function parentIsNeverResource(parent: string): boolean {
+  return reservedPatterns.some((pattern) => pattern.test(parent));
+}
+
 function looksLikeAVariable(stringValue: string): boolean {
-  // any number is a variable
-  if (!isNaN(Number(stringValue))) return true;
+  if (reservedPatterns.some((pattern) => pattern.test(stringValue)))
+    return false;
+
+  if (stringValue)
+    if (!isNaN(Number(stringValue)))
+      // any number is a variable
+      return true;
   // any uuid is a variable
   if (
     /^[0-9A-F]{8}-[0-9A-F]{4}-[4][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i.test(

--- a/projects/openapi-cli/src/specs/patches/generators/missing-path.ts
+++ b/projects/openapi-cli/src/specs/patches/generators/missing-path.ts
@@ -41,6 +41,9 @@ export function* missingPathPatches(
               in: 'path',
               name: parameterName,
               required: true,
+              schema: {
+                type: 'string',
+              },
             };
           }
         ),


### PR DESCRIPTION
## 🍗 Description
Two big improvements within: 

1.  When documenting an API you don't know, sometimes you can't tell if the inference is right. Now Optic prints an example path right underneath the inferred pattern. Hopefully if you see it and it looks screwy you know before you realize before you add it to the openapi. Once you add the weird cases by hand the inference gets really good
2. We were getting a lot of weird learnings where certain obvious keywords were being learned as resource names. Like `api` `v2` etc. The logic is going to end up being a ton of heuristics no matter what we do -- inference is never clean. Now there are checks that certain keywords or patterns do not become resource names in the tree 

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
