### PR TITLE
oas document command

### DIFF
--- a/projects/optic/src/commands/oas/captures/capture-storage.ts
+++ b/projects/optic/src/commands/oas/captures/capture-storage.ts
@@ -6,7 +6,7 @@ import crypto from 'crypto';
 
 export async function captureStorage(
   filePath: string
-): Promise<[boolean, string]> {
+): Promise<[boolean, string, number]> {
   const resolvedFilepath = Path.resolve(filePath);
   const openApiExists: boolean = await fs.pathExists(resolvedFilepath);
 
@@ -24,5 +24,9 @@ export async function captureStorage(
 
   if (openApiExists) await fs.ensureDir(trafficDirectory);
 
-  return [openApiExists, trafficDirectory];
+  return [
+    openApiExists,
+    trafficDirectory,
+    (await fs.readdir(trafficDirectory)).length,
+  ];
 }

--- a/projects/optic/src/commands/oas/document.ts
+++ b/projects/optic/src/commands/oas/document.ts
@@ -1,0 +1,121 @@
+import { Command } from 'commander';
+
+import { createCommandFeedback, InputErrors } from './reporters/feedback';
+
+import chalk from 'chalk';
+import { readDeferencedSpec } from './specs';
+import {
+  addIfUndocumented,
+  matchInteractions,
+  parseAddOperations,
+} from './diffing/document';
+import Path from 'path';
+import * as fs from 'fs-extra';
+import { getInteractions } from './verify';
+import { getApiFromOpticUrl } from '../../utils/cloud-urls';
+import { OPTIC_URL_KEY } from '../../constants';
+
+type DocumentOptions = {
+  all?: string;
+  har?: string;
+};
+
+export function documentCommand(): Command {
+  const command = new Command('document');
+  const feedback = createCommandFeedback(command);
+
+  command
+    .description('document a new operation in the OpenAPI')
+    .argument(
+      '<openapi-file>',
+      'an OpenAPI spec to match up to observed traffic'
+    )
+    .option('--har <har-file>', 'path to HttpArchive file (v1.2, v1.3)')
+    .option('--all', 'Patch existing operations to resolve diffs')
+    .argument(
+      '[operations...]',
+      'the paths to document format "get /path/{id}"',
+      []
+    )
+    .action(async (specPath, operations) => {
+      const analytics: { event: string; properties: any }[] = [];
+      const options: DocumentOptions = command.opts();
+
+      const operationsToAdd = parseAddOperations(operations);
+      if (operationsToAdd.err) {
+        return feedback.inputError(
+          'To document an operation you must use the format "get /path/{id}"...',
+          InputErrors.DOCUMENT_OPERATION_FORMAT
+        );
+      }
+      const isAddAll = Boolean(options.all);
+
+      const absoluteSpecPath = Path.resolve(specPath);
+      if (!(await fs.pathExists(absoluteSpecPath))) {
+        return await feedback.inputError(
+          'OpenAPI specification file could not be found',
+          InputErrors.SPEC_FILE_NOT_FOUND
+        );
+      }
+
+      const specReadResult = await readDeferencedSpec(absoluteSpecPath);
+      if (specReadResult.err) {
+        return await feedback.inputError(
+          `OpenAPI specification could not be fully resolved: ${specReadResult.val.message}`,
+          InputErrors.SPEC_FILE_NOT_READABLE
+        );
+      }
+
+      const opticUrlDetails = getApiFromOpticUrl(
+        specReadResult.val.jsonLike[OPTIC_URL_KEY]
+      );
+
+      const makeInteractionsIterator = async () =>
+        getInteractions(options, specPath, feedback);
+
+      const { jsonLike: spec, sourcemap } = specReadResult.unwrap();
+
+      feedback.notable('Documenting operations...');
+
+      let { observations } = matchInteractions(
+        spec,
+        await makeInteractionsIterator()
+      );
+
+      const result = await addIfUndocumented(
+        operationsToAdd.val,
+        isAddAll,
+        observations,
+        await makeInteractionsIterator(),
+        spec,
+        sourcemap
+      );
+
+      if (result.ok) {
+        analytics.push({
+          event: 'openapi.verify.document',
+          properties: {
+            allFlag: isAddAll,
+            numberDocumented: result.val.length,
+          },
+        });
+        result.val.map((operation) => {
+          console.log(
+            `  ${chalk.green('added')}  ${operation.method} ${
+              operation.pathPattern
+            }`
+          );
+        });
+      }
+
+      if (!opticUrlDetails) {
+        console.log('');
+        console.log(
+          `Share a link to documentation with your team (${chalk.bold(
+            `optic api add ${specPath})`
+          )}`
+        );
+      }
+    });
+  return command;
+}

--- a/projects/optic/src/commands/oas/reporters/feedback.ts
+++ b/projects/optic/src/commands/oas/reporters/feedback.ts
@@ -49,7 +49,7 @@ export function createCommandFeedback(
   }
 
   function notable(message: string) {
-    destination.write(chalk.blueBright(' » ') + message + '\n');
+    destination.write(chalk.blueBright('» ') + message + '\n');
   }
 
   function warning(message: string) {
@@ -109,5 +109,6 @@ export enum InputErrors {
   HAR_FILE_NOT_FOUND = 'har-file-not-found',
   PROXY_IN_NON_TTY = 'proxy-in-non-tty',
   SPEC_FILE_NOT_FOUND = 'spec-file-not-found',
+  DOCUMENT_OPERATION_FORMAT = 'document-operation-format',
   SPEC_FILE_NOT_READABLE = 'spec-file-not-readable',
 }

--- a/projects/optic/src/init.ts
+++ b/projects/optic/src/init.ts
@@ -27,6 +27,7 @@ import chalk from 'chalk';
 import { registerDereference } from './commands/dereference/dereference';
 import { registerCiSetup } from './commands/ci/setup';
 import { registerLint } from './commands/lint/lint';
+import { documentCommand } from './commands/oas/document';
 
 const packageJson = require('../package.json');
 
@@ -86,6 +87,7 @@ Run ${chalk.yellow('npm i -g @useoptic/optic')} to upgrade Optic`
   );
   // commands for tracking changes with openapi
   oas.addCommand(await captureCommand(cliConfig));
+  oas.addCommand(await documentCommand());
   oas.addCommand(await newCommand());
   oas.addCommand(await setupTlsCommand());
   oas.addCommand(await clearCommand());


### PR DESCRIPTION
## 🍗 Description
Now you document your APIs by running 
`optic oas document --all` or `optic oas document "get /xyz" "post /abc"`

Captures are more explicit 

```
» Verifying API behavior with traffic from last 10 captures. Reset captures with "optic oas clear todo-api.yaml"` 
```

Verify doesn't have a document flag anymore. 

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
