### PR TITLE
Windows readline fix

### DIFF
--- a/projects/openapi-cli/src/captures/system-proxy.ts
+++ b/projects/openapi-cli/src/captures/system-proxy.ts
@@ -2,7 +2,7 @@ import { exec } from 'child_process';
 import url from 'url';
 import { createCommandFeedback } from '../commands/reporters/feedback';
 
-const platform: 'mac' | 'windows' | 'linux' =
+export const platform: 'mac' | 'windows' | 'linux' =
   process.platform === 'win32'
     ? 'windows'
     : process.platform === 'darwin'

--- a/projects/openapi-cli/src/commands/capture.ts
+++ b/projects/openapi-cli/src/commands/capture.ts
@@ -141,10 +141,6 @@ export async function captureCommand(): Promise<Command> {
 
           for await (let line of lines) {
             if (line.trim().length === 0) {
-              if (process.stdin.isTTY) {
-                readline.moveCursor(process.stdin, 0, -1);
-                readline.clearLine(process.stdin, 1);
-              }
               sourcesController.abort();
             }
           }

--- a/projects/openapi-cli/src/commands/capture.ts
+++ b/projects/openapi-cli/src/commands/capture.ts
@@ -18,7 +18,7 @@ import {
   ProxyCertAuthority,
   ProxyInteractions,
 } from '../captures';
-import { SystemProxy } from '../captures/system-proxy';
+import { platform, SystemProxy } from '../captures/system-proxy';
 import { captureStorage } from '../captures/capture-storage';
 import { RunCommand } from '../captures/run-command';
 
@@ -141,6 +141,11 @@ export async function captureCommand(): Promise<Command> {
 
           for await (let line of lines) {
             if (line.trim().length === 0) {
+              // @todo get this working on windows. It cleans up the incremental request count but fails on windows. It's not essential
+              if (process.stdin.isTTY && platform !== 'windows') {
+                readline.moveCursor(process.stdin, 0, -1);
+                readline.clearLine(process.stdin, 1);
+              }
               sourcesController.abort();
             }
           }


### PR DESCRIPTION
## 🍗 Description
Windows and WSL shells are failing if you ENTER end a capture instead of CTRL-C ing the process. We tell users to use ENTER so this should work. 

After investigating the issue, I realized we clear the line -- purely a stylistic choice, that is causing the error moving the cursor. 

@MatthijsKok raised this https://github.com/opticdev/optic/pull/1489

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
