### PR TITLE
forward effective_at to tags for api history add

### DIFF
--- a/projects/optic/src/client/optic-backend.ts
+++ b/projects/optic/src/client/optic-backend.ts
@@ -137,13 +137,15 @@ export class OpticBackendClient extends JsonHttpClient {
     git_name?: string;
     git_email?: string;
     commit_message?: string;
+    forward_effective_at_to_tags?: boolean;
   }): Promise<{ id: string }> {
     return this.postJson(`/api/specs`, spec);
   }
 
-  public async tagSpec(specId: string, tags: string[]) {
+  public async tagSpec(specId: string, tags: string[], effective_at?: Date) {
     return this.patchJson(`/api/specs/${specId}/tags`, {
       tags,
+      effective_at,
     });
   }
 

--- a/projects/optic/src/utils/cloud-specs.ts
+++ b/projects/optic/src/utils/cloud-specs.ts
@@ -22,6 +22,8 @@ export async function uploadSpec(
     client: OpticBackendClient;
     tags: string[];
     orgId: string;
+    // Sets spec_tag.effective_at to spec.effective_at instead of current date
+    forward_effective_at_to_tags?: boolean;
   }
 ): Promise<string> {
   const stableSpecString = stableStringify(opts.spec.jsonLike);
@@ -75,6 +77,7 @@ export async function uploadSpec(
       git_name,
       git_email,
       commit_message,
+      forward_effective_at_to_tags: opts.forward_effective_at_to_tags,
     });
     trackEvent('spec.added', {
       apiId,


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Trying to do the following:

- when adding historical specs form `api add`, use `spec.effective_at` as `spec_tag.effective_at`
- otherwise just let bwts use `new Date()` as `spec.effective_at`

- [x] Need to adapt the `/spec/id/tag` route first.

@niclim am I doing it correctly?

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
