### PR TITLE
Open in uploaded --web if diff was uploaded

### DIFF
--- a/projects/optic/src/commands/diff/diff-all.ts
+++ b/projects/optic/src/commands/diff/diff-all.ts
@@ -291,28 +291,32 @@ function handleWarnings(warnings: Warnings, options: DiffAllActionOptions) {
 }
 
 async function openWebpage(
+  url: string | null,
   { fromParseResults, toParseResults, specResults }: Result,
   config: OpticCliConfig
 ) {
-  const meta = {
-    createdAt: new Date(),
-    command: ['optic', ...process.argv.slice(2)].join(' '),
-  };
-
-  const compressedData = compressData(
-    fromParseResults,
-    toParseResults,
-    specResults,
-    meta
-  );
-  const anonymousId = await getAnonId();
-  trackEvent('optic.diff_all.view_web', anonymousId, {
-    compressedDataLength: compressedData.length,
+  const analyticsData: Record<string, any> = {
     isInCi: process.env.CI === 'true',
-  });
-  await open(`${config.client.getWebBase()}/cli/diff#${compressedData}`, {
-    wait: false,
-  });
+  };
+  if (!url) {
+    const meta = {
+      createdAt: new Date(),
+      command: ['optic', ...process.argv.slice(2)].join(' '),
+    };
+
+    const compressedData = compressData(
+      fromParseResults,
+      toParseResults,
+      specResults,
+      meta
+    );
+    analyticsData.compressedDataLength = compressedData.length;
+    url = `${config.client.getWebBase()}/cli/diff#${compressedData}`;
+  }
+  const anonymousId = await getAnonId();
+  trackEvent('optic.diff_all.view_web', anonymousId, analyticsData);
+
+  await open(url, { wait: false });
 }
 
 const getDiffAllAction =
@@ -385,12 +389,9 @@ const getDiffAllAction =
           specResults,
           config
         );
+        let url: string | null = null;
         if (run) {
-          const url = getRunUrl(
-            config.client.getWebBase(),
-            run.orgId,
-            run.runId
-          );
+          url = getRunUrl(config.client.getWebBase(), run.orgId, run.runId);
           logger.info(`Uploaded results of diff to ${url}`);
         }
         if (
@@ -398,7 +399,7 @@ const getDiffAllAction =
           (specResults.changes.length > 0 ||
             (!options.check && specResults.results.length > 0))
         ) {
-          openWebpage(result, config);
+          openWebpage(url, result, config);
         }
       }
     }


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Updates optic diff + diff-all to open the uploaded diff instead of the cli compressed diff flow if logged in.

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
