### PR TITLE
Loosen non strict file loading

### DIFF
--- a/projects/openapi-io/src/validation/__snapshots__/validator.test.ts.snap
+++ b/projects/openapi-io/src/validation/__snapshots__/validator.test.ts.snap
@@ -1,31 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`advanced validators run and append their results 1`] = `
-"[31minvalid openapi: [39m[1m[31mpaths > /api/users/{userId} > get > responses > 200 > content > application/json > schema > oneOf must NOT have fewer than 1 items[39m[22m
-/paths/~1api~1users~1{userId}/get/responses/200/content/application~1json/schema/oneOf
-[31minvalid openapi: [39m[1m[31mpaths > /api/users/{userId} > get > responses > 200 > content > application/json > schema > anyOf must NOT have fewer than 1 items[39m[22m
-/paths/~1api~1users~1{userId}/get/responses/200/content/application~1json/schema/anyOf
-[31minvalid openapi: [39m[1m[31mpaths > /api/users/{userId} > get > responses > 200 > content > application/json > schema > items must be object[39m[22m
-/paths/~1api~1users~1{userId}/get/responses/200/content/application~1json/schema/items
-[31minvalid openapi: [39m[1m[31mpaths > /api/users/{userId} > get > responses > 200 > content > application/json > schema schema with type "object" cannot also include keywords: items[39m[22m
-/paths/~1api~1users~1{userId}/get/responses/200/content/application~1json/schema"
-`;
-
-exports[`error cases with messages additional properties in invalid place 1`] = `
-"[31minvalid openapi: [39m[1m[31mpaths > /example > get must have required property 'responses'[39m[22m
-/paths/~1example/get
-[31minvalid openapi: [39m[1m[31minfo must NOT have additional properties[39m[22m
-/info"
-`;
-
-exports[`error cases with messages open api doc with no description in response 1`] = `
-"[31minvalid openapi: [39m[1m[31mpaths > /example > get must have required property 'responses'[39m[22m
-/paths/~1example/get"
-`;
-
-exports[`error cases with messages open api doc with no path should throw an error 1`] = `
+exports[`non-strict validation should fail open api doc with no path should throw an error 1`] = `
 "[31minvalid openapi: [39m[1m[31m must have required property 'paths'[39m[22m
 "
+`;
+
+exports[`non-strict validation should fail open api doc without responses 1`] = `
+"[31minvalid openapi: [39m[1m[31mpaths > /example > get must have required property 'responses'[39m[22m
+/paths/~1example/get"
 `;
 
 exports[`processValidatorErrors 1`] = `
@@ -50,4 +32,20 @@ exports[`processValidatorErrors attaches the sourcemap 1`] = `
 [90m39 |[39m     }
 [90m40 |[39m   }
 [90m41 |[39m }"
+`;
+
+exports[`strict validation advanced validators run and append their results 1`] = `
+"[31minvalid openapi: [39m[1m[31mpaths > /api/users/{userId} > get > responses > 200 > content > application/json > schema > oneOf must NOT have fewer than 1 items[39m[22m
+/paths/~1api~1users~1{userId}/get/responses/200/content/application~1json/schema/oneOf
+[31minvalid openapi: [39m[1m[31mpaths > /api/users/{userId} > get > responses > 200 > content > application/json > schema > anyOf must NOT have fewer than 1 items[39m[22m
+/paths/~1api~1users~1{userId}/get/responses/200/content/application~1json/schema/anyOf
+[31minvalid openapi: [39m[1m[31mpaths > /api/users/{userId} > get > responses > 200 > content > application/json > schema > items must be object[39m[22m
+/paths/~1api~1users~1{userId}/get/responses/200/content/application~1json/schema/items
+[31minvalid openapi: [39m[1m[31mpaths > /api/users/{userId} > get > responses > 200 > content > application/json > schema schema with type "object" cannot also include keywords: items[39m[22m
+/paths/~1api~1users~1{userId}/get/responses/200/content/application~1json/schema"
+`;
+
+exports[`strict validation open api doc with no description in response should throw 1`] = `
+"[31minvalid openapi: [39m[1m[31mpaths > /example > get > responses > 200 must have required property 'description'[39m[22m
+/paths/~1example/get/responses/200"
 `;

--- a/projects/openapi-io/src/validation/validation-schemas.ts
+++ b/projects/openapi-io/src/validation/validation-schemas.ts
@@ -1456,6 +1456,66 @@ const createOpenAPIValidationSchema = (schema: any) => ({
   },
 });
 
