### PR TITLE
Allow diff-all usage without an x-optic-url

### DIFF
--- a/projects/optic/src/__tests__/integration/__snapshots__/diff-all.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/diff-all.test.ts.snap
@@ -196,7 +196,7 @@ specification details:
 "
 `;
 
-exports[`diff-all diffs all files in an workspace with x-optic-url keys 1`] = `
+exports[`diff-all diffs all files in a workspace with x-optic-url keys with --upload 1`] = `
 "[34mDiffing HEAD~1:folder/in-folder.yml to folder/in-folder.yml[39m
 No changes were detected
 
@@ -346,7 +346,7 @@ specwithoutkey.yml
 "
 `;
 
-exports[`diff-all diffs all files in an workspace with x-optic-url keys 2`] = `
+exports[`diff-all diffs all files in a workspace with x-optic-url keys with --upload 2`] = `
 {
   "completed": [
     {
@@ -739,6 +739,69 @@ exports[`diff-all diffs all files in an workspace with x-optic-url keys 2`] = `
   "noop": [],
   "severity": 2,
 }
+`;
+
+exports[`diff-all diffs all files in a workspace without --upload 1`] = `
+"[34mDiffing HEAD~1:mvspec.yml to empty spec[39m
+
+specification details:
+- /info/description [31mremoved[39m
+
+[1mPOST[22m /filler_route: [31mremoved[39m
+  
+[1mPOST[22m /api/filler-route: [31mremoved[39m
+  
+Checks
+
+  [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /filler_route
+    removed rule[31m [error][39m: prevent operation removal
+      [31m[31mx[39m[31m cannot remove an operation. This is a breaking change.[39m
+      at [4m$workspace$/mvspec.yml:8:105[24m
+
+    removed rule[31m [error][39m: prevent removing response property
+      [31m[31mx[39m[31m cannot remove response property 'id'. This is a breaking change.[39m
+      at [4m$workspace$/mvspec.yml:18:359[24m
+
+    removed rule[31m [error][39m: prevent response status code removal
+      [31m[31mx[39m[31m must not remove response status code 201. This is a breaking change.[39m
+      at [4m$workspace$/mvspec.yml:11:162[24m
+
+
+
+  [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /api/filler-route
+    removed rule[31m [error][39m: prevent operation removal
+      [31m[31mx[39m[31m cannot remove an operation. This is a breaking change.[39m
+      at [4m$workspace$/mvspec.yml:23:520[24m
+
+    removed rule[31m [error][39m: prevent removing response property
+      [31m[31mx[39m[31m cannot remove response property 'id'. This is a breaking change.[39m
+      at [4m$workspace$/mvspec.yml:33:774[24m
+
+    removed rule[31m [error][39m: prevent response status code removal
+      [31m[31mx[39m[31m must not remove response status code 201. This is a breaking change.[39m
+      at [4m$workspace$/mvspec.yml:26:577[24m
+
+
+
+2 operations removed
+[32m[1m0 passed[22m[39m
+[31m[1m6 errors[22m[39m
+
+[34mDiffing empty spec to movedspec.yml[39m
+
+specification details:
+- /info/description [32madded[39m
+- /openapi, /info/version, /info/title [33mchanged[39m
+
+[1mPOST[22m /filler_route: [32madded[39m
+  
+[1mPOST[22m /api/filler-route: [32madded[39m
+  
+2 operations added
+[32m[1m0 passed[22m[39m
+[31m[1m0 errors[22m[39m
+
+"
 `;
 
 exports[`diff-all diffs all files with --json 1`] = `

--- a/projects/optic/src/__tests__/integration/diff-all.test.ts
+++ b/projects/optic/src/__tests__/integration/diff-all.test.ts
@@ -49,7 +49,24 @@ describe('diff-all', () => {
     process.env = { ...oldEnv };
   });
 
-  test('diffs all files in an workspace with x-optic-url keys', async () => {
+  test('diffs all files in a workspace without --upload', async () => {
+    const workspace = await setupWorkspace('diff-all/without-optic-url', {
+      repo: true,
+      commit: true,
+    });
+
+    await run(
+      `mv ./mvspec.yml ./movedspec.yml && git add . && git commit -m 'move spec'`,
+      false,
+      workspace
+    );
+    const { combined, code } = await runOptic(workspace, 'diff-all --check');
+
+    expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
+    expect(code).toBe(1);
+  });
+
+  test('diffs all files in a workspace with x-optic-url keys with --upload', async () => {
     const workspace = await setupWorkspace('diff-all/repo', {
       repo: true,
       commit: true,

--- a/projects/optic/src/__tests__/integration/workspaces/diff-all/without-optic-url/mvspec.yml
+++ b/projects/optic/src/__tests__/integration/workspaces/diff-all/without-optic-url/mvspec.yml
@@ -1,0 +1,36 @@
+openapi: 3.0.3
+info:
+  title: a spec
+  description: The API
+  version: 0.1.0
+paths:
+  /filler_route:
+    post:
+      operationId: create
+      responses:
+        "201":
+          description: Created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                    example: d5b640e5-d88c-4c17-9bf0-93597b7a1ce2
+  /api/filler-route:
+    post:
+      operationId: create
+      responses:
+        "201":
+          description: Created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                    example: d5b640e5-d88c-4c17-9bf0-93597b7a1ce2

--- a/projects/optic/src/commands/diff/diff-all.ts
+++ b/projects/optic/src/commands/diff/diff-all.ts
@@ -218,7 +218,7 @@ async function computeAll(
     try {
       const hasOpticUrl = getApiFromOpticUrl(rawSpec[OPTIC_URL_KEY]);
       checkOpenAPIVersion(rawSpec);
-      if (!hasOpticUrl) {
+      if (!hasOpticUrl && options.upload) {
         logger.debug(
           `Skipping comparison from ${candidate.from} to ${candidate.to} because there was no x-optic-url`
         );


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Update diff-all to allow running against specs without `x-optic-url`, but only when `--upload` is not set.

This should keep existing behavior the same. The original reason we only allowed diff-all was to allow this to `opt-in` to diff-all, or control the behavior here, but now diff-all includes `--match` and `--ignore` where a user can specify what they want to bulk diff

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._
https://github.com/opticdev/optic/issues/1831#issuecomment-1506791962


## 👹 QA
_How can other humans verify that this PR is correct?_
