### PR TITLE
Add no-missing-urls to diff-all options

### DIFF
--- a/projects/optic/src/commands/diff/diff-all.ts
+++ b/projects/optic/src/commands/diff/diff-all.ts
@@ -79,6 +79,11 @@ comma separated values (e.g. "**/*.yml,**/*.json")'
     .option('--upload', 'upload specs', false)
     .option('--web', 'view the diff in the optic changelog web view', false)
     .option('--json', 'output as json', false)
+    .option(
+      '--no-missing-urls',
+      'fail with exit code 1 if there are detected specs missing x-optic-url',
+      false
+    )
     .action(errorHandler(getDiffAllAction(config)));
 };
 
@@ -92,6 +97,7 @@ type DiffAllActionOptions = {
   web: boolean;
   upload: boolean;
   json: boolean;
+  noMissingUrls: boolean;
 };
 
 // Match up the to and from candidates
@@ -319,6 +325,10 @@ function handleWarnings(warnings: Warnings, options: DiffAllActionOptions) {
     logger.info('Run the `optic api add` command to add these specs to optic');
     logger.info(warnings.missingOpticUrl.map((f) => f.path).join('\n'));
     logger.info('');
+
+    if (options.noMissingUrls) {
+      process.exitCode = 1;
+    }
   }
 
   if (warnings.unparseableFromSpec.length > 0) {

--- a/projects/optic/src/commands/diff/diff-all.ts
+++ b/projects/optic/src/commands/diff/diff-all.ts
@@ -80,8 +80,8 @@ comma separated values (e.g. "**/*.yml,**/*.json")'
     .option('--web', 'view the diff in the optic changelog web view', false)
     .option('--json', 'output as json', false)
     .option(
-      '--no-missing-urls',
-      'fail with exit code 1 if there are detected specs missing x-optic-url',
+      '--fail-on-untracked-openapi',
+      'fail with exit code 1 if there are detected untracked apis',
       false
     )
     .action(errorHandler(getDiffAllAction(config)));
@@ -97,7 +97,7 @@ type DiffAllActionOptions = {
   web: boolean;
   upload: boolean;
   json: boolean;
-  noMissingUrls: boolean;
+  failOnUntrackedApi: boolean;
 };
 
 // Match up the to and from candidates
@@ -326,7 +326,7 @@ function handleWarnings(warnings: Warnings, options: DiffAllActionOptions) {
     logger.info(warnings.missingOpticUrl.map((f) => f.path).join('\n'));
     logger.info('');
 
-    if (options.noMissingUrls) {
+    if (options.failOnUntrackedApi) {
       process.exitCode = 1;
     }
   }


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Add an option to return `exitCode = 1` if diff-all detects a spec that does not have an `x-optic-url`

A user can also scope this down by specifying a `match` or `ignore` glob to ignore false positives

TODO
- [ ] Also add this to the github action options

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
