### PR TITLE
Update login to use env backed url

### DIFF
--- a/projects/optic/src/commands/login/login.ts
+++ b/projects/optic/src/commands/login/login.ts
@@ -7,7 +7,7 @@ import { wrapActionHandlerWithSentry } from '@useoptic/openapi-utilities/build/u
 import { OpticCliConfig, USER_CONFIG_PATH, readUserConfig } from '../../config';
 import { logger } from '../../logger';
 import chalk from 'chalk';
-import { OPTIC_LOGIN_PAT_LINK } from '../../constants';
+import { getNewTokenUrl } from '../../utils/cloud-urls';
 
 export const registerLogin = (cli: Command, config: OpticCliConfig) => {
   cli
@@ -32,7 +32,9 @@ const getLoginAction = (config: OpticCliConfig) => async () => {
 
   logger.info(`${chalk.blue('Generate a token below')}
 
-Create an account and generate a personal access token at ${OPTIC_LOGIN_PAT_LINK}.
+Create an account and generate a personal access token at ${getNewTokenUrl(
+    config.client.getWebBase()
+  )}.
 
 Once you've created a token, enter it below.
   

--- a/projects/optic/src/constants.ts
+++ b/projects/optic/src/constants.ts
@@ -1,4 +1,2 @@
 export const OPTIC_STANDARD_KEY = 'x-optic-standard';
 export const OPTIC_URL_KEY = 'x-optic-url';
-export const OPTIC_LOGIN_PAT_LINK =
-  'https://app.useoptic.com/user-settings/personal-access-token/new';

--- a/projects/optic/src/utils/cloud-urls.ts
+++ b/projects/optic/src/utils/cloud-urls.ts
@@ -55,3 +55,7 @@ export function getStandardsUrl(
 ) {
   return urljoin(baseUrl, `organizations/${orgId}/standards/${standardId}`);
 }
+
+export function getNewTokenUrl(baseUrl: string) {
+  return urljoin(baseUrl, 'user-settings/personal-access-token/new');
+}


### PR DESCRIPTION
## 🍗 Description

_What does this PR do? Anything folks should know?_

I noticed when using optic login with OPTIC_ENV=staging it still gave me a production url. So this fixes that.

## 📚 References

_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA

_How can other humans verify that this PR is correct?_
