### PR TITLE
Add `optic api create` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.42.10",
+  "version": "0.42.11",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@3.5.0",
-  "version": "0.42.10",
+  "version": "0.42.11",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@3.5.0",
-  "version": "0.42.10",
+  "version": "0.42.11",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@3.5.0",
-  "version": "0.42.10",
+  "version": "0.42.11",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.5.0",
-  "version": "0.42.10",
+  "version": "0.42.11",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.5.0",
-  "version": "0.42.10",
+  "version": "0.42.11",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/src/commands/api/create.ts
+++ b/projects/optic/src/commands/api/create.ts
@@ -1,0 +1,115 @@
+import { Command } from 'commander';
+import { errorHandler } from '../../error-handler';
+import { OpticCliConfig, VCS } from '../../config';
+import { OPTIC_URL_KEY } from '../../constants';
+import chalk from 'chalk';
+import { logger } from '../../logger';
+import { getOrganizationFromToken } from '../../utils/organization';
+import * as Git from '../../utils/git-utils';
+import prompts from 'prompts';
+import { getApiUrl } from '../../utils/cloud-urls';
+
+const usage = () => `
+  optic api create <api_name>`;
+
+const helpText = `
+Example usage:
+  Add an Optic API URL to a spec file.
+  $ optic spec add-api-url <path_to_spec.yml> <optic-api-url>
+`;
+
+export const registerApiCreate = (cli: Command, config: OpticCliConfig) => {
+  cli
+    .command('create')
+    .configureHelp({
+      commandUsage: usage,
+    })
+    .addHelpText('after', helpText)
+    .description('Generate an optic url to add to your specs')
+    .argument('<name>', 'the name of the api')
+    .action(errorHandler(getApiCreateAction(config)));
+};
+
+const getApiCreateAction = (config: OpticCliConfig) => async (name: string) => {
+  if (!config.isAuthenticated) {
+    logger.error(
+      chalk.red(
+        'You must be logged in to create an API in Optic Cloud. Please run "optic login"'
+      )
+    );
+    process.exitCode = 1;
+    return;
+  }
+  const orgRes = await getOrganizationFromToken(
+    config.client,
+    'Select the organization you want to create this API in'
+  );
+  if (!orgRes.ok) {
+    logger.error(orgRes.error);
+    process.exitCode = 1;
+    return;
+  }
+  logger.info('');
+  let default_branch: string = '';
+  let default_tag: string | undefined = undefined;
+  let web_url: string | undefined = undefined;
+
+  logger.info('');
+
+  if (config.vcs && config.vcs?.type === VCS.Git) {
+    const maybeDefaultBranch = await Git.getDefaultBranchName();
+    if (maybeDefaultBranch) {
+      default_branch = maybeDefaultBranch;
+      default_tag = `gitbranch:${default_branch}`;
+    }
+    const maybeOrigin = await Git.guessRemoteOrigin();
+    if (maybeOrigin) {
+      web_url = maybeOrigin.web_url;
+    } else {
+      logger.info(
+        chalk.red(
+          'Could not parse git origin details for where this repository lives.'
+        )
+      );
+      const results = await prompts(
+        [
+          {
+            message:
+              'Do you want to enter the origin details manually? This will help optic link your specs back to your git hosting provider',
+            type: 'confirm',
+
+            name: 'add',
+            initial: true,
+          },
+          {
+            type: (prev) => (prev ? 'text' : null),
+            message:
+              'Enter the web url where this API is uploaded (example: https://github.com/opticdev/optic)',
+            name: 'webUrl',
+          },
+        ],
+        { onCancel: () => process.exit(1) }
+      );
+      if (results.webUrl) {
+        web_url = results.webUrl;
+      }
+      logger.info('');
+    }
+  }
+
+  const { id } = await config.client.createApi(orgRes.org.id, {
+    name,
+    default_branch,
+    default_tag,
+    web_url,
+  });
+  const url = getApiUrl(config.client.getWebBase(), orgRes.org.id, id);
+  logger.info(`API created at ${url}`);
+  logger.info('');
+
+  logger.info(
+    chalk.green(
+      `Add this url to your spec under the '${OPTIC_URL_KEY}' key or run "optic spec add-api-url ${url}"`
+    )
+  );
+};

--- a/projects/optic/src/commands/api/create.ts
+++ b/projects/optic/src/commands/api/create.ts
@@ -15,7 +15,7 @@ const usage = () => `
 const helpText = `
 Example usage:
   Add an Optic API URL to a spec file.
-  $ optic spec add-api-url <path_to_spec.yml> <optic-api-url>
+  $ optic api create <api_name>
 `;
 
 export const registerApiCreate = (cli: Command, config: OpticCliConfig) => {

--- a/projects/optic/src/commands/spec/add-api-url.ts
+++ b/projects/optic/src/commands/spec/add-api-url.ts
@@ -40,5 +40,5 @@ const getAddApiUrlAction =
       });
     }
 
-    logger.info(chalk.green(`Added x-optic-url to ${spec_path}`));
+    logger.info(chalk.green(`Added ${OPTIC_URL_KEY} to ${spec_path}`));
   };

--- a/projects/optic/src/init.ts
+++ b/projects/optic/src/init.ts
@@ -13,6 +13,7 @@ import { registerRulesetUpload } from './commands/ruleset/upload';
 import { OpticCliConfig, initializeConfig } from './config';
 import { registerRulesetInit } from './commands/ruleset/init';
 import { registerApiAdd } from './commands/api/add';
+import { registerApiCreate } from './commands/api/create';
 import { captureCommand } from './commands/oas/capture';
 import { newCommand } from './commands/oas/new';
 import { setupTlsCommand } from './commands/oas/setup-tls';
@@ -132,6 +133,7 @@ Run ${chalk.yellow('npm i -g @useoptic/optic')} to upgrade Optic`
 
   const apiSubcommands = cli.command('api').addHelpCommand(false);
   registerApiAdd(apiSubcommands, cliConfig);
+  registerApiCreate(apiSubcommands, cliConfig);
 
   const specSubcommands = cli.command('spec').addHelpCommand(false);
   registerSpecPush(specSubcommands, cliConfig);

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.5.0",
-  "version": "0.42.10",
+  "version": "0.42.11",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.5.0",
-  "version": "0.42.10",
+  "version": "0.42.11",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Adding an optic api create command, this would be similar to the github create repo case where you dont have a spec but want a place holder.

this fits into the spec generation case, where you would want to specify a URL and add to it when generating, rather than creating a spec and then adding the url

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
