### PR TITLE
make yaml output non-alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.36.10",
+  "version": "0.36.11",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
-  "version": "0.36.10",
+  "version": "0.36.11",
   "packageManager": "yarn@3.3.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-cli",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.36.10",
+  "version": "0.36.11",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-io",
   "license": "MIT",
-  "version": "0.36.10",
+  "version": "0.36.11",
   "packageManager": "yarn@3.3.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/openapi-io/src/write/index.ts
+++ b/projects/openapi-io/src/write/index.ts
@@ -1,7 +1,7 @@
 import yaml from 'yaml';
 
 export function writeYaml(document: any, indent: 2 | 4 = 2) {
-  return yaml.stringify(document);
+  return yaml.stringify(document, { aliasDuplicateObjects: false });
 }
 
 export function loadYaml(contents: string) {

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
-  "version": "0.36.10",
+  "version": "0.36.11",
   "packageManager": "yarn@3.3.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.36.10",
+  "version": "0.36.11",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.36.10",
+  "version": "0.36.11",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.36.10",
+  "version": "0.36.11",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.3.1",
-  "version": "0.36.10",
+  "version": "0.36.11",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
## 🍗 Description
Defaults in our YAML library started mattering in https://github.com/opticdev/optic/pull/1545 for a customer. 

They just reported it was YAML aliasing everything we wrote to disk. AWS and other openapi tools don't know about YAML aliases and don't support them -- also WTF, I didn't even know they existed and I think I read the grammar twice. 

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
