### PR TITLE
fix `optic api add` to push spec when not in git repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.40.4",
+  "version": "0.40.5",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.40.4",
+  "version": "0.40.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-cli",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.40.4",
+  "version": "0.40.5",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.40.4",
+  "version": "0.40.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.40.4",
+  "version": "0.40.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.40.4",
+  "version": "0.40.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.40.4",
+  "version": "0.40.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/src/commands/api/add.ts
+++ b/projects/optic/src/commands/api/add.ts
@@ -261,6 +261,18 @@ export const getApiAddAction =
       );
       process.exitCode = 1;
       return;
+    } else if (config.vcs?.type === VCS.Git && config.vcs.status === 'dirty') {
+      logger.error(
+        chalk.red(
+          'Error: optic api add only tracks OpenAPI files that have been committed to git history.'
+        )
+      );
+
+      logger.error(
+        chalk.red('Commit your changes and then run optic api add again')
+      );
+      process.exitCode = 1;
+      return;
     }
 
     let file: {

--- a/projects/optic/src/commands/api/add.ts
+++ b/projects/optic/src/commands/api/add.ts
@@ -195,6 +195,14 @@ async function crawlCandidateSpecs(
         await config.client.tagSpec(specId, tag);
       }
     }
+  } else {
+    // Outside of a git repo, we should just upload it as a spec without tags
+    await uploadSpec(api.id, {
+      spec: parseResult,
+      tags: [],
+      client: config.client,
+      orgId,
+    });
   }
 
   // Write to file only if optic-url is not set or is invalid

--- a/projects/optic/src/commands/api/add.ts
+++ b/projects/optic/src/commands/api/add.ts
@@ -144,6 +144,16 @@ async function crawlCandidateSpecs(
   }
 
   if (config.vcs?.type === VCS.Git) {
+    // If the git workspace is dirty, we should upload the spec with changes
+    // such that first use of optic you will have a spec (even without tags)
+    if (config.vcs.status === 'dirty') {
+      await uploadSpec(api.id, {
+        spec: parseResult,
+        tags: [],
+        client: config.client,
+        orgId,
+      });
+    }
     const specsToTag: [string, string][] = [];
     for await (const sha of shas) {
       let parseResult: ParseResult;
@@ -258,18 +268,6 @@ export const getApiAddAction =
         chalk.red(
           'You must be logged in to add APIs to Optic Cloud. Please run "optic login"'
         )
-      );
-      process.exitCode = 1;
-      return;
-    } else if (config.vcs?.type === VCS.Git && config.vcs.status === 'dirty') {
-      logger.error(
-        chalk.red(
-          'Error: optic api add only tracks OpenAPI files that have been committed to git history.'
-        )
-      );
-
-      logger.error(
-        chalk.red('Commit your changes and then run optic api add again')
       );
       process.exitCode = 1;
       return;

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.40.4",
+  "version": "0.40.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.40.4",
+  "version": "0.40.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Two fixes
- if a user is outside of a git repo, push the current spec
- if a user is in a git repo, but the repo has uncommitted changes, exit optic api add and log an error
  - I thought about being a little more lax here, and telling them to run `optic spec push` instead, but I think this is easier to explain and be stricter

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
