### PR TITLE
export lib and rulesets in optic lib

### DIFF
--- a/projects/optic/src/commands/diff/generate-rule-runner.ts
+++ b/projects/optic/src/commands/diff/generate-rule-runner.ts
@@ -11,6 +11,12 @@ import { loadCliConfig } from '../../config';
 import { logger } from '../../logger';
 import chalk from 'chalk';
 
+const baseRulesets: (Ruleset | ExternalRule)[] = [];
+
+export function setRulesets(rulesets: (Ruleset | ExternalRule)[]) {
+  baseRulesets.push(...rulesets);
+}
+
 const isLocalJsFile = (name: string) => name.endsWith('.js');
 
 type InputPayload = Parameters<typeof prepareRulesets>[0];
@@ -59,7 +65,7 @@ export const generateRuleRunner = async (
     options,
     checksEnabled,
   });
-  let rulesets: (Ruleset | ExternalRule)[] = [];
+  let rulesets: (Ruleset | ExternalRule)[] = [...baseRulesets];
   let ruleNames: string[] = [];
   let warnings: string[] = [];
 

--- a/projects/optic/src/commands/diff/generate-rule-runner.ts
+++ b/projects/optic/src/commands/diff/generate-rule-runner.ts
@@ -124,7 +124,7 @@ export const generateRuleRunner = async (
       hostedRulesets,
     });
 
-    rulesets = results.rulesets;
+    rulesets.push(...results.rulesets);
 
     warnings.push(...results.warnings);
   }

--- a/projects/optic/src/config.ts
+++ b/projects/optic/src/config.ts
@@ -23,7 +23,7 @@ export const USER_CONFIG_PATH =
     ? path.join(USER_CONFIG_DIR, 'config.local.json')
     : path.join(USER_CONFIG_DIR, 'config.json');
 
-type ConfigRuleset = { name: string; config: unknown };
+export type ConfigRuleset = { name: string; config: unknown };
 
 export type RawYmlConfig = {
   ruleset?: unknown[];
@@ -44,7 +44,7 @@ export type OpticCliConfig = Omit<RawYmlConfig, 'ruleset' | 'extends'> & {
     status: 'clean' | 'dirty';
   };
 
-  ruleset: ConfigRuleset[];
+  ruleset?: ConfigRuleset[];
   isAuthenticated: boolean;
   authenticationType?: 'user' | 'env';
   client: OpticBackendClient;
@@ -55,7 +55,7 @@ export type OpticCliConfig = Omit<RawYmlConfig, 'ruleset' | 'extends'> & {
 const DefaultOpticCliConfig: OpticCliConfig = {
   root: process.cwd(),
   configPath: undefined,
-  ruleset: [{ name: 'breaking-changes', config: {} }],
+  ruleset: undefined,
   isAuthenticated: false,
   client: createOpticClient('no_token'),
   isInCi: process.env.CI === 'true',

--- a/projects/optic/src/lib.ts
+++ b/projects/optic/src/lib.ts
@@ -1,0 +1,2 @@
+export { initCli } from './init';
+export { setRulesets } from './commands/diff/generate-rule-runner';


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Export functions to allow users to bundle rulesets / and customize their own CLI 

```javascript
import { initCli, setRulesets }  from 'lib';

(async () => {
  const cli = await initCli();
  setRulesets([your own rulesets])

  cli.parse(process.argv);
})()
```

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
