### PR TITLE
Render json path in rule results

### DIFF
--- a/projects/optic/src/__tests__/integration/__snapshots__/diff-all.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/diff-all.test.ts.snap
@@ -9,14 +9,14 @@ Checks
   [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /filler_route
     requirement rule[31m [error][39m: operation path component naming check
       [31m[31mx[39m[31m filler_route is not camelCase[39m
-      at [4m$workspace$/folder/in-folder.yml:9:178[24m
+      at paths > /filler_route > post [4m($workspace$/folder/in-folder.yml:9:178)[24m
 
 
 
   [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /api/filler-route
     requirement rule[31m [error][39m: operation path component naming check
       [31m[31mx[39m[31m filler-route is not camelCase[39m
-      at [4m$workspace$/folder/in-folder.yml:24:593[24m
+      at paths > /api/filler-route > post [4m($workspace$/folder/in-folder.yml:24:593)[24m
 
 
 
@@ -39,30 +39,30 @@ Checks
   [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /filler_route
     removed rule[31m [error][39m: prevent operation removal
       [31m[31mx[39m[31m cannot remove an operation. This is a breaking change.[39m
-      at [4m$workspace$/mvspec.yml:9:178[24m
+      at paths > /filler_route > post [4m($workspace$/mvspec.yml:9:178)[24m
 
     removed rule[31m [error][39m: prevent removing response property
       [31m[31mx[39m[31m cannot remove response property 'id'. This is a breaking change.[39m
-      at [4m$workspace$/mvspec.yml:19:432[24m
+      at paths > /filler_route > post > responses > 201 > content > application/json > schema > properties > id [4m($workspace$/mvspec.yml:19:432)[24m
 
     removed rule[31m [error][39m: prevent response status code removal
       [31m[31mx[39m[31m must not remove response status code 201. This is a breaking change.[39m
-      at [4m$workspace$/mvspec.yml:12:235[24m
+      at paths > /filler_route > post > responses > 201 [4m($workspace$/mvspec.yml:12:235)[24m
 
 
 
   [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /api/filler-route
     removed rule[31m [error][39m: prevent operation removal
       [31m[31mx[39m[31m cannot remove an operation. This is a breaking change.[39m
-      at [4m$workspace$/mvspec.yml:24:593[24m
+      at paths > /api/filler-route > post [4m($workspace$/mvspec.yml:24:593)[24m
 
     removed rule[31m [error][39m: prevent removing response property
       [31m[31mx[39m[31m cannot remove response property 'id'. This is a breaking change.[39m
-      at [4m$workspace$/mvspec.yml:34:847[24m
+      at paths > /api/filler-route > post > responses > 201 > content > application/json > schema > properties > id [4m($workspace$/mvspec.yml:34:847)[24m
 
     removed rule[31m [error][39m: prevent response status code removal
       [31m[31mx[39m[31m must not remove response status code 201. This is a breaking change.[39m
-      at [4m$workspace$/mvspec.yml:27:650[24m
+      at paths > /api/filler-route > post > responses > 201 [4m($workspace$/mvspec.yml:27:650)[24m
 
 
 
@@ -101,7 +101,7 @@ Checks
   [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /filler_route
     requirement rule[31m [error][39m: operation path component naming check
       [31m[31mx[39m[31m filler_route is not camelCase[39m
-      at [4m$workspace$/specwithkey.yml:9:178[24m
+      at paths > /filler_route > post [4m($workspace$/specwithkey.yml:9:178)[24m
 
 
 
@@ -125,14 +125,14 @@ Checks
   [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /filler_route
     requirement rule[31m [error][39m: operation path component naming check
       [31m[31mx[39m[31m filler_route is not camelCase[39m
-      at [4m$workspace$/movedspec.yml:9:178[24m
+      at paths > /filler_route > post [4m($workspace$/movedspec.yml:9:178)[24m
 
 
 
   [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /api/filler-route
     requirement rule[31m [error][39m: operation path component naming check
       [31m[31mx[39m[31m filler-route is not camelCase[39m
-      at [4m$workspace$/movedspec.yml:24:593[24m
+      at paths > /api/filler-route > post [4m($workspace$/movedspec.yml:24:593)[24m
 
 
 
@@ -163,15 +163,15 @@ Checks
   [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /filler_route
     removed rule[31m [error][39m: prevent operation removal
       [31m[31mx[39m[31m cannot remove an operation. This is a breaking change.[39m
-      at [4m$workspace$/folder-to-run/should-run.yml:9:178[24m
+      at paths > /filler_route > post [4m($workspace$/folder-to-run/should-run.yml:9:178)[24m
 
     removed rule[31m [error][39m: prevent removing response property
       [31m[31mx[39m[31m cannot remove response property 'id'. This is a breaking change.[39m
-      at [4m$workspace$/folder-to-run/should-run.yml:19:432[24m
+      at paths > /filler_route > post > responses > 201 > content > application/json > schema > properties > id [4m($workspace$/folder-to-run/should-run.yml:19:432)[24m
 
     removed rule[31m [error][39m: prevent response status code removal
       [31m[31mx[39m[31m must not remove response status code 201. This is a breaking change.[39m
-      at [4m$workspace$/folder-to-run/should-run.yml:12:235[24m
+      at paths > /filler_route > post > responses > 201 [4m($workspace$/folder-to-run/should-run.yml:12:235)[24m
 
 
 
@@ -205,14 +205,14 @@ Checks
   [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /filler_route
     requirement rule[31m [error][39m: operation path component naming check
       [31m[31mx[39m[31m filler_route is not camelCase[39m
-      at [4m$workspace$/folder/in-folder.yml:9:178[24m
+      at paths > /filler_route > post [4m($workspace$/folder/in-folder.yml:9:178)[24m
 
 
 
   [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /api/filler-route
     requirement rule[31m [error][39m: operation path component naming check
       [31m[31mx[39m[31m filler-route is not camelCase[39m
-      at [4m$workspace$/folder/in-folder.yml:24:593[24m
+      at paths > /api/filler-route > post [4m($workspace$/folder/in-folder.yml:24:593)[24m
 
 
 
@@ -235,30 +235,30 @@ Checks
   [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /filler_route
     removed rule[31m [error][39m: prevent operation removal
       [31m[31mx[39m[31m cannot remove an operation. This is a breaking change.[39m
-      at [4m$workspace$/mvspec.yml:9:178[24m
+      at paths > /filler_route > post [4m($workspace$/mvspec.yml:9:178)[24m
 
     removed rule[31m [error][39m: prevent removing response property
       [31m[31mx[39m[31m cannot remove response property 'id'. This is a breaking change.[39m
-      at [4m$workspace$/mvspec.yml:19:432[24m
+      at paths > /filler_route > post > responses > 201 > content > application/json > schema > properties > id [4m($workspace$/mvspec.yml:19:432)[24m
 
     removed rule[31m [error][39m: prevent response status code removal
       [31m[31mx[39m[31m must not remove response status code 201. This is a breaking change.[39m
-      at [4m$workspace$/mvspec.yml:12:235[24m
+      at paths > /filler_route > post > responses > 201 [4m($workspace$/mvspec.yml:12:235)[24m
 
 
 
   [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /api/filler-route
     removed rule[31m [error][39m: prevent operation removal
       [31m[31mx[39m[31m cannot remove an operation. This is a breaking change.[39m
-      at [4m$workspace$/mvspec.yml:24:593[24m
+      at paths > /api/filler-route > post [4m($workspace$/mvspec.yml:24:593)[24m
 
     removed rule[31m [error][39m: prevent removing response property
       [31m[31mx[39m[31m cannot remove response property 'id'. This is a breaking change.[39m
-      at [4m$workspace$/mvspec.yml:34:847[24m
+      at paths > /api/filler-route > post > responses > 201 > content > application/json > schema > properties > id [4m($workspace$/mvspec.yml:34:847)[24m
 
     removed rule[31m [error][39m: prevent response status code removal
       [31m[31mx[39m[31m must not remove response status code 201. This is a breaking change.[39m
-      at [4m$workspace$/mvspec.yml:27:650[24m
+      at paths > /api/filler-route > post > responses > 201 [4m($workspace$/mvspec.yml:27:650)[24m
 
 
 
@@ -297,7 +297,7 @@ Checks
   [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /filler_route
     requirement rule[31m [error][39m: operation path component naming check
       [31m[31mx[39m[31m filler_route is not camelCase[39m
-      at [4m$workspace$/specwithkey.yml:9:178[24m
+      at paths > /filler_route > post [4m($workspace$/specwithkey.yml:9:178)[24m
 
 
 
@@ -321,14 +321,14 @@ Checks
   [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /filler_route
     requirement rule[31m [error][39m: operation path component naming check
       [31m[31mx[39m[31m filler_route is not camelCase[39m
-      at [4m$workspace$/movedspec.yml:9:178[24m
+      at paths > /filler_route > post [4m($workspace$/movedspec.yml:9:178)[24m
 
 
 
   [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /api/filler-route
     requirement rule[31m [error][39m: operation path component naming check
       [31m[31mx[39m[31m filler-route is not camelCase[39m
-      at [4m$workspace$/movedspec.yml:24:593[24m
+      at paths > /api/filler-route > post [4m($workspace$/movedspec.yml:24:593)[24m
 
 
 
@@ -756,30 +756,30 @@ Checks
   [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /filler_route
     removed rule[31m [error][39m: prevent operation removal
       [31m[31mx[39m[31m cannot remove an operation. This is a breaking change.[39m
-      at [4m$workspace$/mvspec.yml:8:105[24m
+      at paths > /filler_route > post [4m($workspace$/mvspec.yml:8:105)[24m
 
     removed rule[31m [error][39m: prevent removing response property
       [31m[31mx[39m[31m cannot remove response property 'id'. This is a breaking change.[39m
-      at [4m$workspace$/mvspec.yml:18:359[24m
+      at paths > /filler_route > post > responses > 201 > content > application/json > schema > properties > id [4m($workspace$/mvspec.yml:18:359)[24m
 
     removed rule[31m [error][39m: prevent response status code removal
       [31m[31mx[39m[31m must not remove response status code 201. This is a breaking change.[39m
-      at [4m$workspace$/mvspec.yml:11:162[24m
+      at paths > /filler_route > post > responses > 201 [4m($workspace$/mvspec.yml:11:162)[24m
 
 
 
   [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /api/filler-route
     removed rule[31m [error][39m: prevent operation removal
       [31m[31mx[39m[31m cannot remove an operation. This is a breaking change.[39m
-      at [4m$workspace$/mvspec.yml:23:520[24m
+      at paths > /api/filler-route > post [4m($workspace$/mvspec.yml:23:520)[24m
 
     removed rule[31m [error][39m: prevent removing response property
       [31m[31mx[39m[31m cannot remove response property 'id'. This is a breaking change.[39m
-      at [4m$workspace$/mvspec.yml:33:774[24m
+      at paths > /api/filler-route > post > responses > 201 > content > application/json > schema > properties > id [4m($workspace$/mvspec.yml:33:774)[24m
 
     removed rule[31m [error][39m: prevent response status code removal
       [31m[31mx[39m[31m must not remove response status code 201. This is a breaking change.[39m
-      at [4m$workspace$/mvspec.yml:26:577[24m
+      at paths > /api/filler-route > post > responses > 201 [4m($workspace$/mvspec.yml:26:577)[24m
 
 
 

--- a/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
@@ -155,103 +155,103 @@ Checks
   [1m[41m[37m FAIL [39m[49m[22m [1mGET[22m /example
     added rule[31m [error][39m: prevent new required query parameters
       [31m[31mx[39m[31m cannot add required query parameter addedQueryParameter to an existing operation. This is a breaking change.[39m
-      at [4m$workspace$/petstore-updated.json:60:1906[24m
+      at paths > /example > get > parameters > 2 [4m($workspace$/petstore-updated.json:60:1906)[24m
 
     changed rule[31m [error][39m: prevent requiring existing query parameters
       [31m[31mx[39m[31m cannot make optional query parameter 'optionalToRequired' required. This is a breaking change.[39m
-      at [4m$workspace$/petstore-updated.json:47:1494[24m
+      at paths > /example > get > parameters > 0 [4m($workspace$/petstore-updated.json:47:1494)[24m
 
     added rule[31m [error][39m: query parameter naming check
       [31m[31mx[39m[31m addedQueryParameter is not snake_case[39m
-      at [4m$workspace$/petstore-updated.json:60:1906[24m
+      at paths > /example > get > parameters > 2 [4m($workspace$/petstore-updated.json:60:1906)[24m
 
     changed rule[31m [error][39m: prevent making response property optional
       [31m[31mx[39m[31m cannot make required response property 'requiredToOptional' optional. This is a breaking change.[39m
-      at [4m$workspace$/petstore-updated.json:114:3902[24m
+      at paths > /example > get > responses > 200 > content > application/json > schema > properties > requiredKeys > properties > requiredToOptional [4m($workspace$/petstore-updated.json:114:3902)[24m
 
     removed rule[31m [error][39m: prevent removing response property
       [31m[31mx[39m[31m cannot remove response property 'orderId'. This is a breaking change.[39m
-      at [4m$workspace$/petstore-base.json:81:2600[24m
+      at paths > /example > get > responses > 200 > content > application/json > schema > properties > stringOrNumberOrObject > oneOf > 2 > properties > orderId [4m($workspace$/petstore-base.json:81:2600)[24m
 
     removed rule[31m [error][39m: prevent removing response property
       [31m[31mx[39m[31m cannot remove response property 'deletedRequiredKey'. This is a breaking change.[39m
-      at [4m$workspace$/petstore-base.json:112:3802[24m
+      at paths > /example > get > responses > 200 > content > application/json > schema > properties > requiredKeys > properties > deletedRequiredKey [4m($workspace$/petstore-base.json:112:3802)[24m
 
     changed rule[31m [error][39m: prevent response property type changes
       [31m[31mx[39m[31m expected response body property 'orderId' to not change type. This is a breaking change.[39m
-      at [4m$workspace$/petstore-updated.json:83:2701[24m
+      at paths > /example > get > responses > 200 > content > application/json > schema > properties > composedObject > properties > orderId [4m($workspace$/petstore-updated.json:83:2701)[24m
 
     changed rule[31m [error][39m: prevent response property type changes
       [31m[31mx[39m[31m expected response body property 'fromTypeArrays' to not change type. This is a breaking change.[39m
-      at [4m$workspace$/petstore-updated.json:120:4226[24m
+      at paths > /example > get > responses > 200 > content > application/json > schema > properties > fromTypeArrays [4m($workspace$/petstore-updated.json:120:4226)[24m
 
     changed rule[31m [error][39m: prevent response property type changes
       [31m[31mx[39m[31m expected response body property 'toTypeArrays' to not change type. This is a breaking change.[39m
-      at [4m$workspace$/petstore-updated.json:119:4156[24m
+      at paths > /example > get > responses > 200 > content > application/json > schema > properties > toTypeArrays [4m($workspace$/petstore-updated.json:119:4156)[24m
 
     added rule[31m [error][39m: response property naming check
       [31m[31mx[39m[31m addedRequiredKey is not snake_case[39m
-      at [4m$workspace$/petstore-updated.json:115:3970[24m
+      at paths > /example > get > responses > 200 > content > application/json > schema > properties > requiredKeys > properties > addedRequiredKey [4m($workspace$/petstore-updated.json:115:3970)[24m
 
 
 
   [1m[41m[37m FAIL [39m[49m[22m [1mGET[22m /parameters_at_path
     added rule[31m [error][39m: prevent new required query parameters
       [31m[31mx[39m[31m cannot add required query parameter query_in_path to an existing operation. This is a breaking change.[39m
-      at [4m$workspace$/petstore-updated.json:143:4710[24m
+      at paths > /parameters_at_path > get > parameters > 0 [4m($workspace$/petstore-updated.json:143:4710)[24m
 
 
 
   [1m[41m[37m FAIL [39m[49m[22m [1mGET[22m /pet
     removed rule[31m [error][39m: prevent operation removal
       [31m[31mx[39m[31m cannot remove an operation. This is a breaking change.[39m
-      at [4m$workspace$/petstore-base.json:158:4984[24m
+      at paths > /pet > get [4m($workspace$/petstore-base.json:158:4984)[24m
 
     removed rule[31m [error][39m: prevent response status code removal
       [31m[31mx[39m[31m must not remove response status code 404. This is a breaking change.[39m
-      at [4m$workspace$/petstore-base.json:160:5026[24m
+      at paths > /pet > get > responses > 404 [4m($workspace$/petstore-base.json:160:5026)[24m
 
     removed rule[31m [error][39m: prevent response status code removal
       [31m[31mx[39m[31m must not remove response status code 405. This is a breaking change.[39m
-      at [4m$workspace$/petstore-base.json:161:5094[24m
+      at paths > /pet > get > responses > 405 [4m($workspace$/petstore-base.json:161:5094)[24m
 
 
 
   [1m[41m[37m FAIL [39m[49m[22m [1mPUT[22m /pet
     added rule[31m [error][39m: prevent changing request property to required
       [31m[31mx[39m[31m cannot add a required request property 'number' to an existing operation. This is a breaking change.[39m
-      at [4m$workspace$/petstore-updated.json:173:5555[24m
+      at paths > /pet > put > requestBody > content > application/json > schema > properties > number [4m($workspace$/petstore-updated.json:173:5555)[24m
 
     removed rule[31m [error][39m: prevent response status code removal
       [31m[31mx[39m[31m must not remove response status code 400. This is a breaking change.[39m
-      at [4m$workspace$/petstore-base.json:254:8639[24m
+      at paths > /pet > put > responses > 400 [4m($workspace$/petstore-base.json:254:8639)[24m
 
 
 
   [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /pet/{petId}/uploadImage
     changed rule[31m [error][39m: prevent cookie parameters enum breaking changes
       [31m[31mx[39m[31m cannot add an enum to restrict possible values for cookie parameter 'debug'. This is a breaking change.[39m
-      at [4m$workspace$/petstore-updated.json:740:27031[24m
+      at paths > /pet/{petId}/uploadImage > post > parameters > 1 [4m($workspace$/petstore-updated.json:740:27031)[24m
 
     removed rule[31m [error][39m: prevent removing response property
       [31m[31mx[39m[31m cannot remove response property 'code'. This is a breaking change.[39m
-      at [4m$workspace$/petstore-base.json:406:14080[24m
+      at paths > /pet/{petId}/uploadImage > post > responses > 200 > content > application/json > schema > properties > code [4m($workspace$/petstore-base.json:406:14080)[24m
 
     removed rule[31m [error][39m: prevent removing response property
       [31m[31mx[39m[31m cannot remove response property 'type'. This is a breaking change.[39m
-      at [4m$workspace$/petstore-base.json:407:14150[24m
+      at paths > /pet/{petId}/uploadImage > post > responses > 200 > content > application/json > schema > properties > type [4m($workspace$/petstore-base.json:407:14150)[24m
 
     removed rule[31m [error][39m: prevent removing response property
       [31m[31mx[39m[31m cannot remove response property 'message'. This is a breaking change.[39m
-      at [4m$workspace$/petstore-base.json:408:14200[24m
+      at paths > /pet/{petId}/uploadImage > post > responses > 200 > content > application/json > schema > properties > message [4m($workspace$/petstore-base.json:408:14200)[24m
 
     removed rule[31m [error][39m: prevent response status code removal
       [31m[31mx[39m[31m must not remove response status code 200. This is a breaking change.[39m
-      at [4m$workspace$/petstore-base.json:399:13841[24m
+      at paths > /pet/{petId}/uploadImage > post > responses > 200 [4m($workspace$/petstore-base.json:399:13841)[24m
 
     changed rule[31m [error][39m: prevent response property type changes
       [31m[31mx[39m[31m expected response body property 'type' to not change type. This is a breaking change.[39m
-      at [4m$workspace$/petstore-updated.json:806:29115[24m
+      at paths > /pet/{petId}/uploadImage > post > responses > default > content > application/json > schema > properties > type [4m($workspace$/petstore-updated.json:806:29115)[24m
 
 
 
@@ -261,7 +261,7 @@ Checks
   [1m[41m[37m FAIL [39m[49m[22m [1mGET[22m /store/order/{orderId}
     changed rule[31m [error][39m: prevent making response property optional
       [31m[31mx[39m[31m cannot make required response property 'petId' optional. This is a breaking change.[39m
-      at [4m$workspace$/petstore-updated.json:969:34944[24m
+      at paths > /store/order/{orderId} > get > responses > 200 > content > application/xml > schema > properties > petId [4m($workspace$/petstore-updated.json:969:34944)[24m
 
 
 
@@ -271,119 +271,119 @@ Checks
   [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /user
     changed rule[31m [error][39m: prevent changing request property to required
       [31m[31mx[39m[31m cannot make a request property required. This is a breaking change.[39m
-      at [4m$workspace$/petstore-updated.json:1077:39015[24m
+      at paths > /user > post > requestBody > content > */* > schema > properties > username [4m($workspace$/petstore-updated.json:1077:39015)[24m
 
     changed rule[31m [error][39m: prevent request property type changes
       [31m[31mx[39m[31m expected request body property 'userStatus' to not change type. This is a breaking change.[39m
-      at [4m$workspace$/petstore-updated.json:1082:39273[24m
+      at paths > /user > post > requestBody > content > */* > schema > properties > userStatus [4m($workspace$/petstore-updated.json:1082:39273)[24m
 
 
 
   [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /user/createWithArray
     changed rule[31m [error][39m: prevent changing request property to required
       [31m[31mx[39m[31m cannot make a request property required. This is a breaking change.[39m
-      at [4m$workspace$/petstore-updated.json:1117:40460[24m
+      at paths > /user/createWithArray > post > requestBody > content > */* > schema > items > properties > username [4m($workspace$/petstore-updated.json:1117:40460)[24m
 
     changed rule[31m [error][39m: prevent request property type changes
       [31m[31mx[39m[31m expected request body property 'userStatus' to not change type. This is a breaking change.[39m
-      at [4m$workspace$/petstore-updated.json:1122:40728[24m
+      at paths > /user/createWithArray > post > requestBody > content > */* > schema > items > properties > userStatus [4m($workspace$/petstore-updated.json:1122:40728)[24m
 
 
 
   [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /user/createWithList
     changed rule[31m [error][39m: prevent changing request property to required
       [31m[31mx[39m[31m cannot make a request property required. This is a breaking change.[39m
-      at [4m$workspace$/petstore-updated.json:1158:41945[24m
+      at paths > /user/createWithList > post > requestBody > content > */* > schema > items > properties > username [4m($workspace$/petstore-updated.json:1158:41945)[24m
 
     changed rule[31m [error][39m: prevent request property type changes
       [31m[31mx[39m[31m expected request body property 'userStatus' to not change type. This is a breaking change.[39m
-      at [4m$workspace$/petstore-updated.json:1163:42213[24m
+      at paths > /user/createWithList > post > requestBody > content > */* > schema > items > properties > userStatus [4m($workspace$/petstore-updated.json:1163:42213)[24m
 
 
 
   [1m[41m[37m FAIL [39m[49m[22m [1mGET[22m /user/login
     added rule[31m [error][39m: header parameter naming check
       [31m[31mx[39m[31m X-Rate-Limit is not snake_case[39m
-      at [4m$workspace$/petstore-updated.json:1208:43553[24m
+      at paths > /user/login > get > responses > 200 > headers > X-Rate-Limit [4m($workspace$/petstore-updated.json:1208:43553)[24m
 
 
 
   [1m[41m[37m FAIL [39m[49m[22m [1mGET[22m /user/{username}
     changed rule[31m [error][39m: prevent making response property optional
       [31m[31mx[39m[31m cannot make required response property 'lastName' optional. This is a breaking change.[39m
-      at [4m$workspace$/petstore-updated.json:1265:45501[24m
+      at paths > /user/{username} > get > responses > 200 > content > application/xml > schema > properties > lastName [4m($workspace$/petstore-updated.json:1265:45501)[24m
 
     changed rule[31m [error][39m: prevent making response property optional
       [31m[31mx[39m[31m cannot make required response property 'lastName' optional. This is a breaking change.[39m
-      at [4m$workspace$/petstore-updated.json:1286:46420[24m
+      at paths > /user/{username} > get > responses > 200 > content > application/json > schema > properties > lastName [4m($workspace$/petstore-updated.json:1286:46420)[24m
 
     removed rule[31m [error][39m: prevent removing response property
       [31m[31mx[39m[31m cannot remove response property 'phone'. This is a breaking change.[39m
-      at [4m$workspace$/petstore-base.json:827:29057[24m
+      at paths > /user/{username} > get > responses > 200 > content > application/xml > schema > properties > phone [4m($workspace$/petstore-base.json:827:29057)[24m
 
     removed rule[31m [error][39m: prevent removing response property
       [31m[31mx[39m[31m cannot remove response property 'phone'. This is a breaking change.[39m
-      at [4m$workspace$/petstore-base.json:848:29942[24m
+      at paths > /user/{username} > get > responses > 200 > content > application/json > schema > properties > phone [4m($workspace$/petstore-base.json:848:29942)[24m
 
     changed rule[31m [error][39m: prevent response property type changes
       [31m[31mx[39m[31m expected response body property 'userStatus' to not change type. This is a breaking change.[39m
-      at [4m$workspace$/petstore-updated.json:1268:45660[24m
+      at paths > /user/{username} > get > responses > 200 > content > application/xml > schema > properties > userStatus [4m($workspace$/petstore-updated.json:1268:45660)[24m
 
     changed rule[31m [error][39m: prevent response property type changes
       [31m[31mx[39m[31m expected response body property 'userStatus' to not change type. This is a breaking change.[39m
-      at [4m$workspace$/petstore-updated.json:1289:46579[24m
+      at paths > /user/{username} > get > responses > 200 > content > application/json > schema > properties > userStatus [4m($workspace$/petstore-updated.json:1289:46579)[24m
 
 
 
   [1m[41m[37m FAIL [39m[49m[22m [1mPUT[22m /user/{username}
     changed rule[31m [error][39m: prevent changing request property to required
       [31m[31mx[39m[31m cannot make a request property required. This is a breaking change.[39m
-      at [4m$workspace$/petstore-updated.json:1342:48332[24m
+      at paths > /user/{username} > put > requestBody > content > */* > schema > properties > username [4m($workspace$/petstore-updated.json:1342:48332)[24m
 
     changed rule[31m [error][39m: prevent request property type changes
       [31m[31mx[39m[31m expected request body property 'userStatus' to not change type. This is a breaking change.[39m
-      at [4m$workspace$/petstore-updated.json:1347:48590[24m
+      at paths > /user/{username} > put > requestBody > content > */* > schema > properties > userStatus [4m($workspace$/petstore-updated.json:1347:48590)[24m
 
 
 
   [1m[41m[37m FAIL [39m[49m[22m [1mGET[22m /pet/findByStatus
     added rule[31m [error][39m: operation path component naming check
       [31m[31mx[39m[31m findByStatus is not snake_case[39m
-      at [4m$workspace$/petstore-updated.json:316:10941[24m
+      at paths > /pet/findByStatus > get [4m($workspace$/petstore-updated.json:316:10941)[24m
 
     added rule[31m [error][39m: response property naming check
       [31m[31mx[39m[31m photoUrls is not snake_case[39m
-      at [4m$workspace$/petstore-updated.json:367:12791[24m
+      at paths > /pet/findByStatus > get > responses > 200 > content > application/xml > schema > items > properties > photoUrls [4m($workspace$/petstore-updated.json:367:12791)[24m
 
     added rule[31m [error][39m: response property naming check
       [31m[31mx[39m[31m photoUrls is not snake_case[39m
-      at [4m$workspace$/petstore-updated.json:411:14652[24m
+      at paths > /pet/findByStatus > get > responses > 200 > content > application/json > schema > items > properties > photoUrls [4m($workspace$/petstore-updated.json:411:14652)[24m
 
 
 
   [1m[41m[37m FAIL [39m[49m[22m [1mGET[22m /pet/findByTags
     added rule[31m [error][39m: operation path component naming check
       [31m[31mx[39m[31m findByTags is not snake_case[39m
-      at [4m$workspace$/petstore-updated.json:446:15966[24m
+      at paths > /pet/findByTags > get [4m($workspace$/petstore-updated.json:446:15966)[24m
 
     added rule[31m [error][39m: response property naming check
       [31m[31mx[39m[31m photoUrls is not snake_case[39m
-      at [4m$workspace$/petstore-updated.json:483:17424[24m
+      at paths > /pet/findByTags > get > responses > 200 > content > application/xml > schema > items > properties > photoUrls [4m($workspace$/petstore-updated.json:483:17424)[24m
 
     added rule[31m [error][39m: response property naming check
       [31m[31mx[39m[31m photoUrls is not snake_case[39m
-      at [4m$workspace$/petstore-updated.json:527:19285[24m
+      at paths > /pet/findByTags > get > responses > 200 > content > application/json > schema > items > properties > photoUrls [4m($workspace$/petstore-updated.json:527:19285)[24m
 
 
 
   [1m[41m[37m FAIL [39m[49m[22m [1mGET[22m /pet/{petId}
     added rule[31m [error][39m: response property naming check
       [31m[31mx[39m[31m photoUrls is not snake_case[39m
-      at [4m$workspace$/petstore-updated.json:596:21833[24m
+      at paths > /pet/{petId} > get > responses > 200 > content > application/xml > schema > properties > photoUrls [4m($workspace$/petstore-updated.json:596:21833)[24m
 
     added rule[31m [error][39m: response property naming check
       [31m[31mx[39m[31m photoUrls is not snake_case[39m
-      at [4m$workspace$/petstore-updated.json:637:23536[24m
+      at paths > /pet/{petId} > get > responses > 200 > content > application/json > schema > properties > photoUrls [4m($workspace$/petstore-updated.json:637:23536)[24m
 
 
 
@@ -430,7 +430,7 @@ Checks
   [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /example
     removed rule[31m [error][39m: prevent operation removal
       [31m[31mx[39m[31m cannot remove an operation. This is a breaking change.[39m
-      at [4m$workspace$/example-api-v0.json:9:150[24m
+      at paths > /example > post [4m($workspace$/example-api-v0.json:9:150)[24m
 
 
 
@@ -440,7 +440,7 @@ Checks
   [1m[41m[37m FAIL [39m[49m[22m [1mGET[22m /invalid_name
     requirement rule[31m [error][39m: operation path component naming check
       [31m[31mx[39m[31m invalid_name is not camelCase[39m
-      at [4m$workspace$/example-api-v1.json:31:632[24m
+      at paths > /invalid_name > get [4m($workspace$/example-api-v1.json:31:632)[24m
 
 
 
@@ -501,7 +501,7 @@ Checks
   [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /example
     removed rule[31m [error][39m: prevent operation removal
       [31m[31mx[39m[31m cannot remove an operation. This is a breaking change.[39m
-      at [4m$workspace$/example-api-v0.json:9:150[24m
+      at paths > /example > post [4m($workspace$/example-api-v0.json:9:150)[24m
 
 
 
@@ -511,7 +511,7 @@ Checks
   [1m[41m[37m FAIL [39m[49m[22m [1mGET[22m /invalid_name
     requirement rule[31m [error][39m: operation path component naming check
       [31m[31mx[39m[31m invalid_name is not camelCase[39m
-      at [4m$workspace$/example-api-v1.json:31:632[24m
+      at paths > /invalid_name > get [4m($workspace$/example-api-v1.json:31:632)[24m
 
 
 
@@ -555,7 +555,7 @@ Checks
   [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /example
     removed rule[31m [error][39m: prevent operation removal
       [31m[31mx[39m[31m cannot remove an operation. This is a breaking change.[39m
-      at [4m$workspace$/example-api-v0.json:9:150[24m
+      at paths > /example > post [4m($workspace$/example-api-v0.json:9:150)[24m
 
 
 
@@ -565,7 +565,7 @@ Checks
   [1m[41m[37m FAIL [39m[49m[22m [1mGET[22m /invalid_name
     requirement rule[31m [error][39m: operation path component naming check
       [31m[31mx[39m[31m invalid_name is not camelCase[39m
-      at [4m$workspace$/example-api-v1.json:31:632[24m
+      at paths > /invalid_name > get [4m($workspace$/example-api-v1.json:31:632)[24m
 
 
 
@@ -607,7 +607,7 @@ Checks
   [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /example
     removed rule[31m [error][39m: prevent operation removal
       [31m[31mx[39m[31m cannot remove an operation. This is a breaking change.[39m
-      at [4m$workspace$/example-api-v0.json:9:150[24m
+      at paths > /example > post [4m($workspace$/example-api-v0.json:9:150)[24m
 
 
 
@@ -617,7 +617,7 @@ Checks
   [1m[41m[37m FAIL [39m[49m[22m [1mGET[22m /invalid_name
     requirement rule[31m [error][39m: operation path component naming check
       [31m[31mx[39m[31m invalid_name is not camelCase[39m
-      at [4m$workspace$/example-api-v1.json:31:632[24m
+      at paths > /invalid_name > get [4m($workspace$/example-api-v1.json:31:632)[24m
 
 
 
@@ -655,7 +655,7 @@ Checks
   [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /example
     removed rule[31m [error][39m: prevent operation removal
       [31m[31mx[39m[31m cannot remove an operation. This is a breaking change.[39m
-      at [4m$workspace$/example-api-v0.json:9:150[24m
+      at paths > /example > post [4m($workspace$/example-api-v0.json:9:150)[24m
 
 
 
@@ -678,7 +678,7 @@ Checks
   [1m[41m[37m FAIL [39m[49m[22m [1mPATCH[22m /example
     changed rule[31m [error][39m: prevent response property type changes
       [31m[31mx[39m[31m expected response body application/json root shape to not change type. This is a breaking change.[39m
-      at [4m$workspace$/spec.json:24:565[24m
+      at paths > /example > patch > responses > 200 > content > application/json [4m($workspace$/spec.json:24:565)[24m
 
 
 

--- a/projects/optic/src/__tests__/integration/__snapshots__/lint.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/lint.test.ts.snap
@@ -28,7 +28,7 @@ Checks
   [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /filler_route
     requirement rule[31m [error][39m: response property naming check
       [31m[31mx[39m[31m id_thing is not camelCase[39m
-      at [4m$workspace$/spec-fails-requirement.yml:18:359[24m
+      at paths > /filler_route > post > responses > 201 > content > application/json > schema > properties > id_thing [4m($workspace$/spec-fails-requirement.yml:18:359)[24m
 
 
 

--- a/projects/optic/src/utils/__tests__/__snapshots__/diff-renderer.test.ts.snap
+++ b/projects/optic/src/utils/__tests__/__snapshots__/diff-renderer.test.ts.snap
@@ -5,19 +5,21 @@ exports[`generateComparisonLogsV2 renders results 1`] = `
   "  [1m[42m[37m PASS [39m[49m[22m [1mPOST[22m /user",
   "    requirement rule[34m [info][39m: info",
   "      [34m[34mⓘ[39m[34m should have been correct but was not[39m",
-  "      at [4m/specs/smallpetstore1.json:10:436[24m",
+  "      at paths > /user > post [4m(/specs/smallpetstore1.json:10:436)[24m",
   "",
   "
 ",
   "  [1m[42m[37m PASS [39m[49m[22m [1mGET[22m /user",
   "    requirement rule[33m [warn][39m: warn",
   "      [33m[33m⚠[39m[33m should have been correct but was not[39m",
+  "      at paths > /user > get",
   "",
   "
 ",
   "  [1m[41m[37m FAIL [39m[49m[22m [1mPATCH[22m /user",
   "    requirement rule[31m [error][39m: error",
   "      [31m[31mx[39m[31m should have been correct but was not[39m",
+  "      at paths > /user > patch",
   "",
   "
 ",

--- a/projects/optic/src/utils/diff-renderer.ts
+++ b/projects/optic/src/utils/diff-renderer.ts
@@ -197,15 +197,20 @@ export function* generateComparisonLogsV2(
         result.location.spec === 'before'
           ? findFileAndLinesFromBefore(result.location.jsonPath)
           : findFileAndLinesFromAfter(result.location.jsonPath);
-      if (sourcemap) {
-        yield `${getIndent(3)}at ${
-          isUrl(sourcemap.filePath)
-            ? `${underline(sourcemap.filePath)} line ${sourcemap.startLine}`
-            : underline(
-                `${sourcemap.filePath}:${sourcemap.startLine}:${sourcemap.startPosition}`
-              )
-        }`;
-      }
+
+      const sourcemapText = sourcemap
+        ? isUrl(sourcemap.filePath)
+          ? ` (${underline(sourcemap.filePath)} line ${sourcemap.startLine})`
+          : ' ' +
+            underline(
+              `(${sourcemap.filePath}:${sourcemap.startLine}:${sourcemap.startPosition})`
+            )
+        : '';
+
+      const jsonPath = jsonPointerHelpers
+        .decode(result.location.jsonPath)
+        .join(' > ');
+      yield `${getIndent(3)}at ${jsonPath}${sourcemapText}`;
       yield '';
     }
     yield '\n';


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Improve the scanability of our results by adding json paths to where the rule failed

<img width="716" alt="Screenshot 2023-04-19 at 1 11 25 PM" src="https://user-images.githubusercontent.com/18374483/233149832-0d17ff46-eec6-425d-84f6-098355da6b6e.png">

Thoughts? Too cluttered or is this fine?

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
