### PR TITLE
allOf diffing

### DIFF
--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -27,13 +27,13 @@
     "@types/node": "^18.0.0",
     "babel-jest": "^29.3.1",
     "jest": "^29.3.1",
-    "minimatch": "7.1.0",
     "prettier": "^2.4.1",
     "ts-jest": "^29.0.3",
     "ts-node": "^10.3.1",
     "typescript": "^4.4.4"
   },
   "dependencies": {
-    "jsonpointer": "^5.0.1"
+    "jsonpointer": "^5.0.1",
+    "minimatch": "7.1.0"
   }
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -27,6 +27,7 @@
     "@types/node": "^18.0.0",
     "babel-jest": "^29.3.1",
     "jest": "^29.3.1",
+    "minimatch": "7.1.0",
     "prettier": "^2.4.1",
     "ts-jest": "^29.0.3",
     "ts-node": "^10.3.1",

--- a/projects/json-pointer-helpers/src/json-pointers/json-pointer-helpers.test.ts
+++ b/projects/json-pointer-helpers/src/json-pointers/json-pointer-helpers.test.ts
@@ -101,3 +101,66 @@ describe('get', () => {
     ).toMatchSnapshot();
   });
 });
+
+describe('matchers', () => {
+  const exampleOperation = jsonPointerHelpers.compile([
+    'paths',
+    '/me/{them}',
+    'get',
+  ]);
+  const info = jsonPointerHelpers.compile(['info']);
+
+  it('can match startsWith when using constants', () => {
+    expect(jsonPointerHelpers.startsWith(exampleOperation, ['info'])).toBe(
+      false
+    );
+    expect(jsonPointerHelpers.startsWith(exampleOperation, ['paths'])).toBe(
+      true
+    );
+
+    expect(
+      jsonPointerHelpers.startsWith(exampleOperation, ['paths', '/me/{them}'])
+    ).toBe(true);
+    expect(
+      jsonPointerHelpers.startsWith(exampleOperation, ['paths', '/me'])
+    ).toBe(false);
+  });
+
+  it('can match startsWith when using globs', () => {
+    expect(jsonPointerHelpers.startsWith(exampleOperation, ['*'])).toBe(true);
+    expect(
+      jsonPointerHelpers.startsWith(exampleOperation, ['paths', '**'])
+    ).toBe(true);
+  });
+  it('can match startsWith at size bounds', () => {
+    expect(jsonPointerHelpers.startsWith(info, ['info', 'contact'])).toBe(
+      false
+    );
+    expect(jsonPointerHelpers.startsWith(info, [])).toBe(true);
+  });
+
+  it('can match endsWith when using constants', () => {
+    expect(jsonPointerHelpers.endsWith(exampleOperation, ['post'])).toBe(false);
+    expect(jsonPointerHelpers.endsWith(exampleOperation, ['get'])).toBe(true);
+
+    expect(
+      jsonPointerHelpers.endsWith(exampleOperation, ['/me/{them}', 'get'])
+    ).toBe(true);
+    expect(
+      jsonPointerHelpers.endsWith(exampleOperation, ['/me/{them}', 'post'])
+    ).toBe(false);
+  });
+
+  it('can match endsWith when using globs', () => {
+    expect(
+      jsonPointerHelpers.endsWith(exampleOperation, ['paths', '**', 'get'])
+    ).toBe(true);
+    expect(
+      jsonPointerHelpers.endsWith(exampleOperation, ['paths', '**', 'post'])
+    ).toBe(false);
+  });
+  it('can match endsWith at size bounds', () => {
+    expect(jsonPointerHelpers.endsWith(info, ['info'])).toBe(true);
+    expect(jsonPointerHelpers.endsWith(info, ['info', 'contact'])).toBe(false);
+  });
+});

