### PR TITLE
Handle invalid token

### DIFF
--- a/projects/optic/src/client/JsonHttpClient.ts
+++ b/projects/optic/src/client/JsonHttpClient.ts
@@ -33,19 +33,20 @@ export class JsonHttpClient {
       const text = await response.text();
       const message = `${response.status} ${response.statusText} \n${text}`;
       const ErrorClass =
-        response.statusText === '400'
+        response.status === 400
           ? BadRequestError
-          : response.statusText === '401'
+          : response.status === 401
           ? UnauthorizedError
-          : response.statusText === '403'
+          : response.status === 403
           ? ForbiddenError
-          : response.statusText === '404'
+          : response.status === 404
           ? NotFoundError
-          : response.statusText === '500'
+          : response.status === 500
           ? InternalError
-          : response.statusText === '503'
+          : response.status === 503
           ? ServiceUnavailableError
           : Error;
+
       throw new ErrorClass(message);
     }
   }

--- a/projects/optic/src/client/JsonHttpClient.ts
+++ b/projects/optic/src/client/JsonHttpClient.ts
@@ -1,4 +1,12 @@
 import fetch, { Response } from 'node-fetch';
+import {
+  BadRequestError,
+  UnauthorizedError,
+  ForbiddenError,
+  NotFoundError,
+  InternalError,
+  ServiceUnavailableError,
+} from './errors';
 
 export class JsonHttpClient {
   // Create overridable this.fetch instance
@@ -23,7 +31,22 @@ export class JsonHttpClient {
       return json;
     } else {
       const text = await response.text();
-      throw new Error(`${response.status} ${response.statusText} \n${text}`);
+      const message = `${response.status} ${response.statusText} \n${text}`;
+      const ErrorClass =
+        response.statusText === '400'
+          ? BadRequestError
+          : response.statusText === '401'
+          ? UnauthorizedError
+          : response.statusText === '403'
+          ? ForbiddenError
+          : response.statusText === '404'
+          ? NotFoundError
+          : response.statusText === '500'
+          ? InternalError
+          : response.statusText === '503'
+          ? ServiceUnavailableError
+          : Error;
+      throw new ErrorClass(message);
     }
   }
 

--- a/projects/optic/src/client/errors.ts
+++ b/projects/optic/src/client/errors.ts
@@ -1,0 +1,69 @@
+export class BadRequestError extends Error {
+  code: number;
+  constructor(msg: string) {
+    super(msg);
+    this.code = 400;
+
+    // https://github.com/Microsoft/TypeScript-wiki/blob/main/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+    Object.setPrototypeOf(this, BadRequestError.prototype);
+  }
+}
+
+export class UnauthorizedError extends Error {
+  code: number;
+  constructor(msg: string) {
+    super(msg);
+    this.code = 401;
+
+    // https://github.com/Microsoft/TypeScript-wiki/blob/main/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+    Object.setPrototypeOf(this, UnauthorizedError.prototype);
+  }
+}
+
+export class ForbiddenError extends Error {
+  code: number;
+
+  constructor(msg: string) {
+    super(msg);
+    this.code = 403;
+
+    // https://github.com/Microsoft/TypeScript-wiki/blob/main/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+    Object.setPrototypeOf(this, ForbiddenError.prototype);
+  }
+}
+
+export class NotFoundError extends Error {
+  code: number;
+
+  constructor(msg: string = 'Not found') {
+    super(msg);
+    this.code = 404;
+
+    // https://github.com/Microsoft/TypeScript-wiki/blob/main/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+    Object.setPrototypeOf(this, NotFoundError.prototype);
+  }
+}
+
+export class InternalError extends Error {
+  code: number;
+
+  constructor(msg: string) {
+    super(msg);
+    this.code = 500;
+
+    // https://github.com/Microsoft/TypeScript-wiki/blob/main/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+    Object.setPrototypeOf(this, InternalError.prototype);
+  }
+}
+
+export class ServiceUnavailableError extends Error {
+  code: number;
+
+  constructor(msg: string) {
+    super(msg);
+    this.code = 503;
+
+    // https://github.com/Microsoft/TypeScript-wiki/blob/main/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+    Object.setPrototypeOf(this, ServiceUnavailableError.prototype);
+  }
+}

