### PR TITLE
Add https to the front of github and gitlab urls

### DIFF
--- a/projects/optic/src/utils/git-utils.ts
+++ b/projects/optic/src/utils/git-utils.ts
@@ -177,12 +177,12 @@ export const guessRemoteOrigin = async (): Promise<{
     if (/github/i.test(parsed.resource)) {
       return {
         provider: 'github',
-        web_url: urljoin(parsed.resource, parsed.full_name),
+        web_url: `https://${urljoin(parsed.resource, parsed.full_name)}`,
       };
     } else if (/gitlab/i.test(parsed.resource)) {
       return {
         provider: 'gitlab',
-        web_url: urljoin(parsed.resource, parsed.full_name),
+        web_url: `https://${urljoin(parsed.resource, parsed.full_name)}`,
       };
     }
   } catch (e) {


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Right now `api add` ends up giving us urls without https up front. This fixes (changes?) that.

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
