### PR TITLE
Make comment command also write to stdout

### DIFF
--- a/projects/optic/src/commands/ci/comment/comment.ts
+++ b/projects/optic/src/commands/ci/comment/comment.ts
@@ -9,6 +9,7 @@ import {
 import { logger } from '../../../logger';
 import { CommentApi, GithubCommenter, GitlabCommenter } from './comment-api';
 import { errorHandler } from '../../../error-handler';
+import chalk from 'chalk';
 
 const usage = () => `
   GITHUB_TOKEN=<github-token> optic ci comment --provider github --owner <repo-owner> --repo <repo-name> --pull-request <pr-number> --sha <commit-sha>
@@ -152,5 +153,28 @@ const getCiCommentAction =
       if (data.completed.length > 0 || data.failed.length > 0) {
         await commenter.createComment(body);
       }
+    }
+
+    logger.log(body);
+    if (data.failed.length || data.noop.length)
+      logger.log(
+        chalk.red(`${data.failed.length + data.noop.length} failures`)
+      );
+    if (data.completed.length) {
+      logger.log('Visual Changelogs:');
+      data.completed.forEach((result) => {
+        const results = result.warnings.length
+          ? `${result.warnings.length}/${result.comparison.results.length} failures`
+          : `all ${result.comparison.results.length} checks passed`;
+
+        const leadIcon = result.warnings.length
+          ? chalk.red('⚠')
+          : chalk.green('✓');
+        logger.log(
+          `- ${leadIcon} ${result.apiName} (${results})  \n  ${chalk.blue(
+            result.opticWebUrl
+          )}`
+        );
+      });
     }
   };


### PR DESCRIPTION
## 🍗 Description
A lot of developers click into our CI action expecting to see changelog results + links. This makes sense since that's where they usually find data like this. 

I think we should log a basic comment-like message out at the very end of our comment process. This is also a nice fallback if you don't have a token...you still get something


## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
