### PR TITLE
fix: reverse-proxy against remote urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.42.13",
+  "version": "0.42.14",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@3.5.0",
-  "version": "0.42.13",
+  "version": "0.42.14",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@3.5.0",
-  "version": "0.42.13",
+  "version": "0.42.14",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@3.5.0",
-  "version": "0.42.13",
+  "version": "0.42.14",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.5.0",
-  "version": "0.42.13",
+  "version": "0.42.14",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.5.0",
-  "version": "0.42.13",
+  "version": "0.42.14",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/src/commands/oas/captures/streams/sources/proxy.ts
+++ b/projects/optic/src/commands/oas/captures/streams/sources/proxy.ts
@@ -95,6 +95,7 @@ export class ProxyInteractions {
         beforeRequest: onTargetedRequest,
         forwarding: {
           targetHost: targetOrigin,
+          // bug: updateHostHeader isn't rewriting the request header - we're manually rewriting this in `beforeRequest`
           updateHostHeader: true,
         },
         trustAdditionalCAs: options.targetCA || [],
@@ -126,8 +127,14 @@ export class ProxyInteractions {
         body: { buffer: body.buffer },
         timingEvents: timingEvents as TimingEvents,
       };
-
       requestsById.set(request.id, request);
+
+      return {
+        headers: {
+          ...capturedRequest.headers,
+          host,
+        },
+      };
     }
 
     function onResponse(capturedResponse: CompletedResponse) {
@@ -142,7 +149,6 @@ export class ProxyInteractions {
         body: { buffer: body.buffer },
         timingEvents: timingEvents as TimingEvents,
       };
-      console.log(request, capturedResponse);
       interactions.onNext({
         request,
         response,

--- a/projects/optic/src/commands/oas/captures/streams/sources/proxy.ts
+++ b/projects/optic/src/commands/oas/captures/streams/sources/proxy.ts
@@ -39,7 +39,7 @@ export class ProxyInteractions {
       targetCA?: Array<{ cert: Buffer | string }>;
     } = {}
   ): Promise<[ProxyInteractions, string, string]> {
-    let { host, protocol } = new URL(targetHost);
+    let { host, protocol, origin: targetOrigin } = new URL(targetHost);
     if (targetHost.includes('/')) {
       // accept urls to be passed in rather than pure hosts
       targetHost = host;
@@ -61,7 +61,7 @@ export class ProxyInteractions {
       },
     });
 
-    let forwardedHosts = [targetHost];
+    let forwardedHosts = [targetOrigin];
     await capturingProxy
       .forAnyRequest()
       .always()
@@ -94,7 +94,7 @@ export class ProxyInteractions {
       .thenPassThrough({
         beforeRequest: onTargetedRequest,
         forwarding: {
-          targetHost,
+          targetHost: targetOrigin,
           updateHostHeader: true,
         },
         trustAdditionalCAs: options.targetCA || [],
@@ -142,6 +142,7 @@ export class ProxyInteractions {
         body: { buffer: body.buffer },
         timingEvents: timingEvents as TimingEvents,
       };
+      console.log(request, capturedResponse);
       interactions.onNext({
         request,
         response,

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.5.0",
-  "version": "0.42.13",
+  "version": "0.42.14",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.5.0",
-  "version": "0.42.13",
+  "version": "0.42.14",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

running `optic capture spec https://api.useoptic.com --reverse-proxy` would strip out the protocol, which meant `https` servers would sometimes return a 301 (because we tried to hit the http:// endpoint)

additionally, we were not updating the host header, leading to certain servers rejecting requests. manually updating the host header fixes this (and it appears redirection also works now with the correct host header)


## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._
https://github.com/opticdev/optic/issues/1857

## 👹 QA
_How can other humans verify that this PR is correct?_
