### PR TITLE
Allow --validation strict or loose in diff and diff-all

### DIFF
--- a/projects/openapi-io/src/validation/validation-schemas.ts
+++ b/projects/openapi-io/src/validation/validation-schemas.ts
@@ -1510,6 +1510,9 @@ export const basic3openapi_schema = {
       properties: {
         responses: {
           type: 'object',
+          additionalProperties: {
+            type: 'object',
+          },
         },
       },
     },

--- a/projects/openapi-io/src/validation/validator.test.ts
+++ b/projects/openapi-io/src/validation/validator.test.ts
@@ -227,6 +227,28 @@ describe('non-strict validation', () => {
       }).toThrowErrorMatchingSnapshot();
     });
 
+    test('open api doc with invalid status code shape', () => {
+      expect(() => {
+        validateOpenApiV3Document(
+          {
+            openapi: '3.1.3',
+            info: { version: '0.0.0', title: 'Empty' },
+            paths: {
+              '/example': {
+                get: {
+                  responses: {
+                    '202': null,
+                  },
+                },
+              },
+            },
+          },
+          undefined,
+          { strictOpenAPI: false }
+        );
+      }).toThrowErrorMatchingSnapshot();
+    });
+
     test('open api doc with no path should throw an error', () => {
       expect(() => {
         validateOpenApiV3Document(

--- a/projects/optic/src/commands/diff/diff-all.ts
+++ b/projects/optic/src/commands/diff/diff-all.ts
@@ -1,4 +1,4 @@
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import pm from 'picomatch';
 import { OpticCliConfig, VCS } from '../../config';
 import { findOpenApiSpecsCandidates } from '../../utils/git-utils';
@@ -79,6 +79,14 @@ comma separated values (e.g. "**/*.yml,**/*.json")'
       '--standard <standard>',
       'run comparison with a locally defined standard, if not set, looks for the standard on the [x-optic-standard] key on the spec, and then the optic.dev.yml file.'
     )
+    .addOption(
+      new Option(
+        '--validation <validation>',
+        'specify the level of validation on HEAD specs'
+      )
+        .choices(['strict', 'loose'])
+        .default('strict')
+    )
     .option('--check', 'enable checks', false)
     .option('--upload', 'upload specs', false)
     .option('--web', 'view the diff in the optic changelog web view', false)
@@ -102,6 +110,7 @@ type DiffAllActionOptions = {
   web: boolean;
   upload: boolean;
   json: boolean;
+  validation: 'strict' | 'loose';
   failOnUntrackedOpenapi: boolean;
 };
 
@@ -227,7 +236,7 @@ async function computeAll(
 
     try {
       toParseResults = await getFileFromFsOrGit(candidate.to, config, {
-        strict: true,
+        strict: options.validation === 'strict',
         denormalize: true,
       });
     } catch (e) {

--- a/projects/optic/src/utils/spec-loaders.ts
+++ b/projects/optic/src/utils/spec-loaders.ts
@@ -212,6 +212,7 @@ export const parseFilesFromRef = async (
   config: OpticCliConfig,
   options: {
     denormalize: boolean;
+    headStrict: boolean;
   }
 ): Promise<{
   baseFile: ParseResult;
@@ -249,7 +250,7 @@ export const parseFilesFromRef = async (
     ).then((file) => {
       return validateAndDenormalize(file, {
         denormalize: options.denormalize,
-        strict: true,
+        strict: options.headStrict,
       });
     }),
     pathFromGitRoot: gitFileName,


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Allows a user to specify `--validation strict / loose` which defaults to strict (the default values)

Also fixes a bug with loose validation where we weren't failing on below
```yml
responses:
  "202": null
```

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
