### PR TITLE
Remove abort controller dependency

### DIFF
--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -81,7 +81,6 @@
     "log-node": "^8.0.3",
     "minimatch": "6.1.6",
     "mockttp": "^3.3.1",
-    "node-abort-controller": "^3.0.1",
     "node-forge": "^1.2.1",
     "node-machine-id": "^1.1.12",
     "object-hash": "^3.0.0",

--- a/projects/openapi-cli/src/captures/streams/sources/proxy.test.ts
+++ b/projects/openapi-cli/src/captures/streams/sources/proxy.test.ts
@@ -4,7 +4,6 @@ import { ProxyCertAuthority, ProxyInteractions } from './proxy';
 import * as mockttp from 'mockttp';
 import bent from 'bent';
 import { collect } from '../../../lib/async-tools';
-import { AbortController } from 'node-abort-controller'; // remove when Node v14 is out of LTS
 import fetch from 'node-fetch';
 import https from 'https';
 import UrlJoin from 'url-join';

--- a/projects/openapi-cli/src/captures/streams/sources/proxy.ts
+++ b/projects/openapi-cli/src/captures/streams/sources/proxy.ts
@@ -7,7 +7,6 @@ import {
 } from 'mockttp';
 // import { getCA, CAOptions } from 'mockttp/dist/util/tls';
 import { Subject } from '../../../lib/async-tools';
-import { AbortSignal, AbortController } from 'node-abort-controller'; // remove when Node v14 is out of LTS
 import { pki, md } from 'node-forge';
 import { randomBytes } from 'crypto';
 import { Readable } from 'stream';

--- a/projects/openapi-cli/src/commands/capture.ts
+++ b/projects/openapi-cli/src/commands/capture.ts
@@ -2,7 +2,6 @@ import { Command } from 'commander';
 import path from 'path';
 import * as fs from 'fs-extra';
 import readline from 'readline';
-import { AbortController, AbortSignal } from 'node-abort-controller';
 import { Writable } from 'stream';
 import exitHook from 'async-exit-hook';
 import * as AT from '../lib/async-tools';

--- a/projects/openapi-cli/src/segment.ts
+++ b/projects/openapi-cli/src/segment.ts
@@ -1,7 +1,6 @@
 import { machineIdSync } from 'node-machine-id';
 import exitHook from 'async-exit-hook';
 
-import { AbortSignal } from 'node-abort-controller';
 import {
   flushEvents,
   trackEvent as _trackEvent,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3774,7 +3774,6 @@ __metadata:
     log-node: ^8.0.3
     minimatch: 6.1.6
     mockttp: ^3.3.1
-    node-abort-controller: ^3.0.1
     node-fetch: ^2.6.7
     node-forge: ^1.2.1
     node-machine-id: ^1.1.12
@@ -8996,13 +8995,6 @@ __metadata:
     lodash.topath:
       optional: true
   checksum: 6dcf4aa3dd35c714142f04cfde76727202e1aea802cde0584ef35eabf45d217a9352c55e65045ff91956bb348b3b07ede4ca13af5a6bc8e7ce2f3b2ca353f9bd
-  languageName: node
-  linkType: hard
-
-"node-abort-controller@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "node-abort-controller@npm:3.0.1"
-  checksum: 2b3d75c65249fea99e8ba22da3a8bc553f034f44dd12f5f4b38b520f718b01c88718c978f0c24c2a460fc01de9a80b567028f547b94440cb47adeacfeb82c2ee
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

https://nodejs.org/docs/latest-v16.x/api/globals.html#globals_class_abortcontroller

We're already requiring node16 with usage of `node:fs/promises` in our `optic` codebase - so we can just use the built in abort controller

When installing I'm getting:
```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'node-abort-controller@3.1.0',
npm WARN EBADENGINE   required: { node: '<14.7.0' },
npm WARN EBADENGINE   current: { node: 'v18.12.1', npm: '8.19.2' }
npm WARN EBADENGINE }
```

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
