### PR TITLE
Skip pushing the branch on spec push when detached

### DIFF
--- a/projects/optic/src/__tests__/integration/__snapshots__/spec-push.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/spec-push.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`optic spec push can push a spec to a repo 1`] = `
-"Automatically adding the git sha git:COMMIT-HASH and branch gitbranch:master as tags 
+"Automatically adding the git sha git:COMMIT-HASH and branch gitbranch:master as tags
 
 Uploading spec for api at https://app.useoptic.com/organizations/org-id/apis/api-id with tags env:production, the-favorite-api, git:COMMIT-HASH, gitbranch:master
 Succesfully uploaded spec to Optic. View the spec here http://localhost:3001/organizations/org-id/apis/api-id/specs/spec-id
@@ -17,7 +17,7 @@ Succesfully uploaded spec to Optic. View the spec here http://localhost:3001/org
 `;
 
 exports[`optic spec push requires x-optic-url 1`] = `
-"Automatically adding the git sha git:COMMIT-HASH and branch gitbranch:master as tags 
+"Automatically adding the git sha git:COMMIT-HASH and branch gitbranch:master as tags
 File ./spec.yml does not have an optic url. Files must be added to Optic and have an x-optic-url key before specs can be pushed up to Optic.
 [33mHint: [39m Run optic api add ./spec.yml
 "

--- a/projects/optic/src/commands/spec/push.ts
+++ b/projects/optic/src/commands/spec/push.ts
@@ -77,13 +77,20 @@ const getSpecPushAction =
     if (config.vcs?.type === VCS.Git) {
       if (config.vcs.status === 'clean') {
         const sha = `git:${config.vcs.sha}`;
+        tagsToAdd.push(sha);
+
         const branch = sanitizeGitTag(
           `gitbranch:${await Git.getCurrentBranchName()}`
         );
-        tagsToAdd.push(sha, branch);
-        logger.info(
-          `Automatically adding the git sha ${sha} and branch ${branch} as tags `
-        );
+
+        if (branch !== 'HEAD') {
+          tagsToAdd.push(branch);
+          logger.info(
+            `Automatically adding the git sha ${sha} and branch ${branch} as tags`
+          );
+        } else {
+          logger.info(`Automatically adding the git sha ${sha} as a tag`);
+        }
       } else {
         logger.info(
           'Not automatically including any git tags because the current working directory has uncommited changes.'


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Found another place where we were pushing `gitbranch:HEAD` if detached.

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
