### PR TITLE
make it easier to set TLS for mac

### DIFF
--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -46,6 +46,7 @@
     "babel-jest": "^29.3.1",
     "babel-plugin-inline-dotenv": "^1.7.0",
     "bent": "^7.3.12",
+    "is-elevated": "^4.0.0",
     "jest": "^29.3.1",
     "node-fetch": "^2.6.7",
     "prettier": "^2.4.1",

--- a/projects/openapi-cli/src/captures/system-proxy.ts
+++ b/projects/openapi-cli/src/captures/system-proxy.ts
@@ -1,13 +1,6 @@
-import { exec } from 'child_process';
 import url from 'url';
 import { createCommandFeedback } from '../commands/reporters/feedback';
-
-export const platform: 'mac' | 'windows' | 'linux' =
-  process.platform === 'win32'
-    ? 'windows'
-    : process.platform === 'darwin'
-    ? 'mac'
-    : 'linux';
+import { platform, runCommand } from '../shell-utils';
 
 export class SystemProxy {
   constructor(
@@ -78,16 +71,4 @@ export async function chooseInterfaceMac() {
     }
   });
   return name || 'Wi-Fi';
-}
-
-async function runCommand(command: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    exec(command, (err, stdout, stderr) => {
-      if (err) {
-        console.error(`exec error: ${err}`);
-        return reject(err);
-      }
-      resolve(stdout);
-    });
-  });
 }

--- a/projects/openapi-cli/src/cli.ts
+++ b/projects/openapi-cli/src/cli.ts
@@ -10,7 +10,7 @@ import { verifyCommand } from './commands/verify';
 import { CliConfig, readConfig } from './config';
 import { trackEvent } from './segment';
 import { clearCommand } from './commands/clear';
