### PR TITLE
Expose ajv config for examples ruleset

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.40.5",
+  "version": "0.40.6",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-cli",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/src/examples/__tests__/examples-are-valid-rules.test.ts
+++ b/projects/standard-rulesets/src/examples/__tests__/examples-are-valid-rules.test.ts
@@ -2,8 +2,9 @@ import { test, expect, describe } from '@jest/globals';
 import { OpenAPIV3 } from '@useoptic/openapi-utilities';
 import { TestHelpers } from '@useoptic/rulesets-base';
 import { ExamplesRuleset } from '../index';
-import { validateSchema } from '../requireValidExamples';
+import { defaultAjv, validateSchema } from '../requireValidExamples';
 
+const ajvInstance = defaultAjv();
 describe('fromOpticConfig', () => {
   test('invalid configuration', async () => {
     const out = await ExamplesRuleset.fromOpticConfig({
@@ -278,7 +279,8 @@ describe('examples should default to additional properties false', () => {
           b: { type: 'string' },
         },
       },
-      { a: 'abc', b: 'def', c: 'xyz' }
+      { a: 'abc', b: 'def', c: 'xyz' },
+      ajvInstance
     );
     expect(result.pass).toBe(false);
     expect(result).toMatchSnapshot();
@@ -302,7 +304,8 @@ describe('examples should default to additional properties false', () => {
           },
         ],
       },
-      { a: 'abc', b: 'def', c: 'A' }
+      { a: 'abc', b: 'def', c: 'A' },
+      ajvInstance
     );
     expect(result.pass).toBe(false);
     expect(result).toMatchSnapshot();
@@ -326,7 +329,8 @@ describe('examples should default to additional properties false', () => {
           },
         ],
       },
-      { a: 'abc', b: { l: '' }, c: 'A' }
+      { a: 'abc', b: { l: '' }, c: 'A' },
+      ajvInstance
     );
     expect(result.pass).toBe(false);
     expect(result).toMatchSnapshot();
@@ -342,7 +346,8 @@ describe('examples should default to additional properties false', () => {
           b: { type: 'string' },
         },
       },
-      { a: 'abc', b: 'def', c: 'xyz' }
+      { a: 'abc', b: 'def', c: 'xyz' },
+      ajvInstance
     );
     expect(result.pass).toBe(true);
     expect(result).toMatchSnapshot();

--- a/projects/standard-rulesets/src/examples/index.ts
+++ b/projects/standard-rulesets/src/examples/index.ts
@@ -12,6 +12,7 @@ import {
   requireResponseExamples,
 } from './requireExample';
 import {
+  defaultAjv,
   requirePropertyExamplesMatchSchema,
   requireValidParameterExamples,
   requireValidRequestExamples,
@@ -91,12 +92,17 @@ export class ExamplesRuleset extends Ruleset {
     return new ExamplesRuleset(validatedConfig);
   }
 
-  constructor(config: ExampleConstructor) {
+  constructor(config: ExampleConstructor, configureAjv?: (ajv: Ajv) => void) {
+    const customAjv = defaultAjv();
+    if (configureAjv) {
+      configureAjv(customAjv);
+    }
+
     const rules: Rule[] = [
-      requireValidResponseExamples,
-      requirePropertyExamplesMatchSchema,
-      requireValidParameterExamples,
-      requireValidRequestExamples,
+      requireValidResponseExamples(customAjv),
+      requirePropertyExamplesMatchSchema(customAjv),
+      requireValidParameterExamples(customAjv),
+      requireValidRequestExamples(customAjv),
     ];
 
     if (config.require_response_examples)
@@ -117,3 +123,7 @@ export class ExamplesRuleset extends Ruleset {
     });
   }
 }
+
+new ExamplesRuleset({}, (ajv) => {
+  ajv.addFormat();
+});

