### PR TITLE
Run strict validation on diff variant with 2 files

### DIFF
--- a/projects/optic/src/commands/diff/diff.ts
+++ b/projects/optic/src/commands/diff/diff.ts
@@ -83,7 +83,7 @@ const getBaseAndHeadFromFiles = async (
   try {
     // TODO update function to try download from spec-id cloud
     return await Promise.all([
-      getFileFromFsOrGit(file1, config, { strict: false, denormalize: true }),
+      getFileFromFsOrGit(file1, config, { strict: true, denormalize: true }),
       getFileFromFsOrGit(file2, config, { strict: true, denormalize: true }),
     ]);
   } catch (e) {


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

In the case we run `optic diff file1 file2` we should run strict validation. The reason we usually don't is because `optic diff file --base ...` means we cannot fix the before spec, but in this diff instance, we should be able to.

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
