### PR TITLE
fix generation for gitlab to checkout branch

### DIFF
--- a/projects/optic/ci/configs/gitlab_fail.yml
+++ b/projects/optic/ci/configs/gitlab_fail.yml
@@ -16,6 +16,7 @@ optic-diff-push:
   rules:
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_REF_NAME == $CI_DEFAULT_BRANCH
   script:
+    - git checkout -B "$CI_BUILD_REF_NAME" "$CI_BUILD_REF"
     - npm install -g @useoptic/optic
     - optic diff-all --check --upload
 

--- a/projects/optic/ci/configs/gitlab_no_fail.yml
+++ b/projects/optic/ci/configs/gitlab_no_fail.yml
@@ -16,6 +16,7 @@ optic-diff-push:
   rules:
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_REF_NAME == $CI_DEFAULT_BRANCH
   script:
+    - git checkout -B "$CI_BUILD_REF_NAME" "$CI_BUILD_REF"
     - npm install -g @useoptic/optic
     - optic diff-all --check --upload
 


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Gitlab checks out using a detached head (https://gitlab.com/gitlab-org/gitlab/-/issues/15409) - we can force it to pull the branch name by adding a `git checkout command`. This is important, otherwise we cannot add a `gitbranch` tag to push events

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