+export const basic3openapi_schema = {
+  $id: 'http://openapis.org/v3/schema.json#',
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  required: ['openapi', 'info', 'paths'],
+  properties: {
+    openapi: {
+      type: 'string',
+    },
+    info: {
+      type: 'object',
+    },
+    paths: {
+      type: 'object',
+      patternProperties: {
+        '^/': {
+          type: 'object',
+          properties: {
+            get: {
+              $ref: '#/definitions/operation',
+            },
+            put: {
+              $ref: '#/definitions/operation',
+            },
+            post: {
+              $ref: '#/definitions/operation',
+            },
+            delete: {
+              $ref: '#/definitions/operation',
+            },
+            options: {
+              $ref: '#/definitions/operation',
+            },
+            head: {
+              $ref: '#/definitions/operation',
+            },
+            patch: {
+              $ref: '#/definitions/operation',
+            },
+            trace: {
+              $ref: '#/definitions/operation',
+            },
+          },
+        },
+      },
+    },
+  },
+  definitions: {
+    operation: {
+      type: 'object',
+      required: ['responses'],
+      properties: {
+        responses: {
+          type: 'object',
+        },
+      },
+    },
+  },
+};
+
 export const openapi3_0_json_schema = createOpenAPIValidationSchema(
   openapi3_0_schema_object
 );

--- a/projects/openapi-io/src/validation/validator.test.ts
+++ b/projects/openapi-io/src/validation/validator.test.ts
@@ -11,144 +11,234 @@ async function readJson(p: string) {
   return JSON.parse(contents);
 }
 