--- a/projects/json-pointer-helpers/src/json-pointers/json-pointer-helpers.ts
+++ b/projects/json-pointer-helpers/src/json-pointers/json-pointer-helpers.ts
@@ -1,3 +1,5 @@
+import minimatch from 'minimatch';
+
 const escape = (str: string) => str.replace(/~/g, '~0').replace(/\//g, '~1');
 
 const unescape = (str: string) => str.replace(/~0/g, '~').replace(/~1/g, '/');
@@ -55,6 +57,37 @@ function relative(pointer: string, from: string) {
   return compile(targetDecoded.slice(fromDecoded.length));
 }
 
+function startsWith(pointer: string, pattern: string[]): boolean {
+  const components = parse(pointer);
+  const sliced = components.slice(0, pattern.length);
+
+  if (!(sliced.length >= pattern.length)) {
+    return false;
+  }
+
+  return sliced.every((comp, index) => minimatch(comp, pattern[index]));
+}
+
+function matches(pointer: string, pattern: string[]): boolean {
+  const components = parse(pointer);
+
+  if (components.length !== pattern.length) {
+    return false;
+  }
+
+  return components.every((comp, index) => minimatch(comp, pattern[index]));
+}
+function endsWith(pointer: string, pattern: string[]): boolean {
+  const components = parse(pointer);
+  const sliced = components.slice(components.length - pattern.length);
+
+  if (!(sliced.length >= pattern.length)) {
+    return false;
+  }
+
+  return sliced.every((comp, index) => minimatch(comp, pattern[index]));
+}
+
 function tryGet(
   input: any,
   pointer: string
@@ -84,4 +117,7 @@ export default {
   tryGet,
   compile,
   relative,
+  startsWith,
+  matches,
+  endsWith,
 };

--- a/projects/openapi-utilities/src/diff/__tests__/__snapshots__/diff.test.ts.snap
+++ b/projects/openapi-utilities/src/diff/__tests__/__snapshots__/diff.test.ts.snap
@@ -138,10 +138,10 @@ exports[`diff openapi diff behavior removing a key 1`] = `
 exports[`diff openapi diff behavior removing a key with path reconciliation 1`] = `
 [
   {
-    "before": "/parameters/0/nested/schema/removeme",
+    "before": "/paths/~1me/get/parameters/0/nested/schema/removeme",
     "pathReconciliation": [
       [
-        1,
+        4,
         "2",
       ],
     ],
@@ -152,7 +152,7 @@ exports[`diff openapi diff behavior removing a key with path reconciliation 1`] 
 exports[`diff openapi diff with array values diffs for parameters 1`] = `
 [
   {
-    "before": "/1",
+    "before": "/paths/~1me/get/parameters/1",
     "pathReconciliation": [],
   },
 ]
@@ -176,6 +176,15 @@ exports[`diff openapi diff with array values diffs for primitive values 1`] = `
   {
     "before": "/1",
     "pathReconciliation": [],
+  },
+]
+`;
+
+exports[`diff openapi diff with array values diffs operations even if variable names change  1`] = `
+[
+  {
+    "after": "/paths/~1user~1{user_Id}/get/operationId",
+    "before": "/paths/~1user~1{userId}/get/operationId",
   },
 ]
 `;

--- a/projects/openapi-utilities/src/diff/__tests__/__snapshots__/diff.test.ts.snap
+++ b/projects/openapi-utilities/src/diff/__tests__/__snapshots__/diff.test.ts.snap
@@ -189,6 +189,20 @@ exports[`diff openapi diff with array values diffs operations even if variable n
 ]
 `;
 
+exports[`diff openapi diff with array values diffs operations even if variable names change request body 1`] = `
+[
+  {
+    "before": "/paths/~1user~1{userId}/get/requestBody/content/application~1json/schema/properties/abc",
+    "pathReconciliation": [
+      [
+        1,
+        "/user/{user_Id}",
+      ],
+    ],
+  },
+]
+`;
+
 exports[`diff openapi diff with empty array 1`] = `
 [
   {

--- a/projects/openapi-utilities/src/diff/__tests__/__snapshots__/diff.test.ts.snap
+++ b/projects/openapi-utilities/src/diff/__tests__/__snapshots__/diff.test.ts.snap
@@ -1,5 +1,43 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`diff openapi allOf <> allOf compares properties properly diff when made required properties 1`] = `
+[
+  {
+    "after": "/paths/~1users/get/responses/200/content/application~1json/schema/allOf/0/required/0",
+  },
+]
+`;
+
+exports[`diff openapi allOf <> allOf compares properties properly last property definition wins 1`] = `
+[
+  {
+    "after": "/paths/~1users/get/responses/200/content/application~1json/schema/allOf/1/properties/a/type",
+    "before": "/paths/~1users/get/responses/200/content/application~1json/schema/allOf/1/properties/a/type",
+  },
+]
+`;
+
+exports[`diff openapi allOf <> allOf compares properties properly other properties work when all objects 1`] = `
+[
+  {
+    "after": "/paths/~1users/get/responses/200/content/application~1json/schema/allOf/0/title",
+    "before": "/paths/~1users/get/responses/200/content/application~1json/schema/allOf/0/title",
+  },
+]
+`;
+
+exports[`diff openapi allOf <> allOf compares properties properly works for nested allOf 1`] = `
+[
+  {
+    "after": "/paths/~1users/get/responses/200/content/application~1json/schema/allOf/1",
+  },
+  {
+    "after": "/paths/~1users/get/responses/200/content/application~1json/schema/allOf/1/properties/a/allOf/0/properties/b/type",
+    "before": "/paths/~1users/get/responses/200/content/application~1json/schema/allOf/0/properties/a/allOf/0/properties/b/type",
+  },
+]
+`;
+
 exports[`diff openapi can diff an openapi spec 1`] = `
 [
   {
@@ -213,6 +251,40 @@ exports[`diff openapi diff with empty array 1`] = `
   },
   {
     "after": "/paths",
+  },
+]
+`;
+
+exports[`diff openapi object <> allOf compares properties properly properties made optional 1`] = `
+[
+  {
+    "before": "/paths/~1users/get/responses/200/content/application~1json/schema/required/0",
+    "pathReconciliation": [],
+  },
+  {
+    "before": "/paths/~1users/get/responses/200/content/application~1json/schema/required/1",
+    "pathReconciliation": [],
+  },
+]
+`;
+
+exports[`diff openapi object <> allOf compares properties properly removals of properties 1`] = `
+[
+  {
+    "before": "/paths/~1users/get/responses/200/content/application~1json/schema/required/0",
+    "pathReconciliation": [],
+  },
+  {
+    "before": "/paths/~1users/get/responses/200/content/application~1json/schema/required/1",
+    "pathReconciliation": [],
+  },
+  {
+    "before": "/paths/~1users/get/responses/200/content/application~1json/schema/properties/a",
+    "pathReconciliation": [],
+  },
+  {
+    "before": "/paths/~1users/get/responses/200/content/application~1json/schema/properties/b",
+    "pathReconciliation": [],
   },
 ]
 `;

--- a/projects/openapi-utilities/src/diff/__tests__/diff.test.ts
+++ b/projects/openapi-utilities/src/diff/__tests__/diff.test.ts
@@ -163,6 +163,93 @@ describe('diff openapi', () => {
       expect(diffWithChanges.length).toBe(1);
       expect(diffWithChanges).toMatchSnapshot();
     });
+
+    test('diffs operations even if variable names change request body', () => {
+      const diffNoChanges = diff(
+        {
+          paths: {
+            '/user/{userId}': {
+              get: {
+                responses: {},
+                requestBody: {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'object',
+                        properties: { abc: { type: 'string' } },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        {
+          paths: {
+            '/user/{user_id}': {
+              get: {
+                responses: {},
+                requestBody: {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'object',
+                        properties: { abc: { type: 'string' } },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        }
+      );
+      const diffWithChanges = diff(
+        {
+          paths: {
+            '/user/{userId}': {
+              get: {
+                responses: {},
+                requestBody: {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'object',
+                        properties: { abc: { type: 'string' } },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        {
+          paths: {
+            '/user/{user_Id}': {
+              get: {
+                responses: {},
+                requestBody: {
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'object',
+                        properties: {},
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        }
+      );
+      expect(diffNoChanges.length).toBe(0);
+
+      expect(diffWithChanges.length).toBe(1);
+      expect(diffWithChanges).toMatchSnapshot();
+    });
   });
 
   test('diff with empty array', () => {

--- a/projects/openapi-utilities/src/diff/__tests__/openapi-matchers.test.ts
+++ b/projects/openapi-utilities/src/diff/__tests__/openapi-matchers.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from '@jest/globals';
+import { isPathParameterArray } from '../openapi-matchers';
+import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
+
+describe('openapi matchers', () => {
+  it('matches parameters array', () => {
+    expect(
+      isPathParameterArray(
+        jsonPointerHelpers.compile(['paths', '/me/them', 'get', 'parameters'])
+      )
+    ).toBe(true);
+    expect(
+      isPathParameterArray(
+        jsonPointerHelpers.compile(['paths', '/me/them', 'parameters'])
+      )
+    ).toBe(true);
+    isPathParameterArray(
+      jsonPointerHelpers.compile(['paths', '/me/them', 'get', 'responses'])
+    );
+    expect(
+      isPathParameterArray(
+        jsonPointerHelpers.compile(['paths', '/me/them', 'parameters'])
+      )
+    ).toBe(true);
+  });
+});

--- a/projects/openapi-utilities/src/diff/__tests__/openapi-matchers.test.ts
+++ b/projects/openapi-utilities/src/diff/__tests__/openapi-matchers.test.ts
@@ -9,6 +9,17 @@ describe('openapi matchers', () => {
         jsonPointerHelpers.compile(['paths', '/me/them', 'get', 'parameters'])
       )
     ).toBe(true);
+
+    expect(
+      isPathParameterArray(
+        jsonPointerHelpers.compile([
+          'paths',
+          '/me/them',
+          'summary',
+          'parameters',
+        ])
+      )
+    ).toBe(false);
     expect(
       isPathParameterArray(
         jsonPointerHelpers.compile(['paths', '/me/them', 'parameters'])

--- a/projects/openapi-utilities/src/diff/diff.ts
+++ b/projects/openapi-utilities/src/diff/diff.ts
@@ -129,12 +129,7 @@ export function diff(
           afterPath,
         });
       }
-    } else if (
-      !Array.isArray(before.value) &&
-      !Array.isArray(after.value) &&
-      Object.prototype.toString.call(before.value) &&
-      Object.prototype.toString.call(after.value)
-    ) {
+    } else if (!Array.isArray(before.value) && !Array.isArray(after.value)) {
       const objectIdFn: (key: string, v: any) => string =
         isPathsMap(before.path) && isPathsMap(after.path)
           ? (key) => normalizeOpenApiPath(key)

--- a/projects/openapi-utilities/src/diff/diff.ts
+++ b/projects/openapi-utilities/src/diff/diff.ts
@@ -1,5 +1,7 @@
 import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
 import { getParameterIdentity, isParameterObject } from './array-identifiers';
+import { isPathParameterArray, isPathsMap } from './openapi-matchers';
+import { normalizeOpenApiPath } from '../openapi3/implementations/openapi3/openapi-traverser';
 
 export type JSONValue =
   | null
@@ -60,12 +62,16 @@ export function typeofDiff(
 }
 
 // Diffs two objects, generating the leaf nodes that have changes
-export function diff(before: any, after: any): ObjectDiff[] {
+export function diff(
+  before: any,
+  after: any,
+  initialPath: string = ''
+): ObjectDiff[] {
   const diffResults: ObjectDiff[] = [];
   const stack: StackItem[] = [
     [
-      { value: before, path: '' },
-      { value: after, path: '' },
+      { value: before, path: initialPath },
+      { value: after, path: initialPath },
     ],
   ];
   while (stack.length > 0) {
@@ -84,13 +90,13 @@ export function diff(before: any, after: any): ObjectDiff[] {
     // for objects, we just use the key
     if (Array.isArray(before.value) && Array.isArray(after.value)) {
       const allValues = [...before.value, ...after.value];
-      const arrayIdFn: (v: any, i: number) => string = allValues.every((v) =>
-        isParameterObject(v)
-      )
-        ? getParameterIdentity
-        : allValues.every((v) => typeof v !== 'object')
-        ? (v: any) => String(v)
-        : (_, i: number) => String(i);
+
+      const arrayIdFn: (v: any, i: number) => string =
+        isPathParameterArray(before.path) && isPathParameterArray(after.path)
+          ? getParameterIdentity
+          : allValues.every((v) => typeof v !== 'object')
+          ? (v: any) => String(v)
+          : (_, i: number) => String(i);
 
       const beforeValuesById: Map<string, [JSONValue, number]> = new Map(
         before.value.map((v, i) => [arrayIdFn(v, i), [v, i]])
@@ -103,6 +109,7 @@ export function diff(before: any, after: any): ObjectDiff[] {
         ...beforeValuesById.keys(),
         ...afterValuesById.keys(),
       ]);
+
       for (const key of keys) {
         const [beforeValue, beforeIdx] = beforeValuesById.get(key) ?? [];
         const [afterValue, afterIdx] = afterValuesById.get(key) ?? [];
@@ -122,17 +129,40 @@ export function diff(before: any, after: any): ObjectDiff[] {
           afterPath,
         });
       }
-    } else if (!Array.isArray(before.value) && !Array.isArray(after.value)) {
+    } else if (
+      !Array.isArray(before.value) &&
+      !Array.isArray(after.value) &&
+      Object.prototype.toString.call(before.value) &&
+      Object.prototype.toString.call(after.value)
+    ) {
+      const objectIdFn: (key: string, v: any) => string =
+        isPathsMap(before.path) && isPathsMap(after.path)
+          ? (key) => normalizeOpenApiPath(key)
+          : (key: string, value) => String(key);
+
+      const beforeValuesById: Map<string, [JSONValue, string]> = new Map(
+        Object.entries(before.value).map(([k, v]) => [objectIdFn(k, v), [v, k]])
+      );
+      const afterValuesById: Map<string, [JSONValue, string]> = new Map(
+        Object.entries(after.value).map(([k, v]) => [objectIdFn(k, v), [v, k]])
+      );
+
       const keys = new Set([
-        ...Object.keys(before.value),
-        ...Object.keys(after.value),
+        ...beforeValuesById.keys(),
+        ...afterValuesById.keys(),
       ]);
 
       for (const key of keys) {
-        const beforeValue = before.value[key];
-        const beforePath = jsonPointerHelpers.append(before.path, key);
-        const afterValue = after.value[key];
-        const afterPath = jsonPointerHelpers.append(after.path, key);
+        const [beforeValue, beforeId] = beforeValuesById.get(key) ?? [];
+        const beforePath = jsonPointerHelpers.append(
+          before.path,
+          String(beforeId)
+        );
+        const [afterValue, afterId] = afterValuesById.get(key) ?? [];
+        const afterPath = jsonPointerHelpers.append(
+          after.path,
+          String(afterId)
+        );
         comparisons.push({
           beforeValue,
           beforePath,

--- a/projects/openapi-utilities/src/diff/openapi-matchers.ts
+++ b/projects/openapi-utilities/src/diff/openapi-matchers.ts
@@ -183,8 +183,6 @@ export const comparisonsForAllOf = (
     const afterAllOfSchemas =
       (after.value as unknown as FlatOpenAPIV3.SchemaObject).allOf || [];
 
-    Math.max(beforeAllOfSchemas.length, afterAllOfSchemas.length);
-
     const withoutProperties = (obj: FlatOpenAPIV3.SchemaObject | undefined) => {
       if (obj) {
         const { properties, required, ...others } = obj;

--- a/projects/openapi-utilities/src/diff/openapi-matchers.ts
+++ b/projects/openapi-utilities/src/diff/openapi-matchers.ts
@@ -1,6 +1,7 @@
 import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
 import { getParameterIdentity } from './array-identifiers';
 import { FlatOpenAPIV3 } from '../flat-openapi-types';
+import { JSONArray, JSONObject, JSONValue, ObjectDiff } from './diff';
 
 const methods = `{get,post,put,delete,patch,head,options}`;
 export const isPathParameterArray = (pointer: string): boolean => {
@@ -46,26 +47,174 @@ export const inJsonSchema = (pointer: string): boolean => {
   );
 };
 
-export const isAnObjectAllOf = (
-  pointer: string,
-  schema: FlatOpenAPIV3.SchemaObject
-) => {
+export const isAnObjectAllOf = (pointer: string, schema: any) => {
   return (
     inJsonSchema(pointer) &&
-    schema.allOf &&
+    Array.isArray(schema.allOf) &&
     schema.allOf.length &&
-    schema.allOf.every((childSchema) => childSchema.type === 'object')
+    schema.allOf.every((childSchema: any) => childSchema.type === 'object')
   );
 };
 
-export const isAnObject = (
-  pointer: string,
-  schema: FlatOpenAPIV3.SchemaObject
-) => {
+export const isAnObject = (pointer: string, schema: any) => {
   return (
     inJsonSchema(pointer) &&
     !schema.allOf &&
     schema.type &&
     schema.type === 'object'
   );
+};
+
+export const isAllOfDiff = (
+  before: { path: string; value: JSONObject | JSONArray },
+  after: { path: string; value: JSONObject | JSONArray }
+) => {
+  return (
+    (isAnObjectAllOf(before.path, before.value) &&
+      isAnObjectAllOf(after.path, after.value)) ||
+    (isAnObjectAllOf(before.path, before.value) &&
+      isAnObject(after.path, after.value)) ||
+    (isAnObject(before.path, before.value) &&
+      isAnObjectAllOf(after.path, after.value))
+  );
+};
+
+export const propertiesForAllOf = (allOfOrObject: {
+  path: string;
+  value: JSONObject | JSONArray;
+}): Map<string, [any, string, boolean, string | null]> => {
+  let keyPathMap = new Map<string, [any, string, boolean, string | null]>();
+
+  if (isAnObject(allOfOrObject.path, allOfOrObject.value)) {
+    const obj = allOfOrObject.value as unknown as FlatOpenAPIV3.SchemaObject & {
+      type: 'object';
+    };
+    Object.keys(obj.properties || {}).forEach((prop) => {
+      const isRequired: boolean = obj.required
+        ? obj.required.includes(prop)
+        : false;
+      keyPathMap.set(prop, [
+        obj.properties![prop],
+        jsonPointerHelpers.append(allOfOrObject.path, 'properties', prop),
+        isRequired,
+        isRequired
+          ? jsonPointerHelpers.append(
+              allOfOrObject.path,
+              'required',
+              String(obj.required?.indexOf(prop))
+            )
+          : null,
+      ]);
+    });
+  } else if (isAnObjectAllOf(allOfOrObject.path, allOfOrObject.value)) {
+    const allOf = allOfOrObject.value as unknown as FlatOpenAPIV3.SchemaObject;
+    (allOf.allOf || []).forEach((schema, index) => {
+      keyPathMap = new Map([
+        ...keyPathMap,
+        ...propertiesForAllOf({
+          value: schema as any,
+          path: jsonPointerHelpers.append(
+            allOfOrObject.path,
+            'allOf',
+            String(index)
+          ),
+        }),
+      ]);
+    });
+  }
+
+  return keyPathMap;
+};
+export const comparisonsForAllOf = (
+  before: { path: string; value: JSONObject | JSONArray },
+  after: { path: string; value: JSONObject | JSONArray }
+) => {
+  const beforeProperties = propertiesForAllOf(before);
+  const afterProperties = propertiesForAllOf(after);
+
+  const propertyKeys = new Set([
+    ...beforeProperties.keys(),
+    ...afterProperties.keys(),
+  ]);
+
+  const comparisons: {
+    beforeValue: JSONValue | undefined;
+    beforePath: string;
+    afterValue: JSONValue | undefined;
+    afterPath: string;
+  }[] = [];
+
+  const requiredDiffResults: ObjectDiff[] = [];
+
+  for (const key of propertyKeys) {
+    const [beforeValue, beforePath, beforeIsRequired, beforeRequiredPath] =
+      beforeProperties.get(key) ?? [];
+    const [afterValue, afterPath, afterIsRequired, afterRequiredPath] =
+      afterProperties.get(key) ?? [];
+
+    comparisons.push({
+      beforeValue,
+      beforePath: (beforePath || afterPath)!,
+      afterPath: (afterPath || beforePath)!,
+      afterValue,
+    });
+
+    // became optional
+    if (beforeIsRequired && !afterIsRequired && beforeRequiredPath) {
+      requiredDiffResults.push({
+        before: beforeRequiredPath,
+        pathReconciliation: [],
+      });
+    }
+    // became required
+    if (afterIsRequired && !beforeIsRequired && afterRequiredPath) {
+      requiredDiffResults.push({
+        after: afterRequiredPath,
+      });
+    }
+  }
+
+  if (
+    isAnObjectAllOf(before.path, before.value) &&
+    isAnObjectAllOf(after.path, after.value)
+  ) {
+    const beforeAllOfSchemas =
+      (before.value as unknown as FlatOpenAPIV3.SchemaObject).allOf || [];
+    const afterAllOfSchemas =
+      (after.value as unknown as FlatOpenAPIV3.SchemaObject).allOf || [];
+
+    Math.max(beforeAllOfSchemas.length, afterAllOfSchemas.length);
+
+    const withoutProperties = (obj: FlatOpenAPIV3.SchemaObject | undefined) => {
+      if (obj) {
+        const { properties, required, ...others } = obj;
+        return others;
+      } else {
+        return undefined;
+      }
+    };
+
+    Array(Math.max(beforeAllOfSchemas.length, afterAllOfSchemas.length))
+      .fill(undefined)
+      .forEach((_, index) => {
+        const beforeVal = beforeAllOfSchemas[index];
+        const afterVal = afterAllOfSchemas[index];
+        comparisons.push({
+          beforeValue: withoutProperties(beforeVal) as JSONObject,
+          afterValue: withoutProperties(afterVal) as JSONObject,
+          beforePath: jsonPointerHelpers.append(
+            before.path,
+            'allOf',
+            String(index)
+          ),
+          afterPath: jsonPointerHelpers.append(
+            after.path,
+            'allOf',
+            String(index)
+          ),
+        });
+      });
+  }
+
+  return { comparisons, requiredDiffResults };
 };

--- a/projects/openapi-utilities/src/diff/openapi-matchers.ts
+++ b/projects/openapi-utilities/src/diff/openapi-matchers.ts
@@ -1,0 +1,18 @@
+import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
+import { getParameterIdentity } from './array-identifiers';
+
+export const isPathParameterArray = (pointer: string): boolean => {
+  return (
+    jsonPointerHelpers.matches(pointer, ['paths', '**', 'parameters']) ||
+    jsonPointerHelpers.matches(pointer, [
+      'paths',
+      '**',
+      '!parameters',
+      'parameters',
+    ])
+  );
+};
+
+export const isPathsMap = (pointer: string): boolean => {
+  return jsonPointerHelpers.matches(pointer, ['paths']);
+};

--- a/projects/openapi-utilities/src/diff/openapi-matchers.ts
+++ b/projects/openapi-utilities/src/diff/openapi-matchers.ts
@@ -47,24 +47,45 @@ export const inJsonSchema = (pointer: string): boolean => {
   );
 };
 
+/*
+Checks if a schema is an allOf with every child as an object. If this is true, we can diff it as-if it is an object
+ */
 export const isAnObjectAllOf = (pointer: string, schema: any) => {
   return (
     inJsonSchema(pointer) &&
     Array.isArray(schema.allOf) &&
     schema.allOf.length &&
-    schema.allOf.every((childSchema: any) => childSchema.type === 'object')
+    schema.allOf.every(
+      (childSchema: any) =>
+        childSchema.type === 'object' ||
+        (Array.isArray(childSchema.type) &&
+          childSchema.type.length === 1 &&
+          childSchema.type[0] === 'object')
+    )
   );
 };
 
+/*
+Checks if a schema is an object
+ */
 export const isAnObject = (pointer: string, schema: any) => {
   return (
-    inJsonSchema(pointer) &&
-    !schema.allOf &&
-    schema.type &&
-    schema.type === 'object'
+    (inJsonSchema(pointer) &&
+      !schema.allOf &&
+      schema.type &&
+      schema.type === 'object') ||
+    (Array.isArray(schema.type) &&
+      schema.type.length === 1 &&
+      schema.type[0] === 'object')
   );
 };
 
+/*
+Checks for the 3 possible allOf diffs
+- was an object before, now it's an allOf object
+- was an allOf object before, now it's an object
+- two allOf objects
+ */
 export const isAllOfDiff = (
   before: { path: string; value: JSONObject | JSONArray },
   after: { path: string; value: JSONObject | JSONArray }
@@ -79,9 +100,15 @@ export const isAllOfDiff = (
   );
 };
 
+/*
+Finds all the properties (unique by name) across all the schemas in an allOf.
+- If the properties overlap the last in the tree wins
+- The property will be required if its parent object has required to be specified
+ */
 export const propertiesForAllOf = (allOfOrObject: {
   path: string;
   value: JSONObject | JSONArray;
+  // key  schema path is required  path of required entry (explicitly required) or null (implicitly option)
 }): Map<string, [any, string, boolean, string | null]> => {
   let keyPathMap = new Map<string, [any, string, boolean, string | null]>();
 
@@ -125,6 +152,12 @@ export const propertiesForAllOf = (allOfOrObject: {
 
   return keyPathMap;
 };
+
+/*
+Walks each of the schemas from before / after
+- computes next comparisons to diff
+- manually diffs the required arrays. There are (n) possible required arrays (one in each schema) so we need alternative logic here
+ */
 export const comparisonsForAllOf = (
   before: { path: string; value: JSONObject | JSONArray },
   after: { path: string; value: JSONObject | JSONArray }
@@ -159,14 +192,14 @@ export const comparisonsForAllOf = (
       afterValue,
     });
 
-    // became optional
+    // if the property became optional, return the correct diff
     if (beforeIsRequired && !afterIsRequired && beforeRequiredPath) {
       requiredDiffResults.push({
         before: beforeRequiredPath,
         pathReconciliation: [],
       });
     }
-    // became required
+    // became required, return the correct diff
     if (afterIsRequired && !beforeIsRequired && afterRequiredPath) {
       requiredDiffResults.push({
         after: afterRequiredPath,
@@ -174,6 +207,10 @@ export const comparisonsForAllOf = (
     }
   }
 
+  /* when both are allOf we can compare the other properties of the object, like summary, description, etc.
+     We ignore these during the transition from object to allOf because it creates conflict and they probably need to refactor anyway. For instance title...what does it mean for all of the sub schemas to have a title? not last one wins, you probably want the title to be compared to the title next to allOf: []
+
+   */
   if (
     isAnObjectAllOf(before.path, before.value) &&
     isAnObjectAllOf(after.path, after.value)

--- a/projects/openapi-utilities/src/diff/openapi-matchers.ts
+++ b/projects/openapi-utilities/src/diff/openapi-matchers.ts
@@ -1,18 +1,71 @@
 import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
 import { getParameterIdentity } from './array-identifiers';
+import { FlatOpenAPIV3 } from '../flat-openapi-types';
 
+const methods = `{get,post,put,delete,patch,head,options}`;
 export const isPathParameterArray = (pointer: string): boolean => {
   return (
     jsonPointerHelpers.matches(pointer, ['paths', '**', 'parameters']) ||
-    jsonPointerHelpers.matches(pointer, [
-      'paths',
-      '**',
-      '!parameters',
-      'parameters',
-    ])
+    jsonPointerHelpers.matches(pointer, ['paths', '**', methods, 'parameters'])
   );
 };
 
 export const isPathsMap = (pointer: string): boolean => {
   return jsonPointerHelpers.matches(pointer, ['paths']);
+};
+
+export const inJsonSchema = (pointer: string): boolean => {
+  return (
+    jsonPointerHelpers.startsWith(pointer, [
+      'paths',
+      '**',
+      methods,
+      'parameters',
+      '**',
+      'schema',
+    ]) ||
+    jsonPointerHelpers.startsWith(pointer, [
+      'paths',
+      '**',
+      methods,
+      'responses',
+      '**',
+      'content',
+      '**/**',
+      'schema',
+    ]) ||
+    jsonPointerHelpers.startsWith(pointer, [
+      'paths',
+      '**',
+      methods,
+      'requestBody',
+      'content',
+      '**/**',
+      'schema',
+    ])
+  );
+};
+
+export const isAnObjectAllOf = (
+  pointer: string,
+  schema: FlatOpenAPIV3.SchemaObject
+) => {
+  return (
+    inJsonSchema(pointer) &&
+    schema.allOf &&
+    schema.allOf.length &&
+    schema.allOf.every((childSchema) => childSchema.type === 'object')
+  );
+};
+
+export const isAnObject = (
+  pointer: string,
+  schema: FlatOpenAPIV3.SchemaObject
+) => {
+  return (
+    inJsonSchema(pointer) &&
+    !schema.allOf &&
+    schema.type &&
+    schema.type === 'object'
+  );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3718,6 +3718,7 @@ __metadata:
     babel-jest: ^29.3.1
     jest: ^29.3.1
     jsonpointer: ^5.0.1
+    minimatch: 7.1.0
     prettier: ^2.4.1
     ts-jest: ^29.0.3
     ts-node: ^10.3.1


### PR DESCRIPTION
## 🍗 Description
Specifically targets objects + allOf objects (the primary use case) and does not try to work with anything that isn't an object. 
- `object` -> `allOf` 
- `allOf` -> `object`
- `allOf(n) <> allOf(n)` where n can be different

When we see an allOf of objects being compared to another allOf or an object: 
- manually create the correct comparisons for properties and enqueue them
- manually diff the required 
- enqueue a diff for the other attributes of objects

Future
- we may want to add validation rules for impossible allofs -- no other tools do this, but really easy to make something that can't exist in the real world like 
```
allOf:
 -  type: object
    properties: []...
 - type: object
   additionalProperties: false
```


## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
