### PR TITLE
Fix for circular reference validation

### DIFF
--- a/projects/openapi-io/src/validation/validation-schemas.ts
+++ b/projects/openapi-io/src/validation/validation-schemas.ts
@@ -132,7 +132,7 @@ const openapi3_0_schema_object = {
       },
     },
     additionalProperties: {
-      oneOf: [
+      anyOf: [
         {
           $ref: '#/definitions/schemaOrReference',
         },
@@ -1294,7 +1294,7 @@ const createOpenAPIValidationSchema = (schema: any) => ({
       ],
     },
     schemaOrReference: {
-      oneOf: [
+      anyOf: [
         {
           $ref: '#/definitions/schema',
         },
@@ -1304,7 +1304,7 @@ const createOpenAPIValidationSchema = (schema: any) => ({
       ],
     },
     securitySchemeOrReference: {
-      oneOf: [
+      anyOf: [
         {
           $ref: '#/definitions/securityScheme',
         },


### PR DESCRIPTION
## 🍗 Description
A user reported that their circular $ref's were causing validation issues. Optic supports circular refs, but terminates after one cycle. This leaves a few spots in the flat spec that look like this: 

```
additionalProperties: 
   $ref: ...
```

That is a valid schema AND a valid reference -- which means using `oneOf` here in the validation schema fails, even though they both match. 


## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
