### PR TITLE
add warning when downloading a standard that doesnt exist

### DIFF
--- a/projects/optic/src/commands/diff/generate-rule-runner.ts
+++ b/projects/optic/src/commands/diff/generate-rule-runner.ts
@@ -9,6 +9,7 @@ import {
 } from '@useoptic/rulesets-base';
 import { loadCliConfig } from '../../config';
 import { logger } from '../../logger';
+import chalk from 'chalk';
 
 const isLocalJsFile = (name: string) => name.endsWith('.js');
 
@@ -27,10 +28,19 @@ const getStandardToUse = async (options: {
     );
     return config.ruleset;
   } else if (options.specRuleset) {
-    const ruleset = await options.config.client.getStandard(
-      options.specRuleset
-    );
-    return ruleset.config.ruleset;
+    try {
+      const ruleset = await options.config.client.getStandard(
+        options.specRuleset
+      );
+      return ruleset.config.ruleset;
+    } catch (e) {
+      logger.warn(
+        `${chalk.red('Warning:')} Could not download standard ${
+          options.specRuleset
+        }. Please check the ruleset name and whether you are authenticated (run: optic login).`
+      );
+      return [];
+    }
   } else {
     return options.config.ruleset;
   }


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

- Downlaoding a standard that doesn't exist - now returns `[]` as ruleset and logs a warning
- Downloading a ruleset that doesn't exist - endpoint does not include that ruleset.



## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
