### PR TITLE
Use different configs per env

### DIFF
--- a/projects/optic/src/config.ts
+++ b/projects/optic/src/config.ts
@@ -14,12 +14,14 @@ export enum VCS {
 
 export const OPTIC_YML_NAME = 'optic.yml';
 export const OPTIC_DEV_YML_NAME = 'optic.dev.yml';
-export const USER_CONFIG_PATH = path.join(
-  os.homedir(),
-  '.config',
-  'optic',
-  'config.json'
-);
+export const USER_CONFIG_DIR = path.join(os.homedir(), '.config', 'optic');
+
+export const USER_CONFIG_PATH =
+  process.env.OPTIC_ENV === 'staging'
+    ? path.join(USER_CONFIG_DIR, 'config.staging.json')
+    : process.env.OPTIC_ENV === 'local'
+    ? path.join(USER_CONFIG_DIR, 'config.local.json')
+    : path.join(USER_CONFIG_DIR, 'config.json');
 
 type ConfigRuleset = { name: string; config: unknown };
 


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

This uses a different config per env, so we won't have to log in and out constantly depending on what we're running against.

All configs are stored to `~/.config/optic/`, and production configs still go to `~/.config/optic/config.json`, but staging now stores to `~/.config/optic/config.staging.json` and local stores to `~/.config/optic/config.local.json`.

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
