### PR TITLE
handle parameter enum array viewing

### DIFF
--- a/projects/openapi-utilities/src/examples/petstore-base.ts
+++ b/projects/openapi-utilities/src/examples/petstore-base.ts
@@ -54,6 +54,25 @@ export const openAPI: OpenAPIV3.Document = {
     '/example': {
       get: {
         operationId: 'getExamples',
+        parameters: [
+          {
+            name: 'nothing',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'string',
+            },
+          },
+          {
+            name: 'status',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'string',
+              enum: ['available', 'sold'],
+            },
+          },
+        ],
         responses: {
           '200': {
             description: 'succesful',

--- a/projects/openapi-utilities/src/examples/petstore-updated.ts
+++ b/projects/openapi-utilities/src/examples/petstore-updated.ts
@@ -57,6 +57,25 @@ export const openAPI: OpenAPIV3.Document = {
     '/example': {
       get: {
         operationId: 'get_examples',
+        parameters: [
+          {
+            name: 'status',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'string',
+              enum: ['available', 'pending', 'sold'],
+            },
+          },
+          {
+            name: 'nothing',
+            in: 'query',
+            required: true,
+            schema: {
+              type: 'string',
+            },
+          },
+        ],
         responses: {
           '200': {
             description: 'succesful',

--- a/projects/openapi-utilities/src/utilities/__tests__/__snapshots__/group-changes.test.ts.snap
+++ b/projects/openapi-utilities/src/utilities/__tests__/__snapshots__/group-changes.test.ts.snap
@@ -48,7 +48,57 @@ exports[`groupChangesAndRules diffs and groups changes between two open api file
         "hasRules": false,
       },
       "queryParameters": {
-        "changes": Map {},
+        "changes": Map {
+          "status" => {
+            "changeType": "changed",
+            "changed": {
+              "after": {
+                "in": "query",
+                "name": "status",
+                "required": true,
+                "schema": {
+                  "enum": [
+                    "available",
+                    "pending",
+                    "sold",
+                  ],
+                  "type": "string",
+                },
+              },
+              "before": {
+                "in": "query",
+                "name": "status",
+                "required": true,
+                "schema": {
+                  "enum": [
+                    "available",
+                    "sold",
+                  ],
+                  "type": "string",
+                },
+              },
+            },
+            "location": {
+              "conceptualLocation": {
+                "inRequest": {
+                  "query": "status",
+                },
+                "method": "get",
+                "path": "/example",
+              },
+              "conceptualPath": [
+                "operations",
+                "/example",
+                "get",
+                "parameters",
+                "query",
+                "status",
+              ],
+              "jsonPath": "/paths/~1example/get/parameters/1",
+              "kind": "query-parameter",
+            },
+          },
+        },
         "hasRules": false,
       },
       "request": {

--- a/projects/openapi-utilities/src/utilities/changelog-renderers/__tests__/__snapshots__/json-changelog.test.ts.snap
+++ b/projects/openapi-utilities/src/utilities/changelog-renderers/__tests__/__snapshots__/json-changelog.test.ts.snap
@@ -2092,7 +2092,27 @@ exports[`json changelog collects changes properly: jsonChangelog 1`] = `
       ],
       "change": "changed",
       "name": "GET /example",
-      "parameters": [],
+      "parameters": [
+        {
+          "attributes": [
+            {
+              "after": [
+                "available",
+                "pending",
+                "sold",
+              ],
+              "before": [
+                "available",
+                "sold",
+              ],
+              "change": "changed",
+              "key": "/schema/enum",
+            },
+          ],
+          "change": "changed",
+          "name": "query parameter 'status'",
+        },
+      ],
       "requestBody": undefined,
       "responses": [
         {


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

This updates the `json-changelog` to render `enums` at the enum level, not individual level..

e.g.
```
{
  "after": [
    "available",
    "pending",
    "sold",
  ],
  "before": [
    "available",
    "sold",
  ],
  "change": "changed",
  "key": "/schema/enum",
},
```

I considered implementing a generic array handler here, in the entire group diffs, but that wouldn't work because arrays can be found in other locations (allOf, anyOf, required). I think the only other place we needed to add better "array" viewing on a json-changelog is the parameter piece. I created a generic array handler so we can group other array fields for parameter in the future.

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
