### PR TITLE
fix capture storage when no openapi spec

### DIFF
--- a/projects/optic/src/commands/oas/capture-clear.ts
+++ b/projects/optic/src/commands/oas/capture-clear.ts
@@ -24,13 +24,15 @@ export function clearCommand(): Command {
       }
       if (specPath) {
         const absoluteSpecPath = Path.resolve(specPath);
-        if (!(await fs.pathExists(absoluteSpecPath))) {
+        const { trafficDirectory, openApiExists } = await captureStorage(
+          specPath
+        );
+        if (!openApiExists) {
           return await feedback.inputError(
             'OpenAPI specification file could not be found',
             InputErrors.SPEC_FILE_NOT_FOUND
           );
         }
-        const { trafficDirectory } = await captureStorage(specPath);
         await fs.remove(trafficDirectory);
         feedback.success(
           'Cleared capture folder for ' +

--- a/projects/optic/src/commands/oas/captures/capture-storage.ts
+++ b/projects/optic/src/commands/oas/captures/capture-storage.ts
@@ -4,9 +4,7 @@ import os from 'os';
 const tmpDirectory = os.tmpdir();
 import crypto from 'crypto';
 
-export async function captureStorage(
-  filePath: string
-): Promise<{
+export async function captureStorage(filePath: string): Promise<{
   openApiExists: boolean;
   trafficDirectory: string;
   existingCaptures: number;
@@ -26,7 +24,7 @@ export async function captureStorage(
     specPathHash
   );
 
-  if (openApiExists) await fs.ensureDir(trafficDirectory);
+  await fs.ensureDir(trafficDirectory);
 
   return {
     openApiExists,

--- a/projects/optic/src/commands/oas/verify.ts
+++ b/projects/optic/src/commands/oas/verify.ts
@@ -93,17 +93,16 @@ export async function runVerify(
     }
   }
 
-  const absoluteSpecPath = Path.resolve(specPath);
-  if (!(await fs.pathExists(absoluteSpecPath))) {
+  console.log('');
+
+  const { existingCaptures, openApiExists } = await captureStorage(specPath);
+  if (!openApiExists) {
     return await feedback.inputError(
       'OpenAPI specification file could not be found',
       InputErrors.SPEC_FILE_NOT_FOUND
     );
   }
-
-  console.log('');
-
-  const { trafficDirectory, existingCaptures } = await captureStorage(specPath);
+  const absoluteSpecPath = Path.resolve(specPath);
 
   const makeInteractionsIterator = async () =>
     getInteractions(options, specPath, feedback);


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Fix capture error message when run against an openapi spec that does not exist on disk

`optic capture doesnotexist.yml http://localhost:8080` 



## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

https://github.com/opticdev/optic/issues/1778

## 👹 QA
_How can other humans verify that this PR is correct?_
