### PR TITLE
Denormalize spec when running verification / upload

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.40.6",
+  "version": "0.40.7",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.40.6",
+  "version": "0.40.7",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-cli/package.json
+++ b/projects/openapi-cli/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-cli",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.40.6",
+  "version": "0.40.7",
   "main": "build/lib.js",
   "types": "build/lib.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.40.6",
+  "version": "0.40.7",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.40.6",
+  "version": "0.40.7",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.40.6",
+  "version": "0.40.7",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.40.6",
+  "version": "0.40.7",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/src/commands/oas/verify.ts
+++ b/projects/optic/src/commands/oas/verify.ts
@@ -164,7 +164,7 @@ export function verifyCommand(config: OpticCliConfig): Command {
       /// Run to verify with the latest specification
       const parseResult = await getFileFromFsOrGit(absoluteSpecPath, config, {
         strict: false,
-        denormalize: false,
+        denormalize: true,
       });
 
       const { jsonLike: spec, sourcemap } = parseResult;

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.40.6",
+  "version": "0.40.7",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.4.1",
-  "version": "0.40.6",
+  "version": "0.40.7",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Denormalize the spec (i.e. copy path parameters into each endpoint). I initially didn't do this because I thought it would interfere with the patching code, but this is after all the patching code, and it only affects parameters (for now)

We need the denormalized spec in cloud otherwise we cannot effectively diff between versions. (i.e. inconsistent loading)

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
