### PR TITLE
Update JSON changelog to handle new results format

### DIFF
--- a/projects/openapi-utilities/src/diff/diff.ts
+++ b/projects/openapi-utilities/src/diff/diff.ts
@@ -49,10 +49,12 @@ type StackItem<T extends JSONObject | JSONArray = JSONObject | JSONArray> = [
   }
 ];
 
-export function typeofDiff(diff: ObjectDiff): 'added' | 'changed' | 'removed' {
-  return diff.after && diff.before
+export function typeofDiff(
+  diff: Omit<ObjectDiff, 'pathReconciliation'>
+): 'added' | 'changed' | 'removed' {
+  return diff.after !== undefined && diff.before !== undefined
     ? 'changed'
-    : diff.after
+    : diff.after !== undefined
     ? 'added'
     : 'removed';
 }

--- a/projects/openapi-utilities/src/openapi3/group-diff.ts
+++ b/projects/openapi-utilities/src/openapi3/group-diff.ts
@@ -14,24 +14,35 @@ function constructTree(spec: OpenAPIV3.Document) {
   return constructFactTree([...traverser.facts()]);
 }
 
-type Diff = {
+export type Diff = {
   trail: string; // The relative path from the diff to the significant node
   change: 'added' | 'changed' | 'removed';
-  before?: string;
-  after?: string;
-};
+} & (
+  | {
+      before?: undefined;
+      after: string;
+    }
+  | {
+      before: string;
+      after: string;
+    }
+  | {
+      before: string;
+      after?: undefined;
+    }
+);
 
-type Body = {
+export type Body = {
   diffs: Diff[];
 };
 
-type Response = {
+export type Response = {
   diffs: Diff[];
   headers: Diff[];
   contents: Record<string, Body>;
 };
 
-type Endpoint = {
+export type Endpoint = {
   diffs: Diff[];
   queryParameters: Diff[];
   pathParameters: Diff[];
@@ -44,7 +55,7 @@ type Endpoint = {
   responses: Record<string, Response>;
 };
 
-class GroupedDiffs {
+export class GroupedDiffs {
   public specification: Diff[];
   public paths: Record<
     string,

--- a/projects/openapi-utilities/src/utilities/__tests__/__snapshots__/json-changelog.test.ts.snap
+++ b/projects/openapi-utilities/src/utilities/__tests__/__snapshots__/json-changelog.test.ts.snap
@@ -6,9 +6,1828 @@ exports[`json changelog collects changes properly: jsonChangelog 1`] = `
     {
       "attributes": [
         {
+          "after": {
+            "description": "Multiple status values can be provided with comma separated strings",
+            "operationId": "findPetsByStatus",
+            "parameters": [
+              {
+                "description": "Status values that need to be considered for filter",
+                "explode": true,
+                "in": "query",
+                "name": "status",
+                "required": true,
+                "schema": {
+                  "items": {
+                    "default": "available",
+                    "enum": [
+                      "available",
+                      "pending",
+                      "sold",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                "style": "form",
+              },
+              {
+                "description": "A debug token",
+                "in": "cookie",
+                "name": "debug",
+                "required": false,
+                "schema": {
+                  "enum": [
+                    0,
+                    1,
+                  ],
+                  "type": "integer",
+                },
+              },
+            ],
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "items": {
+                        "properties": {
+                          "category": {
+                            "properties": {
+                              "id": {
+                                "format": "int64",
+                                "type": "integer",
+                              },
+                              "name": {
+                                "type": "string",
+                              },
+                            },
+                            "type": "object",
+                            "xml": {
+                              "name": "Category",
+                            },
+                          },
+                          "id": {
+                            "format": "int64",
+                            "type": "integer",
+                          },
+                          "name": {
+                            "example": "doggie",
+                            "type": "string",
+                          },
+                          "photoUrls": {
+                            "items": {
+                              "type": "string",
+                            },
+                            "type": "array",
+                            "xml": {
+                              "name": "photoUrl",
+                              "wrapped": true,
+                            },
+                          },
+                          "status": {
+                            "description": "pet status in the store",
+                            "enum": [
+                              "available",
+                              "pending",
+                              "sold",
+                            ],
+                            "type": "string",
+                          },
+                          "tags": {
+                            "items": {
+                              "properties": {
+                                "id": {
+                                  "format": "int64",
+                                  "type": "integer",
+                                },
+                                "name": {
+                                  "type": "string",
+                                },
+                              },
+                              "type": "object",
+                              "xml": {
+                                "name": "Tag",
+                              },
+                            },
+                            "type": "array",
+                            "xml": {
+                              "name": "tag",
+                              "wrapped": true,
+                            },
+                          },
+                        },
+                        "required": [
+                          "name",
+                          "photoUrls",
+                        ],
+                        "type": "object",
+                        "xml": {
+                          "name": "Pet",
+                        },
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "application/xml": {
+                    "schema": {
+                      "items": {
+                        "properties": {
+                          "category": {
+                            "properties": {
+                              "id": {
+                                "format": "int64",
+                                "type": "integer",
+                              },
+                              "name": {
+                                "type": "string",
+                              },
+                            },
+                            "type": "object",
+                            "xml": {
+                              "name": "Category",
+                            },
+                          },
+                          "id": {
+                            "format": "int64",
+                            "type": "integer",
+                          },
+                          "name": {
+                            "example": "doggie",
+                            "type": "string",
+                          },
+                          "photoUrls": {
+                            "items": {
+                              "type": "string",
+                            },
+                            "type": "array",
+                            "xml": {
+                              "name": "photoUrl",
+                              "wrapped": true,
+                            },
+                          },
+                          "status": {
+                            "description": "pet status in the store",
+                            "enum": [
+                              "available",
+                              "pending",
+                              "sold",
+                            ],
+                            "type": "string",
+                          },
+                          "tags": {
+                            "items": {
+                              "properties": {
+                                "id": {
+                                  "format": "int64",
+                                  "type": "integer",
+                                },
+                                "name": {
+                                  "type": "string",
+                                },
+                              },
+                              "type": "object",
+                              "xml": {
+                                "name": "Tag",
+                              },
+                            },
+                            "type": "array",
+                            "xml": {
+                              "name": "tag",
+                              "wrapped": true,
+                            },
+                          },
+                        },
+                        "required": [
+                          "name",
+                          "photoUrls",
+                        ],
+                        "type": "object",
+                        "xml": {
+                          "name": "Pet",
+                        },
+                      },
+                      "type": "array",
+                    },
+                  },
+                },
+                "description": "successful operation",
+              },
+              "400": {
+                "content": {},
+                "description": "Invalid status value",
+              },
+            },
+            "security": [
+              {
+                "petstore_auth": [
+                  "write:pets",
+                  "read:pets",
+                ],
+              },
+            ],
+            "summary": "Finds Pets by status",
+            "tags": [
+              "pet",
+            ],
+          },
+          "before": undefined,
+          "key": "",
+        },
+      ],
+      "change": "added",
+      "name": "get /pet/findByStatus",
+      "parameters": [],
+      "requestBody": undefined,
+      "responses": [],
+    },
+    {
+      "attributes": [
+        {
+          "after": {
+            "deprecated": true,
+            "description": "Muliple tags can be provided with comma separated strings. Use         tag1, tag2, tag3 for testing.",
+            "operationId": "findPetsByTags",
+            "parameters": [
+              {
+                "description": "Tags to filter by",
+                "explode": true,
+                "in": "query",
+                "name": "tags",
+                "required": true,
+                "schema": {
+                  "items": {
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                "style": "form",
+              },
+            ],
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "items": {
+                        "properties": {
+                          "category": {
+                            "properties": {
+                              "id": {
+                                "format": "int64",
+                                "type": "integer",
+                              },
+                              "name": {
+                                "type": "string",
+                              },
+                            },
+                            "type": "object",
+                            "xml": {
+                              "name": "Category",
+                            },
+                          },
+                          "id": {
+                            "format": "int64",
+                            "type": "integer",
+                          },
+                          "name": {
+                            "example": "doggie",
+                            "type": "string",
+                          },
+                          "photoUrls": {
+                            "items": {
+                              "type": "string",
+                            },
+                            "type": "array",
+                            "xml": {
+                              "name": "photoUrl",
+                              "wrapped": true,
+                            },
+                          },
+                          "status": {
+                            "description": "pet status in the store",
+                            "enum": [
+                              "available",
+                              "pending",
+                              "sold",
+                            ],
+                            "type": "string",
+                          },
+                          "tags": {
+                            "items": {
+                              "properties": {
+                                "id": {
+                                  "format": "int64",
+                                  "type": "integer",
+                                },
+                                "name": {
+                                  "type": "string",
+                                },
+                              },
+                              "type": "object",
+                              "xml": {
+                                "name": "Tag",
+                              },
+                            },
+                            "type": "array",
+                            "xml": {
+                              "name": "tag",
+                              "wrapped": true,
+                            },
+                          },
+                        },
+                        "required": [
+                          "name",
+                          "photoUrls",
+                        ],
+                        "type": "object",
+                        "xml": {
+                          "name": "Pet",
+                        },
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "application/xml": {
+                    "schema": {
+                      "items": {
+                        "properties": {
+                          "category": {
+                            "properties": {
+                              "id": {
+                                "format": "int64",
+                                "type": "integer",
+                              },
+                              "name": {
+                                "type": "string",
+                              },
+                            },
+                            "type": "object",
+                            "xml": {
+                              "name": "Category",
+                            },
+                          },
+                          "id": {
+                            "format": "int64",
+                            "type": "integer",
+                          },
+                          "name": {
+                            "example": "doggie",
+                            "type": "string",
+                          },
+                          "photoUrls": {
+                            "items": {
+                              "type": "string",
+                            },
+                            "type": "array",
+                            "xml": {
+                              "name": "photoUrl",
+                              "wrapped": true,
+                            },
+                          },
+                          "status": {
+                            "description": "pet status in the store",
+                            "enum": [
+                              "available",
+                              "pending",
+                              "sold",
+                            ],
+                            "type": "string",
+                          },
+                          "tags": {
+                            "items": {
+                              "properties": {
+                                "id": {
+                                  "format": "int64",
+                                  "type": "integer",
+                                },
+                                "name": {
+                                  "type": "string",
+                                },
+                              },
+                              "type": "object",
+                              "xml": {
+                                "name": "Tag",
+                              },
+                            },
+                            "type": "array",
+                            "xml": {
+                              "name": "tag",
+                              "wrapped": true,
+                            },
+                          },
+                        },
+                        "required": [
+                          "name",
+                          "photoUrls",
+                        ],
+                        "type": "object",
+                        "xml": {
+                          "name": "Pet",
+                        },
+                      },
+                      "type": "array",
+                    },
+                  },
+                },
+                "description": "successful operation",
+              },
+              "400": {
+                "content": {},
+                "description": "Invalid tag value",
+              },
+            },
+            "security": [
+              {
+                "petstore_auth": [
+                  "write:pets",
+                  "read:pets",
+                ],
+              },
+            ],
+            "summary": "Finds Pets by tags",
+            "tags": [
+              "pet",
+            ],
+          },
+          "before": undefined,
+          "key": "",
+        },
+      ],
+      "change": "added",
+      "name": "get /pet/findByTags",
+      "parameters": [],
+      "requestBody": undefined,
+      "responses": [],
+    },
+    {
+      "attributes": [
+        {
+          "after": {
+            "description": "Returns a single pet",
+            "operationId": "getPetById",
+            "parameters": [
+              {
+                "description": "ID of pet to return",
+                "in": "path",
+                "name": "petId",
+                "required": true,
+                "schema": {
+                  "format": "int64",
+                  "type": "integer",
+                },
+              },
+            ],
+            "responses": {
+              "200": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "properties": {
+                        "category": {
+                          "properties": {
+                            "id": {
+                              "format": "int64",
+                              "type": "integer",
+                            },
+                            "name": {
+                              "type": "string",
+                            },
+                          },
+                          "type": "object",
+                          "xml": {
+                            "name": "Category",
+                          },
+                        },
+                        "id": {
+                          "format": "int64",
+                          "type": "integer",
+                        },
+                        "name": {
+                          "example": "doggie",
+                          "type": "string",
+                        },
+                        "photoUrls": {
+                          "items": {
+                            "type": "string",
+                          },
+                          "type": "array",
+                          "xml": {
+                            "name": "photoUrl",
+                            "wrapped": true,
+                          },
+                        },
+                        "status": {
+                          "description": "pet status in the store",
+                          "enum": [
+                            "available",
+                            "pending",
+                            "sold",
+                          ],
+                          "type": "string",
+                        },
+                        "tags": {
+                          "items": {
+                            "properties": {
+                              "id": {
+                                "format": "int64",
+                                "type": "integer",
+                              },
+                              "name": {
+                                "type": "string",
+                              },
+                            },
+                            "type": "object",
+                            "xml": {
+                              "name": "Tag",
+                            },
+                          },
+                          "type": "array",
+                          "xml": {
+                            "name": "tag",
+                            "wrapped": true,
+                          },
+                        },
+                      },
+                      "required": [
+                        "name",
+                        "photoUrls",
+                      ],
+                      "type": "object",
+                      "xml": {
+                        "name": "Pet",
+                      },
+                    },
+                  },
+                  "application/xml": {
+                    "schema": {
+                      "properties": {
+                        "category": {
+                          "properties": {
+                            "id": {
+                              "format": "int64",
+                              "type": "integer",
+                            },
+                            "name": {
+                              "type": "string",
+                            },
+                          },
+                          "type": "object",
+                          "xml": {
+                            "name": "Category",
+                          },
+                        },
+                        "id": {
+                          "format": "int64",
+                          "type": "integer",
+                        },
+                        "name": {
+                          "example": "doggie",
+                          "type": "string",
+                        },
+                        "photoUrls": {
+                          "items": {
+                            "type": "string",
+                          },
+                          "type": "array",
+                          "xml": {
+                            "name": "photoUrl",
+                            "wrapped": true,
+                          },
+                        },
+                        "status": {
+                          "description": "pet status in the store",
+                          "enum": [
+                            "available",
+                            "pending",
+                            "sold",
+                          ],
+                          "type": "string",
+                        },
+                        "tags": {
+                          "items": {
+                            "properties": {
+                              "id": {
+                                "format": "int64",
+                                "type": "integer",
+                              },
+                              "name": {
+                                "type": "string",
+                              },
+                            },
+                            "type": "object",
+                            "xml": {
+                              "name": "Tag",
+                            },
+                          },
+                          "type": "array",
+                          "xml": {
+                            "name": "tag",
+                            "wrapped": true,
+                          },
+                        },
+                      },
+                      "required": [
+                        "name",
+                        "photoUrls",
+                      ],
+                      "type": "object",
+                      "xml": {
+                        "name": "Pet",
+                      },
+                    },
+                  },
+                },
+                "description": "successful operation",
+              },
+              "400": {
+                "content": {},
+                "description": "Invalid ID supplied",
+              },
+              "404": {
+                "content": {},
+                "description": "Pet not found",
+              },
+            },
+            "security": [
+              {
+                "api_key": [],
+              },
+            ],
+            "summary": "Find pet by ID",
+            "tags": [
+              "pet",
+            ],
+          },
+          "before": undefined,
+          "key": "",
+        },
+      ],
+      "change": "added",
+      "name": "get /pet/{petId}",
+      "parameters": [],
+      "requestBody": undefined,
+      "responses": [],
+    },
+    {
+      "attributes": [
+        {
+          "after": {
+            "operationId": "updatePetWithForm",
+            "parameters": [
+              {
+                "description": "ID of pet that needs to be updated",
+                "in": "path",
+                "name": "petId",
+                "required": true,
+                "schema": {
+                  "format": "int64",
+                  "type": "integer",
+                },
+              },
+            ],
+            "requestBody": {
+              "content": {
+                "application/x-www-form-urlencoded": {
+                  "examples": {
+                    "available": {
+                      "name": "new name",
+                      "status": "available",
+                    },
+                    "sold": {
+                      "name": "good boy",
+                      "status": "sold",
+                    },
+                  },
+                  "schema": {
+                    "properties": {
+                      "name": {
+                        "description": "Updated name of the pet",
+                        "type": "string",
+                      },
+                      "status": {
+                        "description": "Updated status of the pet",
+                        "type": "string",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            "responses": {
+              "405": {
+                "content": {},
+                "description": "Invalid input",
+              },
+            },
+            "security": [
+              {
+                "petstore_auth": [
+                  "write:pets",
+                  "read:pets",
+                ],
+              },
+            ],
+            "summary": "Updates a pet in the store with form data",
+            "tags": [
+              "pet",
+            ],
+          },
+          "before": undefined,
+          "key": "",
+        },
+      ],
+      "change": "added",
+      "name": "post /pet/{petId}",
+      "parameters": [],
+      "requestBody": undefined,
+      "responses": [],
+    },
+    {
+      "attributes": [
+        {
+          "after": {
+            "operationId": "deletePet",
+            "parameters": [
+              {
+                "in": "header",
+                "name": "api_key",
+                "schema": {
+                  "type": "string",
+                },
+              },
+              {
+                "description": "Pet id to delete",
+                "in": "path",
+                "name": "petId",
+                "required": true,
+                "schema": {
+                  "format": "int64",
+                  "type": "integer",
+                },
+              },
+            ],
+            "responses": {
+              "400": {
+                "content": {},
+                "description": "Invalid ID supplied",
+              },
+              "404": {
+                "content": {},
+                "description": "Pet not found",
+              },
+            },
+            "security": [
+              {
+                "petstore_auth": [
+                  "write:pets",
+                  "read:pets",
+                ],
+              },
+            ],
+            "summary": "Deletes a pet",
+            "tags": [
+              "pet",
+            ],
+          },
+          "before": undefined,
+          "key": "",
+        },
+      ],
+      "change": "added",
+      "name": "delete /pet/{petId}",
+      "parameters": [],
+      "requestBody": undefined,
+      "responses": [],
+    },
+    {
+      "attributes": [],
+      "change": null,
+      "name": "put /user/{username}",
+      "parameters": [],
+      "requestBody": {
+        "attributes": [],
+        "change": null,
+        "contentTypes": [
+          {
+            "attributes": [
+              {
+                "after": undefined,
+                "before": {
+                  "type": "string",
+                },
+                "key": "/schema/properties/phone",
+              },
+              {
+                "after": {
+                  "type": "string",
+                },
+                "before": undefined,
+                "key": "/schema/properties/bio",
+              },
+              {
+                "after": "string",
+                "before": "integer",
+                "key": "/schema/properties/userStatus/type",
+              },
+              {
+                "after": undefined,
+                "before": "int32",
+                "key": "/schema/properties/userStatus/format",
+              },
+              {
+                "after": [
+                  "activation-pending",
+                  "activated",
+                  "blocked",
+                ],
+                "before": undefined,
+                "key": "/schema/properties/userStatus/enum",
+              },
+              {
+                "after": undefined,
+                "before": "lastName",
+                "key": "/schema/required/2",
+              },
+              {
+                "after": "username",
+                "before": undefined,
+                "key": "/schema/required/2",
+              },
+            ],
+            "change": "changed",
+            "name": "*/*",
+          },
+        ],
+        "name": "Request Body",
+      },
+      "responses": [],
+    },
+    {
+      "attributes": [],
+      "change": null,
+      "name": "get /user/{username}",
+      "parameters": [],
+      "requestBody": undefined,
+      "responses": [
+        {
+          "attributes": [],
+          "change": null,
+          "contentTypes": [
+            {
+              "attributes": [
+                {
+                  "after": undefined,
+                  "before": {
+                    "type": "string",
+                  },
+                  "key": "/schema/properties/phone",
+                },
+                {
+                  "after": {
+                    "type": "string",
+                  },
+                  "before": undefined,
+                  "key": "/schema/properties/bio",
+                },
+                {
+                  "after": "string",
+                  "before": "integer",
+                  "key": "/schema/properties/userStatus/type",
+                },
+                {
+                  "after": undefined,
+                  "before": "int32",
+                  "key": "/schema/properties/userStatus/format",
+                },
+                {
+                  "after": [
+                    "activation-pending",
+                    "activated",
+                    "blocked",
+                  ],
+                  "before": undefined,
+                  "key": "/schema/properties/userStatus/enum",
+                },
+                {
+                  "after": undefined,
+                  "before": "lastName",
+                  "key": "/schema/required/2",
+                },
+                {
+                  "after": "username",
+                  "before": undefined,
+                  "key": "/schema/required/2",
+                },
+              ],
+              "change": "changed",
+              "name": "application/json",
+            },
+            {
+              "attributes": [
+                {
+                  "after": undefined,
+                  "before": {
+                    "type": "string",
+                  },
+                  "key": "/schema/properties/phone",
+                },
+                {
+                  "after": {
+                    "type": "string",
+                  },
+                  "before": undefined,
+                  "key": "/schema/properties/bio",
+                },
+                {
+                  "after": "string",
+                  "before": "integer",
+                  "key": "/schema/properties/userStatus/type",
+                },
+                {
+                  "after": undefined,
+                  "before": "int32",
+                  "key": "/schema/properties/userStatus/format",
+                },
+                {
+                  "after": [
+                    "activation-pending",
+                    "activated",
+                    "blocked",
+                  ],
+                  "before": undefined,
+                  "key": "/schema/properties/userStatus/enum",
+                },
+                {
+                  "after": undefined,
+                  "before": "lastName",
+                  "key": "/schema/required/2",
+                },
+                {
+                  "after": "username",
+                  "before": undefined,
+                  "key": "/schema/required/2",
+                },
+              ],
+              "change": "changed",
+              "name": "application/xml",
+            },
+          ],
+          "name": "200 response",
+        },
+        {
+          "attributes": [],
+          "change": null,
+          "contentTypes": [
+            {
+              "attributes": [
+                {
+                  "after": {
+                    "schema": {
+                      "properties": {
+                        "code": {
+                          "format": "int32",
+                          "type": "integer",
+                        },
+                        "message": {
+                          "type": "string",
+                        },
+                        "type": {
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                  },
+                  "before": undefined,
+                  "key": "",
+                },
+              ],
+              "change": "added",
+              "name": "application/json",
+            },
+          ],
+          "name": "404 response",
+        },
+      ],
+    },
+    {
+      "attributes": [],
+      "change": null,
+      "name": "get /user/login",
+      "parameters": [],
+      "requestBody": undefined,
+      "responses": [
+        {
+          "attributes": [],
+          "change": null,
+          "contentTypes": [],
+          "name": "200 response",
+        },
+      ],
+    },
+    {
+      "attributes": [],
+      "change": null,
+      "name": "post /user/createWithList",
+      "parameters": [],
+      "requestBody": {
+        "attributes": [],
+        "change": null,
+        "contentTypes": [
+          {
+            "attributes": [
+              {
+                "after": undefined,
+                "before": {
+                  "type": "string",
+                },
+                "key": "/schema/items/properties/phone",
+              },
+              {
+                "after": {
+                  "type": "string",
+                },
+                "before": undefined,
+                "key": "/schema/items/properties/bio",
+              },
+              {
+                "after": "string",
+                "before": "integer",
+                "key": "/schema/items/properties/userStatus/type",
+              },
+              {
+                "after": undefined,
+                "before": "int32",
+                "key": "/schema/items/properties/userStatus/format",
+              },
+              {
+                "after": [
+                  "activation-pending",
+                  "activated",
+                  "blocked",
+                ],
+                "before": undefined,
+                "key": "/schema/items/properties/userStatus/enum",
+              },
+              {
+                "after": undefined,
+                "before": "lastName",
+                "key": "/schema/items/required/2",
+              },
+              {
+                "after": "username",
+                "before": undefined,
+                "key": "/schema/items/required/2",
+              },
+            ],
+            "change": "changed",
+            "name": "*/*",
+          },
+        ],
+        "name": "Request Body",
+      },
+      "responses": [],
+    },
+    {
+      "attributes": [],
+      "change": null,
+      "name": "post /user/createWithArray",
+      "parameters": [],
+      "requestBody": {
+        "attributes": [],
+        "change": null,
+        "contentTypes": [
+          {
+            "attributes": [
+              {
+                "after": undefined,
+                "before": {
+                  "type": "string",
+                },
+                "key": "/schema/items/properties/phone",
+              },
+              {
+                "after": {
+                  "type": "string",
+                },
+                "before": undefined,
+                "key": "/schema/items/properties/bio",
+              },
+              {
+                "after": "string",
+                "before": "integer",
+                "key": "/schema/items/properties/userStatus/type",
+              },
+              {
+                "after": undefined,
+                "before": "int32",
+                "key": "/schema/items/properties/userStatus/format",
+              },
+              {
+                "after": [
+                  "activation-pending",
+                  "activated",
+                  "blocked",
+                ],
+                "before": undefined,
+                "key": "/schema/items/properties/userStatus/enum",
+              },
+              {
+                "after": undefined,
+                "before": "lastName",
+                "key": "/schema/items/required/2",
+              },
+              {
+                "after": "username",
+                "before": undefined,
+                "key": "/schema/items/required/2",
+              },
+            ],
+            "change": "changed",
+            "name": "*/*",
+          },
+        ],
+        "name": "Request Body",
+      },
+      "responses": [],
+    },
+    {
+      "attributes": [],
+      "change": null,
+      "name": "post /user",
+      "parameters": [],
+      "requestBody": {
+        "attributes": [],
+        "change": null,
+        "contentTypes": [
+          {
+            "attributes": [
+              {
+                "after": undefined,
+                "before": {
+                  "type": "string",
+                },
+                "key": "/schema/properties/phone",
+              },
+              {
+                "after": {
+                  "type": "string",
+                },
+                "before": undefined,
+                "key": "/schema/properties/bio",
+              },
+              {
+                "after": "string",
+                "before": "integer",
+                "key": "/schema/properties/userStatus/type",
+              },
+              {
+                "after": undefined,
+                "before": "int32",
+                "key": "/schema/properties/userStatus/format",
+              },
+              {
+                "after": [
+                  "activation-pending",
+                  "activated",
+                  "blocked",
+                ],
+                "before": undefined,
+                "key": "/schema/properties/userStatus/enum",
+              },
+              {
+                "after": undefined,
+                "before": "lastName",
+                "key": "/schema/required/2",
+              },
+              {
+                "after": "username",
+                "before": undefined,
+                "key": "/schema/required/2",
+              },
+            ],
+            "change": "changed",
+            "name": "*/*",
+          },
+        ],
+        "name": "Request Body",
+      },
+      "responses": [],
+    },
+    {
+      "attributes": [],
+      "change": null,
+      "name": "delete /store/order/{orderId}",
+      "parameters": [],
+      "requestBody": undefined,
+      "responses": [
+        {
+          "attributes": [],
+          "change": null,
+          "contentTypes": [
+            {
+              "attributes": [
+                {
+                  "after": {
+                    "schema": {
+                      "properties": {
+                        "code": {
+                          "format": "int32",
+                          "type": "integer",
+                        },
+                        "message": {
+                          "type": "string",
+                        },
+                        "type": {
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                  },
+                  "before": undefined,
+                  "key": "",
+                },
+              ],
+              "change": "added",
+              "name": "application/json",
+            },
+          ],
+          "name": "404 response",
+        },
+      ],
+    },
+    {
+      "attributes": [],
+      "change": null,
+      "name": "get /store/order/{orderId}",
+      "parameters": [],
+      "requestBody": undefined,
+      "responses": [
+        {
+          "attributes": [],
+          "change": null,
+          "contentTypes": [
+            {
+              "attributes": [
+                {
+                  "after": {
+                    "description": "Human readable summary of order",
+                    "type": "string",
+                  },
+                  "before": undefined,
+                  "key": "/schema/properties/summary",
+                },
+                {
+                  "after": undefined,
+                  "before": "approved",
+                  "key": "/schema/properties/status/enum/1",
+                },
+                {
+                  "after": "canceled",
+                  "before": undefined,
+                  "key": "/schema/properties/status/enum/2",
+                },
+              ],
+              "change": "changed",
+              "name": "application/json",
+            },
+            {
+              "attributes": [
+                {
+                  "after": {
+                    "description": "Human readable summary of order",
+                    "type": "string",
+                  },
+                  "before": undefined,
+                  "key": "/schema/properties/summary",
+                },
+                {
+                  "after": undefined,
+                  "before": "approved",
+                  "key": "/schema/properties/status/enum/1",
+                },
+                {
+                  "after": "canceled",
+                  "before": undefined,
+                  "key": "/schema/properties/status/enum/2",
+                },
+                {
+                  "after": undefined,
+                  "before": "petId",
+                  "key": "/schema/required/1",
+                },
+              ],
+              "change": "changed",
+              "name": "application/xml",
+            },
+          ],
+          "name": "200 response",
+        },
+        {
+          "attributes": [],
+          "change": null,
+          "contentTypes": [
+            {
+              "attributes": [
+                {
+                  "after": {
+                    "schema": {
+                      "properties": {
+                        "code": {
+                          "format": "int32",
+                          "type": "integer",
+                        },
+                        "message": {
+                          "type": "string",
+                        },
+                        "type": {
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                  },
+                  "before": undefined,
+                  "key": "",
+                },
+              ],
+              "change": "added",
+              "name": "application/json",
+            },
+          ],
+          "name": "404 response",
+        },
+      ],
+    },
+    {
+      "attributes": [],
+      "change": null,
+      "name": "post /store/order",
+      "parameters": [],
+      "requestBody": {
+        "attributes": [],
+        "change": null,
+        "contentTypes": [
+          {
+            "attributes": [
+              {
+                "after": {
+                  "description": "Human readable summary of order",
+                  "type": "string",
+                },
+                "before": undefined,
+                "key": "/schema/properties/summary",
+              },
+              {
+                "after": undefined,
+                "before": "approved",
+                "key": "/schema/properties/status/enum/1",
+              },
+              {
+                "after": "canceled",
+                "before": undefined,
+                "key": "/schema/properties/status/enum/2",
+              },
+            ],
+            "change": "changed",
+            "name": "*/*",
+          },
+        ],
+        "name": "Request Body",
+      },
+      "responses": [
+        {
+          "attributes": [],
+          "change": null,
+          "contentTypes": [
+            {
+              "attributes": [
+                {
+                  "after": {
+                    "complete": false,
+                    "id": 458102,
+                    "petId": 581231,
+                    "quantity": 31,
+                    "shipDate": "2022-03-04T22:54:32.631Z",
+                    "status": "delivered",
+                    "summary": "31 boxes of dog food",
+                  },
+                  "before": undefined,
+                  "key": "",
+                },
+                {
+                  "after": {
+                    "description": "Human readable summary of order",
+                    "type": "string",
+                  },
+                  "before": undefined,
+                  "key": "/schema/properties/summary",
+                },
+                {
+                  "after": undefined,
+                  "before": "approved",
+                  "key": "/schema/properties/status/enum/1",
+                },
+                {
+                  "after": "canceled",
+                  "before": undefined,
+                  "key": "/schema/properties/status/enum/2",
+                },
+              ],
+              "change": "changed",
+              "name": "application/json",
+            },
+            {
+              "attributes": [
+                {
+                  "after": {
+                    "description": "Human readable summary of order",
+                    "type": "string",
+                  },
+                  "before": undefined,
+                  "key": "/schema/properties/summary",
+                },
+                {
+                  "after": undefined,
+                  "before": "approved",
+                  "key": "/schema/properties/status/enum/1",
+                },
+                {
+                  "after": "canceled",
+                  "before": undefined,
+                  "key": "/schema/properties/status/enum/2",
+                },
+              ],
+              "change": "changed",
+              "name": "application/xml",
+            },
+          ],
+          "name": "200 response",
+        },
+      ],
+    },
+    {
+      "attributes": [],
+      "change": null,
+      "name": "post /pet/{petId}/uploadImage",
+      "parameters": [
+        {
+          "attributes": [
+            {
+              "after": [
+                0,
+                1,
+              ],
+              "before": undefined,
+              "key": "/schema/enum",
+            },
+          ],
+          "change": "added",
+          "name": "request-cookie parameter 'undefined'",
+        },
+      ],
+      "requestBody": undefined,
+      "responses": [
+        {
+          "attributes": [
+            {
+              "after": undefined,
+              "before": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "properties": {
+                        "code": {
+                          "format": "int32",
+                          "type": "integer",
+                        },
+                        "message": {
+                          "type": "string",
+                        },
+                        "type": {
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                  },
+                },
+                "description": "successful operation",
+              },
+              "key": "",
+            },
+          ],
+          "change": "removed",
+          "contentTypes": [],
+          "name": "200 response",
+        },
+        {
+          "attributes": [
+            {
+              "after": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "properties": {
+                        "code": {
+                          "format": "int32",
+                          "type": "integer",
+                        },
+                        "message": {
+                          "type": "string",
+                        },
+                        "type": {
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                  },
+                },
+                "description": "successful operation",
+              },
+              "before": undefined,
+              "key": "",
+            },
+          ],
+          "change": "added",
+          "contentTypes": [],
+          "name": "201 response",
+        },
+        {
+          "attributes": [
+            {
+              "after": {
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "properties": {
+                        "code": {
+                          "format": "int32",
+                          "type": "integer",
+                        },
+                        "message": {
+                          "type": "string",
+                        },
+                        "type": {
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                  },
+                },
+                "description": "Pet not found",
+              },
+              "before": undefined,
+              "key": "",
+            },
+          ],
+          "change": "added",
+          "contentTypes": [],
+          "name": "404 response",
+        },
+        {
+          "attributes": [],
+          "change": null,
+          "contentTypes": [
+            {
+              "attributes": [
+                {
+                  "after": "integer",
+                  "before": "string",
+                  "key": "/schema/properties/type/type",
+                },
+              ],
+              "change": "changed",
+              "name": "application/json",
+            },
+          ],
+          "name": "default response",
+        },
+      ],
+    },
+    {
+      "attributes": [
+        {
+          "after": undefined,
+          "before": {
+            "responses": {
+              "404": {
+                "content": {},
+                "description": "Pet not found",
+              },
+              "405": {
+                "content": {},
+                "description": "Validation exception",
+              },
+            },
+          },
+          "key": "",
+        },
+      ],
+      "change": "removed",
+      "name": "get /pet",
+      "parameters": [],
+      "requestBody": undefined,
+      "responses": [],
+    },
+    {
+      "attributes": [
+        {
+          "after": "addPet-change",
+          "before": "addPet",
+          "key": "/operationId",
+        },
+      ],
+      "change": "changed",
+      "name": "post /pet",
+      "parameters": [],
+      "requestBody": {
+        "attributes": [],
+        "change": null,
+        "contentTypes": [
+          {
+            "attributes": [
+              {
+                "after": {
+                  "type": "string",
+                },
+                "before": undefined,
+                "key": "/schema/properties/category/properties/other",
+              },
+            ],
+            "change": "added",
+            "name": "application/json",
+          },
+        ],
+        "name": "Request Body",
+      },
+      "responses": [],
+    },
+    {
+      "attributes": [],
+      "change": null,
+      "name": "put /pet",
+      "parameters": [],
+      "requestBody": {
+        "attributes": [],
+        "change": null,
+        "contentTypes": [
+          {
+            "attributes": [
+              {
+                "after": undefined,
+                "before": {
+                  "schema": {
+                    "properties": {
+                      "category": {
+                        "properties": {
+                          "id": {
+                            "format": "int64",
+                            "type": "integer",
+                          },
+                          "name": {
+                            "type": "string",
+                          },
+                        },
+                        "type": "object",
+                        "xml": {
+                          "name": "Category",
+                        },
+                      },
+                      "id": {
+                        "format": "int64",
+                        "type": "integer",
+                      },
+                      "name": {
+                        "example": "doggie",
+                        "type": "string",
+                      },
+                      "photoUrls": {
+                        "items": {
+                          "type": "string",
+                        },
+                        "type": "array",
+                        "xml": {
+                          "name": "photoUrl",
+                          "wrapped": true,
+                        },
+                      },
+                      "status": {
+                        "description": "pet status in the store",
+                        "enum": [
+                          "available",
+                          "pending",
+                          "sold",
+                        ],
+                        "type": "string",
+                      },
+                      "tags": {
+                        "items": {
+                          "properties": {
+                            "id": {
+                              "format": "int64",
+                              "type": "integer",
+                            },
+                            "name": {
+                              "type": "string",
+                            },
+                          },
+                          "type": "object",
+                          "xml": {
+                            "name": "Tag",
+                          },
+                        },
+                        "type": "array",
+                        "xml": {
+                          "name": "tag",
+                          "wrapped": true,
+                        },
+                      },
+                    },
+                    "required": [
+                      "name",
+                      "photoUrls",
+                    ],
+                    "type": "object",
+                    "xml": {
+                      "name": "Pet",
+                    },
+                  },
+                },
+                "key": "",
+              },
+            ],
+            "change": "removed",
+            "name": "application/xml",
+          },
+          {
+            "attributes": [
+              {
+                "after": undefined,
+                "before": {
+                  "example": "doggie",
+                  "type": "string",
+                },
+                "key": "/schema/properties/name",
+              },
+              {
+                "after": {
+                  "type": "string",
+                },
+                "before": undefined,
+                "key": "/schema/properties/example",
+              },
+              {
+                "after": {
+                  "type": "string",
+                },
+                "before": undefined,
+                "key": "/schema/properties/number",
+              },
+              {
+                "after": undefined,
+                "before": "name",
+                "key": "/schema/required/0",
+              },
+              {
+                "after": "number",
+                "before": undefined,
+                "key": "/schema/required/0",
+              },
+            ],
+            "change": "changed",
+            "name": "application/json",
+          },
+        ],
+        "name": "Request Body",
+      },
+      "responses": [
+        {
+          "attributes": [
+            {
+              "after": undefined,
+              "before": {
+                "content": {},
+                "description": "Invalid ID supplied",
+              },
+              "key": "",
+            },
+          ],
+          "change": "removed",
+          "contentTypes": [],
+          "name": "400 response",
+        },
+      ],
+    },
+    {
+      "attributes": [
+        {
           "after": "get_examples",
           "before": "getExamples",
-          "key": "operationId",
+          "key": "/operationId",
         },
       ],
       "change": "changed",
@@ -18,1732 +1837,52 @@ exports[`json changelog collects changes properly: jsonChangelog 1`] = `
       "responses": [
         {
           "attributes": [],
-          "change": "changed",
+          "change": null,
           "contentTypes": [
             {
-              "attributes": [],
+              "attributes": [
+                {
+                  "after": {
+                    "properties": {
+                      "order": {
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                          },
+                        },
+                        "type": "object",
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "before": undefined,
+                  "key": "/schema/properties/expandableObject/anyOf/1",
+                },
+                {
+                  "after": "number",
+                  "before": "string",
+                  "key": "/schema/properties/composedObject/allOf/0/properties/orderId/type",
+                },
+                {
+                  "after": undefined,
+                  "before": {
+                    "properties": {
+                      "orderId": {
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "key": "/schema/properties/stringOrNumberOrObject/oneOf/2",
+                },
+              ],
               "change": "changed",
               "name": "application/json",
-              "schemaChanges": [
-                {
-                  "attributes": [
-                    {
-                      "after": [
-                        {
-                          "properties": {
-                            "orderId": {
-                              "type": "number",
-                            },
-                          },
-                          "type": "object",
-                        },
-                        {
-                          "properties": {
-                            "fulfillmentId": {
-                              "type": "string",
-                            },
-                          },
-                          "type": "object",
-                        },
-                      ],
-                      "before": [
-                        {
-                          "properties": {
-                            "orderId": {
-                              "type": "string",
-                            },
-                          },
-                          "type": "object",
-                        },
-                        {
-                          "properties": {
-                            "fulfillmentId": {
-                              "type": "string",
-                            },
-                          },
-                          "type": "object",
-                        },
-                      ],
-                      "key": "allOf",
-                    },
-                  ],
-                  "change": "changed",
-                  "name": "composedObject",
-                },
-                {
-                  "attributes": [
-                    {
-                      "after": "number",
-                      "before": "string",
-                      "key": "type",
-                    },
-                  ],
-                  "change": "changed",
-                  "name": "composedObject.orderId",
-                },
-                {
-                  "attributes": [
-                    {
-                      "after": [
-                        {
-                          "properties": {
-                            "orderId": {
-                              "type": "string",
-                            },
-                          },
-                          "type": "object",
-                        },
-                        {
-                          "properties": {
-                            "order": {
-                              "properties": {
-                                "id": {
-                                  "type": "string",
-                                },
-                              },
-                              "type": "object",
-                            },
-                          },
-                          "type": "object",
-                        },
-                      ],
-                      "before": [
-                        {
-                          "properties": {
-                            "orderId": {
-                              "type": "string",
-                            },
-                          },
-                          "type": "object",
-                        },
-                      ],
-                      "key": "anyOf",
-                    },
-                  ],
-                  "change": "changed",
-                  "name": "expandableObject",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "expandableObject.order",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "expandableObject.order.id",
-                },
-                {
-                  "attributes": [
-                    {
-                      "after": [
-                        {
-                          "type": "string",
-                        },
-                        {
-                          "type": "number",
-                        },
-                      ],
-                      "before": [
-                        {
-                          "type": "string",
-                        },
-                        {
-                          "type": "number",
-                        },
-                        {
-                          "properties": {
-                            "orderId": {
-                              "type": "string",
-                            },
-                          },
-                          "type": "object",
-                        },
-                      ],
-                      "key": "oneOf",
-                    },
-                  ],
-                  "change": "changed",
-                  "name": "stringOrNumberOrObject",
-                },
-                {
-                  "attributes": [],
-                  "change": "removed",
-                  "name": "stringOrNumberOrObject.orderId",
-                },
-              ],
             },
           ],
           "name": "200 response",
         },
       ],
-    },
-    {
-      "attributes": [],
-      "change": "removed",
-      "name": "get /pet",
-      "parameters": [],
-      "requestBody": undefined,
-      "responses": [
-        {
-          "attributes": [],
-          "change": "removed",
-          "contentTypes": [],
-          "name": "404 response",
-        },
-        {
-          "attributes": [],
-          "change": "removed",
-          "contentTypes": [],
-          "name": "405 response",
-        },
-      ],
-    },
-    {
-      "attributes": [
-        {
-          "after": "addPet-change",
-          "before": "addPet",
-          "key": "operationId",
-        },
-      ],
-      "change": "changed",
-      "name": "post /pet",
-      "parameters": [],
-      "requestBody": {
-        "attributes": [],
-        "change": "changed",
-        "contentTypes": [
-          {
-            "attributes": [],
-            "change": "changed",
-            "name": "application/json",
-            "schemaChanges": [
-              {
-                "attributes": [],
-                "change": "added",
-                "name": "category.other",
-              },
-            ],
-          },
-        ],
-        "name": "Request Body",
-      },
-      "responses": [],
-    },
-    {
-      "attributes": [],
-      "change": "changed",
-      "name": "put /pet",
-      "parameters": [],
-      "requestBody": {
-        "attributes": [],
-        "change": "changed",
-        "contentTypes": [
-          {
-            "attributes": [],
-            "change": "changed",
-            "name": "application/json",
-            "schemaChanges": [
-              {
-                "attributes": [],
-                "change": "added",
-                "name": "example",
-              },
-              {
-                "attributes": [],
-                "change": "removed",
-                "name": "name",
-              },
-              {
-                "attributes": [],
-                "change": "added",
-                "name": "number",
-              },
-            ],
-          },
-          {
-            "attributes": [],
-            "change": "removed",
-            "name": "application/xml",
-            "schemaChanges": [
-              {
-                "attributes": [],
-                "change": "removed",
-                "name": "category",
-              },
-              {
-                "attributes": [],
-                "change": "removed",
-                "name": "category.id",
-              },
-              {
-                "attributes": [],
-                "change": "removed",
-                "name": "category.name",
-              },
-              {
-                "attributes": [],
-                "change": "removed",
-                "name": "id",
-              },
-              {
-                "attributes": [],
-                "change": "removed",
-                "name": "name",
-              },
-              {
-                "attributes": [],
-                "change": "removed",
-                "name": "photoUrls",
-              },
-              {
-                "attributes": [],
-                "change": "removed",
-                "name": "status",
-              },
-              {
-                "attributes": [],
-                "change": "removed",
-                "name": "tags",
-              },
-              {
-                "attributes": [],
-                "change": "removed",
-                "name": "tags.items.id",
-              },
-              {
-                "attributes": [],
-                "change": "removed",
-                "name": "tags.items.name",
-              },
-            ],
-          },
-        ],
-        "name": "Request Body",
-      },
-      "responses": [
-        {
-          "attributes": [],
-          "change": "removed",
-          "contentTypes": [],
-          "name": "400 response",
-        },
-      ],
-    },
-    {
-      "attributes": [],
-      "change": "added",
-      "name": "get /pet/findByStatus",
-      "parameters": [
-        {
-          "attributes": [],
-          "change": "added",
-          "name": "query parameter 'status'",
-        },
-        {
-          "attributes": [],
-          "change": "added",
-          "name": "cookie parameter 'debug'",
-        },
-      ],
-      "requestBody": undefined,
-      "responses": [
-        {
-          "attributes": [],
-          "change": "added",
-          "contentTypes": [
-            {
-              "attributes": [],
-              "change": "added",
-              "name": "application/json",
-              "schemaChanges": [
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.category",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.category.id",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.category.name",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.id",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.name",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.photoUrls",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.status",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.tags",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.tags.items.id",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.tags.items.name",
-                },
-              ],
-            },
-            {
-              "attributes": [],
-              "change": "added",
-              "name": "application/xml",
-              "schemaChanges": [
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.category",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.category.id",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.category.name",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.id",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.name",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.photoUrls",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.status",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.tags",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.tags.items.id",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.tags.items.name",
-                },
-              ],
-            },
-          ],
-          "name": "200 response",
-        },
-        {
-          "attributes": [],
-          "change": "added",
-          "contentTypes": [],
-          "name": "400 response",
-        },
-      ],
-    },
-    {
-      "attributes": [],
-      "change": "added",
-      "name": "get /pet/findByTags",
-      "parameters": [
-        {
-          "attributes": [],
-          "change": "added",
-          "name": "query parameter 'tags'",
-        },
-      ],
-      "requestBody": undefined,
-      "responses": [
-        {
-          "attributes": [],
-          "change": "added",
-          "contentTypes": [
-            {
-              "attributes": [],
-              "change": "added",
-              "name": "application/json",
-              "schemaChanges": [
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.category",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.category.id",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.category.name",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.id",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.name",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.photoUrls",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.status",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.tags",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.tags.items.id",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.tags.items.name",
-                },
-              ],
-            },
-            {
-              "attributes": [],
-              "change": "added",
-              "name": "application/xml",
-              "schemaChanges": [
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.category",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.category.id",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.category.name",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.id",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.name",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.photoUrls",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.status",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.tags",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.tags.items.id",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "items.tags.items.name",
-                },
-              ],
-            },
-          ],
-          "name": "200 response",
-        },
-        {
-          "attributes": [],
-          "change": "added",
-          "contentTypes": [],
-          "name": "400 response",
-        },
-      ],
-    },
-    {
-      "attributes": [],
-      "change": "added",
-      "name": "delete /pet/{petId}",
-      "parameters": [
-        {
-          "attributes": [],
-          "change": "added",
-          "name": "path parameter 'petId'",
-        },
-        {
-          "attributes": [],
-          "change": "added",
-          "name": "header parameter 'api_key'",
-        },
-      ],
-      "requestBody": undefined,
-      "responses": [
-        {
-          "attributes": [],
-          "change": "added",
-          "contentTypes": [],
-          "name": "400 response",
-        },
-        {
-          "attributes": [],
-          "change": "added",
-          "contentTypes": [],
-          "name": "404 response",
-        },
-      ],
-    },
-    {
-      "attributes": [],
-      "change": "added",
-      "name": "get /pet/{petId}",
-      "parameters": [
-        {
-          "attributes": [],
-          "change": "added",
-          "name": "path parameter 'petId'",
-        },
-      ],
-      "requestBody": undefined,
-      "responses": [
-        {
-          "attributes": [],
-          "change": "added",
-          "contentTypes": [
-            {
-              "attributes": [],
-              "change": "added",
-              "name": "application/json",
-              "schemaChanges": [
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "category",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "category.id",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "category.name",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "id",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "name",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "photoUrls",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "status",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "tags",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "tags.items.id",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "tags.items.name",
-                },
-              ],
-            },
-            {
-              "attributes": [],
-              "change": "added",
-              "name": "application/xml",
-              "schemaChanges": [
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "category",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "category.id",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "category.name",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "id",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "name",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "photoUrls",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "status",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "tags",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "tags.items.id",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "tags.items.name",
-                },
-              ],
-            },
-          ],
-          "name": "200 response",
-        },
-        {
-          "attributes": [],
-          "change": "added",
-          "contentTypes": [],
-          "name": "400 response",
-        },
-        {
-          "attributes": [],
-          "change": "added",
-          "contentTypes": [],
-          "name": "404 response",
-        },
-      ],
-    },
-    {
-      "attributes": [],
-      "change": "added",
-      "name": "post /pet/{petId}",
-      "parameters": [
-        {
-          "attributes": [],
-          "change": "added",
-          "name": "path parameter 'petId'",
-        },
-      ],
-      "requestBody": {
-        "attributes": [],
-        "change": "added",
-        "contentTypes": [
-          {
-            "attributes": [],
-            "change": "added",
-            "name": "application/x-www-form-urlencoded",
-            "schemaChanges": [],
-          },
-        ],
-        "name": "Request Body",
-      },
-      "responses": [
-        {
-          "attributes": [],
-          "change": "added",
-          "contentTypes": [],
-          "name": "405 response",
-        },
-      ],
-    },
-    {
-      "attributes": [],
-      "change": "changed",
-      "name": "post /pet/{petId}/uploadImage",
-      "parameters": [
-        {
-          "attributes": [
-            {
-              "after": {
-                "enum": [
-                  0,
-                  1,
-                ],
-                "type": "integer",
-              },
-              "before": {
-                "type": "integer",
-              },
-              "key": "schema",
-            },
-          ],
-          "change": "changed",
-          "name": "cookie parameter 'debug'",
-        },
-      ],
-      "requestBody": undefined,
-      "responses": [
-        {
-          "attributes": [],
-          "change": "removed",
-          "contentTypes": [
-            {
-              "attributes": [],
-              "change": "removed",
-              "name": "application/json",
-              "schemaChanges": [
-                {
-                  "attributes": [],
-                  "change": "removed",
-                  "name": "code",
-                },
-                {
-                  "attributes": [],
-                  "change": "removed",
-                  "name": "message",
-                },
-                {
-                  "attributes": [],
-                  "change": "removed",
-                  "name": "type",
-                },
-              ],
-            },
-          ],
-          "name": "200 response",
-        },
-        {
-          "attributes": [],
-          "change": "added",
-          "contentTypes": [
-            {
-              "attributes": [],
-              "change": "added",
-              "name": "application/json",
-              "schemaChanges": [
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "code",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "message",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "type",
-                },
-              ],
-            },
-          ],
-          "name": "201 response",
-        },
-        {
-          "attributes": [],
-          "change": "added",
-          "contentTypes": [
-            {
-              "attributes": [],
-              "change": "added",
-              "name": "application/json",
-              "schemaChanges": [
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "code",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "message",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "type",
-                },
-              ],
-            },
-          ],
-          "name": "404 response",
-        },
-        {
-          "attributes": [],
-          "change": "changed",
-          "contentTypes": [
-            {
-              "attributes": [],
-              "change": "changed",
-              "name": "application/json",
-              "schemaChanges": [
-                {
-                  "attributes": [
-                    {
-                      "after": "integer",
-                      "before": "string",
-                      "key": "type",
-                    },
-                  ],
-                  "change": "changed",
-                  "name": "type",
-                },
-              ],
-            },
-          ],
-          "name": "default response",
-        },
-      ],
-    },
-    {
-      "attributes": [],
-      "change": "changed",
-      "name": "post /store/order",
-      "parameters": [],
-      "requestBody": {
-        "attributes": [],
-        "change": "changed",
-        "contentTypes": [
-          {
-            "attributes": [],
-            "change": "changed",
-            "name": "*/*",
-            "schemaChanges": [
-              {
-                "attributes": [
-                  {
-                    "after": [
-                      "placed",
-                      "delivered",
-                      "canceled",
-                    ],
-                    "before": [
-                      "placed",
-                      "approved",
-                      "delivered",
-                    ],
-                    "key": "enum",
-                  },
-                ],
-                "change": "changed",
-                "name": "status",
-              },
-              {
-                "attributes": [],
-                "change": "added",
-                "name": "summary",
-              },
-            ],
-          },
-        ],
-        "name": "Request Body",
-      },
-      "responses": [
-        {
-          "attributes": [],
-          "change": "changed",
-          "contentTypes": [
-            {
-              "attributes": [],
-              "change": "changed",
-              "name": "application/json",
-              "schemaChanges": [
-                {
-                  "attributes": [
-                    {
-                      "after": [
-                        "placed",
-                        "delivered",
-                        "canceled",
-                      ],
-                      "before": [
-                        "placed",
-                        "approved",
-                        "delivered",
-                      ],
-                      "key": "enum",
-                    },
-                  ],
-                  "change": "changed",
-                  "name": "status",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "summary",
-                },
-              ],
-            },
-            {
-              "attributes": [],
-              "change": "changed",
-              "name": "application/xml",
-              "schemaChanges": [
-                {
-                  "attributes": [
-                    {
-                      "after": [
-                        "placed",
-                        "delivered",
-                        "canceled",
-                      ],
-                      "before": [
-                        "placed",
-                        "approved",
-                        "delivered",
-                      ],
-                      "key": "enum",
-                    },
-                  ],
-                  "change": "changed",
-                  "name": "status",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "summary",
-                },
-              ],
-            },
-          ],
-          "name": "200 response",
-        },
-      ],
-    },
-    {
-      "attributes": [],
-      "change": "changed",
-      "name": "delete /store/order/{orderId}",
-      "parameters": [],
-      "requestBody": undefined,
-      "responses": [
-        {
-          "attributes": [],
-          "change": "changed",
-          "contentTypes": [
-            {
-              "attributes": [],
-              "change": "added",
-              "name": "application/json",
-              "schemaChanges": [
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "code",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "message",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "type",
-                },
-              ],
-            },
-          ],
-          "name": "404 response",
-        },
-      ],
-    },
-    {
-      "attributes": [],
-      "change": "changed",
-      "name": "get /store/order/{orderId}",
-      "parameters": [],
-      "requestBody": undefined,
-      "responses": [
-        {
-          "attributes": [],
-          "change": "changed",
-          "contentTypes": [
-            {
-              "attributes": [],
-              "change": "changed",
-              "name": "application/json",
-              "schemaChanges": [
-                {
-                  "attributes": [
-                    {
-                      "after": [
-                        "placed",
-                        "delivered",
-                        "canceled",
-                      ],
-                      "before": [
-                        "placed",
-                        "approved",
-                        "delivered",
-                      ],
-                      "key": "enum",
-                    },
-                  ],
-                  "change": "changed",
-                  "name": "status",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "summary",
-                },
-              ],
-            },
-            {
-              "attributes": [],
-              "change": "changed",
-              "name": "application/xml",
-              "schemaChanges": [
-                {
-                  "attributes": [
-                    {
-                      "after": false,
-                      "before": true,
-                      "key": "required",
-                    },
-                  ],
-                  "change": "changed",
-                  "name": "petId",
-                },
-                {
-                  "attributes": [
-                    {
-                      "after": [
-                        "placed",
-                        "delivered",
-                        "canceled",
-                      ],
-                      "before": [
-                        "placed",
-                        "approved",
-                        "delivered",
-                      ],
-                      "key": "enum",
-                    },
-                  ],
-                  "change": "changed",
-                  "name": "status",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "summary",
-                },
-              ],
-            },
-          ],
-          "name": "200 response",
-        },
-        {
-          "attributes": [],
-          "change": "changed",
-          "contentTypes": [
-            {
-              "attributes": [],
-              "change": "added",
-              "name": "application/json",
-              "schemaChanges": [
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "code",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "message",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "type",
-                },
-              ],
-            },
-          ],
-          "name": "404 response",
-        },
-      ],
-    },
-    {
-      "attributes": [],
-      "change": "changed",
-      "name": "post /user",
-      "parameters": [],
-      "requestBody": {
-        "attributes": [],
-        "change": "changed",
-        "contentTypes": [
-          {
-            "attributes": [],
-            "change": "changed",
-            "name": "*/*",
-            "schemaChanges": [
-              {
-                "attributes": [],
-                "change": "added",
-                "name": "bio",
-              },
-              {
-                "attributes": [
-                  {
-                    "after": false,
-                    "before": true,
-                    "key": "required",
-                  },
-                ],
-                "change": "changed",
-                "name": "lastName",
-              },
-              {
-                "attributes": [],
-                "change": "removed",
-                "name": "phone",
-              },
-              {
-                "attributes": [
-                  {
-                    "after": [
-                      "activation-pending",
-                      "activated",
-                      "blocked",
-                    ],
-                    "before": undefined,
-                    "key": "enum",
-                  },
-                  {
-                    "after": undefined,
-                    "before": "int32",
-                    "key": "format",
-                  },
-                  {
-                    "after": "string",
-                    "before": "integer",
-                    "key": "type",
-                  },
-                ],
-                "change": "changed",
-                "name": "userStatus",
-              },
-              {
-                "attributes": [
-                  {
-                    "after": true,
-                    "before": false,
-                    "key": "required",
-                  },
-                ],
-                "change": "changed",
-                "name": "username",
-              },
-            ],
-          },
-        ],
-        "name": "Request Body",
-      },
-      "responses": [],
-    },
-    {
-      "attributes": [],
-      "change": "changed",
-      "name": "post /user/createWithArray",
-      "parameters": [],
-      "requestBody": {
-        "attributes": [],
-        "change": "changed",
-        "contentTypes": [
-          {
-            "attributes": [],
-            "change": "changed",
-            "name": "*/*",
-            "schemaChanges": [
-              {
-                "attributes": [],
-                "change": "added",
-                "name": "items.bio",
-              },
-              {
-                "attributes": [
-                  {
-                    "after": false,
-                    "before": true,
-                    "key": "required",
-                  },
-                ],
-                "change": "changed",
-                "name": "items.lastName",
-              },
-              {
-                "attributes": [],
-                "change": "removed",
-                "name": "items.phone",
-              },
-              {
-                "attributes": [
-                  {
-                    "after": [
-                      "activation-pending",
-                      "activated",
-                      "blocked",
-                    ],
-                    "before": undefined,
-                    "key": "enum",
-                  },
-                  {
-                    "after": undefined,
-                    "before": "int32",
-                    "key": "format",
-                  },
-                  {
-                    "after": "string",
-                    "before": "integer",
-                    "key": "type",
-                  },
-                ],
-                "change": "changed",
-                "name": "items.userStatus",
-              },
-              {
-                "attributes": [
-                  {
-                    "after": true,
-                    "before": false,
-                    "key": "required",
-                  },
-                ],
-                "change": "changed",
-                "name": "items.username",
-              },
-            ],
-          },
-        ],
-        "name": "Request Body",
-      },
-      "responses": [],
-    },
-    {
-      "attributes": [],
-      "change": "changed",
-      "name": "post /user/createWithList",
-      "parameters": [],
-      "requestBody": {
-        "attributes": [],
-        "change": "changed",
-        "contentTypes": [
-          {
-            "attributes": [],
-            "change": "changed",
-            "name": "*/*",
-            "schemaChanges": [
-              {
-                "attributes": [],
-                "change": "added",
-                "name": "items.bio",
-              },
-              {
-                "attributes": [
-                  {
-                    "after": false,
-                    "before": true,
-                    "key": "required",
-                  },
-                ],
-                "change": "changed",
-                "name": "items.lastName",
-              },
-              {
-                "attributes": [],
-                "change": "removed",
-                "name": "items.phone",
-              },
-              {
-                "attributes": [
-                  {
-                    "after": [
-                      "activation-pending",
-                      "activated",
-                      "blocked",
-                    ],
-                    "before": undefined,
-                    "key": "enum",
-                  },
-                  {
-                    "after": undefined,
-                    "before": "int32",
-                    "key": "format",
-                  },
-                  {
-                    "after": "string",
-                    "before": "integer",
-                    "key": "type",
-                  },
-                ],
-                "change": "changed",
-                "name": "items.userStatus",
-              },
-              {
-                "attributes": [
-                  {
-                    "after": true,
-                    "before": false,
-                    "key": "required",
-                  },
-                ],
-                "change": "changed",
-                "name": "items.username",
-              },
-            ],
-          },
-        ],
-        "name": "Request Body",
-      },
-      "responses": [],
-    },
-    {
-      "attributes": [],
-      "change": "changed",
-      "name": "get /user/login",
-      "parameters": [],
-      "requestBody": undefined,
-      "responses": [
-        {
-          "attributes": [],
-          "change": "changed",
-          "contentTypes": [],
-          "name": "200 response",
-        },
-      ],
-    },
-    {
-      "attributes": [],
-      "change": "changed",
-      "name": "get /user/{username}",
-      "parameters": [],
-      "requestBody": undefined,
-      "responses": [
-        {
-          "attributes": [],
-          "change": "changed",
-          "contentTypes": [
-            {
-              "attributes": [],
-              "change": "changed",
-              "name": "application/json",
-              "schemaChanges": [
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "bio",
-                },
-                {
-                  "attributes": [
-                    {
-                      "after": false,
-                      "before": true,
-                      "key": "required",
-                    },
-                  ],
-                  "change": "changed",
-                  "name": "lastName",
-                },
-                {
-                  "attributes": [],
-                  "change": "removed",
-                  "name": "phone",
-                },
-                {
-                  "attributes": [
-                    {
-                      "after": [
-                        "activation-pending",
-                        "activated",
-                        "blocked",
-                      ],
-                      "before": undefined,
-                      "key": "enum",
-                    },
-                    {
-                      "after": undefined,
-                      "before": "int32",
-                      "key": "format",
-                    },
-                    {
-                      "after": "string",
-                      "before": "integer",
-                      "key": "type",
-                    },
-                  ],
-                  "change": "changed",
-                  "name": "userStatus",
-                },
-                {
-                  "attributes": [
-                    {
-                      "after": true,
-                      "before": false,
-                      "key": "required",
-                    },
-                  ],
-                  "change": "changed",
-                  "name": "username",
-                },
-              ],
-            },
-            {
-              "attributes": [],
-              "change": "changed",
-              "name": "application/xml",
-              "schemaChanges": [
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "bio",
-                },
-                {
-                  "attributes": [
-                    {
-                      "after": false,
-                      "before": true,
-                      "key": "required",
-                    },
-                  ],
-                  "change": "changed",
-                  "name": "lastName",
-                },
-                {
-                  "attributes": [],
-                  "change": "removed",
-                  "name": "phone",
-                },
-                {
-                  "attributes": [
-                    {
-                      "after": [
-                        "activation-pending",
-                        "activated",
-                        "blocked",
-                      ],
-                      "before": undefined,
-                      "key": "enum",
-                    },
-                    {
-                      "after": undefined,
-                      "before": "int32",
-                      "key": "format",
-                    },
-                    {
-                      "after": "string",
-                      "before": "integer",
-                      "key": "type",
-                    },
-                  ],
-                  "change": "changed",
-                  "name": "userStatus",
-                },
-                {
-                  "attributes": [
-                    {
-                      "after": true,
-                      "before": false,
-                      "key": "required",
-                    },
-                  ],
-                  "change": "changed",
-                  "name": "username",
-                },
-              ],
-            },
-          ],
-          "name": "200 response",
-        },
-        {
-          "attributes": [],
-          "change": "changed",
-          "contentTypes": [
-            {
-              "attributes": [],
-              "change": "added",
-              "name": "application/json",
-              "schemaChanges": [
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "code",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "message",
-                },
-                {
-                  "attributes": [],
-                  "change": "added",
-                  "name": "type",
-                },
-              ],
-            },
-          ],
-          "name": "404 response",
-        },
-      ],
-    },
-    {
-      "attributes": [],
-      "change": "changed",
-      "name": "put /user/{username}",
-      "parameters": [],
-      "requestBody": {
-        "attributes": [],
-        "change": "changed",
-        "contentTypes": [
-          {
-            "attributes": [],
-            "change": "changed",
-            "name": "*/*",
-            "schemaChanges": [
-              {
-                "attributes": [],
-                "change": "added",
-                "name": "bio",
-              },
-              {
-                "attributes": [
-                  {
-                    "after": false,
-                    "before": true,
-                    "key": "required",
-                  },
-                ],
-                "change": "changed",
-                "name": "lastName",
-              },
-              {
-                "attributes": [],
-                "change": "removed",
-                "name": "phone",
-              },
-              {
-                "attributes": [
-                  {
-                    "after": [
-                      "activation-pending",
-                      "activated",
-                      "blocked",
-                    ],
-                    "before": undefined,
-                    "key": "enum",
-                  },
-                  {
-                    "after": undefined,
-                    "before": "int32",
-                    "key": "format",
-                  },
-                  {
-                    "after": "string",
-                    "before": "integer",
-                    "key": "type",
-                  },
-                ],
-                "change": "changed",
-                "name": "userStatus",
-              },
-              {
-                "attributes": [
-                  {
-                    "after": true,
-                    "before": false,
-                    "key": "required",
-                  },
-                ],
-                "change": "changed",
-                "name": "username",
-              },
-            ],
-          },
-        ],
-        "name": "Request Body",
-      },
-      "responses": [],
     },
   ],
 }

