### PR TITLE
Handle error handling and logging

### DIFF
--- a/projects/optic/src/__tests__/config.test.ts
+++ b/projects/optic/src/__tests__/config.test.ts
@@ -18,9 +18,6 @@ describe('detectConfig', () => {
   test('finds config', async () => {
     const path = await detectCliConfig('src/__tests__/');
     expect(path).toBe('src/__tests__/optic.yml');
-
-    // Expecting deprecation warning
-    expect(console.warn).toHaveBeenCalled();
   });
 
   test("doesn't find config", async () => {

--- a/projects/optic/src/config.ts
+++ b/projects/optic/src/config.ts
@@ -110,14 +110,7 @@ export async function loadCliConfig(
   configPath: string,
   client: OpticBackendClient
 ): Promise<OpticCliConfig> {
-  let config: unknown;
-  try {
-    config = yaml.load(await fs.readFile(configPath, 'utf-8'));
-  } catch (e) {
-    logger.error(e);
-    throw new UserError();
-  }
-
+  const config = yaml.load(await fs.readFile(configPath, 'utf-8'));
   validateConfig(config, configPath);
   const rawConfig = config as RawYmlConfig;
   await initializeRules(rawConfig, client);

--- a/projects/optic/src/init.ts
+++ b/projects/optic/src/init.ts
@@ -10,7 +10,7 @@ import {
 import { registerDiff } from './commands/diff/diff';
 import { registerRulesetUpload } from './commands/ruleset/upload';
 
-import { initializeConfig } from './config';
+import { OpticCliConfig, initializeConfig } from './config';
 import { registerRulesetInit } from './commands/ruleset/init';
 import { registerApiAdd } from './commands/api/add';
 import { captureCommand } from './commands/oas/capture';
@@ -80,7 +80,16 @@ Run ${chalk.yellow('npm i -g @useoptic/optic')} to upgrade Optic`
     } catch (e) {}
   });
 
-  const cliConfig = await initializeConfig();
+  let cliConfig: OpticCliConfig;
+
+  try {
+    cliConfig = await initializeConfig();
+  } catch (e) {
+    logger.error(chalk.red('Error initializing the cli config'));
+    logger.error((e as Error).message);
+    process.exitCode = 1;
+    return cli;
+  }
 
   cli.version(packageJson.version);
   cli.addHelpCommand(false);

--- a/projects/rulesets-base/src/extended-rules/spectral-rule.ts
+++ b/projects/rulesets-base/src/extended-rules/spectral-rule.ts
@@ -10,6 +10,7 @@ import {
   Result,
   RuleResult,
   typeofDiff,
+  UserError,
 } from '@useoptic/openapi-utilities';
 import { ExternalRuleBase } from '../rules/external-rule-base';
 import { isExempted } from '../rule-runner/utils';
@@ -135,7 +136,7 @@ export class SpectralRule extends ExternalRuleBase {
       try {
         spectralResults = await this.spectral.run(inputs.toSpec);
       } catch (e: any) {
-        throw new Error(e.message ? e.message : e);
+        throw new UserError(e.message ? e.message : e);
       }
     } else if (this.rulesetPointer && this.flatSpecFile) {
       try {
@@ -147,10 +148,10 @@ export class SpectralRule extends ExternalRuleBase {
         const withoutLeading = output.substring(output.indexOf('[')).trim();
         spectralResults = JSON.parse(withoutLeading) as SpectralResult[];
       } catch (e: any) {
-        throw new Error(e.message ? e.message : e);
+        throw new UserError(e.message ? e.message : e);
       }
     } else {
-      throw new Error(
+      throw new UserError(
         'Invalid configuration for spectral rules - must provide rulesetPointer and flatSpecFile or a spectral instance'
       );
     }
@@ -260,7 +261,7 @@ export class SpectralRule extends ExternalRuleBase {
       try {
         spectralResults = await this.spectral.run(inputs.nextJsonLike);
       } catch (e: any) {
-        throw new Error(e.message ? e.message : e);
+        throw new UserError(e.message ? e.message : e);
       }
     } else if (this.rulesetPointer && this.flatSpecFile) {
       try {
@@ -272,10 +273,10 @@ export class SpectralRule extends ExternalRuleBase {
         const withoutLeading = output.substring(output.indexOf('[')).trim();
         spectralResults = JSON.parse(withoutLeading) as SpectralResult[];
       } catch (e: any) {
-        throw new Error(e.message ? e.message : e);
+        throw new UserError(e.message ? e.message : e);
       }
     } else {
-      throw new Error(
+      throw new UserError(
         'Invalid configuration for spectral rules - must provide rulesetPointer and flatSpecFile or a spectral instance'
       );
     }


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

- Removes deprecation warning for using `optic.yml` - I think we could just use `optic.yml` or `optic.dev.yml` - given we're no longer using the application flow where this would be confusing
- handle errors when initializing CLI config (catch + log)
- prevent spectral plus errors from reporting to sentry

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