-import { captureCertCommand } from './commands/setup-tls';
+import { setupTlsCommand } from './commands/setup-tls';
 
 export async function makeCli(config: CliConfig) {
   const cli = new Command('oas');
@@ -20,7 +20,7 @@ export async function makeCli(config: CliConfig) {
 
   cli.addCommand(await captureCommand());
   cli.addCommand(await newCommand());
-  cli.addCommand(await captureCertCommand());
+  cli.addCommand(await setupTlsCommand());
   cli.addCommand(await clearCommand());
   cli.addCommand(await verifyCommand());
   // registerDebugTemplateCommand(cli);

--- a/projects/openapi-cli/src/cli.ts
+++ b/projects/openapi-cli/src/cli.ts
@@ -10,7 +10,7 @@ import { verifyCommand } from './commands/verify';
 import { CliConfig, readConfig } from './config';
 import { trackEvent } from './segment';
 import { clearCommand } from './commands/clear';
-import { captureCertCommand } from './commands/capture-cert';
+import { captureCertCommand } from './commands/setup-tls';
 
 export async function makeCli(config: CliConfig) {
   const cli = new Command('oas');
@@ -41,10 +41,10 @@ export async function runCli(packageManifest?: {
     distTag: config.updateNotifier.distTag,
   }).notify();
 
-  console.log('oas commands are now part of the optic cli');
-  console.log(
-    'Updated documented is at: http://useoptic.com/docs/document-existing-api\n\n'
-  );
+  // console.log('oas commands are now part of the optic cli');
+  // console.log(
+  //   'Updated documented is at: http://useoptic.com/docs/document-existing-api\n\n'
+  // );
 
   const cli = await makeCli(config);
   const feedback = createCommandFeedback(cli);

--- a/projects/openapi-cli/src/commands/capture.ts
+++ b/projects/openapi-cli/src/commands/capture.ts
@@ -10,7 +10,7 @@ import { createCommandFeedback, InputErrors } from './reporters/feedback';
 import { trackCompletion } from '../segment';
 import logNode from 'log-node';
 
-import { getCertStore } from './capture-cert';
+import { getCertStore } from './setup-tls';
 import {
   CapturedInteraction,
   HarEntries,
@@ -18,9 +18,10 @@ import {
   ProxyCertAuthority,
   ProxyInteractions,
 } from '../captures';
-import { platform, SystemProxy } from '../captures/system-proxy';
+import { SystemProxy } from '../captures/system-proxy';
 import { captureStorage } from '../captures/capture-storage';
 import { RunCommand } from '../captures/run-command';
+import { platform } from '../shell-utils';
 
 export async function captureCommand(): Promise<Command> {
   const command = new Command('capture');

--- a/projects/openapi-cli/src/commands/setup-tls.ts
+++ b/projects/openapi-cli/src/commands/setup-tls.ts
@@ -7,12 +7,11 @@ import { finished } from 'stream/promises';
 import fs from 'fs-extra';
 import { ProxyCertAuthority } from '../captures';
 import { Option, Some, None } from 'ts-results';
-import readline from 'readline';
 import chalk from 'chalk';
 import path from 'path';
 import { exitIfNotElevated, platform, runCommand } from '../shell-utils';
 
-export async function captureCertCommand(): Promise<Command> {
+export async function setupTlsCommand(): Promise<Command> {
   const command = new Command('setup-tls');
 
   const feedback = createCommandFeedback(command);

--- a/projects/openapi-cli/src/commands/setup-tls.ts
+++ b/projects/openapi-cli/src/commands/setup-tls.ts
@@ -51,6 +51,10 @@ export async function setupTlsCommand(): Promise<Command> {
       const destination: Writable = fs.createWriteStream(absoluteFilePath);
       await writeCert(ca, destination);
 
+      console.log(
+        'Hey Optic here. We take privacy seriously so we wanted to let you know how intercepting TLS traffic works: A self-signed certificate generated on your machine (we do not have it) is added to your trust chain. That allows the Optic proxy to read TLS traffic that is sent through it. The CLI will save TLS traffic to the target host (your API) in the tmp directory. It is never sent to us and all the processing happens locally. All the code is Open Source https://github.com/opticdev/optic'
+      );
+
       switch (platform) {
         case 'mac': {
           await exitIfNotElevated(

--- a/projects/openapi-cli/src/shell-utils.ts
+++ b/projects/openapi-cli/src/shell-utils.ts
@@ -1,0 +1,33 @@
+import chalk from 'chalk';
+import { exec } from 'child_process';
+
+export const platform: 'mac' | 'windows' | 'linux' =
+  process.platform === 'win32'
+    ? 'windows'
+    : process.platform === 'darwin'
+    ? 'mac'
+    : 'linux';
+
+const elevatedModulePromise = import('is-elevated');
+export async function exitIfNotElevated(withError: string) {
+  const isElevated = (await elevatedModulePromise).default;
+  const result = await isElevated();
+  if (result) {
+    return;
+  } else {
+    console.log(chalk.red(withError));
+    process.exit(2);
+  }
+}
+
+export async function runCommand(command: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    exec(command, (err, stdout, stderr) => {
+      if (err) {
+        console.error(`exec error: ${err}`);
+        return reject(err);
+      }
+      resolve(stdout);
+    });
+  });
+}

--- a/projects/optic/src/init.ts
+++ b/projects/optic/src/init.ts
@@ -16,7 +16,7 @@ import { registerRulesetInit } from './commands/ruleset/init';
 import { registerApiAdd } from './commands/api/add';
 import { captureCommand } from '@useoptic/openapi-cli/build/commands/capture';
 import { newCommand } from '@useoptic/openapi-cli/build/commands/new';
-import { captureCertCommand } from '@useoptic/openapi-cli/build/commands/capture-cert';
+import { setupTlsCommand } from '@useoptic/openapi-cli/build/commands/setup-tls';
 import { clearCommand } from '@useoptic/openapi-cli/build/commands/clear';
 import { verifyCommand } from '@useoptic/openapi-cli/build/commands/verify';
 import { registerDiffAll } from './commands/diff/diff-all';

--- a/projects/optic/src/init.ts
+++ b/projects/optic/src/init.ts
@@ -87,7 +87,7 @@ Run ${chalk.yellow('npm i -g @useoptic/optic')} to upgrade Optic`
   // commands for tracking changes with openapi
   oas.addCommand(await captureCommand());
   oas.addCommand(await newCommand());
-  oas.addCommand(await captureCertCommand());
+  oas.addCommand(await setupTlsCommand());
   oas.addCommand(await clearCommand());
   oas.addCommand(await verifyCommand());
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3765,6 +3765,7 @@ __metadata:
     fast-deep-equal: ^3.1.3
     fs-extra: ^11.1.0
     har-schema: ^2.0.0
+    is-elevated: ^4.0.0
     is-url: ^1.2.4
     jest: ^29.3.1
     json-schema-traverse: ^1.0.0
@@ -6205,7 +6206,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"execa@npm:^5.0.0":
+"execa@npm:^5.0.0, execa@npm:^5.1.1":
   version: 5.1.1
   resolution: "execa@npm:5.1.1"
   dependencies:
@@ -7123,6 +7124,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-admin@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "is-admin@npm:4.0.0"
+  dependencies:
+    execa: ^5.1.1
+  checksum: 215c96c13d94a55791062ccd171620f6744ce80e95aa922247b00870def7ea315309b6e4a17003301c95b08c0ed84f3b191a0b23202fc46a6721c58cedccaf62
+  languageName: node
+  linkType: hard
+
 "is-arrayish@npm:^0.2.1":
   version: 0.2.1
   resolution: "is-arrayish@npm:0.2.1"
@@ -7183,6 +7193,16 @@ __metadata:
   bin:
     is-docker: cli.js
   checksum: 3fef7ddbf0be25958e8991ad941901bf5922ab2753c46980b60b05c1bf9c9c2402d35e6dc32e4380b980ef5e1970a5d9d5e5aa2e02d77727c3b6b5e918474c56
+  languageName: node
+  linkType: hard
+
+"is-elevated@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "is-elevated@npm:4.0.0"
+  dependencies:
+    is-admin: ^4.0.0
+    is-root: ^3.0.0
+  checksum: 3a737b85863f685ca9fc9488061e18a6654aba44d19da7f2cc4bd5e9b8384831dc6f2dcd5de0286f60b6c79dc34a353531c1a6fd05d65c07be4b94c180729a15
   languageName: node
   linkType: hard
 
@@ -7300,6 +7320,13 @@ __metadata:
   version: 1.2.0
   resolution: "is-retry-allowed@npm:1.2.0"
   checksum: 50d700a89ae31926b1c91b3eb0104dbceeac8790d8b80d02f5c76d9a75c2056f1bb24b5268a8a018dead606bddf116b2262e5ac07401eb8b8783b266ed22558d
+  languageName: node
+  linkType: hard
+
+"is-root@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "is-root@npm:3.0.0"
+  checksum: 4b9f39193951a701ce3b2957b83ce00a80455971b09d6e99ca829c7b9504bf2e0f26b4a1586dd066cb519a92dfefce5f447f3ecc61cf69e7c861826c48682317
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 🍗 Description
Improved the DX for Mac

1. To accept the cert, you are directed to run `setup-tls` with sudo and it does it for you
2. If you get a cert error while capturing (indicating you did not do step 1), you get instructions to do step 1. This is a lot better than what we did before...yell "make sure you did this..." and hope people did. 
<img width="843" alt="Screenshot 2023-01-23 at 7 04 30 PM" src="https://user-images.githubusercontent.com/5900338/214181185-cd22bd9a-cc64-46de-919a-5e85da612c52.png">


I think we can mimic this pattern on linux and then windows. Users on discord have been giving advice on which native commands to run

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
