### PR TITLE
Remove `--parallel` from task test

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -32,12 +32,12 @@ tasks:
   test:
     desc: Test
     cmds:
-      - yarn workspaces foreach -pv --no-private run test {{.CLI_ARGS}}
+      - yarn workspaces foreach -v --no-private run test {{.CLI_ARGS}}
 
   update-snapshots:
     desc: Update snapshots
     cmds:
-      - yarn workspaces foreach -pv --no-private run test -u
+      - yarn workspaces foreach -v --no-private run test -u
 
   publish:
     desc: "Publish built artifacts. Passes CLI_ARGS to 'npm publish'"


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Our tests in optic (particularly integration tests) are resource intensive, generally we're struggling to run `task test` locally because too many tests try to run in parallel and end up timing out other tests.

I think CI works fine because we run on 2core CPUs https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources but will double check test run times here (looks like test times are roughly the same time - [with parallization ~10 minutes](https://github.com/opticdev/optic/actions/runs/4621983376/jobs/8174087466) and [without parallization ~10 minutes](https://github.com/opticdev/optic/actions/runs/4622240181/jobs/8174668354?pr=1809))

Separately, we'll want to look into:
- speeding up our tests (maybe changing how integration tests are triggered, rather than via ts-node, compiling -> running node)
- removing duplicate integration tests

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