--- a/projects/optic/src/commands/api/add.ts
+++ b/projects/optic/src/commands/api/add.ts
@@ -2,7 +2,6 @@ import { Command } from 'commander';
 import prompts from 'prompts';
 import open from 'open';
 import path from 'path';
-import { wrapActionHandlerWithSentry } from '@useoptic/openapi-utilities/build/utilities/sentry';
 import ora from 'ora';
 import { OpticCliConfig, VCS } from '../../config';
 import { getFileFromFsOrGit, ParseResult } from '../../utils/spec-loaders';
@@ -24,6 +23,7 @@ import {
   flushEvents,
   trackEvent,
 } from '@useoptic/openapi-utilities/build/utilities/segment';
+import { errorHandler } from '../../error-handler';
 
 function short(sha: string) {
   return sha.slice(0, 8);
@@ -73,7 +73,7 @@ export const registerApiAdd = (cli: Command, config: OpticCliConfig) => {
       'Set a standard to run on API diffs. You can always add this later by setting the `[x-optic-standard]` key on your OpenAPI spec'
     )
     .option('--web', 'open to the added API in Optic Cloud', false)
-    .action(wrapActionHandlerWithSentry(getApiAddAction(config)));
+    .action(errorHandler(getApiAddAction(config)));
 };
 
 type ApiAddActionOptions = {

--- a/projects/optic/src/commands/ci/comment/comment.ts
+++ b/projects/optic/src/commands/ci/comment/comment.ts
@@ -1,5 +1,4 @@
 import { Command, Option } from 'commander';
-import { wrapActionHandlerWithSentry } from '@useoptic/openapi-utilities/build/utilities/sentry';
 
 import { OpticCliConfig } from '../../../config';
 import { CiRunDetails, readDataForCi } from '../../../utils/ci-data';
@@ -9,6 +8,7 @@ import {
 } from './common';
 import { logger } from '../../../logger';
 import { CommentApi, GithubCommenter, GitlabCommenter } from './comment-api';
+import { errorHandler } from '../../../error-handler';
 
 const usage = () => `
   GITHUB_TOKEN=<github-token> optic ci comment --provider github --owner <repo-owner> --repo <repo-name> --pull-request <pr-number> --sha <commit-sha>
@@ -52,7 +52,7 @@ export const registerCiComment = (cli: Command, config: OpticCliConfig) => {
       '(only for enterprise versions of github or gitlab) - the base url to your enterprise github / gitlab instance'
     )
     .description('comment on a pull request / merge request')
-    .action(wrapActionHandlerWithSentry(getCiCommentAction(config)));
+    .action(errorHandler(getCiCommentAction(config)));
 };
 
 type UnvalidatedOptions = {

--- a/projects/optic/src/commands/ci/setup.ts
+++ b/projects/optic/src/commands/ci/setup.ts
@@ -1,6 +1,5 @@
-import { Command, Option } from 'commander';
+import { Command } from 'commander';
 import { OpticCliConfig } from '../../config';
-import { wrapActionHandlerWithSentry } from '@useoptic/openapi-utilities/build/utilities/sentry';
 import prompts from 'prompts';
 import fs from 'fs/promises';
 import path from 'path';
@@ -8,6 +7,7 @@ import chalk from 'chalk';
 import open from 'open';
 import { getRemoteUrl, remotes } from '../../utils/git-utils';
 import { getApiAddAction } from '../api/add';
+import { errorHandler } from '../../error-handler';
 
 const configsPath = path.join(__dirname, '..', '..', '..', 'ci', 'configs');
 
@@ -27,7 +27,7 @@ export const registerCiSetup = (cli: Command, config: OpticCliConfig) => {
     .description(
       'Answer a series of prompts to generate CI configuration for Optic'
     )
-    .action(wrapActionHandlerWithSentry(getCiSetupAction(config)));
+    .action(errorHandler(getCiSetupAction(config)));
 };
 
 type PromptAnswers = {

--- a/projects/optic/src/commands/dereference/dereference.ts
+++ b/projects/optic/src/commands/dereference/dereference.ts
@@ -1,11 +1,11 @@
 import { Command } from 'commander';
-import { wrapActionHandlerWithSentry } from '@useoptic/openapi-utilities/build/utilities/sentry';
 import { ParseResult, getFileFromFsOrGit } from '../../utils/spec-loaders';
 import { OpticCliConfig } from '../../config';
 import { UserError } from '@useoptic/openapi-utilities';
 import { isYaml, writeYaml } from '@useoptic/openapi-io';
 import fs from 'node:fs/promises';
 import path from 'path';
+import { errorHandler } from '../../error-handler';
 const description = `dereference an OpenAPI specification`;
 
 const usage = () => `
@@ -27,7 +27,7 @@ export const registerDereference = (cli: Command, config: OpticCliConfig) => {
     .description(description)
     .argument('[file_path]', 'openapi file to dereference')
     .option('-o [output]', 'output file name')
-    .action(wrapActionHandlerWithSentry(deferenceAction(config)));
+    .action(errorHandler(deferenceAction(config)));
 };
 
 const getDereferencedSpec = async (

--- a/projects/optic/src/commands/diff/diff-all.ts
+++ b/projects/optic/src/commands/diff/diff-all.ts
@@ -1,6 +1,5 @@
 import { Command } from 'commander';
 import { OpticCliConfig, VCS } from '../../config';
-import { wrapActionHandlerWithSentry } from '@useoptic/openapi-utilities/build/utilities/sentry';
 import { findOpenApiSpecsCandidates } from '../../utils/git-utils';
 import { getFileFromFsOrGit, ParseResult } from '../../utils/spec-loaders';
 import { logger } from '../../logger';
@@ -21,6 +20,7 @@ import {
 import { uploadDiff } from './upload-diff';
 import { getApiFromOpticUrl, getRunUrl } from '../../utils/cloud-urls';
 import { writeDataForCi } from '../../utils/ci-data';
+import { errorHandler } from '../../error-handler';
 
 const usage = () => `
   optic diff-all
@@ -62,7 +62,7 @@ export const registerDiffAll = (cli: Command, config: OpticCliConfig) => {
     .option('--check', 'enable checks', false)
     .option('--web', 'view the diff in the optic changelog web view', false)
     .option('--json', 'output as json', false)
-    .action(wrapActionHandlerWithSentry(getDiffAllAction(config)));
+    .action(errorHandler(getDiffAllAction(config)));
 };
 
 type DiffAllActionOptions = {

--- a/projects/optic/src/commands/diff/diff.ts
+++ b/projects/optic/src/commands/diff/diff.ts
@@ -8,7 +8,6 @@ import {
   jsonChangelog,
   generateSpecResults,
 } from '@useoptic/openapi-utilities';
-import { wrapActionHandlerWithSentry } from '@useoptic/openapi-utilities/build/utilities/sentry';
 import {
   parseFilesFromRef,
   ParseResult,
@@ -28,6 +27,7 @@ import { uploadDiff } from './upload-diff';
 import { getRunUrl } from '../../utils/cloud-urls';
 import { writeDataForCi } from '../../utils/ci-data';
 import { logger } from '../../logger';
+import { errorHandler } from '../../error-handler';
 
 const description = `run a diff between two API specs`;
 
@@ -74,7 +74,7 @@ export const registerDiff = (cli: Command, config: OpticCliConfig) => {
     .option('--check', 'enable checks', false)
     .option('--web', 'view the diff in the optic changelog web view', false)
     .option('--json', 'output as json', false)
-    .action(wrapActionHandlerWithSentry(getDiffAction(config)));
+    .action(errorHandler(getDiffAction(config)));
 };
 
 const getBaseAndHeadFromFiles = async (

--- a/projects/optic/src/commands/login/login.ts
+++ b/projects/optic/src/commands/login/login.ts
@@ -2,19 +2,19 @@ import { Command } from 'commander';
 import prompts from 'prompts';
 import path from 'path';
 import fs from 'node:fs/promises';
-import { wrapActionHandlerWithSentry } from '@useoptic/openapi-utilities/build/utilities/sentry';
 import open from 'open';
 
 import { OpticCliConfig, USER_CONFIG_PATH, readUserConfig } from '../../config';
 import { logger } from '../../logger';
 import chalk from 'chalk';
 import { getNewTokenUrl } from '../../utils/cloud-urls';
+import { errorHandler } from '../../error-handler';
 
 export const registerLogin = (cli: Command, config: OpticCliConfig) => {
   cli
     .command('login', { hidden: true })
     .description('Login to Optic')
-    .action(wrapActionHandlerWithSentry(getLoginAction(config)));
+    .action(errorHandler(getLoginAction(config)));
 };
 
 const getLoginAction = (config: OpticCliConfig) => async () => {

--- a/projects/optic/src/commands/ruleset/init.ts
+++ b/projects/optic/src/commands/ruleset/init.ts
@@ -1,11 +1,11 @@
 import fs from 'node:fs/promises';
-import { wrapActionHandlerWithSentry } from '@useoptic/openapi-utilities/build/utilities/sentry';
 import { Command } from 'commander';
 import fetch from 'node-fetch';
 import { OpticCliConfig } from '../../config';
 import tar from 'tar';
 import path from 'path';
 import chalk from 'chalk';
+import { errorHandler } from '../../error-handler';
 
 const DEFAULT_INIT_FOLDER = 'optic-ruleset';
 const owner = 'opticdev';
@@ -18,7 +18,7 @@ export const registerRulesetInit = (cli: Command, config: OpticCliConfig) => {
     .command('init')
     .description('Initializes a new ruleset project')
     .argument('[name]', 'the name of the new ruleset project')
-    .action(wrapActionHandlerWithSentry(getInitAction()));
+    .action(errorHandler(getInitAction()));
 };
 
 const getInitAction = () => async (name?: string) => {

--- a/projects/optic/src/commands/ruleset/upload.ts
+++ b/projects/optic/src/commands/ruleset/upload.ts
@@ -4,11 +4,11 @@ import path from 'path';
 import { Command } from 'commander';
 import Ajv from 'ajv';
 
-import { wrapActionHandlerWithSentry } from '@useoptic/openapi-utilities/build/utilities/sentry';
 import { UserError } from '@useoptic/openapi-utilities';
 
 import { OpticCliConfig } from '../../config';
 import { uploadFileToS3 } from '../../utils/s3';
+import { errorHandler } from '../../error-handler';
 
 const expectedFileShape = `Expected ruleset file to have a default export with the shape
 {
@@ -35,7 +35,7 @@ This command also requires a token to be provided via the environment variable O
       '<path_to_ruleset>',
       'the path to the javascript ruleset file to upload, typically "./build/main.js".'
     )
-    .action(wrapActionHandlerWithSentry(getUploadAction(config)));
+    .action(errorHandler(getUploadAction(config)));
 };
 
 const getUploadAction =

--- a/projects/optic/src/commands/spec/push.ts
+++ b/projects/optic/src/commands/spec/push.ts
@@ -1,6 +1,5 @@
 import { Command } from 'commander';
 import open from 'open';
-import { wrapActionHandlerWithSentry } from '@useoptic/openapi-utilities/build/utilities/sentry';
 import { SPEC_TAG_REGEXP } from '@useoptic/openapi-utilities';
 
 import { OpticCliConfig, VCS } from '../../config';
@@ -11,6 +10,7 @@ import * as Git from '../../utils/git-utils';
 import chalk from 'chalk';
 import { uploadSpec } from '../../utils/cloud-specs';
 import { getApiFromOpticUrl, getSpecUrl } from '../../utils/cloud-urls';
+import { errorHandler } from '../../error-handler';
 
 const usage = () => `
   optic spec push <path_to_spec.yml>
@@ -39,7 +39,7 @@ export const registerSpecPush = (cli: Command, config: OpticCliConfig) => {
       'Adds additional tags to the spec version. In git repositories with a clean working directory, a git tag will automatically be included. Tags must be alphanumeric or the - _ : characters'
     )
     .option('--web', 'open to the push spec in Optic Cloud', false)
-    .action(wrapActionHandlerWithSentry(getSpecPushAction(config)));
+    .action(errorHandler(getSpecPushAction(config)));
 };
 
 type SpecPushActionOptions = {

--- a/projects/optic/src/error-handler.ts
+++ b/projects/optic/src/error-handler.ts
@@ -11,14 +11,14 @@ export const errorHandler = <Args extends any[], Return extends any>(
     try {
       return await fn(...args);
     } catch (e) {
-      const err = e as Error;
-      logger.error(err.message);
       if (UserError.isInstance(e)) {
-        // TODO nothing
+        logger.error(e.message);
       } else if (
         e instanceof BadRequestError &&
-        /Invalid Token/i.test(e.message)
+        /Invalid token/i.test(e.message)
       ) {
+        logger.error('');
+        logger.error(chalk.red.bold('Error making request to Optic'));
         logger.error(
           chalk.red(
             'It looks like your token is invalid (this could mean your token has expired, or it has been revoked).'
@@ -27,6 +27,7 @@ export const errorHandler = <Args extends any[], Return extends any>(
         logger.error('');
         logger.error(chalk.green('Run optic login to generate a new token'));
       } else {
+        logger.error((e as Error).message);
         SentryClient.captureException(e);
         await SentryClient.flush();
       }

--- a/projects/optic/src/error-handler.ts
+++ b/projects/optic/src/error-handler.ts
@@ -1,0 +1,37 @@
+import { UserError } from '@useoptic/openapi-utilities';
+import { SentryClient } from '@useoptic/openapi-utilities/build/utilities/sentry';
+import chalk from 'chalk';
+import { BadRequestError } from './client/errors';
+import { logger } from './logger';
+
+export const errorHandler = <Args extends any[], Return extends any>(
+  fn: (...args: Args) => Promise<Return>
+): ((...args: Args) => Promise<Return>) => {
+  return async (...args) => {
+    try {
+      return await fn(...args);
+    } catch (e) {
+      const err = e as Error;
+      logger.error(err.message);
+      if (UserError.isInstance(e)) {
+        // TODO nothing
+      } else if (
+        e instanceof BadRequestError &&
+        /Invalid Token/i.test(e.message)
+      ) {
+        logger.error(
+          chalk.red(
+            'It looks like your token is invalid (this could mean your token has expired, or it has been revoked).'
+          )
+        );
+        logger.error('');
+        logger.error(chalk.green('Run optic login to generate a new token'));
+      } else {
+        SentryClient.captureException(e);
+        await SentryClient.flush();
+      }
+
+      process.exit(1);
+    }
+  };
+};


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Handles the case where a token is invalid. To do this I:
- created ErrorClasses JsonHttpClient throws for different status codes
- Replaced sentry wrapper with a more generic error handle that we can use to handle / look for specific error classes

```
➜  optic git:(handle-token-invalid) ✗ OPTIC_TOKEN=123 yarn run local:run diff ./specs/test-spec.yml --base HEAD~1
No changes were detected

Error making request to Optic
It looks like your token is invalid (this could mean your token has expired, or it has been revoked).

Run optic login to generate a new token
```

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