--- a/projects/standard-rulesets/src/examples/index.ts
+++ b/projects/standard-rulesets/src/examples/index.ts
@@ -57,6 +57,7 @@ const configSchema = {
 type ExampleConstructor = YamlConfig & {
   matches?: (context: RuleContext) => boolean;
   docsLink?: string;
+  configureAjv?: (ajv: Ajv) => void;
 };
 
 const validateConfigSchema = ajv.compile(configSchema);
@@ -92,10 +93,10 @@ export class ExamplesRuleset extends Ruleset {
     return new ExamplesRuleset(validatedConfig);
   }
 
-  constructor(config: ExampleConstructor, configureAjv?: (ajv: Ajv) => void) {
+  constructor(config: ExampleConstructor) {
     const customAjv = defaultAjv();
-    if (configureAjv) {
-      configureAjv(customAjv);
+    if (config.configureAjv) {
+      config.configureAjv(customAjv);
     }
 
     const rules: Rule[] = [

--- a/projects/standard-rulesets/src/examples/index.ts
+++ b/projects/standard-rulesets/src/examples/index.ts
@@ -123,7 +123,3 @@ export class ExamplesRuleset extends Ruleset {
     });
   }
 }
-
-new ExamplesRuleset({}, (ajv) => {
-  ajv.addFormat();
-});

--- a/projects/standard-rulesets/src/examples/requireValidExamples.ts
+++ b/projects/standard-rulesets/src/examples/requireValidExamples.ts
@@ -9,7 +9,7 @@ import { OpenAPIV3 } from 'openapi-types';
 import Ajv, { SchemaObject } from 'ajv/dist/2019';
 import addFormats from 'ajv-formats';
 
-const ajv = (() => {
+export function defaultAjv() {
   const validator = new Ajv({ strict: false, unevaluated: true });
   addFormats(validator);
   // override pattern keyword when invalid regex
@@ -34,11 +34,12 @@ const ajv = (() => {
     },
   });
   return validator;
-})();
+}
 
 export function validateSchema(
   schema: SchemaObject,
-  example: unknown
+  example: unknown,
+  ajv: Ajv
 ): { pass: true } | { pass: false; error: string } {
   const copy = JSON.parse(JSON.stringify(schema));
   strictAdditionalProperties(copy);
@@ -108,50 +109,16 @@ function strictAdditionalProperties(schema: any, inAllOf: boolean = false) {
   }
 }
 
-export const requireValidRequestExamples = new RequestRule({
-  name: 'request body examples must match schema',
-  rule: (requestAssertions) => {
-    requestAssertions.body.requirement((value) => {
-      const { schema, examples, example } =
-        value.raw as OpenAPIV3.MediaTypeObject;
+export const requireValidRequestExamples = (ajv: Ajv) =>
+  new RequestRule({
+    name: 'request body examples must match schema',
+    rule: (requestAssertions) => {
+      requestAssertions.body.requirement((value) => {
+        const { schema, examples, example } =
+          value.raw as OpenAPIV3.MediaTypeObject;
 
-      if (example) {
-        const result = validateSchema(schema || {}, example);
-        if (!result.pass) {
-          throw new RuleError({
-            message: `the example does not match the schema. \n${result.error} `,
-          });
-        }
-      }
-
-      if (examples) {
-        Object.entries(examples).forEach((example) => {
-          const [exampleName, exampleValue] = example as [
-            string,
-            OpenAPIV3.ExampleObject
-          ];
-          const result = validateSchema(schema || {}, exampleValue.value);
-          if (!result.pass) {
-            throw new RuleError({
-              message: `the example named '${exampleName}' does not match the schema. \n${result.error} `,
-            });
-          }
-        });
-      }
-    });
-  },
-});
-
-export const requireValidResponseExamples = new ResponseRule({
-  name: 'response body examples must match schemas',
-  rule: (responseAssertions) => {
-    responseAssertions.requirement((value) => {
-      value.bodies.forEach((body) => {
-        if (body.raw.example) {
-          const result = validateSchema(
-            body.raw.schema || {},
-            body.raw.example
-          );
+        if (example) {
+          const result = validateSchema(schema || {}, example, ajv);
           if (!result.pass) {
             throw new RuleError({
               message: `the example does not match the schema. \n${result.error} `,
@@ -159,15 +126,16 @@ export const requireValidResponseExamples = new ResponseRule({
           }
         }
 
-        if (body.raw.examples) {
-          Object.entries(body.raw.examples).forEach((example) => {
+        if (examples) {
+          Object.entries(examples).forEach((example) => {
             const [exampleName, exampleValue] = example as [
               string,
               OpenAPIV3.ExampleObject
             ];
             const result = validateSchema(
-              body.raw.schema || {},
-              exampleValue.value
+              schema || {},
+              exampleValue.value,
+              ajv
             );
             if (!result.pass) {
               throw new RuleError({
@@ -177,101 +145,150 @@ export const requireValidResponseExamples = new ResponseRule({
           });
         }
       });
-    });
-  },
-});
+    },
+  });
 
-export const requireValidParameterExamples = new OperationRule({
-  name: 'parameter examples must match schemas',
-  rule: (operation) => {
-    operation.headerParameter.requirement((header) => {
-      if (header.raw.example) {
-        const result = validateSchema(
-          header.raw.schema || {},
-          header.raw.example
-        );
-        if (!result.pass) {
-          throw new RuleError({
-            message: `header '${header.value.name}' example does not match the schema. \n${result.error} `,
-          });
-        }
-      }
-      if (header.raw.schema && 'example' in header.raw.schema) {
-        const result = validateSchema(
-          header.raw.schema || {},
-          header.raw.schema.example
-        );
-        if (!result.pass) {
-          throw new RuleError({
-            message: `header '${header.value.name}' example does not match the schema. \n${result.error} `,
-          });
-        }
-      }
-    });
-    operation.queryParameter.requirement((query) => {
-      if (query.raw.example) {
-        const result = validateSchema(
-          query.raw.schema || {},
-          query.raw.example
-        );
-        if (!result.pass) {
-          throw new RuleError({
-            message: `query parameter '${query.value.name}' example does not match the schema. \n${result.error} `,
-          });
-        }
-      }
-      if (query.raw.schema && 'example' in query.raw.schema) {
-        const result = validateSchema(
-          query.raw.schema || {},
-          query.raw.schema.example
-        );
-        if (!result.pass) {
-          throw new RuleError({
-            message: `query parameter '${query.value.name}' example does not match the schema. \n${result.error} `,
-          });
-        }
-      }
-    });
-    operation.cookieParameter.requirement((cookie) => {
-      if (cookie.raw.example) {
-        const result = validateSchema(
-          cookie.raw.schema || {},
-          cookie.raw.example
-        );
-        if (!result.pass) {
-          throw new RuleError({
-            message: `cookie '${cookie.value.name}' example does not match the schema. \n${result.error} `,
-          });
-        }
-      }
-      if (cookie.raw.schema && 'example' in cookie.raw.schema) {
-        const result = validateSchema(
-          cookie.raw.schema || {},
-          cookie.raw.schema.example
-        );
-        if (!result.pass) {
-          throw new RuleError({
-            message: `cookie '${cookie.value.name}' example does not match the schema. \n${result.error} `,
-          });
-        }
-      }
-    });
-  },
-});
+export const requireValidResponseExamples = (ajv: Ajv) =>
+  new ResponseRule({
+    name: 'response body examples must match schemas',
+    rule: (responseAssertions) => {
+      responseAssertions.requirement((value) => {
+        value.bodies.forEach((body) => {
+          if (body.raw.example) {
+            const result = validateSchema(
+              body.raw.schema || {},
+              body.raw.example,
+              ajv
+            );
+            if (!result.pass) {
+              throw new RuleError({
+                message: `the example does not match the schema. \n${result.error} `,
+              });
+            }
+          }
 
-export const requirePropertyExamplesMatchSchema = new PropertyRule({
-  name: 'require property examples match schemas',
-  rule: (property) => {
-    property.requirement((property) => {
-      const flatSchema = property.value.flatSchema;
-      if (property.raw.example) {
-        const result = validateSchema(flatSchema, property.raw.example);
-        if (!result.pass) {
-          throw new RuleError({
-            message: `'${property.value.key}' example does not match the schema. \n${result.error} `,
-          });
+          if (body.raw.examples) {
+            Object.entries(body.raw.examples).forEach((example) => {
+              const [exampleName, exampleValue] = example as [
+                string,
+                OpenAPIV3.ExampleObject
+              ];
+              const result = validateSchema(
+                body.raw.schema || {},
+                exampleValue.value,
+                ajv
+              );
+              if (!result.pass) {
+                throw new RuleError({
+                  message: `the example named '${exampleName}' does not match the schema. \n${result.error} `,
+                });
+              }
+            });
+          }
+        });
+      });
+    },
+  });
+
+export const requireValidParameterExamples = (ajv: Ajv) =>
+  new OperationRule({
+    name: 'parameter examples must match schemas',
+    rule: (operation) => {
+      operation.headerParameter.requirement((header) => {
+        if (header.raw.example) {
+          const result = validateSchema(
+            header.raw.schema || {},
+            header.raw.example,
+            ajv
+          );
+          if (!result.pass) {
+            throw new RuleError({
+              message: `header '${header.value.name}' example does not match the schema. \n${result.error} `,
+            });
+          }
         }
-      }
-    });
-  },
-});
+        if (header.raw.schema && 'example' in header.raw.schema) {
+          const result = validateSchema(
+            header.raw.schema || {},
+            header.raw.schema.example,
+            ajv
+          );
+          if (!result.pass) {
+            throw new RuleError({
+              message: `header '${header.value.name}' example does not match the schema. \n${result.error} `,
+            });
+          }
+        }
+      });
+      operation.queryParameter.requirement((query) => {
+        if (query.raw.example) {
+          const result = validateSchema(
+            query.raw.schema || {},
+            query.raw.example,
+            ajv
+          );
+          if (!result.pass) {
+            throw new RuleError({
+              message: `query parameter '${query.value.name}' example does not match the schema. \n${result.error} `,
+            });
+          }
+        }
+        if (query.raw.schema && 'example' in query.raw.schema) {
+          const result = validateSchema(
+            query.raw.schema || {},
+            query.raw.schema.example,
+            ajv
+          );
+          if (!result.pass) {
+            throw new RuleError({
+              message: `query parameter '${query.value.name}' example does not match the schema. \n${result.error} `,
+            });
+          }
+        }
+      });
+      operation.cookieParameter.requirement((cookie) => {
+        if (cookie.raw.example) {
+          const result = validateSchema(
+            cookie.raw.schema || {},
+            cookie.raw.example,
+            ajv
+          );
+          if (!result.pass) {
+            throw new RuleError({
+              message: `cookie '${cookie.value.name}' example does not match the schema. \n${result.error} `,
+            });
+          }
+        }
+        if (cookie.raw.schema && 'example' in cookie.raw.schema) {
+          const result = validateSchema(
+            cookie.raw.schema || {},
+            cookie.raw.schema.example,
+            ajv
+          );
+          if (!result.pass) {
+            throw new RuleError({
+              message: `cookie '${cookie.value.name}' example does not match the schema. \n${result.error} `,
+            });
+          }
+        }
+      });
+    },
+  });
+
+export const requirePropertyExamplesMatchSchema = (ajv: Ajv) =>
+  new PropertyRule({
+    name: 'require property examples match schemas',
+    rule: (property) => {
+      property.requirement((property) => {
+        const flatSchema = property.value.flatSchema;
+        if (property.raw.example) {
+          const result = validateSchema(flatSchema, property.raw.example, ajv);
+          if (!result.pass) {
+            throw new RuleError({
+              message: `'${property.value.key}' example does not match the schema. \n${result.error} `,
+            });
+          }
+        }
+      });
+    },
+  });


### PR DESCRIPTION
## 🍗 Description
Allow customizing AJV validation for examples. use case extra formats
```
new ExamplesRuleset(config, (ajv) => {
  ajv.addFormat(...)
});
```

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
