### PR TITLE
Allow diff-all to specify match + ignore

### DIFF
--- a/projects/optic/src/__tests__/integration/__snapshots__/diff-all.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/diff-all.test.ts.snap
@@ -1,5 +1,51 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`diff-all diff all with glob and ignores 1`] = `
+"[34mDiffing HEAD~1:folder-to-run/should-run.yml to empty spec[39m
+
+specification details:
+- /x-optic-url, /info/description [31mremoved[39m
+
+[1mPOST[22m /filler_route: [31mremoved[39m
+  
+Checks
+
+  [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /filler_route
+    removed rule: prevent operation removal
+      [31m[31mx[39m[31m cannot remove an operation. This is a breaking change.[39m
+      at [4m$workspace$/folder-to-run/should-run.yml:9:178[24m
+
+    removed rule: prevent removing response property
+      [31m[31mx[39m[31m cannot remove response property 'id'. This is a breaking change.[39m
+      at [4m$workspace$/folder-to-run/should-run.yml:19:432[24m
+
+    removed rule: prevent response status code removal
+      [31m[31mx[39m[31m must not remove response status code 201. This is a breaking change.[39m
+      at [4m$workspace$/folder-to-run/should-run.yml:12:235[24m
+
+
+
+1 operation removed
+[32m[1m0 checks passed[22m[39m
+[31m[1m3 checks failed[22m[39m
+
+[32m✔[39m Uploaded results of diff to http://localhost:3000/organizations/org-id/apis/api-id/runs/run-id
+[34mDiffing empty spec to folder-to-run/should-run-mved.yml[39m
+
+specification details:
+- /x-optic-url, /info/description [32madded[39m
+- /openapi, /info/version, /info/title [33mchanged[39m
+
+[1mPOST[22m /filler_route: [32madded[39m
+  
+1 operation added
+[32m[1m0 checks passed[22m[39m
+[31m[1m0 checks failed[22m[39m
+
+[32m✔[39m Uploaded results of diff to http://localhost:3000/organizations/org-id/apis/api-id/runs/run-id
+"
+`;
+
 exports[`diff-all diffs all files in an workspace with x-optic-url keys 1`] = `
 "[34mDiffing HEAD~1:mvspec.yml to empty spec[39m
 

--- a/projects/optic/src/__tests__/integration/__snapshots__/diff-all.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/diff-all.test.ts.snap
@@ -29,7 +29,7 @@ Checks
 [32m[1m0 checks passed[22m[39m
 [31m[1m3 checks failed[22m[39m
 
-[32m✔[39m Uploaded results of diff to http://localhost:3000/organizations/org-id/apis/api-id/runs/run-id
+[32m✔[39m Uploaded results of diff to http://localhost:3001/organizations/org-id/apis/api-id/runs/run-id
 [34mDiffing empty spec to folder-to-run/should-run-mved.yml[39m
 
 specification details:
@@ -42,7 +42,7 @@ specification details:
 [32m[1m0 checks passed[22m[39m
 [31m[1m0 checks failed[22m[39m
 
-[32m✔[39m Uploaded results of diff to http://localhost:3000/organizations/org-id/apis/api-id/runs/run-id
+[32m✔[39m Uploaded results of diff to http://localhost:3001/organizations/org-id/apis/api-id/runs/run-id
 "
 `;
 

--- a/projects/optic/src/__tests__/integration/diff-all.test.ts
+++ b/projects/optic/src/__tests__/integration/diff-all.test.ts
@@ -90,4 +90,26 @@ describe('diff-all', () => {
     expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
     expect(code).toBe(1);
   });
+
+  test('diff all with glob and ignores', async () => {
+    const workspace = await setupWorkspace('diff-all/globs', {
+      repo: true,
+      commit: true,
+    });
+
+    await run(
+      `mv ./folder-to-run/should-run.yml ./folder-to-run/should-run-mved.yml && git add . && git commit -m 'move spec'`,
+      false,
+      workspace
+    );
+    process.env.OPTIC_TOKEN = '123';
+
+    const { combined, code } = await runOptic(
+      workspace,
+      'diff-all --check --upload --match "folder-to-run/**" --ignore "folder-to-run/ignore/**"'
+    );
+
+    expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
+    expect(code).toBe(1);
+  });
 });

--- a/projects/optic/src/__tests__/integration/workspaces/diff-all/globs/folder-to-run/ignore/should-ignore.yml
+++ b/projects/optic/src/__tests__/integration/workspaces/diff-all/globs/folder-to-run/ignore/should-ignore.yml
@@ -1,0 +1,22 @@
+openapi: 3.0.3
+info:
+  title: a spec
+  description: The API
+  version: 0.1.0
+x-optic-url: 'https://app.useoptic.com/organizations/org-id/apis/api-id'
+paths:
+  /filler_route:
+    post:
+      operationId: create
+      responses:
+        "201":
+          description: Created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                    example: d5b640e5-d88c-4c17-9bf0-93597b7a1ce2

