### PR TITLE
Connect `optic api add` to apis

### DIFF
--- a/projects/optic/src/__tests__/integration/__snapshots__/api-add.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/api-add.test.ts.snap
@@ -3,24 +3,28 @@
 exports[`optic api add git - no cli interaction discover all files in repo 1`] = `
 "
 
-Will add detected APIs to organization org1 with standard blah
+Will add detected APIs to organization org-blah with standard blah
 Looking for APIs in the git root ($workspace$)
 Found OpenAPI Spec at example-api-v0.json
 Uploading spec COMMIT-HASH:example-api-v0.json
+Added spec example-api-v0.json to https://app.useoptic.com/organizations/org-id/apis/api-id
 Found OpenAPI Spec at nested/speccopy2.yml
 Uploading spec COMMIT-HASH:nested/speccopy2.yml
+Added spec nested/speccopy2.yml to https://app.useoptic.com/organizations/org-id/apis/api-id
 Found OpenAPI Spec at spec.yml
 Uploading spec COMMIT-HASH:spec.yml
+Added spec spec.yml to https://app.useoptic.com/organizations/org-id/apis/api-id
 "
 `;
 
 exports[`optic api add git - no cli interaction discover one file with history depth 1`] = `
 "
 
-Will add detected APIs to organization org1 with standard blah
+Will add detected APIs to organization org-blah with standard blah
 Adding API ./spec.yml and traversing history to a depth of 1
 Found OpenAPI Spec at ./spec.yml
 Uploading spec COMMIT-HASH:./spec.yml
+Added spec ./spec.yml to https://app.useoptic.com/organizations/org-id/apis/api-id
 "
 `;
 
@@ -46,7 +50,7 @@ paths:
                     type: string
                     format: uuid
                     example: d5b640e5-d88c-4c17-9bf0-93597b7a1ce2
-x-optic-url: todo make API call
+x-optic-url: https://app.useoptic.com/organizations/org-id/apis/api-id
 x-optic-standard: blah
 "
 `;
@@ -54,20 +58,24 @@ x-optic-standard: blah
 exports[`optic api add no vcs - no cli interaction discover all files in repo 1`] = `
 "
 
-Will add detected APIs to organization org1 with standard blah
+Will add detected APIs to organization org-blah with standard blah
 Looking for APIs in the current directory ($workspace$)
 Found OpenAPI Spec at $workspace$/example-api-v0.json
+Added spec $workspace$/example-api-v0.json to https://app.useoptic.com/organizations/org-id/apis/api-id
 Found OpenAPI Spec at $workspace$/spec.yml
+Added spec $workspace$/spec.yml to https://app.useoptic.com/organizations/org-id/apis/api-id
 Found OpenAPI Spec at $workspace$/nested/speccopy2.yml
+Added spec $workspace$/nested/speccopy2.yml to https://app.useoptic.com/organizations/org-id/apis/api-id
 "
 `;
 
 exports[`optic api add no vcs - no cli interaction discover one file with history depth 1`] = `
 "
 
-Will add detected APIs to organization org1 with standard blah
+Will add detected APIs to organization org-blah with standard blah
 Adding API ./spec.yml
 Found OpenAPI Spec at $workspace$/spec.yml
+Added spec $workspace$/spec.yml to https://app.useoptic.com/organizations/org-id/apis/api-id
 "
 `;
 
@@ -93,7 +101,7 @@ paths:
                     type: string
                     format: uuid
                     example: d5b640e5-d88c-4c17-9bf0-93597b7a1ce2
-x-optic-url: todo make API call
+x-optic-url: https://app.useoptic.com/organizations/org-id/apis/api-id
 x-optic-standard: blah
 "
 `;

--- a/projects/optic/src/client/optic-backend-types.ts
+++ b/projects/optic/src/client/optic-backend-types.ts
@@ -2,6 +2,8 @@ export type Standard = {
   config: {
     ruleset: { name: string; config: unknown }[];
   };
+  name: string;
+  slug: string;
   organization_id: string;
   ruleset_id: string;
   created_at: string;

--- a/projects/optic/src/client/optic-backend.ts
+++ b/projects/optic/src/client/optic-backend.ts
@@ -32,6 +32,10 @@ export class OpticBackendClient extends JsonHttpClient {
       : 'https://app.useoptic.com';
   }
 
+  public getTokenOrgs(): Promise<{ id: string; name: string }[]> {
+    return this.getJson(`/api/token/orgs`);
+  }
+
   public async createRuleset(
     name: string,
     description: string,
@@ -80,15 +84,23 @@ export class OpticBackendClient extends JsonHttpClient {
   public async createOrgStandard(
     organizationId: string,
     standard: Types.StandardConfig
-  ) {
-    // TODO
+  ): Promise<{ id: string; slug: string }> {
+    return this.postJson<{ id: string; slug: string }>(
+      `/api/organizations/${organizationId}/ruleset-configs`,
+      {
+        config: { ruleset: standard },
+      }
+    );
   }
 
   public async getOrgStandards(
     organizationId: string
   ): Promise<Types.Standard[]> {
-    // TODO
-    return [];
+    const response = await this.getJson<{
+      data: Types.Standard[];
+    }>(`/api/organizations/${organizationId}/ruleset-configs`);
+
+    return response.data;
   }
 
   public async prepareSpecUpload(body: {
@@ -133,8 +145,14 @@ export class OpticBackendClient extends JsonHttpClient {
     return this.postJson(`/api/runs2`, run);
   }
 
-  public async createApi() {
-    // TODO
+  public async createApi(
+    organizationId: string,
+    name: string
+  ): Promise<{ id: string }> {
+    return this.postJson(`/api/api/create`, {
+      name,
+      organization_id: organizationId,
+    });
   }
 }
 

--- a/projects/optic/src/commands/api/default-ruleset-config.ts
+++ b/projects/optic/src/commands/api/default-ruleset-config.ts
@@ -1,0 +1,24 @@
+export function getDefaultRulesetConfig(rulesetName: string): any {
+  if (rulesetName === 'breaking-changes') {
+    return {};
+  } else if (rulesetName === 'naming') {
+    return {
+      required_on: 'added',
+      requestHeaders: 'snake_case',
+      queryParameters: 'snake_case',
+      responseHeaders: 'snake_case',
+      cookieParameters: 'snake_case',
+      pathComponents: 'snake_case',
+      properties: 'snake_case',
+    };
+  } else if (rulesetName === 'examples') {
+    return {
+      require_request_examples: true,
+      require_response_examples: true,
+      require_parameter_examples: true,
+      required_on: 'always',
+    };
+  }
+
+  return {};
+}

--- a/projects/optic/src/utils/cloud-urls.ts
+++ b/projects/optic/src/utils/cloud-urls.ts
@@ -47,3 +47,11 @@ export function getSpecUrl(
 ): string {
   return urljoin(baseUrl, `organizations/${orgId}/specs/${specId}`);
 }
+
+export function getStandardsUrl(
+  baseUrl: string,
+  orgId: string,
+  standardId: string
+) {
+  return urljoin(baseUrl, `organizations/${orgId}/standards/${standardId}`);
+}


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Connected up APIs for optic api add - this PR adds a couple of things that I think makes it easier for the CLI - would require changes on the endpoint - 

Changes:
- GET /api/organizations/${organizationId}/ruleset-configs to return 'slug: `@orgslug/standard-id`'
- POST /api/organizations/${organizationId}/ruleset-configs to return 'slug: `@orgslug/standard-id`
- GET /api/token/orgs to return `{id: string, name: string}` not just the id
- POST /api/api/create only pases in org id + name

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
