### PR TITLE
Fix diff function to handle identity prefixes correctly

### DIFF
--- a/projects/openapi-utilities/src/diff/__tests__/__snapshots__/diff.test.ts.snap
+++ b/projects/openapi-utilities/src/diff/__tests__/__snapshots__/diff.test.ts.snap
@@ -138,10 +138,10 @@ exports[`diff openapi diff behavior removing a key 1`] = `
 exports[`diff openapi diff behavior removing a key with path reconciliation 1`] = `
 [
   {
-    "before": "/paths/~1me/get/parameters/0/nested/schema/removeme",
+    "before": "/parameters/0/nested/schema/removeme",
     "pathReconciliation": [
       [
-        4,
+        1,
         "2",
       ],
     ],
@@ -152,7 +152,7 @@ exports[`diff openapi diff behavior removing a key with path reconciliation 1`] 
 exports[`diff openapi diff with array values diffs for parameters 1`] = `
 [
   {
-    "before": "/paths/~1me/get/parameters/1",
+    "before": "/1",
     "pathReconciliation": [],
   },
 ]

--- a/projects/openapi-utilities/src/diff/diff.ts
+++ b/projects/openapi-utilities/src/diff/diff.ts
@@ -65,13 +65,13 @@ export function typeofDiff(
 export function diff(
   before: any,
   after: any,
-  initialPath: string = ''
+  identityPrefix: string = ''
 ): ObjectDiff[] {
   const diffResults: ObjectDiff[] = [];
   const stack: StackItem[] = [
     [
-      { value: before, path: initialPath },
-      { value: after, path: initialPath },
+      { value: before, path: '' },
+      { value: after, path: '' },
     ],
   ];
   while (stack.length > 0) {
@@ -83,6 +83,15 @@ export function diff(
       afterPath: string;
     }[] = [];
 
+    const beforePathIdentity = jsonPointerHelpers.join(
+      identityPrefix,
+      before.path
+    );
+    const afterPathIdentity = jsonPointerHelpers.join(
+      identityPrefix,
+      after.path
+    );
+
     // TODO in the future, skip adding comparisons based on diff preprocessing step
 
     // Start by matching up values to compare - match up the before and after values by id
@@ -92,7 +101,8 @@ export function diff(
       const allValues = [...before.value, ...after.value];
 
       const arrayIdFn: (v: any, i: number) => string =
-        isPathParameterArray(before.path) && isPathParameterArray(after.path)
+        isPathParameterArray(beforePathIdentity) &&
+        isPathParameterArray(afterPathIdentity)
           ? getParameterIdentity
           : allValues.every((v) => typeof v !== 'object')
           ? (v: any) => String(v)


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Fixing the diff function when you pass in an initial path. The reason you want to set an initial path is because you want to handle something in the spec at a certain level (e.g. parameters).

The reason passing initialPaths doesn't work, is because the diff that is generated contains the `initialPath`, which is not useful in the context you do not have the root object, only the child.

Take the example:
```js
const a = {a: 'something'};
const b = {a: 'something-else'};
diff(a,b, 'prefix/keys');
```

The diffs that are generated are `prefix/keys/a` which is not useful since we only have access to the `a` key (not the parent keys).

This PR fixes it to generate diff paths on the object level that's passed in (but you can pass a different identity string later on)

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