--- a/projects/optic/src/__tests__/integration/workspaces/diff-all/globs/folder-to-run/should-run.yml
+++ b/projects/optic/src/__tests__/integration/workspaces/diff-all/globs/folder-to-run/should-run.yml
@@ -1,0 +1,22 @@
+openapi: 3.0.3
+info:
+  title: a spec
+  description: The API
+  version: 0.1.0
+x-optic-url: 'https://app.useoptic.com/organizations/org-id/apis/api-id'
+paths:
+  /filler_route:
+    post:
+      operationId: create
+      responses:
+        "201":
+          description: Created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                    example: d5b640e5-d88c-4c17-9bf0-93597b7a1ce2

--- a/projects/optic/src/__tests__/integration/workspaces/diff-all/globs/specwithkey.yml
+++ b/projects/optic/src/__tests__/integration/workspaces/diff-all/globs/specwithkey.yml
@@ -1,0 +1,22 @@
+openapi: 3.0.3
+info:
+  title: a spec
+  description: The API
+  version: 0.1.0
+x-optic-url: 'https://app.useoptic.com/organizations/org-id/apis/api-id'
+paths:
+  /filler_route:
+    post:
+      operationId: create
+      responses:
+        "201":
+          description: Created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                    example: d5b640e5-d88c-4c17-9bf0-93597b7a1ce2

--- a/projects/optic/src/commands/diff/diff-all.ts
+++ b/projects/optic/src/commands/diff/diff-all.ts
@@ -1,4 +1,5 @@
 import { Command } from 'commander';
+import pm from 'picomatch';
 import { OpticCliConfig, VCS } from '../../config';
 import { findOpenApiSpecsCandidates } from '../../utils/git-utils';
 import {
@@ -61,6 +62,16 @@ export const registerDiffAll = (cli: Command, config: OpticCliConfig) => {
       'HEAD~1'
     )
     .option(
+      '--match <match>',
+      'a glob to match specs (e.g. "**/*.yml" or "**/specifications/*.json"). Also takes \
+      comma separated values (e.g. "**/*.yml,**/*.json")'
+    )
+    .option(
+      '--ignore <ignore>',
+      'an ignore glob to ignore certain matches (e.g. "**/*.yml" or "**/specifications/*.json"). Also takes \
+comma separated values (e.g. "**/*.yml,**/*.json")'
+    )
+    .option(
       '--standard <standard>',
       'run comparison with a locally defined standard, if not set, looks for the standard on the [x-optic-standard] key on the spec, and then the optic.dev.yml file.'
     )
@@ -75,6 +86,8 @@ type DiffAllActionOptions = {
   compareTo?: string;
   compareFrom: string;
   standard?: string;
+  match?: string;
+  ignore?: string;
   check: boolean;
   web: boolean;
   upload: boolean;
@@ -370,6 +383,37 @@ async function openWebpage(
   await open(url, { wait: false });
 }
 
+function sanitizeRef(maybeGitRef: string): string {
+  return maybeGitRef.includes(':') ? maybeGitRef.split(':')[1] : maybeGitRef;
+}
+
+function applyGlobFilter(
+  filePaths: string[],
+  globs: {
+    matches?: string;
+    ignores?: string;
+  }
+): string[] {
+  const matches = globs.matches?.split(',').filter((g) => g !== '') ?? [];
+  const ignores = globs.ignores?.split(',').filter((g) => g !== '') ?? [];
+
+  const globMatchers = matches.map((g) => pm(g));
+  const ignoreMatchers = ignores.map((i) => pm(i));
+  const matchedFiles = new Set(
+    filePaths
+      .filter((name) =>
+        globMatchers.length === 0
+          ? true
+          : globMatchers.some((globFilter) => globFilter(sanitizeRef(name)))
+      )
+      .filter((name) =>
+        ignoreMatchers.every((ignoreFilter) => !ignoreFilter(sanitizeRef(name)))
+      )
+  );
+
+  return [...matchedFiles];
+}
+
 const getDiffAllAction =
   (config: OpticCliConfig) => async (options: DiffAllActionOptions) => {
     if (config.vcs?.type !== VCS.Git) {
@@ -423,11 +467,17 @@ const getDiffAllAction =
     const candidatesMap = matchCandidates(
       {
         ref: options.compareFrom,
-        paths: compareFromCandidates,
+        paths: applyGlobFilter(compareFromCandidates, {
+          matches: options.match,
+          ignores: options.ignore,
+        }),
       },
       {
         ref: options.compareTo,
-        paths: compareToCandidates,
+        paths: applyGlobFilter(compareToCandidates, {
+          matches: options.match,
+          ignores: options.ignore,
+        }),
       }
     );
 


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Allow a user to specify `--match "folder/**" --ignore "folder-to-ignore/**"` in diff-all.

there's a few usecases that this could be used for
- compiled specs from source specs include `x-optic-url` (it's probably more correct to remove the optic-url or generate a new one in this case, but this gives you another option)
- running a diff-all in different stages / more control over running on `x-optic-url` 

Note that this uses the same 

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
