### PR TITLE
update optic-api-add to read orgs correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.36.6-2",
+  "version": "0.36.6-4",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
-  "version": "0.36.6-2",
+  "version": "0.36.6-4",
   "packageManager": "yarn@3.3.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-cli",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.36.6-2",
+  "version": "0.36.6-4",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-io",
   "license": "MIT",
-  "version": "0.36.6-2",
+  "version": "0.36.6-4",
   "packageManager": "yarn@3.3.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
-  "version": "0.36.6-2",
+  "version": "0.36.6-4",
   "packageManager": "yarn@3.3.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.36.6-2",
+  "version": "0.36.6-4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.36.6-2",
+  "version": "0.36.6-4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/src/__tests__/integration/api-add.test.ts
+++ b/projects/optic/src/__tests__/integration/api-add.test.ts
@@ -31,7 +31,9 @@ setupTestServer(({ url, method }) => {
       id: 'spec-id',
     });
   } else if (method === 'GET' && /\/api\/token\/orgs/.test(url)) {
-    return JSON.stringify([{ id: 'org-id', name: 'org-blah' }]);
+    return JSON.stringify({
+      organizations: [{ id: 'org-id', name: 'org-blah' }],
+    });
   } else if (method === 'GET' && /\/api\/ruleset-configs/.test(url)) {
     // a return value means it exists
     return JSON.stringify({});

--- a/projects/optic/src/client/optic-backend.ts
+++ b/projects/optic/src/client/optic-backend.ts
@@ -32,7 +32,9 @@ export class OpticBackendClient extends JsonHttpClient {
       : 'https://app.useoptic.com';
   }
 
-  public getTokenOrgs(): Promise<{ id: string; name: string }[]> {
+  public getTokenOrgs(): Promise<{
+    organizations: { id: string; name: string }[];
+  }> {
     return this.getJson(`/api/token/orgs`);
   }
 

--- a/projects/optic/src/commands/api/add.ts
+++ b/projects/optic/src/commands/api/add.ts
@@ -89,7 +89,7 @@ async function getOrganizationToUploadTo(client: OpticBackendClient): Promise<
 > {
   let org: { id: string; name: string };
 
-  const organizations = await client.getTokenOrgs();
+  const { organizations } = await client.getTokenOrgs();
   if (organizations.length > 1) {
     const response = await prompts({
       type: 'select',

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.36.6-2",
+  "version": "0.36.6-4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.36.6-2",
+  "version": "0.36.6-4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Update the endpoint response to match the new org response from token auth


## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._
https://github.com/opticdev/monorail/pull/2772

## 👹 QA
_How can other humans verify that this PR is correct?_
