### PR TITLE
Don't tag gitbranch when on a detached head

### DIFF
--- a/projects/optic/src/commands/diff/upload-diff.ts
+++ b/projects/optic/src/commands/diff/upload-diff.ts
@@ -44,11 +44,11 @@ export async function uploadDiff(
   if (specs.to.context && specDetails) {
     let tags: string[] = [];
     if (specs.to.context.vcs === VCS.Git) {
+      tags.push(`git:${specs.to.context.sha}`);
       const currentBranch = await Git.getCurrentBranchName();
-      tags = [
-        `git:${specs.to.context.sha}`,
-        sanitizeGitTag(`gitbranch:${currentBranch}`),
-      ];
+      if (currentBranch !== 'HEAD') {
+        tags.push(sanitizeGitTag(`gitbranch:${currentBranch}`));
+      }
     }
     headSpecId = await uploadSpec(specDetails.apiId, {
       spec: specs.to,


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

We saw that on a detached head we end up with a tag named HEAD. This just ignores the `gitbranch` tag if it comes back as `HEAD`.

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
