### PR TITLE
Fix/diff all comparisons

### DIFF
--- a/projects/optic/src/__tests__/integration/__snapshots__/diff-all.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/diff-all.test.ts.snap
@@ -93,6 +93,7 @@ Checks
 [32m✔[39m Uploaded results of diff to http://localhost:3000/organizations/org-id/apis/api-id/runs/run-id
 [33mWarning - the following OpenAPI specs were detected but did not have valid x-optic-url keys. \`optic diff-all\` only runs on specs that include \`x-optic-url\` keys that point to specs uploaded to optic.[39m
 Run the \`optic api add\` command to add these specs to optic
+spec-with-invalid-url.yml
 specwithoutkey.json
 specwithoutkey.yml
 
@@ -100,6 +101,6 @@ specwithoutkey.yml
 `;
 
 exports[`diff-all diffs all files with --json 1`] = `
-"{"results":{"mvspec.yml":{"operations":[{"name":"POST /filler_route","change":"removed","attributes":[{"key":"","before":{"operationId":"create","responses":{"201":{"description":"Created successfully","content":{"application/json":{"schema":{"type":"object","properties":{"id":{"type":"string","format":"uuid","example":"d5b640e5-d88c-4c17-9bf0-93597b7a1ce2"}}}}}}}},"change":"removed"}],"parameters":[],"responses":[]}]},"specwithkey.json":{"operations":[]},"specwithkey.yml":{"operations":[]},"movedspec.yml":{"operations":[{"name":"POST /filler_route","change":"added","attributes":[{"key":"","after":{"operationId":"create","responses":{"201":{"description":"Created successfully","content":{"application/json":{"schema":{"type":"object","properties":{"id":{"type":"string","format":"uuid","example":"d5b640e5-d88c-4c17-9bf0-93597b7a1ce2"}}}}}}}},"change":"added"}],"parameters":[],"responses":[]}]}},"warnings":{"missingOpticUrl":[{"path":"specwithoutkey.json"},{"path":"specwithoutkey.yml"}],"unparseableFromSpec":[],"unparseableToSpec":[]}}
+"{"results":{"mvspec.yml":{"operations":[{"name":"POST /filler_route","change":"removed","attributes":[{"key":"","before":{"operationId":"create","responses":{"201":{"description":"Created successfully","content":{"application/json":{"schema":{"type":"object","properties":{"id":{"type":"string","format":"uuid","example":"d5b640e5-d88c-4c17-9bf0-93597b7a1ce2"}}}}}}}},"change":"removed"}],"parameters":[],"responses":[]}]},"specwithkey.json":{"operations":[]},"specwithkey.yml":{"operations":[]},"movedspec.yml":{"operations":[{"name":"POST /filler_route","change":"added","attributes":[{"key":"","after":{"operationId":"create","responses":{"201":{"description":"Created successfully","content":{"application/json":{"schema":{"type":"object","properties":{"id":{"type":"string","format":"uuid","example":"d5b640e5-d88c-4c17-9bf0-93597b7a1ce2"}}}}}}}},"change":"added"}],"parameters":[],"responses":[]}]}},"warnings":{"missingOpticUrl":[{"path":"spec-with-invalid-url.yml"},{"path":"specwithoutkey.json"},{"path":"specwithoutkey.yml"}],"unparseableFromSpec":[],"unparseableToSpec":[]}}
 "
 `;

--- a/projects/optic/src/__tests__/integration/workspaces/diff-all/repo/random-json-with-openapi.json
+++ b/projects/optic/src/__tests__/integration/workspaces/diff-all/repo/random-json-with-openapi.json
@@ -1,0 +1,7 @@
+{
+  "bad": {
+    "this-isnt-a-spec": {
+      "but has word": "openapi"
+    }
+  }
+}

--- a/projects/optic/src/utils/git-utils.ts
+++ b/projects/optic/src/utils/git-utils.ts
@@ -34,6 +34,17 @@ export const getDefaultBranchName = async (): Promise<string | null> =>
     exec(command, cb);
   });
 
+export const gitShow = async (ref: string, path: string): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const cb = (err: unknown, stdout: string, stderr: string) => {
+      if (err || stderr || !stdout) reject(err || new Error(stderr));
+      resolve(stdout.trim());
+    };
+
+    const command = `git show ${ref}:${path}`;
+    exec(command, cb);
+  });
+
 export const getCurrentBranchName = async (): Promise<string> =>
   new Promise((resolve, reject) => {
     const cb = (err: unknown, stdout: string, stderr: string) => {


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Diff all was being triggered on invalid files (any file that included the string `openapi`). The reason is we were running candidates through the validation step.

To handle this, I've updated diff all to:
- try load the candidate file (without dereferencing, since that can error)
- check the api version + the x-optic-url
- continue if both version + url are correct

This should also:
- maintain reporting dereference, validation and openapi parsing errors
  - This will unfortunately error and silently fail if there's malformed yml/json files. This is a little tricky to solve, either we:
    - try validate any spec candidate that has an `x-optic-url` - we could have false positives where a json or yml file includes the key `x-optic-url` will always fail a build
    - do what we're doing here and just ignore comparisons of candidates that have malformed yml/json

I think longer term we could have something that we can set in some config file for "expected apis to find" and exit 1 if we dont find / compare them

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
