### PR TITLE
Fix diff undefined check

### DIFF
--- a/projects/openapi-utilities/src/diff/__tests__/__snapshots__/diff.test.ts.snap
+++ b/projects/openapi-utilities/src/diff/__tests__/__snapshots__/diff.test.ts.snap
@@ -126,6 +126,17 @@ exports[`diff openapi diff behavior changing a key value 1`] = `
 ]
 `;
 
+exports[`diff openapi diff behavior diff for objects with falsy values 1`] = `
+[
+  {
+    "after": "/value",
+  },
+  {
+    "after": "/a",
+  },
+]
+`;
+
 exports[`diff openapi diff behavior removing a key 1`] = `
 [
   {

--- a/projects/openapi-utilities/src/diff/__tests__/diff.test.ts
+++ b/projects/openapi-utilities/src/diff/__tests__/diff.test.ts
@@ -77,6 +77,19 @@ describe('diff openapi', () => {
       expect(diffResults.length).toBe(1);
       expect(diffResults).toMatchSnapshot();
     });
+
+    test('diff for objects with falsy values', () => {
+      const diffs = diff(
+        {},
+        {
+          value: null,
+          a: 2,
+        }
+      );
+
+      expect(diffs.length).toBe(2);
+      expect(diffs).toMatchSnapshot();
+    });
   });
 
   describe('diff with array values', () => {

--- a/projects/openapi-utilities/src/diff/diff.ts
+++ b/projects/openapi-utilities/src/diff/diff.ts
@@ -189,7 +189,7 @@ export function diff(
       afterValue,
       afterPath,
     } of comparisons) {
-      if (beforeValue && afterValue === undefined) {
+      if (beforeValue !== undefined && afterValue === undefined) {
         // Because before + after paths can change diverge due to array rearrangement, we need to track this to determine from where something was removed in an after spec
         // We don't need to look at the last key to see path differences since
         const beforeParts = jsonPointerHelpers.decode(beforePath).slice(0, -1);
@@ -207,7 +207,7 @@ export function diff(
           before: beforePath,
           pathReconciliation,
         });
-      } else if (beforeValue === undefined && afterValue) {
+      } else if (beforeValue === undefined && afterValue !== undefined) {
         diffResults.push({
           after: afterPath,
         });


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Previously, a diff between these two objects would produce a changed diff, instead of a added diff
```js
diff({}, { key: null })
// outputs
// [{before: '/undefined', after: 'key'}]
```

This is because we were using the wrong equality check (i.e. false values like `null` or `0` would evaluate `false` for this check

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
