### PR TITLE
Respect severity level in diff, diff-all and lint

### DIFF
--- a/projects/optic/src/commands/diff/compute.ts
+++ b/projects/optic/src/commands/diff/compute.ts
@@ -85,9 +85,23 @@ export async function compute(
     checks: {
       total: specResults.results.length,
       passed: specResults.results.filter((check) => check.passed).length,
-      failed: specResults.results.filter(
-        (check) => !check.passed && !check.exempted
+      exempted: specResults.results.filter(
+        (check) => !check.passed && check.exempted
       ).length,
+      failed: {
+        info: specResults.results.filter(
+          (check) =>
+            !check.passed && !check.exempted && check.severity === 'info'
+        ).length,
+        error: specResults.results.filter(
+          (check) =>
+            !check.passed && !check.exempted && check.severity === 'error'
+        ).length,
+        warn: specResults.results.filter(
+          (check) =>
+            !check.passed && !check.exempted && check.severity === 'warn'
+        ).length,
+      },
     },
   };
 }


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

In previous PRs, we're now allowing a user to set a severity level on rules (and also passing severity from spectral). This PR updates the diff/diff-all/lint to respect this in processing the error codes.

In future PRs going to update the terminal output

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
