### PR TITLE
Fix diff with base failing when not at root of git repo

### DIFF
--- a/projects/optic/src/commands/diff/diff.ts
+++ b/projects/optic/src/commands/diff/diff.ts
@@ -114,7 +114,6 @@ const getBaseAndHeadFromFileAndBase = async (
 };
 
 const runDiff = async (
-  [file1, file2]: [string | undefined, string | undefined],
   [baseFile, headFile]: [ParseResult, ParseResult],
   config: OpticCliConfig,
   options: DiffActionOptions
@@ -207,7 +206,6 @@ const getDiffAction =
     if (options.ruleset && !options.standard) {
       options.standard = options.ruleset;
     }
-    const files: [string | undefined, string | undefined] = [file1, file2];
     let parsedFiles: [ParseResult, ParseResult];
     if (file1 && file2) {
       parsedFiles = await getBaseAndHeadFromFiles(file1, file2, config);
@@ -234,7 +232,7 @@ const getDiffAction =
       return;
     }
 
-    const diffResult = await runDiff(files, parsedFiles, config, options);
+    const diffResult = await runDiff(parsedFiles, config, options);
     let maybeUrl: string | null = null;
     const [baseParseResult, headParseResult] = parsedFiles;
     if (config.isAuthenticated) {

--- a/projects/optic/src/config.ts
+++ b/projects/optic/src/config.ts
@@ -238,6 +238,8 @@ export async function initializeConfig(): Promise<OpticCliConfig> {
         ...cliConfig,
         ...(await loadCliConfig(opticYmlPath, cliConfig.client)),
       };
+    } else {
+      cliConfig.root = gitRoot;
     }
 
     try {

--- a/projects/optic/src/utils/spec-loaders.ts
+++ b/projects/optic/src/utils/spec-loaders.ts
@@ -163,7 +163,7 @@ export const parseFilesFromRef = async (
   headFile: ParseResult;
   pathFromGitRoot: string;
 }> => {
-  const absolutePath = path.join(rootGitPath, filePath);
+  const absolutePath = path.resolve(filePath);
   const gitFileName = filePathToGitPath(rootGitPath, filePath);
   const fileExistsOnBasePromise = exec(`git show ${base}:${gitFileName}`)
     .then(() => true)


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Fixes the bug where running `optic diff file --base gitref` is run _not_ at the root of the repo and does not have an optic.dev.yml file.

Without this, the parser picks up the wrong git ref path (`main:spec.yml`) instead of the git root path (`main:folder/spec.yml`) when there isn't a optic.dev.yml (i.e. we don't set the `git root` correctly when we dont detect the CLI config

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