-test('valid open api document should not raise errors', async () => {
-  validateOpenApiV3Document(defaultEmptySpec);
-  validateOpenApiV3Document(
-    (await readJson('./inputs/openapi3/petstore0.json.flattened.json')).jsonLike
-  );
-});
-
-test('valid open 3.1 api document should not raise errors', async () => {
-  validateOpenApiV3Document(defaultEmptySpec);
-  validateOpenApiV3Document(
-    await readJson('./inputs/openapi3/todo-api-3_1.json')
-  );
-});
-
-describe('error cases with messages', () => {
-  test('open api doc with no path should throw an error', () => {
-    expect(() => {
-      validateOpenApiV3Document({
-        openapi: '3.1.3',
-        info: { version: '0.0.0', title: 'Empty' },
-      });
-    }).toThrowErrorMatchingSnapshot();
+describe('strict validation', () => {
+  test('valid open api document should not raise errors', async () => {
+    validateOpenApiV3Document(defaultEmptySpec);
+    validateOpenApiV3Document(
+      (await readJson('./inputs/openapi3/petstore0.json.flattened.json'))
+        .jsonLike
+    );
   });
 
-  test('open api doc with no description in response', () => {
+  test('valid open 3.1 api document should not raise errors', async () => {
+    validateOpenApiV3Document(defaultEmptySpec);
+    validateOpenApiV3Document(
+      await readJson('./inputs/openapi3/todo-api-3_1.json')
+    );
+  });
+
+  test('open api doc with no description in response should throw', () => {
     expect(() => {
-      validateOpenApiV3Document({
-        openapi: '3.1.3',
-        info: { version: '0.0.0', title: 'Empty' },
-        paths: {
-          '/example': {
-            get: {
-              response: {
-                '200': {},
+      validateOpenApiV3Document(
+        {
+          openapi: '3.1.3',
+          info: { version: '0.0.0', title: 'Empty' },
+          paths: {
+            '/example': {
+              get: {
+                responses: {
+                  '200': {},
+                },
               },
             },
           },
         },
-      });
+        undefined,
+        { strictOpenAPI: true }
+      );
     }).toThrowErrorMatchingSnapshot();
   });
 
-  test('additional properties in invalid place', () => {
-    expect(() => {
-      validateOpenApiV3Document({
-        openapi: '3.1.3',
-        info: { version: '0.0.0', title: 'Empty', badproperty: ':(' },
-        paths: {
-          '/example': {
-            get: {
-              response: {
-                '200': {},
-              },
-            },
-          },
-        },
-      });
-    }).toThrowErrorMatchingSnapshot();
-  });
-});
-
-test('open api doc with extra custom parameters', () => {
-  validateOpenApiV3Document({
-    ...defaultEmptySpec,
-    'x-extra_property': {
-      abc: 'asd',
-    },
-  });
-
-  validateOpenApiV3Document({
-    ...defaultEmptySpec,
-    paths: {
-      '/user/login': {
-        get: {
-          tags: ['user'],
-          'x-maturity': 'wip',
-          summary: 'Logs user into the system',
-          operationId: 'loginUser',
-          parameters: [
-            {
-              name: 'username',
-              in: 'query',
-              description: 'The user name for login',
-              required: true,
-              schema: {
-                type: 'string',
-              },
-            },
-            {
-              name: 'password',
-              in: 'query',
-              description: 'The password for login in clear text',
-              required: true,
-              schema: {
-                type: 'string',
-              },
-            },
-          ],
-          responses: {
-            '200': {
-              description: 'successful operation',
-              headers: {
-                'X-Rate-Limit': {
-                  description: 'calls per hour allowed by the user',
-                  schema: {
-                    type: 'integer',
-                    format: 'int32',
-                  },
-                },
-                'X-Expires-After': {
-                  description: 'date in UTC when token expires',
-                  schema: {
-                    type: 'string',
-                    format: 'date-time',
+  test('advanced validators run and append their results', () => {
+    const json: any = {
+      ...defaultEmptySpec,
+      paths: {
+        '/api/users/{userId}': {
+          get: {
+            responses: {
+              '200': {
+                description: 'hello',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      oneOf: [],
+                      anyOf: [],
+                      items: [],
+                    },
                   },
                 },
               },
-              content: {
-                'application/xml': {
-                  schema: {
-                    type: 'string',
-                  },
-                },
-                'application/json': {
-                  schema: {
-                    type: 'string',
-                  },
-                },
-              },
-            },
-            '400': {
-              description: 'Invalid username/password supplied',
-              content: {},
             },
           },
         },
       },
-    },
+    };
+
+    expect(() => {
+      validateOpenApiV3Document(json, undefined, { strictOpenAPI: true });
+    }).toThrowErrorMatchingSnapshot();
+  });
+
+  test('open api doc with extra custom parameters', () => {
+    validateOpenApiV3Document({
+      ...defaultEmptySpec,
+      'x-extra_property': {
+        abc: 'asd',
+      },
+    });
+
+    validateOpenApiV3Document(
+      {
+        ...defaultEmptySpec,
+        paths: {
+          '/user/login': {
+            get: {
+              tags: ['user'],
+              'x-maturity': 'wip',
+              summary: 'Logs user into the system',
+              operationId: 'loginUser',
+              parameters: [
+                {
+                  name: 'username',
+                  in: 'query',
+                  description: 'The user name for login',
+                  required: true,
+                  schema: {
+                    type: 'string',
+                  },
+                },
+                {
+                  name: 'password',
+                  in: 'query',
+                  description: 'The password for login in clear text',
+                  required: true,
+                  schema: {
+                    type: 'string',
+                  },
+                },
+              ],
+              responses: {
+                '200': {
+                  description: 'successful operation',
+                  headers: {
+                    'X-Rate-Limit': {
+                      description: 'calls per hour allowed by the user',
+                      schema: {
+                        type: 'integer',
+                        format: 'int32',
+                      },
+                    },
+                    'X-Expires-After': {
+                      description: 'date in UTC when token expires',
+                      schema: {
+                        type: 'string',
+                        format: 'date-time',
+                      },
+                    },
+                  },
+                  content: {
+                    'application/xml': {
+                      schema: {
+                        type: 'string',
+                      },
+                    },
+                    'application/json': {
+                      schema: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+                '400': {
+                  description: 'Invalid username/password supplied',
+                  content: {},
+                },
+              },
+            },
+          },
+        },
+      },
+      undefined,
+      { strictOpenAPI: true }
+    );
+  });
+});
+
+describe('non-strict validation', () => {
+  describe('should pass', () => {
+    test('open api doc with no description in response', () => {
+      validateOpenApiV3Document(
+        {
+          openapi: '3.1.3',
+          info: { version: '0.0.0', title: 'Empty' },
+          paths: {
+            '/example': {
+              get: {
+                responses: {
+                  '200': {},
+                },
+              },
+            },
+          },
+        },
+        undefined,
+        { strictOpenAPI: false }
+      );
+    });
+
+    test('additional properties in invalid place', () => {
+      validateOpenApiV3Document(
+        {
+          openapi: '3.1.3',
+          info: { version: '0.0.0', title: 'Empty', badproperty: ':(' },
+          paths: {
+            '/example': {
+              get: {
+                response: {
+                  '200': {},
+                },
+              },
+            },
+          },
+        },
+        undefined,
+        { strictOpenAPI: false }
+      );
+    });
+  });
+
+  describe('should fail', () => {
+    test.only('open api doc without responses', () => {
+      expect(() => {
+        validateOpenApiV3Document(
+          {
+            openapi: '3.1.3',
+            info: { version: '0.0.0', title: 'Empty' },
+            paths: {
+              '/example': {
+                get: {},
+              },
+            },
+          },
+          undefined,
+          { strictOpenAPI: false }
+        );
+      }).toThrowErrorMatchingSnapshot();
+    });
+
+    test('open api doc with no path should throw an error', () => {
+      expect(() => {
+        validateOpenApiV3Document(
+          {
+            openapi: '3.1.3',
+            info: { version: '0.0.0', title: 'Empty' },
+          },
+          undefined,
+          { strictOpenAPI: false }
+        );
+      }).toThrowErrorMatchingSnapshot();
+    });
   });
 });
 
@@ -191,7 +281,7 @@ test('processValidatorErrors', () => {
     },
   };
   expect(() => {
-    validateOpenApiV3Document(json);
+    validateOpenApiV3Document(json, undefined, { strictOpenAPI: true });
   }).toThrowErrorMatchingSnapshot();
 });
 
@@ -201,7 +291,9 @@ test('processValidatorErrors attaches the sourcemap', async () => {
   );
 
   try {
-    validateOpenApiV3Document(spec.jsonLike, spec.sourcemap);
+    validateOpenApiV3Document(spec.jsonLike, spec.sourcemap, {
+      strictOpenAPI: true,
+    });
   } catch (error) {
     const filterOutFileNames = (error as any).message
       .split('\n')
@@ -210,35 +302,4 @@ test('processValidatorErrors attaches the sourcemap', async () => {
 
     expect(filterOutFileNames).toMatchSnapshot();
   }
-});
-
-test('advanced validators run and append their results', () => {
-  const json: any = {
-    ...defaultEmptySpec,
-    paths: {
-      '/api/users/{userId}': {
-        get: {
-          responses: {
-            '200': {
-              description: 'hello',
-              content: {
-                'application/json': {
-                  schema: {
-                    type: 'object',
-                    oneOf: [],
-                    anyOf: [],
-                    items: [],
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-    },
-  };
-
-  expect(() => {
-    validateOpenApiV3Document(json);
-  }).toThrowErrorMatchingSnapshot();
 });

--- a/projects/openapi-io/src/validation/validator.test.ts
+++ b/projects/openapi-io/src/validation/validator.test.ts
@@ -209,7 +209,7 @@ describe('non-strict validation', () => {
   });
 
   describe('should fail', () => {
-    test.only('open api doc without responses', () => {
+    test('open api doc without responses', () => {
       expect(() => {
         validateOpenApiV3Document(
           {

--- a/projects/openapi-io/src/validation/validator.test.ts
+++ b/projects/openapi-io/src/validation/validator.test.ts
@@ -195,7 +195,7 @@ describe('non-strict validation', () => {
           paths: {
             '/example': {
               get: {
-                response: {
+                responses: {
                   '200': {},
                 },
               },

--- a/projects/openapi-io/src/validation/validator.ts
+++ b/projects/openapi-io/src/validation/validator.ts
@@ -21,25 +21,20 @@ type Options = {
 };
 
 export default class OpenAPISchemaValidator {
-  private v3_0Validator: ValidateFunction | undefined;
-  private v3_1Validator: ValidateFunction | undefined;
-
   constructor(private options: Options) {}
 
   public validate3_0(openapiDoc: OpenAPI.Document): {
     errors: ErrorObject[];
   } {
-    if (!this.v3_0Validator) {
-      const v = new ajv({ allErrors: true, strict: false });
-      ajvErrors(v);
-      addFormats(v);
-      if (this.options.strictOpenAPI) attachAdvancedValidators(v);
-      v.addSchema(openapi3_0_json_schema);
-      this.v3_0Validator = v.compile(openapi3_0_json_schema);
-    }
+    const ajvInstance = new ajv({ allErrors: true, strict: false });
+    ajvErrors(ajvInstance);
+    addFormats(ajvInstance);
+    attachAdvancedValidators(ajvInstance);
+    ajvInstance.addSchema(openapi3_0_json_schema);
+    const validator = ajvInstance.compile(openapi3_0_json_schema);
 
-    if (!this.v3_0Validator(openapiDoc) && this.v3_0Validator.errors) {
-      return { errors: this.v3_0Validator.errors };
+    if (validator(openapiDoc) && validator.errors) {
+      return { errors: validator.errors };
     } else {
       return { errors: [] };
     }
@@ -47,17 +42,15 @@ export default class OpenAPISchemaValidator {
   public validate3_1(openapiDoc: OpenAPI.Document): {
     errors: ErrorObject[];
   } {
-    if (!this.v3_1Validator) {
-      const v = new ajv({ allErrors: true, strict: false });
-      ajvErrors(v);
-      addFormats(v);
-      if (this.options.strictOpenAPI) attachAdvancedValidators(v);
-      v.addSchema(openapi3_1_json_schema);
-      this.v3_1Validator = v.compile(openapi3_1_json_schema);
-    }
+    const ajvInstance = new ajv({ allErrors: true, strict: false });
+    ajvErrors(ajvInstance);
+    addFormats(ajvInstance);
+    attachAdvancedValidators(ajvInstance);
+    ajvInstance.addSchema(openapi3_1_json_schema);
+    const validator = ajvInstance.compile(openapi3_1_json_schema);
 
-    if (!this.v3_1Validator(openapiDoc) && this.v3_1Validator.errors) {
-      return { errors: this.v3_1Validator.errors };
+    if (validator(openapiDoc) && validator.errors) {
+      return { errors: validator.errors };
     } else {
       return { errors: [] };
     }

--- a/projects/openapi-io/src/validation/validator.ts
+++ b/projects/openapi-io/src/validation/validator.ts
@@ -1,11 +1,12 @@
 import { OpenAPIV3, OpenAPI } from 'openapi-types';
-import ajv, { ValidateFunction, ErrorObject } from 'ajv';
+import ajv, { ErrorObject, ValidateFunction } from 'ajv';
 
 import addFormats from 'ajv-formats';
 
 import {
   openapi3_1_json_schema,
   openapi3_0_json_schema,
+  basic3openapi_schema,
 } from './validation-schemas';
 import { checkOpenAPIVersion } from './openapi-versions';
 import ajvErrors from 'ajv-errors';
@@ -29,11 +30,17 @@ export default class OpenAPISchemaValidator {
     const ajvInstance = new ajv({ allErrors: true, strict: false });
     ajvErrors(ajvInstance);
     addFormats(ajvInstance);
-    attachAdvancedValidators(ajvInstance);
-    ajvInstance.addSchema(openapi3_0_json_schema);
-    const validator = ajvInstance.compile(openapi3_0_json_schema);
+    let validator: ValidateFunction;
+    if (this.options.strictOpenAPI) {
+      attachAdvancedValidators(ajvInstance);
+      ajvInstance.addSchema(openapi3_0_json_schema);
+      validator = ajvInstance.compile(openapi3_0_json_schema);
+    } else {
+      ajvInstance.addSchema(basic3openapi_schema);
+      validator = ajvInstance.compile(basic3openapi_schema);
+    }
 
-    if (validator(openapiDoc) && validator.errors) {
+    if (!validator(openapiDoc) && validator.errors) {
       return { errors: validator.errors };
     } else {
       return { errors: [] };
@@ -45,11 +52,17 @@ export default class OpenAPISchemaValidator {
     const ajvInstance = new ajv({ allErrors: true, strict: false });
     ajvErrors(ajvInstance);
     addFormats(ajvInstance);
-    attachAdvancedValidators(ajvInstance);
-    ajvInstance.addSchema(openapi3_1_json_schema);
-    const validator = ajvInstance.compile(openapi3_1_json_schema);
+    let validator: ValidateFunction;
+    if (this.options.strictOpenAPI) {
+      attachAdvancedValidators(ajvInstance);
+      ajvInstance.addSchema(openapi3_1_json_schema);
+      validator = ajvInstance.compile(openapi3_1_json_schema);
+    } else {
+      ajvInstance.addSchema(basic3openapi_schema);
+      validator = ajvInstance.compile(basic3openapi_schema);
+    }
 
-    if (validator(openapiDoc) && validator.errors) {
+    if (!validator(openapiDoc) && validator.errors) {
       return { errors: validator.errors };
     } else {
       return { errors: [] };


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Previously, our definition of "strict" and "not strict" was that strict was checking cases like oneOf / allOf overlaps, and not strict was still checking whether an OpenAPI file matched our `openapi3_0` schemas. This meant things like additional properties in 

This PR updates this to loosen non strict validation to confirm that the file is an openapi file (i.e. has `openapi`, `paths`, and `info`, and all operations have a response key). The reason we're still requiring operations to have a response key is that I think our code typing relies on the assumption that all `operations` have the key `responses`

This should fix issues like:
- on `optic api add`, we don't insert the `optic url` if the spec is not valid openapi (we require that it's parseable JSON/yml and that )
- trying to do a diff against `--base HEAD~1` where you can't change anything in git history

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
