### PR TITLE
fixes for oas path adding issues 

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.38.2-0",
+  "version": "0.38.2-1",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.38.2-1",
+  "version": "0.38.2",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",
@@ -28,6 +28,5 @@
     "**/*.+(js|jsx|ts|tsx|json|css)": [
       "yarn prettier --write"
     ]
-  },
-  "stableVersion": "0.38.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.38.2",
+  "version": "0.38.3",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.38.1",
+  "version": "0.38.2-0",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",
@@ -28,5 +28,6 @@
     "**/*.+(js|jsx|ts|tsx|json|css)": [
       "yarn prettier --write"
     ]
-  }
+  },
+  "stableVersion": "0.38.1"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.38.3",
+  "version": "0.39.0",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.3",
+  "version": "0.39.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.1",
+  "version": "0.38.2-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -34,5 +34,6 @@
   },
   "dependencies": {
     "jsonpointer": "^5.0.1"
-  }
+  },
+  "stableVersion": "0.38.1"
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.2-0",
+  "version": "0.38.2-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.2-1",
+  "version": "0.38.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -34,6 +34,5 @@
   },
   "dependencies": {
     "jsonpointer": "^5.0.1"
-  },
-  "stableVersion": "0.38.1"
+  }
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.2",
+  "version": "0.38.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-cli",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.1",
+  "version": "0.38.2-0",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [
@@ -96,5 +96,6 @@
     "ts-results": "^3.3.0",
     "update-notifier": "^6.0.2",
     "whatwg-mimetype": "^3.0.0"
-  }
+  },
+  "stableVersion": "0.38.1"
 }

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-cli",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.2-0",
+  "version": "0.38.2-1",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-cli",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.2",
+  "version": "0.38.3",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-cli",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.3",
+  "version": "0.39.0",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-cli",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.2-1",
+  "version": "0.38.2",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [
@@ -96,6 +96,5 @@
     "ts-results": "^3.3.0",
     "update-notifier": "^6.0.2",
     "whatwg-mimetype": "^3.0.0"
-  },
-  "stableVersion": "0.38.1"
+  }
 }

