### PR TITLE
hide component changes from terminal changelog

### DIFF
--- a/projects/openapi-utilities/src/openapi3/group-diff.ts
+++ b/projects/openapi-utilities/src/openapi3/group-diff.ts
@@ -251,7 +251,12 @@ export function groupDiffsByEndpoint(
       const specToFetchFrom = diff.after !== undefined ? specs.to : specs.from;
       const diffToAdd = { ...diff, trail, change: typeofDiff(diff) };
       if (fact.type === 'specification') {
-        grouped.specification.push(diffToAdd);
+        const isComponentDiff = /^\/components/i.test(
+          diff.after ?? diff.before
+        );
+        if (!isComponentDiff) {
+          grouped.specification.push(diffToAdd);
+        }
       } else if (fact.type === 'path') {
         // We have a path fact, but we don't want to have to keep looking up each diff, so we'll "convert" the raw diff
         // and just emit endpoint diffs

--- a/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
@@ -3,9 +3,8 @@
 exports[`diff petstore diff 1`] = `
 "
 specification details:
-- /components/schemas/User/properties/bio, /components/schemas/User/properties/userStatus/enum, /components/schemas/User/required/2, /components/schemas/Order/properties/summary, /components/schemas/Order/properties/status/enum/2, /servers/2 [32madded[39m
-- /components/schemas/User/properties/userStatus/type, /info/title [33mchanged[39m
-- /components/schemas/User/properties/phone, /components/schemas/User/properties/userStatus/format, /components/schemas/User/required/2, /components/schemas/Order/properties/status/enum/1 [31mremoved[39m
+- /servers/2 [32madded[39m
+- /info/title [33mchanged[39m
 
 [1mGET[22m /parameters_at_path: [32madded[39m
   


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

The terminal changelog is showing the component changes - we want to hide these since we're dereferencing the specs as part of the diff flow 

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
