### PR TITLE
pin version of json-schema-ref-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.36.6",
+  "version": "0.36.7",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
-  "version": "0.36.6",
+  "version": "0.36.7",
   "packageManager": "yarn@3.3.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-cli",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.36.6",
+  "version": "0.36.7",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-io",
   "license": "MIT",
-  "version": "0.36.6",
+  "version": "0.36.7",
   "packageManager": "yarn@3.3.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -49,7 +49,7 @@
     "typescript": "^4.4.4"
   },
   "dependencies": {
-    "@apidevtools/json-schema-ref-parser": "^9.0.9",
+    "@apidevtools/json-schema-ref-parser": "9.0.9",
     "@jsdevtools/ono": "^7.1.3",
     "@useoptic/json-pointer-helpers": "workspace:*",
     "@useoptic/openapi-utilities": "workspace:*",

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
-  "version": "0.36.6",
+  "version": "0.36.7",
   "packageManager": "yarn@3.3.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.36.6",
+  "version": "0.36.7",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.36.6",
+  "version": "0.36.7",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.36.6",
+  "version": "0.36.7",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.36.6",
+  "version": "0.36.7",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,7 +24,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apidevtools/json-schema-ref-parser@npm:^9.0.9":
+"@apidevtools/json-schema-ref-parser@npm:9.0.9":
   version: 9.0.9
   resolution: "@apidevtools/json-schema-ref-parser@npm:9.0.9"
   dependencies:
@@ -3805,7 +3805,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@useoptic/openapi-io@workspace:projects/openapi-io"
   dependencies:
-    "@apidevtools/json-schema-ref-parser": ^9.0.9
+    "@apidevtools/json-schema-ref-parser": 9.0.9
     "@babel/core": ^7.17.0
     "@babel/plugin-transform-runtime": ^7.17.0
     "@babel/preset-env": ^7.17.0


### PR DESCRIPTION
## 🍗 Description
User reported that Optic wasn't installing and discovered that it's because of our dependency `"@apidevtools/json-schema-ref-parser": "^9.0.9",`

That project just released major changes as a minor version and it broke the install for them. They have since updated to a major version release but the damage is done so getting this pinned for the time being while we assess a migration properly. 

Sorry to anyone who ran into this in the last few hours 


## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
