### PR TITLE
fix: stableVersion breaks `prerelease` keyword versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,9 @@
   ],
   "scripts": {
     "release": "gh release create --target=$(git branch --show-current) v$(node -e \"process.stdout.write(require('./package.json').version)\")",
-    "version": "yarn workspaces foreach -v version",
-    "prepare": "husky install"
+    "version": "yarn run rmStableVersion && yarn workspaces foreach -v version",
+    "prepare": "husky install",
+    "rmStableVersion": "./scripts/remove-stableVersion"
   },
   "devDependencies": {
     "@types/prettier": "^2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "release": "gh release create --target=$(git branch --show-current) v$(node -e \"process.stdout.write(require('./package.json').version)\")",
     "version": "yarn run rmStableVersion && yarn workspaces foreach -v version",
     "prepare": "husky install",
-    "rmStableVersion": "./scripts/remove-stableVersion"
+    "rmStableVersion": "./scripts/remove-stableVersion.sh"
   },
   "devDependencies": {
     "@types/prettier": "^2",

--- a/scripts/remove-stableVersion.sh
+++ b/scripts/remove-stableVersion.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Remove `stableVersion` before relreasing, as it's buggy.
+# Remove `stableVersion` before releasing, as it's buggy.
 # https://github.com/yarnpkg/berry/issues/3868
 echo "$(jq 'del(.stableVersion)' package.json)" >package.json
 

--- a/scripts/remove-stableVersion.sh
+++ b/scripts/remove-stableVersion.sh
@@ -4,6 +4,6 @@
 # https://github.com/yarnpkg/berry/issues/3868
 echo "$(jq 'del(.stableVersion)' package.json)" >package.json
 
-for pkgjson in $(ls projects/*/package.json); do
+for pkgjson in $(find projects/* -name package.json -depth 1); do
   echo $(jq 'del(.stableVersion)' $pkgjson) > $pkgjson
 done

--- a/scripts/remove-stableVersion.sh
+++ b/scripts/remove-stableVersion.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Remove `stableVersion` before relreasing, as it's buggy.
+# https://github.com/yarnpkg/berry/issues/3868
+echo "$(jq 'del(.stableVersion)' package.json)" >package.json
+
+for pkgjson in $(ls projects/*/package.json); do
+  echo $(jq 'del(.stableVersion)' $pkgjson) > $pkgjson
+done


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

when `stableVersion` is set, bumping by `prerelease` breaks. ive replicated 2 different behaviors, one where a prerelease bump doesn't change the version at all, and another where it increments the _patch_ version by 1, and then subsequent bumps do nothing.

for example,
```
➜ jq .version package.json
"0.39.5-0"

➜ yarn run version prerelease
...

➜ jq .version package.json
"0.39.6-0"

➜ yarn run version prerelease
...

➜ jq .version package.json
"0.39.6-0"
```

this looks like https://github.com/yarnpkg/berry/issues/3868. i implemented the same workaround mentioned there with some additions for workspaces support, and it seems to work,

```
➜ jq .version package.json
"0.39.5-0"

➜ yarn run version prerelease
...

➜ jq .version package.json
"0.39.5-1"

➜ yarn run version prerelease
...

➜ jq .version package.json
"0.39.5-2"
```

if we'd rather not add this crud just to preserve bumping with the `prerelease` keyword, we can update our release docs instead to mention that prereleases need to be explicitly versioned, e.g., `yarn run version 0.0.0-0`

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
