### PR TITLE
feat(optic): update spec cloud url

### DIFF
--- a/projects/optic/src/__tests__/integration/__snapshots__/spec-push.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/spec-push.test.ts.snap
@@ -4,7 +4,7 @@ exports[`optic spec push can push a spec to a repo 1`] = `
 "Automatically adding the git sha 'git:COMMIT-HASH' and branch 'gitbranch:master' as tags
 
 Uploading spec for api at https://app.useoptic.com/organizations/org-id/apis/api-id with tags env:production, the-favorite-api, git:COMMIT-HASH, gitbranch:master
-Succesfully uploaded spec to Optic. View the spec here http://localhost:3001/organizations/org-id/apis/api-id/specs/spec-id
+Succesfully uploaded spec to Optic. View the spec here http://localhost:3001/organizations/org-id/apis/api-id?specId=spec-id
 "
 `;
 
@@ -12,7 +12,7 @@ exports[`optic spec push does not automatically add git tags when not clean stat
 "Not automatically including any git tags because the current working directory has uncommited changes.
 
 Uploading spec for api at https://app.useoptic.com/organizations/org-id/apis/api-id 
-Succesfully uploaded spec to Optic. View the spec here http://localhost:3001/organizations/org-id/apis/api-id/specs/spec-id
+Succesfully uploaded spec to Optic. View the spec here http://localhost:3001/organizations/org-id/apis/api-id?specId=spec-id
 "
 `;
 

--- a/projects/optic/src/utils/cloud-urls.ts
+++ b/projects/optic/src/utils/cloud-urls.ts
@@ -50,7 +50,7 @@ export function getSpecUrl(
 ): string {
   return urljoin(
     baseUrl,
-    `organizations/${orgId}/apis/${apiId}/specs/${specId}`
+    `organizations/${orgId}/apis/${apiId}?specId=${specId}`
   );
 }
 


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Update the spec url to point towards `/api/<id>?specId=<id>`
To be merged after https://github.com/opticdev/monorail/pull/3783

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
