### PR TITLE
fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.42.4",
+  "version": "0.42.5",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@3.5.0",
-  "version": "0.42.4",
+  "version": "0.42.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@3.5.0",
-  "version": "0.42.4",
+  "version": "0.42.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@3.5.0",
-  "version": "0.42.4",
+  "version": "0.42.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.5.0",
-  "version": "0.42.4",
+  "version": "0.42.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.5.0",
-  "version": "0.42.4",
+  "version": "0.42.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/src/__tests__/integration/__snapshots__/bundle.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/bundle.test.ts.snap
@@ -46,6 +46,8 @@ exports[`bundle bundles components together 1`] = `
           "type": "string"
         "created_at":
           "$ref": "#/components/schemas/anotherschema"
+        "firstTodo":
+          "$ref": "#/components/schemas/schemas"
         "todos":
           "type": "array"
           "items":

--- a/projects/optic/src/__tests__/integration/bundle.test.ts
+++ b/projects/optic/src/__tests__/integration/bundle.test.ts
@@ -25,6 +25,7 @@ describe('bundle', () => {
   test('bundles components together', async () => {
     const workspace = await setupWorkspace('bundle/specs');
     const { combined, code } = await runOptic(workspace, 'bundle openapi.yml');
+    console.log(combined);
     expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
     expect(code).toBe(0);
   });

--- a/projects/optic/src/__tests__/integration/workspaces/bundle/specs/anotherschema.yml
+++ b/projects/optic/src/__tests__/integration/workspaces/bundle/specs/anotherschema.yml
@@ -1,5 +1,2 @@
 CreatedAt:
-  type: object
-  properties:
-    example:
-      $ref: "schemas.yml#/TodoRead"
+  type: string

--- a/projects/optic/src/__tests__/integration/workspaces/bundle/specs/anotherschema.yml
+++ b/projects/optic/src/__tests__/integration/workspaces/bundle/specs/anotherschema.yml
@@ -1,2 +1,5 @@
 CreatedAt:
-  type: string
+  type: object
+  properties:
+    example:
+      $ref: "schemas.yml#/TodoRead"

--- a/projects/optic/src/__tests__/integration/workspaces/bundle/specs/schemas.yml
+++ b/projects/optic/src/__tests__/integration/workspaces/bundle/specs/schemas.yml
@@ -8,6 +8,8 @@ TodoRead:
       type: string
     created_at:
       $ref: 'anotherschema.yml#/CreatedAt'
+    firstTodo:
+      $ref: "#/TodoRead"
     todos:
       type: array
       items: 

--- a/projects/optic/src/commands/bundle/bundle.ts
+++ b/projects/optic/src/commands/bundle/bundle.ts
@@ -536,17 +536,18 @@ function bundleMatchingRefsAsComponents<T>(
   ).newDocument;
   //
   // // then add $refs in reverse depth order (to prevent conflicts).
-  const sortedUpdateOperations = sortby(
+  specCopy = sortby(
     updateUsagesOperations,
     (op) => jsonPointerHelpers.decode(op.path).length
-  );
-
-  specCopy = jsonpatch.applyPatch(
-    specCopy,
-    sortedUpdateOperations,
-    true,
-    true
-  ).newDocument;
+  ).reduce((specCopy, operation) => {
+    const error = jsonpatch.validate([operation], specCopy);
+    if (!error) {
+      return jsonpatch.applyPatch(specCopy, [operation], true, true)
+        .newDocument;
+    } else {
+      return specCopy;
+    }
+  }, specCopy);
 
   return specCopy;
 }

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.5.0",
-  "version": "0.42.4",
+  "version": "0.42.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.5.0",
-  "version": "0.42.4",
+  "version": "0.42.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
## 🍗 Description
Fixes bundle command. 

We're using a tree walking algorithm to handle nested refs, but sometimes a nested ref containing another nested ref will break the assumption that we can patch these in reverse depth order. 

The correct long term fix is to change how this works, but for now I think we can apply operations sequentially and test their targets. 

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
