### PR TITLE
Expose matches & docslink in examples ruleset

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.36.3",
+  "version": "0.36.4",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
-  "version": "0.36.3",
+  "version": "0.36.4",
   "packageManager": "yarn@3.3.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-cli",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.36.3",
+  "version": "0.36.4",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [

--- a/projects/openapi-cli/src/captures/system-proxy.ts
+++ b/projects/openapi-cli/src/captures/system-proxy.ts
@@ -44,6 +44,9 @@ export class SystemProxy {
         this.feedback.notable(`Mac System Proxy settings cleared`);
       };
     } else {
+      this.feedback.notable(
+        `Proxy running on ${this.proxyUrl}. System proxy updated`
+      );
       console.log(
         `automatic proxy configuration is not supported on ${platform}`
       );

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-io",
   "license": "MIT",
-  "version": "0.36.3",
+  "version": "0.36.4",
   "packageManager": "yarn@3.3.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
-  "version": "0.36.3",
+  "version": "0.36.4",
   "packageManager": "yarn@3.3.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.36.3",
+  "version": "0.36.4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.36.3",
+  "version": "0.36.4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.36.3",
+  "version": "0.36.4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.36.3",
+  "version": "0.36.4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/src/examples/index.ts
+++ b/projects/standard-rulesets/src/examples/index.ts
@@ -1,4 +1,4 @@
-import { Rule, Ruleset } from '@useoptic/rulesets-base';
+import { Rule, RuleContext, Ruleset } from '@useoptic/rulesets-base';
 import Ajv from 'ajv';
 import { appliesWhen } from './constants';
 import {
@@ -60,7 +60,12 @@ export class ExamplesRuleset extends Ruleset {
     return new ExamplesRuleset(validatedConfig);
   }
 
-  constructor(config: YamlConfig = {}) {
+  constructor(
+    config: YamlConfig & {
+      matches?: (context: RuleContext) => boolean;
+      docsLink?: string;
+    }
+  ) {
     const rules: Rule[] = [
       requireValidResponseExamples,
       requirePropertyExamplesMatchSchema,
@@ -81,6 +86,8 @@ export class ExamplesRuleset extends Ruleset {
       ...config,
       name: 'Examples ruleset',
       rules: rules,
+      matches: config.matches,
+      docsLink: config.docsLink,
     });
   }
 }


### PR DESCRIPTION
## 🍗 Description
A team using the example ruleset noticed you cannot match it to specific parts of your spec like the other rulesets. They use an `x-legacy` extensions to exempt certain parts of their OpenAPI specs from rules and asked this functionality to be exposed

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