--- a/projects/openapi-utilities/src/utilities/__tests__/json-changelog.test.ts
+++ b/projects/openapi-utilities/src/utilities/__tests__/json-changelog.test.ts
@@ -1,29 +1,23 @@
 import { test, expect } from '@jest/globals';
-import {
-  factsToChangelog,
-  OpenAPITraverser,
-  groupChangesAndRules,
-} from '../../index';
 import { openAPI as petStoreBase } from '../../examples/petstore-base';
 import { openAPI as petStoreUpdated } from '../../examples/petstore-updated';
 import { jsonChangelog } from '../json-changelog';
+import { groupDiffsByEndpoint } from '../../openapi3/group-diff';
+import { diff } from '../../diff/diff';
 
 test('json changelog collects changes properly', () => {
-  const baseTraverser = new OpenAPITraverser();
-  baseTraverser.traverse(petStoreBase);
-
-  const targetTraverser = new OpenAPITraverser();
-  targetTraverser.traverse(petStoreUpdated);
-
-  const baseFacts = [...baseTraverser.facts()];
-  const targetFacts = [...targetTraverser.facts()];
-
+  const diffs = diff(petStoreBase, petStoreUpdated);
+  const specs = {
+    from: petStoreBase,
+    to: petStoreUpdated,
+  };
+  const groupedDiffs = groupDiffsByEndpoint(specs, diffs);
   const output = jsonChangelog(
-    groupChangesAndRules({
-      toFacts: targetFacts,
-      changes: factsToChangelog(baseFacts, targetFacts),
-      rules: [],
-    })
+    {
+      from: petStoreBase,
+      to: petStoreUpdated,
+    },
+    groupedDiffs
   );
 
   expect(output).toMatchSnapshot('jsonChangelog');

--- a/projects/openapi-utilities/src/utilities/json-changelog.ts
+++ b/projects/openapi-utilities/src/utilities/json-changelog.ts
@@ -1,135 +1,69 @@
-import {
-  groupChangesAndRules,
-  OpenApiEndpointChange,
-  RequestChange,
-  ResponseChange,
-  BodyChange,
-} from './group-changes';
-import { ChangeVariant, OpenApiKind, OpenApiFact } from '../openapi3/sdk/types';
-import isEqual from 'lodash.isequal';
-import omit from 'lodash.omit';
+import { OpenAPIV3 } from 'openapi-types';
+import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
 
-const getChange = (
-  change: ChangeVariant<any> | null
-): 'added' | 'removed' | 'changed' =>
-  change?.added ? 'added' : change?.removed ? 'removed' : 'changed';
+import { typeofDiff } from '../diff/diff';
+import type {
+  GroupedDiffs,
+  Body,
+  Diff,
+  Endpoint,
+  Response,
+} from '../openapi3/group-diff';
+import { getRaw } from '../openapi3/traverser';
 
-const getDiff = (before: object, after: object) => {
-  const output = {
-    added: <{ key: string; value: any }[]>[],
-    changed: <{ key: string; before: any; after: any }[]>[],
-    removed: <{ key: string; value: any }[]>[],
-  };
-
-  const beforeKeys = new Set(Object.keys(before));
-  const afterKeys = new Set(Object.keys(after));
-
-  for (const key of beforeKeys) {
-    if (!afterKeys.has(key))
-      output.removed.push({ key, value: (before as any)[key] });
-    else if (!isEqual((before as any)[key], (after as any)[key]))
-      output.changed.push({
-        key,
-        before: (before as any)[key],
-        after: (after as any)[key],
-      });
-  }
-
-  for (const key of afterKeys) {
-    if (!beforeKeys.has(key))
-      output.added.push({ key, value: (after as any)[key] });
-  }
-
-  return output;
-};
-
-const getDetailsDiff = (
-  change: ChangeVariant<any>,
-  excludedKeys: string[] = []
-) => {
-  const excludeKeys = (fact: OpenApiFact) => omit(fact, excludedKeys);
-
-  const mergeFlatSchema = (fact: OpenApiFact) => {
-    if ('flatSchema' in fact) {
-      const { flatSchema, ...factRest } = fact;
-      return {
-        ...factRest,
-        ...flatSchema,
+type RawChange<T> = { key: string } & (
+  | {
+      added: T;
+      changed?: undefined;
+      removed?: undefined;
+    }
+  | {
+      added?: undefined;
+      removed?: undefined;
+      changed: {
+        before: T;
+        after: T;
       };
-    } else return fact;
-  };
+    }
+  | {
+      added?: undefined;
+      changed?: undefined;
+      removed: T;
+    }
+);
 
-  const before = excludeKeys(
-    mergeFlatSchema(
-      change.added
-        ? {}
-        : change.removed
-        ? change.removed
-        : change.changed
-        ? change.changed.before
-        : {}
-    )
-  );
-
-  const after = excludeKeys(
-    mergeFlatSchema(
-      change.added
-        ? change.added
-        : change.removed
-        ? {}
-        : change.changed
-        ? change.changed.after
-        : {}
-    )
-  );
-
-  return getDiff(before, after);
-};
-
-function getDetailLogs(
-  change: ChangeVariant<any>,
-  options: { label?: string; excludeKeys?: string[] } = {}
-): ChangedNode['attributes'] {
-  const { label, excludeKeys } = options;
-  const diff = getDetailsDiff(change, excludeKeys);
-
-  const diffCount =
-    diff.changed.length + diff.removed.length + diff.added.length;
-
-  if (!diffCount) return [];
-
-  const results: ChangedNode['attributes'] = [];
-
-  // don't show children as added
-  if (!change.added) {
-    diff.added.forEach((added) =>
-      results.push({ key: added.key, after: added.value, before: undefined })
-    );
-  }
-  // don't show children as removed
-  if (!change.removed) {
-    diff.removed.forEach((removed) =>
-      results.push({
-        key: removed.key,
-        before: removed.value,
-        after: undefined,
-      })
-    );
-  }
-  diff.changed.forEach((changed) =>
-    results.push({
-      key: changed.key,
-      before: changed.before,
-      after: changed.after,
-    })
-  );
-
-  return results;
+function getTypeofDiffs(diffs: Diff[]): 'added' | 'changed' | 'removed' | null {
+  return diffs.length === 0
+    ? null
+    : diffs.every((diff) => typeofDiff(diff) === 'added')
+    ? 'added'
+    : diffs.every((diff) => typeofDiff(diff) === 'removed')
+    ? 'removed'
+    : 'changed';
 }
+
+const getDetailsDiff = (change: RawChange<any>): ChangedNode['attributes'] => {
+  return [
+    {
+      key: change.key,
+      ...(change.added
+        ? {
+            before: undefined,
+            after: change.added,
+          }
+        : change.changed
+        ? change.changed
+        : {
+            before: change.removed,
+            after: undefined,
+          }),
+    },
+  ];
+};
 
 type ChangedNode = {
   name: string;
-  change: 'added' | 'removed' | 'changed';
+  change: 'added' | 'removed' | 'changed' | null;
   attributes: { key: string; before: any; after: any }[];
 };
 
@@ -144,62 +78,110 @@ type JsonChangelog = {
 };
 
 export function jsonChangelog(
-  groupedChanges: ReturnType<typeof groupChangesAndRules>
+  specs: { from: OpenAPIV3.Document; to: OpenAPIV3.Document },
+  groupedChanges: GroupedDiffs
 ): JsonChangelog {
   const results: JsonChangelog = { operations: [] };
 
-  const { changesByEndpoint, specification } = groupedChanges;
-  for (const [_, endpointChange] of changesByEndpoint) {
-    results.operations.push(getEndpointLogs(endpointChange));
+  const { paths } = groupedChanges;
+  for (const [path, pathObject] of Object.entries(paths)) {
+    const isAdded = pathObject.diffs.some(
+      (diff) => typeofDiff(diff) === 'added'
+    );
+    const isRemoved = pathObject.diffs.some(
+      (diff) => typeofDiff(diff) === 'removed'
+    );
+    if (isAdded || isRemoved) {
+      const jsonPath = jsonPointerHelpers.compile(['paths', path]);
+      const raw = isAdded
+        ? jsonPointerHelpers.get(specs.to, jsonPath)
+        : jsonPointerHelpers.get(specs.from, jsonPath);
+
+      for (const method of Object.keys(raw)) {
+        results.operations.push(
+          getEndpointLogs(specs, method, path, {
+            diffs: [
+              isAdded
+                ? {
+                    after: jsonPointerHelpers.compile(['paths', path, method]),
+                    trail: '',
+                    change: 'added',
+                  }
+                : {
+                    before: jsonPointerHelpers.compile(['paths', path, method]),
+                    trail: '',
+                    change: 'removed',
+                  },
+            ],
+            queryParameters: [],
+            pathParameters: [],
+            cookieParameters: [],
+            headerParameters: [],
+            request: {
+              diffs: [],
+              contents: {},
+            },
+            responses: {},
+          })
+        );
+      }
+    }
+
+    for (const [method, endpoint] of Object.entries(pathObject.methods))
+      results.operations.push(getEndpointLogs(specs, method, path, endpoint));
   }
 
   return results;
 }
 
 function getEndpointLogs(
-  endpointChange: OpenApiEndpointChange
+  specs: { from: OpenAPIV3.Document; to: OpenAPIV3.Document },
+  method: string,
+  path: string,
+  endpointChange: Endpoint
 ): OperationChangelog {
   const {
-    method,
-    path,
     request,
     responses,
     cookieParameters,
-    change,
-    headers,
+    diffs,
+    headerParameters,
     pathParameters,
     queryParameters,
   } = endpointChange;
 
+  const operationChange = getTypeofDiffs(diffs);
+
   const parameterChanges = [];
-  for (const [name, parameterChange] of queryParameters.changes) {
-    parameterChanges.push(getParameterLogs('query', name, parameterChange));
+  for (const diff of queryParameters) {
+    parameterChanges.push(getParameterLogs(specs, 'request-query', diff));
   }
 
-  for (const [name, parameterChange] of cookieParameters.changes) {
-    parameterChanges.push(getParameterLogs('cookie', name, parameterChange));
+  for (const diff of cookieParameters) {
+    parameterChanges.push(getParameterLogs(specs, 'request-cookie', diff));
   }
 
-  for (const [name, parameterChange] of pathParameters.changes) {
-    parameterChanges.push(getParameterLogs('path', name, parameterChange));
+  for (const diff of pathParameters) {
+    parameterChanges.push(getParameterLogs(specs, 'request-path', diff));
   }
 
-  for (const [name, parameterChange] of headers.changes) {
-    parameterChanges.push(getParameterLogs('header', name, parameterChange));
+  for (const diff of headerParameters) {
+    parameterChanges.push(getParameterLogs(specs, 'request-header', diff));
   }
 
   const responseChanges: ChangedNode[] = [];
-  for (const [key, response] of responses) {
-    responseChanges.push(getResponseChangeLogs(response, key));
+  for (const [statusCode, response] of Object.entries(responses)) {
+    responseChanges.push(getResponseChangeLogs(specs, response, statusCode));
   }
+  const requestChangelogs = getRequestChangeLogs(specs, request);
 
-  const requestChangelogs = getRequestChangeLogs(request);
   return {
     name: `${method} ${path}`,
-    change: getChange(change),
-    attributes: change
-      ? getDetailLogs(change, {
-          excludeKeys: ['pathPattern', 'method'],
+    change: operationChange,
+    attributes: operationChange
+      ? diffs.flatMap((diff) => {
+          const rawChange = getRawChange(diff, specs);
+          return getDetailsDiff(rawChange);
         })
       : [],
     parameters: parameterChanges,
@@ -213,88 +195,127 @@ function getEndpointLogs(
 }
 
 function getResponseChangeLogs(
-  { change, headers, contentTypes }: ResponseChange,
-  key: string
+  specs: { from: OpenAPIV3.Document; to: OpenAPIV3.Document },
+  response: Response,
+  statusCode: string
 ): ChangedNode & {
-  contentTypes: (ChangedNode & { schemaChanges: ChangedNode[] })[];
+  contentTypes: ChangedNode[];
 } {
-  const contentTypeChanges: (ChangedNode & { schemaChanges: ChangedNode[] })[] =
-    [];
+  const contentTypeChanges: ChangedNode[] = [];
+  const responseChange = getTypeofDiffs(response.diffs);
 
-  for (const [key, contentType] of contentTypes) {
-    contentTypeChanges.push(getBodyChangeLogs(contentType, key));
+  for (const [contentType, body] of Object.entries(response.contents)) {
+    contentTypeChanges.push(getBodyChangeLogs(specs, body, contentType));
   }
 
+  // TODO this is missing response-headers
   return {
-    name: `${key} response`,
-    change: getChange(change),
-    attributes: change
-      ? getDetailLogs(change, { excludeKeys: ['statusCode'] })
+    name: `${statusCode} response`,
+    change: responseChange,
+    attributes: responseChange
+      ? response.diffs.flatMap((diff) => {
+          const rawChange = getRawChange(diff, specs);
+          return getDetailsDiff(rawChange);
+        })
       : [],
     contentTypes: contentTypeChanges,
   };
 }
 
-function getRequestChangeLogs({
-  change,
-  bodyChanges,
-}: RequestChange): ChangedNode & {
-  contentTypes: (ChangedNode & { schemaChanges: ChangedNode[] })[];
+function getRequestChangeLogs(
+  specs: { from: OpenAPIV3.Document; to: OpenAPIV3.Document },
+  request: Endpoint['request']
+): ChangedNode & {
+  contentTypes: ChangedNode[];
 } {
-  const contentTypes: (ChangedNode & { schemaChanges: ChangedNode[] })[] = [];
-  for (const [key, bodyChange] of bodyChanges) {
-    contentTypes.push(getBodyChangeLogs(bodyChange, key));
+  const contentTypes: ChangedNode[] = [];
+  const requestChange = getTypeofDiffs(request.diffs);
+
+  for (const [contentType, body] of Object.entries(request.contents)) {
+    contentTypes.push(getBodyChangeLogs(specs, body, contentType));
   }
 
   return {
     name: `Request Body`,
-    change: getChange(change),
-    attributes: change
-      ? getDetailLogs(change, { excludeKeys: ['content'] })
+    change: requestChange,
+    attributes: requestChange
+      ? request.diffs.flatMap((diff) => {
+          const rawChange = getRawChange(diff, specs);
+          return getDetailsDiff(rawChange);
+        })
       : [],
     contentTypes: contentTypes,
   };
 }
 
 function getBodyChangeLogs(
-  { bodyChange, fieldChanges, exampleChanges }: BodyChange,
-  key: string
-): ChangedNode & { schemaChanges: ChangedNode[] } {
+  specs: { from: OpenAPIV3.Document; to: OpenAPIV3.Document },
+  body: Body,
+  contentType: string
+): ChangedNode {
+  const bodyChange = getTypeofDiffs(body.diffs);
+
   return {
-    name: `${key}`,
-    change: getChange(bodyChange),
+    name: `${contentType}`,
+    change: bodyChange,
     attributes: bodyChange
-      ? getDetailLogs(bodyChange, { excludeKeys: ['contentType'] })
+      ? body.diffs.flatMap((diff) => {
+          const rawChange = getRawChange(diff, specs);
+          return getDetailsDiff(rawChange);
+        })
       : [],
-    schemaChanges: fieldChanges.map((fieldChange) => getFieldLogs(fieldChange)),
-  };
-}
-
-function getFieldLogs(change: ChangeVariant<OpenApiKind.Field>): ChangedNode {
-  const path = change.location.conceptualLocation.jsonSchemaTrail
-    .filter((i) => i !== 'properties')
-    .join('.');
-
-  return {
-    name: path,
-    change: getChange(change),
-    attributes: change ? getDetailLogs(change, { excludeKeys: ['key'] }) : [],
   };
 }
 
 function getParameterLogs(
-  parameterType: string,
-  parameterName: string,
-  change: ChangeVariant<
-    | OpenApiKind.QueryParameter
-    | OpenApiKind.CookieParameter
-    | OpenApiKind.PathParameter
-    | OpenApiKind.HeaderParameter
-  >
+  specs: { from: OpenAPIV3.Document; to: OpenAPIV3.Document },
+  parameterType:
+    | 'request-header'
+    | 'request-query'
+    | 'request-cookie'
+    | 'request-path',
+  diff: Diff
 ): ChangedNode {
+  const raw =
+    diff.after !== undefined
+      ? getRaw(specs.to, {
+          location: { jsonPath: diff.after },
+          type: parameterType,
+        })
+      : getRaw(specs.from, {
+          location: { jsonPath: diff.before },
+          type: parameterType,
+        });
+
+  const rawChange = getRawChange(diff, specs);
   return {
-    name: `${parameterType} parameter '${parameterName}'`,
-    change: getChange(change),
-    attributes: getDetailLogs(change, { excludeKeys: ['name', 'in'] }),
+    name: `${parameterType} parameter '${raw.name}'`,
+    change: typeofDiff(diff),
+    attributes: getDetailsDiff(rawChange),
   };
+}
+
+function getRawChange(
+  diff: Diff,
+  specs: { from: OpenAPIV3.Document; to: OpenAPIV3.Document }
+): RawChange<any> {
+  if (diff.before !== undefined && diff.after !== undefined) {
+    return {
+      key: diff.trail,
+      changed: {
+        before: jsonPointerHelpers.get(specs.from, diff.before),
+        after: jsonPointerHelpers.get(specs.to, diff.after),
+      },
+    };
+  } else if (diff.before !== undefined) {
+    return {
+      key: diff.trail,
+      removed: jsonPointerHelpers.get(specs.from, diff.before),
+    };
+  } else {
+    return {
+      key: diff.trail,
+      added: jsonPointerHelpers.get(specs.to, diff.after),
+    };
+  }
 }


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Note - this PR's build will fail until all changelog components have been moved over. Splitting out into multiple PRs to be reviewed separately, and will merge in all together (which will switch over usage)

I initially attempted to keep the results shape the same, but I don't think it's actually correct. Some notable differences with how this works is:
- If a node is `added` or `removed`, we won't actually traverse down and log extra attributes. Instead, the node that was added will be "attribute added"
  - e.g. if we add a new operation, in the old changelog, `requests` would have been "added", in this changelog, it's only on the operation level. This is (I think) more correct for a changelog, but for rule runners we'd need to make sure all child nodes are triggered.
- We only recognize if a node is changed if that node's fact has changed, and not any of it's children (this is old behavior, but I think this was inconsistently implemented before?)

I think it's also ok for us to change the output of this, since this is only used in `optic diff` and we've kept the same format

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
