### PR TITLE
Users expect examples to validate w/ strict mode 

### DIFF
--- a/projects/standard-rulesets/src/examples/__tests__/examples-are-valid-rules.test.ts
+++ b/projects/standard-rulesets/src/examples/__tests__/examples-are-valid-rules.test.ts
@@ -2,6 +2,7 @@ import { test, expect, describe } from '@jest/globals';
 import { OpenAPIV3 } from '@useoptic/openapi-utilities';
 import { TestHelpers } from '@useoptic/rulesets-base';
 import { ExamplesRuleset } from '../index';
+import { validateSchema } from '../requireValidExamples';
 
 describe('fromOpticConfig', () => {
   test('invalid configuration', async () => {
@@ -264,5 +265,35 @@ describe('examples ruleset', () => {
 
     expect(results).toMatchSnapshot();
     expect(results.some((result) => !result.passed)).toBe(true);
+  });
+});
+
+describe('examples should default to additional properties false', () => {
+  test('ajv config will be strict on additional properties', () => {
+    const result = validateSchema(
+      {
+        type: 'object',
+        properties: {
+          a: { type: 'string' },
+          b: { type: 'string' },
+        },
+      },
+      { a: 'abc', b: 'def', c: 'xyz' }
+    );
+    expect(result.pass).toBe(false);
+  });
+  test('ajv config will not override a user defined value', () => {
+    const result = validateSchema(
+      {
+        type: 'object',
+        additionalProperties: true,
+        properties: {
+          a: { type: 'string' },
+          b: { type: 'string' },
+        },
+      },
+      { a: 'abc', b: 'def', c: 'xyz' }
+    );
+    expect(result.pass).toBe(true);
   });
 });


### PR DESCRIPTION
## 🍗 Description

JSON Schema defaults additional properties to true, but for examples this doesn't make sense. You necessarily want those to be stricter. 

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