--- a/projects/openapi-cli/src/commands/diffing/document.ts
+++ b/projects/openapi-cli/src/commands/diffing/document.ts
@@ -94,7 +94,7 @@ export function parseAddOperations(
   const components = rawComponents.filter((s) => s.length > 0);
   const pairs: ParsedOperation[] = [];
 
-  const regex = /(get|post|put|delete|patch|options|head)( +)(\/.*)/;
+  const regex = /(get|post|put|delete|patch|options|head)( +)(\/.*)/i;
 
   components.forEach((comp) => {
     const groups = regex.exec(comp);

--- a/projects/openapi-cli/src/commands/verify.ts
+++ b/projects/openapi-cli/src/commands/verify.ts
@@ -7,7 +7,7 @@ import { createCommandFeedback, InputErrors } from './reporters/feedback';
 import { flushEvents, trackCompletion, trackEvent } from '../segment';
 import { trackWarning } from '../sentry';
 import * as AT from '../lib/async-tools';
-import { readDeferencedSpec } from '../specs';
+import { OpenAPIV3, readDeferencedSpec } from '../specs';
 import { CapturedInteractions, HarEntries } from '../captures';
 import { captureStorage } from '../captures/capture-storage';
 import chalk from 'chalk';
@@ -23,6 +23,7 @@ import {
   renderDiffs,
   updateByInteractions,
 } from './diffing/patch';
+import { specToOperations } from '../operations/queries';
 
 export async function verifyCommand(): Promise<Command> {
   const command = new Command('verify');
@@ -154,6 +155,7 @@ export async function verifyCommand(): Promise<Command> {
 
       const renderingStatus = await renderOperationStatus(
         observations,
+        spec,
         feedback
       );
 
@@ -226,9 +228,13 @@ export async function verifyCommand(): Promise<Command> {
 
 async function renderOperationStatus(
   observations: StatusObservations,
+  spec: OpenAPIV3.Document,
   feedback: ReturnType<typeof createCommandFeedback>
 ) {
-  const { pathsToAdd } = await observationToUndocumented(observations);
+  const { pathsToAdd } = await observationToUndocumented(
+    observations,
+    specToOperations(spec)
+  );
 
   let undocumentedPaths: number = 0;
 

--- a/projects/openapi-cli/src/commands/verify.ts
+++ b/projects/openapi-cli/src/commands/verify.ts
@@ -188,7 +188,7 @@ export async function verifyCommand(): Promise<Command> {
       await flushEvents();
 
       // clear captures
-      if ((options.document || options.patch) && !options.har) {
+      if ((options.document === 'all' || options.patch) && !options.har) {
         const [, captureStorageDirectory] = await captureStorage(specPath);
         console.log('Resetting captured traffic');
         await fs.remove(captureStorageDirectory);
@@ -326,7 +326,7 @@ function renderUndocumentedPath(
     `${chalk.bgYellow('  Undocumented  ')} ${method
       .toUpperCase()
       .padStart(6, ' ')}   ${pathPattern}\n${''.padStart(
-      25, // undocumented + method length
+      26, // undocumented + method length
       ' '
     )}${examplePath}`
   );

--- a/projects/openapi-cli/src/operations/diffs/__snapshots__/index.test.ts.snap
+++ b/projects/openapi-cli/src/operations/diffs/__snapshots__/index.test.ts.snap
@@ -1,5 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`diffOperationWithSpec yields diffs for paths with no methods 1`] = `
+{
+  "kind": "UnmatchedPath",
+  "subject": "/orders/{orderId}/products",
+}
+`;
+
 exports[`diffOperationWithSpec yields diffs for unmatched methods 1`] = `
 {
   "kind": "UnmatchedMethod",

--- a/projects/openapi-cli/src/operations/diffs/index.test.ts
+++ b/projects/openapi-cli/src/operations/diffs/index.test.ts
@@ -48,6 +48,35 @@ describe('diffOperationWithSpec', () => {
     expect(unmatchedPathResult).toMatchSnapshot();
   });
 
+  it('yields diffs for paths with no methods', () => {
+    let testSpec: OpenAPIV3.Document = {
+      openapi: '3.0.3',
+      info: {
+        title: 'test spec',
+        version: '1.0.0',
+      },
+      paths: {
+        '/orders/{orderId}/products': {},
+      },
+    };
+
+    const unmatchingPathResults = [
+      ...diffOperationWithSpec(
+        {
+          pathPattern: '/orders/{orderId}/products',
+          methods: [HttpMethods.GET],
+        },
+        testSpec
+      ),
+    ];
+    expect(unmatchingPathResults).toHaveLength(1);
+    let [unmatchedPathResult] = unmatchingPathResults;
+    expect(unmatchedPathResult.kind).toBe(
+      OperationDiffResultKind.UnmatchedPath
+    );
+    expect(unmatchedPathResult).toMatchSnapshot();
+  });
+
   it('matches paths irrespective of template names', () => {
     let testSpec: OpenAPIV3.Document = {
       openapi: '3.0.3',

--- a/projects/openapi-cli/src/operations/infer-path-structure.test.ts
+++ b/projects/openapi-cli/src/operations/infer-path-structure.test.ts
@@ -74,6 +74,22 @@ it('can expand the structure from new patterns with obvious variables', () => {
   ]);
 });
 
+it('can suggest additional methods get added', () => {
+  const pathStructure = new InferPathStructure([
+    { methods: ['get'], pathPattern: '/orgs' },
+  ]);
+
+  pathStructure.includeObservedUrlPath('post', '/orgs');
+
+  expect(pathStructure.undocumentedPaths()).toEqual([
+    {
+      methods: ['post'],
+      pathPattern: '/orgs',
+      examplePath: '/orgs',
+    },
+  ]);
+});
+
 it('can expand the structure from new patterns with hints in spec variables', () => {
   const pathStructure = new InferPathStructure([
     { methods: ['get'], pathPattern: '/organizations/{organization}' },

--- a/projects/openapi-cli/src/operations/infer-path-structure.ts
+++ b/projects/openapi-cli/src/operations/infer-path-structure.ts
@@ -304,23 +304,26 @@ export class InferPathStructure {
     pathPattern: string;
     examplePath: string;
   }[] = () => {
-    return this.paths.map((pathComponent) => {
-      const pathPattern = reducePathPattern(pathComponent);
+    return this.paths
+      .map((pathComponent) => {
+        const pathPattern = reducePathPattern(pathComponent);
 
-      const methods = Array.from(pathComponent.httpMethods).filter((method) => {
-        // skip known operations
-        return !this.knownOperations.some(
-          (i) => i.pathPattern === pathPattern && i.methods.includes(method)
-        );
-      }) as Array<HttpMethod>;
+        const methods = Array.from(pathComponent.httpMethods).filter(
+          (method) => {
+            // skip known operations
+            return !this.knownOperations.some(
+              (i) => i.pathPattern === pathPattern && i.methods.includes(method)
+            );
+          }
+        ) as Array<HttpMethod>;
 
-      return {
-        methods,
-        pathPattern,
-        examplePath: pathComponent.examplePath ?? '',
-      };
-    });
-    // .filter((i) => i.methods.length > 0);
+        return {
+          methods,
+          pathPattern,
+          examplePath: pathComponent.examplePath ?? '',
+        };
+      })
+      .filter((i) => i.methods.length > 0);
   };
 }
 

--- a/projects/openapi-cli/src/operations/infer-path-structure.ts
+++ b/projects/openapi-cli/src/operations/infer-path-structure.ts
@@ -304,26 +304,23 @@ export class InferPathStructure {
     pathPattern: string;
     examplePath: string;
   }[] = () => {
-    return this.paths
-      .map((pathComponent) => {
-        const pathPattern = reducePathPattern(pathComponent);
+    return this.paths.map((pathComponent) => {
+      const pathPattern = reducePathPattern(pathComponent);
 
-        const methods = Array.from(pathComponent.httpMethods).filter(
-          (method) => {
-            // skip known operations
-            return !this.knownOperations.some(
-              (i) => i.pathPattern === pathPattern && i.methods.includes(method)
-            );
-          }
-        ) as Array<HttpMethod>;
+      const methods = Array.from(pathComponent.httpMethods).filter((method) => {
+        // skip known operations
+        return !this.knownOperations.some(
+          (i) => i.pathPattern === pathPattern && i.methods.includes(method)
+        );
+      }) as Array<HttpMethod>;
 
-        return {
-          methods,
-          pathPattern,
-          examplePath: pathComponent.examplePath ?? '',
-        };
-      })
-      .filter((i) => i.methods.length > 0);
+      return {
+        methods,
+        pathPattern,
+        examplePath: pathComponent.examplePath ?? '',
+      };
+    });
+    // .filter((i) => i.methods.length > 0);
   };
 }
 

--- a/projects/openapi-cli/src/operations/queries.ts
+++ b/projects/openapi-cli/src/operations/queries.ts
@@ -55,9 +55,9 @@ export class OperationQueries {
             const parsed = new Url.URL(url, 'https://example.org');
             const pathName = parsed.pathname;
             if (pathName.endsWith('/') && pathName.length > 1) {
-              return pathName.substring(0, pathName.length - 1)
+              return pathName.substring(0, pathName.length - 1);
             } else {
-              return pathName
+              return pathName;
             }
           })
         : ['/'];
@@ -71,7 +71,7 @@ export class OperationQueries {
         })
       ),
     ];
-    
+
     this.patternsAsComponents = this.patterns.map((pattern) => [
       pattern,
       PathComponents.fromPath(pattern),
@@ -181,4 +181,30 @@ export class OperationQueries {
       return Ok(None);
     }
   }
+}
+
+export function specToOperations(spec: OpenAPIV3.Document) {
+  const operations: { pathPattern: string; methods: string[] }[] = [];
+
+  const allowedKeys = [
+    'get',
+    'post',
+    'put',
+    'delete',
+    'patch',
+    'head',
+    'options',
+  ];
+  Object.entries(spec.paths).forEach(([pathPattern, methods]) => {
+    if (methods) {
+      operations.push({
+        pathPattern,
+        methods: Object.keys(methods).filter((key) =>
+          allowedKeys.includes(key)
+        ),
+      });
+    }
+  });
+
+  return operations;
 }

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.1",
+  "version": "0.38.2-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -75,5 +75,6 @@
     "upath": "^2.0.1",
     "yaml": "^2.2.0",
     "yaml-ast-parser": "^0.0.43"
-  }
+  },
+  "stableVersion": "0.38.1"
 }

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.2-0",
+  "version": "0.38.2-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.2",
+  "version": "0.38.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.3",
+  "version": "0.39.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.2-1",
+  "version": "0.38.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -75,6 +75,5 @@
     "upath": "^2.0.1",
     "yaml": "^2.2.0",
     "yaml-ast-parser": "^0.0.43"
-  },
-  "stableVersion": "0.38.1"
+  }
 }

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.2-0",
+  "version": "0.38.2-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.2",
+  "version": "0.38.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.2-1",
+  "version": "0.38.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -64,6 +64,5 @@
     "openapi-types": "^12.0.2",
     "ts-invariant": "^0.9.3",
     "yaml-ast-parser": "^0.0.43"
-  },
-  "stableVersion": "0.38.1"
+  }
 }

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.3",
+  "version": "0.39.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.1",
+  "version": "0.38.2-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -64,5 +64,6 @@
     "openapi-types": "^12.0.2",
     "ts-invariant": "^0.9.3",
     "yaml-ast-parser": "^0.0.43"
-  }
+  },
+  "stableVersion": "0.38.1"
 }

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.2-0",
+  "version": "0.38.2-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.2",
+  "version": "0.38.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.3",
+  "version": "0.39.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.1",
+  "version": "0.38.2-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -66,5 +66,6 @@
     "picomatch": "^2.3.1",
     "url-join": "^4.0.1",
     "uuid": "^9.0.0"
-  }
+  },
+  "stableVersion": "0.38.1"
 }

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.2-1",
+  "version": "0.38.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -66,6 +66,5 @@
     "picomatch": "^2.3.1",
     "url-join": "^4.0.1",
     "uuid": "^9.0.0"
-  },
-  "stableVersion": "0.38.1"
+  }
 }

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.2-1",
+  "version": "0.38.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -77,6 +77,5 @@
     "update-notifier": "^5.1.0",
     "url-join": "^4.0.1",
     "uuid": "^9.0.0"
-  },
-  "stableVersion": "0.38.1"
+  }
 }

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.2",
+  "version": "0.38.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.2-0",
+  "version": "0.38.2-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.1",
+  "version": "0.38.2-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -77,5 +77,6 @@
     "update-notifier": "^5.1.0",
     "url-join": "^4.0.1",
     "uuid": "^9.0.0"
-  }
+  },
+  "stableVersion": "0.38.1"
 }

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.3",
+  "version": "0.39.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.2",
+  "version": "0.38.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.2-0",
+  "version": "0.38.2-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.1",
+  "version": "0.38.2-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -43,5 +43,6 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.4.0",
     "typescript": "^4.4.4"
-  }
+  },
+  "stableVersion": "0.38.1"
 }

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.3",
+  "version": "0.39.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.2-1",
+  "version": "0.38.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -43,6 +43,5 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.4.0",
     "typescript": "^4.4.4"
-  },
-  "stableVersion": "0.38.1"
+  }
 }

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.2",
+  "version": "0.38.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.1",
+  "version": "0.38.2-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -42,5 +42,6 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.4.0",
     "typescript": "^4.4.4"
-  }
+  },
+  "stableVersion": "0.38.1"
 }

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.3",
+  "version": "0.39.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.2-1",
+  "version": "0.38.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -42,6 +42,5 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.4.0",
     "typescript": "^4.4.4"
-  },
-  "stableVersion": "0.38.1"
+  }
 }

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.38.2-0",
+  "version": "0.38.2-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
## 🍗 Description
Addreses https://github.com/opticdev/optic/issues/1630 

- supports lower case paths 
- added test cases
- made `--document "[method] [path]"` retain captures. Only `--document all` and `--patch` will reset. 


## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
