### PR TITLE
loosen strict validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.40.2",
+  "version": "0.40.3",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-cli",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-io/src/validation/__snapshots__/validator.test.ts.snap
+++ b/projects/openapi-io/src/validation/__snapshots__/validator.test.ts.snap
@@ -7,7 +7,7 @@ exports[`advanced validators run and append their results 1`] = `
 /paths/~1api~1users~1{userId}/get/responses/200/content/application~1json/schema/anyOf
 [31minvalid openapi: [39m[1m[31mpaths > /api/users/{userId} > get > responses > 200 > content > application/json > schema > items must be object[39m[22m
 /paths/~1api~1users~1{userId}/get/responses/200/content/application~1json/schema/items
-[31minvalid openapi: [39m[1m[31mpaths > /api/users/{userId} > get > responses > 200 > content > application/json > schema schema with type "object" cannot also include keywords: anyOf, items, oneOf[39m[22m
+[31minvalid openapi: [39m[1m[31mpaths > /api/users/{userId} > get > responses > 200 > content > application/json > schema schema with type "object" cannot also include keywords: items[39m[22m
 /paths/~1api~1users~1{userId}/get/responses/200/content/application~1json/schema"
 `;
 

--- a/projects/openapi-io/src/validation/advanced-validation.test.ts
+++ b/projects/openapi-io/src/validation/advanced-validation.test.ts
@@ -1,24 +1,6 @@
 import { it, expect } from '@jest/globals';
 import { validateSchema } from './advanced-validation';
 
-it('a polymorphic schema cannot have type', () => {
-  expect(() =>
-    validateSchema({ oneOf: [], type: 'string' })
-  ).toThrowErrorMatchingInlineSnapshot(
-    `"schema with oneOf cannot also include keywords: type"`
-  );
-  expect(() =>
-    validateSchema({ anyOf: [], type: 'string' })
-  ).toThrowErrorMatchingInlineSnapshot(
-    `"schema with anyOf cannot also include keywords: type"`
-  );
-  expect(() =>
-    validateSchema({ allOf: [], type: 'string' })
-  ).toThrowErrorMatchingInlineSnapshot(
-    `"schema with anyOf cannot also include keywords: type"`
-  );
-});
-
 it('a polymorphic schema have overlapping keywords type', () => {
   expect(() =>
     validateSchema({ oneOf: [], anyOf: [], allOf: [] })

--- a/projects/openapi-io/src/validation/advanced-validation.ts
+++ b/projects/openapi-io/src/validation/advanced-validation.ts
@@ -34,31 +34,31 @@ export function validateSchema(schema: SchemaUnion) {
   if (schema.type === 'object') {
     checkForDisallowedKeywords(
       'schema with type "object" cannot also include keywords: ',
-      ['allOf', 'anyOf', 'oneOf', 'items'],
+      ['items'],
       schema
     );
   } else if (schema.type === 'array') {
     checkForDisallowedKeywords(
       'schema with type "array" cannot also include keywords: ',
-      ['allOf', 'anyOf', 'oneOf', 'properties', 'required'],
+      ['properties', 'required'],
       schema
     );
   } else if (schema.oneOf) {
     checkForDisallowedKeywords(
       'schema with oneOf cannot also include keywords: ',
-      ['allOf', 'anyOf', 'type', 'items', 'properties', 'required'],
+      ['allOf', 'anyOf'],
       schema
     );
   } else if (schema.anyOf) {
     checkForDisallowedKeywords(
       'schema with anyOf cannot also include keywords: ',
-      ['allOf', 'oneOf', 'type', 'items', 'properties', 'required'],
+      ['allOf', 'oneOf'],
       schema
     );
   } else if (schema.allOf) {
     checkForDisallowedKeywords(
       'schema with anyOf cannot also include keywords: ',
-      ['anyOf', 'oneOf', 'type', 'items', 'properties', 'required'],
+      ['anyOf', 'oneOf'],
       schema
     );
   }

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
## 🍗 Description
Optic's validation for polymorphic schemas was overly strict. JSON Schema does allow the polymorphism keywords `oneOf` `anyOf` `allOf` alongside `type: object` and `type: array` -- you can make impossible schemas....absolutely, but they are still valid JSON Schema / OpenAPI


## 📚 References
https://json-schema.org/understanding-json-schema/structuring.html#structuring
## 👹 QA
_How can other humans verify that this PR is correct?_
