### PR TITLE
Add effective_at for specs from repo

### DIFF
--- a/projects/optic/src/client/optic-backend.ts
+++ b/projects/optic/src/client/optic-backend.ts
@@ -133,6 +133,7 @@ export class OpticBackendClient extends JsonHttpClient {
     tags: string[];
     upload_id: string;
     api_id: string;
+    effective_at?: Date;
   }): Promise<{ id: string }> {
     return this.postJson(`/api/specs`, spec);
   }

--- a/projects/optic/src/utils/cloud-specs.ts
+++ b/projects/optic/src/utils/cloud-specs.ts
@@ -56,10 +56,13 @@ export async function uploadSpec(
       }),
     ]);
 
+    const effective_at = opts.spec.context?.effective_at;
+
     const { id } = await opts.client.createSpec({
       upload_id: result.upload_id,
       api_id: apiId,
       tags: tags,
+      effective_at,
     });
     trackEvent('spec.added', {
       apiId,

--- a/projects/optic/src/utils/git-utils.ts
+++ b/projects/optic/src/utils/git-utils.ts
@@ -103,6 +103,16 @@ export const resolveGitRef = async (ref: string): Promise<string> =>
     exec(command, cb);
   });
 
+export const commitTime = async (ref: string): Promise<Date> =>
+  new Promise((resolve, reject) => {
+    const cb = (err: unknown, stdout: string, stderr: string) => {
+      if (err || stderr || !stdout) reject(err || stderr);
+      resolve(new Date(parseInt(stdout.trim()) * 1000));
+    };
+    const command = `git show --date=iso-strict --format=%ct ${ref}`;
+    exec(command, cb);
+  });
+
 export const findOpenApiSpecsCandidates = async (
   ref?: string
 ): Promise<string[]> =>


### PR DESCRIPTION
## 🍗 Description

_What does this PR do? Anything folks should know?_

Use commit timestamp to set an effective date for a spec, rather than using when the command is run.

## 📚 References

_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA

_How can other humans verify that this PR is correct?_
