### PR TITLE
Somehow summary was not allowed in info

### DIFF
--- a/projects/openapi-io/src/validation/validation-schemas.ts
+++ b/projects/openapi-io/src/validation/validation-schemas.ts
@@ -441,6 +441,9 @@ const createOpenAPIValidationSchema = (schema: any) => ({
         version: {
           type: 'string',
         },
+        summary: {
+          type: 'string',
+        },
       },
     },
     contact: {


### PR DESCRIPTION
## 🍗 Description
User reported `summary` is not allowed in info. For some reason we're flagging that...can't believe it wasn't found by anyone else earlier

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
