### PR TITLE
Support `oas` prefixed invocations for a longer window

### DIFF
--- a/projects/optic/src/init.ts
+++ b/projects/optic/src/init.ts
@@ -86,17 +86,16 @@ Run ${chalk.yellow('npm i -g @useoptic/optic')} to upgrade Optic`
   registerDiff(cli, cliConfig);
 
   //@todo by 2023/5/10
-  cli.addCommand(
-    new Command('oas')
-      .description('[Renamed] to optic capture/new/verify/update')
-      .action(() =>
-        console.log(
-          `[Renamed] to optic capture/new/verify/update. See ${chalk.blue.underline(
-            'https://www.useoptic.com/docs/openapi/update-from-traffic'
-          )}`
-        )
-      )
+  const oas = new Command('oas').description(
+    '[Deprecated] capture/verify/update are now top-level commands'
   );
+  oas.addCommand(await captureCommand(cliConfig));
+  oas.addCommand(await newCommand());
+  oas.addCommand(await setupTlsCommand());
+  oas.addCommand(verifyCommand(cliConfig));
+  oas.addCommand(updateCommand());
+
+  cli.addCommand(oas);
 
   // commands for tracking changes with openapi
   cli.addCommand(await captureCommand(cliConfig));


### PR DESCRIPTION
## 🍗 Description
We renamed some commands under oas to make them first class. Now you can still call them under OAS but it's not preferred and will be removed in a major version

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
