### PR TITLE
Implement skeleton for `optic ci comment`

### DIFF
--- a/projects/openapi-utilities/src/index.ts
+++ b/projects/openapi-utilities/src/index.ts
@@ -93,6 +93,7 @@ export {
   getOperationsModifsLabel,
   countOperationsModifications,
   getLabel,
+  getOperationsChangedLabel,
 } from './utilities/count-changed-operations';
 
 export { compareSpecs } from './compare-specs/compare-specs';

--- a/projects/openapi-utilities/src/utilities/comparison-render.ts
+++ b/projects/openapi-utilities/src/utilities/comparison-render.ts
@@ -244,7 +244,7 @@ export function* generateComparisonLogsV2(
   ).length;
   const passedNumberOfChecks = totalNumberOfChecks - failedNumberOfChecks;
   const groupedResults = groupBy(comparison.results, (result) => {
-    // Openapi V3 specific
+    // OpenAPIV3 assumption
     const parts = jsonPointerHelpers.decode(result.location.jsonPath);
     if (parts.length >= 3 && parts[0] === 'paths') {
       const location = getLocation({

--- a/projects/openapi-utilities/src/utilities/count-changed-operations.ts
+++ b/projects/openapi-utilities/src/utilities/count-changed-operations.ts
@@ -1,8 +1,6 @@
-import { OpenAPIV3 } from 'openapi-types';
-import { getTypeofDiffs, ObjectDiff, typeofDiff } from '../diff/diff';
+import { getTypeofDiffs } from '../diff/diff';
 import { isChangeVariant } from '../openapi3/sdk/isType';
 import { OpenApiKind, IChange, ChangeType } from '../openapi3/sdk/types';
-import { getLocation } from '../openapi3/traverser';
 import { GroupedDiffs } from '../openapi3/group-diff';
 
 const getChangeOperationId = (change: IChange) => {

--- a/projects/optic/src/commands/ci/comment/comment-api.ts
+++ b/projects/optic/src/commands/ci/comment/comment-api.ts
@@ -1,0 +1,8 @@
+export interface CommentApi {
+  getComment: (
+    commentIdentifier: string
+  ) => Promise<{ id: string; body: string } | null>;
+  getShaCreatedAt: (sha: string) => Promise<Date>;
+  updateComment: (commentId: string, body: string) => Promise<void>;
+  createComment: (body: string) => Promise<void>;
+}

--- a/projects/optic/src/commands/ci/comment/comment.ts
+++ b/projects/optic/src/commands/ci/comment/comment.ts
@@ -1,16 +1,166 @@
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import { wrapActionHandlerWithSentry } from '@useoptic/openapi-utilities/build/utilities/sentry';
 
 import { OpticCliConfig } from '../../../config';
+import { readDataForCi } from '../../../utils/ci-data';
+import {
+  generateCompareSummaryMarkdown,
+  getMetadataFromMarkdown,
+} from './common';
+import { logger } from '../../../logger';
+
+const usage = () => `
+  GITHUB_TOKEN=<github-token> optic ci comment --provider github --owner <repo-owner> --repo <repo-name> --pull-request <pr-number> --sha <commit-sha>
+  GITLAB_TOKEN=<gitlab-token> optic ci comment --provider gitlab --project-id <project-id> --merge-request-id <merge-request-id> --sha <commit-sha>
+`;
 
 export const registerCiComment = (cli: Command, config: OpticCliConfig) => {
   cli
     .command('comment', { hidden: true })
+    .configureHelp({
+      commandUsage: usage,
+    })
+    .addOption(
+      new Option(
+        '--provider <provider>',
+        `the git provider where you want to post this comment. supported providers are: 'github', 'gitlab'`
+      )
+        .choices(['github', 'gitlab'])
+        .makeOptionMandatory()
+    )
+    .option(
+      '--owner <owner>',
+      '[github only] the owner of the repo (this can be an organization or a user)'
+    )
+    .option('--repo <repo>', '[github only] the name of the repo')
+    .option(
+      '--pull-request <pull-request>',
+      '[github only] the pull request number on the repo'
+    )
+    .requiredOption('--sha <sha>', 'the git sha of this run')
+    .option(
+      '--project-id <project-id>',
+      '[gitlab only] the project id of the project'
+    )
+    .option(
+      '--merge-request-id <merge-request-id>',
+      '[gitlab only] the merge request iid in the repo'
+    )
     .description('comment on a pull request / merge request')
     .action(wrapActionHandlerWithSentry(getCiCommentAction(config)));
 };
 
-type CiCommentActionOptions = {};
+type UnvalidatedOptions = {
+  provider: 'github' | 'gitlab';
+  owner?: string;
+  repo?: string;
+  pullRequest?: string;
+  projectId?: string;
+  mergeRequestId?: string;
+  sha: string;
+};
+
+type CiCommentActionOptions =
+  | {
+      provider: 'github';
+      owner: string;
+      repo: string;
+      pullRequest: string;
+      sha: string;
+    }
+  | {
+      provider: 'gitlab';
+      projectId: string;
+      mergeRequestId: string;
+      sha: string;
+    };
 
 const getCiCommentAction =
-  (config: OpticCliConfig) => async (options: CiCommentActionOptions) => {};
+  (config: OpticCliConfig) => async (_options: UnvalidatedOptions) => {
+    const githubToken = process.env.GITHUB_TOKEN!;
+    const gitlabToken = process.env.GITLAB_TOKEN!;
+    if (
+      _options.provider === 'github' &&
+      (!_options.owner ||
+        !_options.repo ||
+        !_options.pullRequest ||
+        !_options.sha)
+    ) {
+      logger.error(
+        'option --provider github must include --owner, --repo, --pull-request and --sha'
+      );
+      process.exitCode = 1;
+      return;
+    } else if (
+      _options.provider === 'gitlab' &&
+      (!_options.projectId || !_options.mergeRequestId || !_options.sha)
+    ) {
+      logger.error(
+        'option --provider gitlab must include --project-id, --merge-request-id and --sha'
+      );
+      process.exitCode = 1;
+      return;
+    } else if (_options.provider === 'github' && !githubToken) {
+      logger.error(
+        'no github token was found. Ensure that the environment variable GITHUB_TOKEN is set'
+      );
+      process.exitCode = 1;
+      return;
+    } else if (_options.provider === 'gitlab' && !gitlabToken) {
+      logger.error(
+        'no gitlab token was found. Ensure that the environment variable GITLAB_TOKEN is set'
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    const options = _options as CiCommentActionOptions;
+
+    const data = await readDataForCi();
+    // todo fetch comment
+    //     const maybeComment = await findOpticComment(
+    //   octokit,
+    //   COMPARE_SUMMARY_IDENTIFIER,
+    //   owner,
+    //   repo,
+    //   pull_request
+    // );
+
+    const maybeComment: { body: string } | null = null as any;
+    // todo fetch commit hash date
+    const commitCreatedAt = new Date();
+    const body = generateCompareSummaryMarkdown(
+      {
+        sha: options.sha,
+        timestamp: commitCreatedAt.toISOString(),
+      },
+      data
+    );
+
+    if (maybeComment) {
+      // If there's a comment already, we need to check whether this session newer than the posted comment
+      const maybeMetadata = getMetadataFromMarkdown(maybeComment.body);
+      const shouldWriteComment =
+        !!maybeMetadata && commitCreatedAt > maybeMetadata.date;
+      if (shouldWriteComment) {
+        // TODO update the comment body
+        // await octokit.rest.issues.updateComment({
+        //   owner,
+        //   repo,
+        //   comment_id: maybeComment.id,
+        //   body,
+        // });
+      }
+    } else {
+      // if does not have comment, we should only comment when there is a completed or failed session
+      if (data.completed.length > 0 || data.failed.length > 0) {
+        // TODO create comment
+        // await octokit.rest.issues.createComment({
+        //   owner,
+        //   repo,
+        //   issue_number: pull_request,
+        //   body,
+        // });
+      }
+    }
+  };

--- a/projects/optic/src/commands/ci/comment/comment.ts
+++ b/projects/optic/src/commands/ci/comment/comment.ts
@@ -1,0 +1,16 @@
+import { Command } from 'commander';
+import { wrapActionHandlerWithSentry } from '@useoptic/openapi-utilities/build/utilities/sentry';
+
+import { OpticCliConfig } from '../../../config';
+
+export const registerCiComment = (cli: Command, config: OpticCliConfig) => {
+  cli
+    .command('comment', { hidden: true })
+    .description('comment on a pull request / merge request')
+    .action(wrapActionHandlerWithSentry(getCiCommentAction(config)));
+};
+
+type CiCommentActionOptions = {};
+
+const getCiCommentAction =
+  (config: OpticCliConfig) => async (options: CiCommentActionOptions) => {};

--- a/projects/optic/src/commands/ci/comment/common.ts
+++ b/projects/optic/src/commands/ci/comment/common.ts
@@ -1,0 +1,153 @@
+import { getOperationsChangedLabel } from '@useoptic/openapi-utilities';
+import { CiRunDetails } from '../../../utils/ci-data';
+
+const getChecksLabel = (
+  results: CiRunDetails['completed'][number]['comparison']['results']
+) => {
+  let totalChecks = results.length;
+  let failingChecks = 0;
+  let exemptedFailingChecks = 0;
+
+  for (const result of results) {
+    if (result.passed) continue;
+    if (result.exempted) exemptedFailingChecks += 1;
+    else failingChecks += 1;
+  }
+
+  const exemptedChunk =
+    exemptedFailingChecks > 0
+      ? ` ${exemptedFailingChecks} were exempted from failing`
+      : '';
+
+  return failingChecks > 0
+    ? `⚠️ **${failingChecks}** / **${totalChecks}** failed${exemptedChunk}`
+    : totalChecks > 0
+    ? `✅ all passed (**${totalChecks}**)${exemptedChunk}`
+    : `ℹ️ No automated checks have run`;
+};
+
+export const COMPARE_SUMMARY_IDENTIFIER = `optic-comment-3UsoJCz_Z0SpGLo5Vjw6o`;
+
+export const getMetadataFromMarkdown = (
+  body: string
+): { commit_sha: string; date: Date } | null => {
+  const maybeSha = body.match(/commit_sha: (.+)\n/i)?.[1] ?? null;
+  const maybeTimestamp = body.match(/timestamp: (.+)\n/i)?.[1] ?? null;
+  const maybeDate = maybeTimestamp ? new Date(maybeTimestamp) : null;
+  const isDateValid = maybeDate && !isNaN(maybeDate.getTime());
+  return maybeSha && isDateValid
+    ? {
+        commit_sha: maybeSha,
+        date: maybeDate,
+      }
+    : null;
+};
+
+export const generateCompareSummaryMarkdown = (
+  commit: { sha: string; timestamp: string },
+  results: CiRunDetails
+) => {
+  const anyCompletedHasWarning = results.completed.some(
+    (s) => s.warnings.length > 0
+  );
+  return `
+<!--
+DO NOT MODIFY
+app_id: ${COMPARE_SUMMARY_IDENTIFIER}
+commit_sha: ${commit.sha}
+timestamp: ${commit.timestamp}
+-->
+${
+  results.completed.length > 0
+    ? `### APIs Changed
+
+<table>
+<thead>
+<tr>
+<th>API</th>
+<th>Operation Changes</th>
+<th>Checks</th>
+${anyCompletedHasWarning ? '<th>Warnings</th>' : ''}
+</tr>
+</thead>
+<tbody>
+${results.completed
+  .map(
+    (s) =>
+      `<tr>
+<td>
+
+[${s.apiName}](${s.opticWebUrl})
+
+</td>
+<td>
+
+${getOperationsChangedLabel(s.comparison.groupedDiffs)} ([view changelog](${
+        s.opticWebUrl
+      }))
+
+</td>
+<td>
+
+${getChecksLabel(s.comparison.results)}
+
+</td>
+${anyCompletedHasWarning ? `<td>${s.warnings.join('\n')}</td>` : ''}
+</tr>`
+  )
+  .join('\n')}
+</tbody>
+</table>
+`
+    : ''
+}
+${
+  results.failed.length > 0
+    ? `### Errors running optic
+
+<table>
+<thead>
+<tr>
+<th>API</th>
+<th>Error</th>
+</tr>
+</thead>
+<tbody>
+${results.failed
+  .map(
+    (s) => `<tr>
+<td>${s.apiName}</td>
+<td>
+
+${'```'}
+${s.error}
+${'```'}
+
+</td>
+</tr>`
+  )
+  .join('\n')}
+</tbody>
+</table>
+`
+    : ''
+}
+
+Summary of API changes for commit (${commit.sha})
+
+${
+  results.noop.length > 0
+    ? `${
+        results.noop.length === 1 ? '1 API' : `${results.noop.length} APIs`
+      } had no changes.`
+    : ''
+}`;
+};
+
+const LOADING_BANNER_IDENTIFIER = 'LOADING-BANNER-zRdRfihnV6eN5__wdKq5A';
+export const getHasLoadingBanner = (body: string) =>
+  new RegExp(LOADING_BANNER_IDENTIFIER).test(body);
+
+export const createLoadingBanner = (commitSha: string) => `
+<!-- ${LOADING_BANNER_IDENTIFIER} -->
+> ℹ️ Running update for commit ${commitSha}`;

--- a/projects/optic/src/init.ts
+++ b/projects/optic/src/init.ts
@@ -21,6 +21,7 @@ import { verifyCommand } from '@useoptic/openapi-cli/build/commands/verify';
 import { registerDiffAll } from './commands/diff/diff-all';
 import { registerSpecPush } from './commands/spec/push';
 import { registerLogin } from './commands/login/login';
+import { registerCiComment } from './commands/ci/comment/comment';
 
 const packageJson = require('../package.json');
 
@@ -28,7 +29,7 @@ export const initCli = async () => {
   initSentry(process.env.SENTRY_URL, packageJson.version);
   initSegment(process.env.SEGMENT_KEY);
   cli.hook('preAction', async (command) => {
-    const subcommands = ['ruleset', 'oas', 'api', 'spec'];
+    const subcommands = ['ruleset', 'oas', 'api', 'spec', 'ci'];
     try {
       let commandName: string;
       let args: string[];
@@ -71,6 +72,9 @@ export const initCli = async () => {
 
   const specSubcommands = cli.command('spec').addHelpCommand(false);
   registerSpecPush(specSubcommands, cliConfig);
+
+  const ciSubcommands = cli.command('ci').addHelpCommand(false);
+  registerCiComment(ciSubcommands, cliConfig);
 
   const oas = cli.command('oas');
   oas.description(

--- a/projects/optic/src/utils/ci-data.ts
+++ b/projects/optic/src/utils/ci-data.ts
@@ -1,0 +1,84 @@
+import fs from 'node:fs/promises';
+import path from 'path';
+import {
+  compareSpecs,
+  RuleResult,
+  groupDiffsByEndpoint,
+} from '@useoptic/openapi-utilities';
+
+type Comparison = {
+  groupedDiffs: ReturnType<typeof groupDiffsByEndpoint>;
+  results: Awaited<ReturnType<typeof compareSpecs>>['results'];
+};
+
+export type CiRunDetails = {
+  completed: {
+    warnings: string[];
+    apiName: string;
+    opticWebUrl: string;
+    comparison: Comparison;
+  }[];
+  failed: { apiName: string; error: string }[];
+  noop: { apiName: string }[];
+};
+
+const CI_DETAILS_FILE_PATH = path.join(process.cwd(), 'ci-run-details.json');
+
+export async function writeDataForCi(
+  specs: (
+    | {
+        warnings: string[];
+        results: RuleResult[];
+        groupedDiffs: ReturnType<typeof groupDiffsByEndpoint>;
+        url: string;
+        name: string;
+      }
+    | {
+        name: string;
+        error: string;
+      }
+  )[]
+) {
+  const data: CiRunDetails = {
+    completed: [],
+    failed: [],
+    noop: [],
+  };
+
+  for (const spec of specs) {
+    if ('error' in spec) {
+      data.failed.push({
+        apiName: spec.name,
+        error: spec.error,
+      });
+    } else {
+      if (
+        Object.keys(spec.groupedDiffs.endpoints).length === 0 &&
+        spec.groupedDiffs.specification.length === 0 &&
+        spec.results.length === 0
+      ) {
+        data.noop.push({
+          apiName: spec.name,
+        });
+      } else {
+        data.completed.push({
+          apiName: spec.name,
+          warnings: spec.warnings,
+          opticWebUrl: spec.url,
+          comparison: {
+            groupedDiffs: spec.groupedDiffs,
+            results: spec.results,
+          },
+        });
+      }
+    }
+  }
+
+  await fs.writeFile(CI_DETAILS_FILE_PATH, JSON.stringify(data), 'utf-8');
+}
+
+export async function readDataForCi(): Promise<CiRunDetails> {
+  const file = await fs.readFile(CI_DETAILS_FILE_PATH, 'utf-8');
+
+  return JSON.parse(file);
+}


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

This PR has a lot of the meat for optic ci comment (taken from monorail + adapted to our new format)

The idea I have here is:
- If `CI===true`, optic diff and optic diff-all will dump a CI results file (see `./utils/ci-data.ts`)
- Calling `optic ci comment` after this will read that data (and error if not found)
- Will comment / update based on the same rules we had for monorail


In follow up PRs I'm going to:
- Implement the github / gitlab connectors for API calls
- update diff to dump a CIRun file if `CI===true`
- update diff-all to dump a CIRun file if `CI===true`

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
