### PR TITLE
chore: add docs link to issues template page

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Create a report to help us improve.
 title: ''
 labels: bug
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Optic Documentation
+    url: https://www.useoptic.com/docs
+    about: View Optic's documentation.
   - name: Optic Discord
     url: https://discord.useoptic.com
     about: Join our community and ask questions.

--- a/.github/ISSUE_TEMPLATE/enhancement_request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature Request
-about: Create a request to help us improve
+about: Create a request to help us improve.
 title: ''
 labels: enhancement
 assignees: ''


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

- adds a button to our docs on the issue template picker

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
