### PR TITLE
support nullable properly across versions

### DIFF
--- a/projects/openapi-io/src/index.ts
+++ b/projects/openapi-io/src/index.ts
@@ -11,7 +11,10 @@ import { JsonPath, JsonSchemaSourcemap } from './parser/sourcemap';
 import { loadYaml, isYaml, isJson, writeYaml } from './write';
 import { validateOpenApiV3Document } from './validation/validator';
 import { ValidationError } from './validation/errors';
-import { checkOpenAPIVersion } from './validation/openapi-versions';
+import {
+  checkOpenAPIVersion,
+  SupportedOpenAPIVersions,
+} from './validation/openapi-versions';
 import { filePathToGitPath } from './parser/resolvers/git-branch-file-resolver';
 import { jsonPointerLogger } from './validation/log-json-pointer';
 import { applyOperationsToYamlString } from './write/yaml-roundtrip';
@@ -33,6 +36,7 @@ export {
   ResolverError,
   validateOpenApiV3Document,
   ValidationError,
+  SupportedOpenAPIVersions,
   checkOpenAPIVersion,
 };
 

--- a/projects/optic/src/__tests__/integration/bundle.test.ts
+++ b/projects/optic/src/__tests__/integration/bundle.test.ts
@@ -25,7 +25,6 @@ describe('bundle', () => {
   test('bundles components together', async () => {
     const workspace = await setupWorkspace('bundle/specs');
     const { combined, code } = await runOptic(workspace, 'bundle openapi.yml');
-    console.log(combined);
     expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
     expect(code).toBe(0);
   });

--- a/projects/optic/src/commands/oas/diffing/document.ts
+++ b/projects/optic/src/commands/oas/diffing/document.ts
@@ -27,6 +27,7 @@ import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
 import { ApiCoverageCounter } from '../coverage/api-coverage';
 import { SchemaInventory } from '../shapes/closeness/schema-inventory';
 import { specToOperations } from '../operations/queries';
+import { checkOpenAPIVersion } from '@useoptic/openapi-io';
 
 export async function addIfUndocumented(
   operationsToAdd: ParsedOperation[],
@@ -337,6 +338,7 @@ export function addOperations(
   requiredOperations: ParsedOperation[],
   interactions: CapturedInteractions
 ): { results: SpecPatches; observations: AsyncIterable<AddObservation> } {
+  const openAPIVersion = checkOpenAPIVersion(spec);
   const observing = new AT.Subject<AddObservation>();
   const observers = {
     // operations
@@ -507,7 +509,8 @@ export function addOperations(
       let shapePatches = SpecPatches.shapeAdditions(
         AT.tap((body: DocumentedBody) => {
           observers.documentedInteractionBody(documentedInteraction, body);
-        })(documentedBodies)
+        })(documentedBodies),
+        openAPIVersion
       );
 
       const addedPaths = new Set<string>();

--- a/projects/optic/src/commands/oas/diffing/patch.ts
+++ b/projects/optic/src/commands/oas/diffing/patch.ts
@@ -8,7 +8,11 @@ import {
   SpecPatch,
   SpecPatches,
 } from '../specs';
-import { jsonPointerLogger, JsonSchemaSourcemap } from '@useoptic/openapi-io';
+import {
+  checkOpenAPIVersion,
+  jsonPointerLogger,
+  JsonSchemaSourcemap,
+} from '@useoptic/openapi-io';
 import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
 import chalk from 'chalk';
 import { ShapeDiffResult } from '../shapes/diffs';
@@ -189,6 +193,7 @@ export function updateByInteractions(
   isAddAll: boolean = true,
   filterToOperations: ParsedOperation[] = []
 ): { results: SpecPatches; observations: UpdateObservations } {
+  const openAPIVersion = checkOpenAPIVersion(spec);
   const updatingSpec = new Subject<OpenAPIV3.Document>();
   const specUpdates = updatingSpec.iterator;
 
@@ -273,7 +278,8 @@ export function updateByInteractions(
       let shapePatches = SpecPatches.shapeAdditions(
         tap((body: DocumentedBody) => {
           observers.documentedInteractionBody(documentedInteraction, body);
-        })(documentedBodies)
+        })(documentedBodies),
+        openAPIVersion
       );
 
       for await (let patch of shapePatches) {

--- a/projects/optic/src/commands/oas/shapes/patches/generators/__snapshots__/type.test.ts.snap
+++ b/projects/optic/src/commands/oas/shapes/patches/generators/__snapshots__/type.test.ts.snap
@@ -242,7 +242,7 @@ exports[`type shape patch generator when provided with another primitive, it can
 exports[`type shape patch generator when provided with null value, it can apply patches 1`] = `
 [
   {
-    "description": "make stringField oneOf",
+    "description": "make stringField null",
     "diff": {
       "description": "'stringField' did not match schema",
       "example": null,
@@ -254,22 +254,14 @@ exports[`type shape patch generator when provided with null value, it can apply 
     },
     "groupedOperations": [
       {
-        "intent": "replace stringField with a one of containing both types",
+        "intent": "make stringField null",
         "operations": [
           {
-            "op": "remove",
+            "op": "replace",
             "path": "/properties/stringField/type",
-          },
-          {
-            "op": "add",
-            "path": "/properties/stringField/oneOf",
             "value": [
-              {
-                "type": "string",
-              },
-              {
-                "type": "null",
-              },
+              "object",
+              "null",
             ],
           },
         ],
@@ -278,35 +270,6 @@ exports[`type shape patch generator when provided with null value, it can apply 
     "impact": [
       "Addition",
       "BackwardsCompatibilityUnknown",
-    ],
-  },
-  {
-    "description": "change type of stringField",
-    "diff": {
-      "description": "'stringField' did not match schema",
-      "example": null,
-      "instancePath": "/stringField",
-      "key": "stringField",
-      "keyword": "type",
-      "kind": "UnmatchedType",
-      "propertyPath": "/properties/stringField",
-    },
-    "groupedOperations": [
-      {
-        "intent": "change stringField type",
-        "operations": [
-          {
-            "op": "replace",
-            "path": "/properties/stringField",
-            "value": {
-              "type": "null",
-            },
-          },
-        ],
-      },
-    ],
-    "impact": [
-      "BackwardsIncompatible",
     ],
   },
 ]

--- a/projects/optic/src/commands/oas/shapes/patches/generators/additionalProperties.ts
+++ b/projects/optic/src/commands/oas/shapes/patches/generators/additionalProperties.ts
@@ -4,11 +4,13 @@ import { SchemaObject } from '../../schema';
 import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
 import { Schema } from '../../schema';
 import { ShapeLocation } from '../..';
+import { SupportedOpenAPIVersions } from '@useoptic/openapi-io';
 
 export function* additionalPropertiesPatches(
   diff: ShapeDiffResult,
   schema: SchemaObject,
-  shapeContext: { location?: ShapeLocation }
+  shapeContext: { location?: ShapeLocation },
+  openAPIVersion: SupportedOpenAPIVersions
 ): IterableIterator<ShapePatch> {
   if (diff.kind !== ShapeDiffResultKind.AdditionalProperty) return;
 
@@ -72,7 +74,7 @@ export function* additionalPropertiesPatches(
         {
           op: 'add',
           path: newPropertyPath,
-          value: Schema.baseFromValue(diff.example),
+          value: Schema.baseFromValue(diff.example, openAPIVersion),
         }
       )
     );

--- a/projects/optic/src/commands/oas/shapes/patches/generators/index.ts
+++ b/projects/optic/src/commands/oas/shapes/patches/generators/index.ts
@@ -8,12 +8,14 @@ import { oneOfPatches } from './oneOf';
 import { requiredPatches } from './required';
 import { typePatches } from './type';
 import { newSchemaPatch } from './newSchema';
+import { SupportedOpenAPIVersions } from '@useoptic/openapi-io';
 
 export interface DiffShapePatchGenerator {
   (
     diff: ShapeDiffResult,
     schema: SchemaObject,
-    shapeContext: { location?: ShapeLocation }
+    shapeContext: { location?: ShapeLocation },
+    openAPIVersion: SupportedOpenAPIVersions
   ): IterableIterator<ShapePatch>;
 }
 

--- a/projects/optic/src/commands/oas/shapes/patches/generators/oneOf.test.ts
+++ b/projects/optic/src/commands/oas/shapes/patches/generators/oneOf.test.ts
@@ -22,7 +22,7 @@ describe('one of shape patch generator', () => {
     const diffs = [...diffValueBySchema(input, jsonSchema)];
 
     const patches = diffs.flatMap((diff) => [
-      ...generateShapePatchesByDiff(diff, jsonSchema, {}),
+      ...generateShapePatchesByDiff(diff, jsonSchema, {}, '3.1.x'),
     ]);
 
     expect(patches).toMatchSnapshot();
@@ -45,7 +45,7 @@ describe('one of shape patch generator', () => {
     const diffs = [...diffValueBySchema(input, jsonSchema)];
 
     const patches = diffs.flatMap((diff) => [
-      ...generateShapePatchesByDiff(diff, jsonSchema, {}),
+      ...generateShapePatchesByDiff(diff, jsonSchema, {}, '3.1.x'),
     ]);
 
     expect(patches).toMatchSnapshot();
@@ -64,7 +64,7 @@ describe('one of shape patch generator', () => {
     const diffs = [...diffValueBySchema(input, jsonSchema)];
 
     const patches = diffs.flatMap((diff) => [
-      ...generateShapePatchesByDiff(diff, jsonSchema, {}),
+      ...generateShapePatchesByDiff(diff, jsonSchema, {}, '3.1.x'),
     ]);
 
     expect(patches).toMatchSnapshot();
@@ -86,7 +86,7 @@ describe('one of shape patch generator', () => {
     const diffs = [...diffValueBySchema(input, jsonSchema)];
 
     const patches = diffs.flatMap((diff) => [
-      ...generateShapePatchesByDiff(diff, jsonSchema, {}),
+      ...generateShapePatchesByDiff(diff, jsonSchema, {}, '3.1.x'),
     ]);
 
     expect(patches).toMatchSnapshot();

--- a/projects/optic/src/commands/oas/shapes/patches/generators/oneOf.ts
+++ b/projects/optic/src/commands/oas/shapes/patches/generators/oneOf.ts
@@ -6,17 +6,20 @@ import {
 import { OperationGroup, PatchImpact, ShapePatch } from '..';
 import { SchemaObject, Schema } from '../../schema';
 import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
-import { JsonPath } from '@useoptic/openapi-io';
+import { JsonPath, SupportedOpenAPIVersions } from '@useoptic/openapi-io';
 import { ShapeLocation } from '../..';
 
 export function* oneOfPatches(
   diff: ShapeDiffResult,
   schema: SchemaObject,
-  shapeContext: { location?: ShapeLocation }
+  shapeContext: { location?: ShapeLocation },
+  openAPIVersion: SupportedOpenAPIVersions
 ): IterableIterator<ShapePatch> {
   if (
     diff.kind !== ShapeDiffResultKind.UnmatchedType ||
-    diff.keyword !== JsonSchemaKnownKeyword.oneOf
+    diff.keyword !== JsonSchemaKnownKeyword.oneOf ||
+    // @ts-ignore
+    (diff.keyword === JsonSchemaKnownKeyword.type && diff.example === null)
   )
     return;
 
@@ -26,7 +29,7 @@ export function* oneOfPatches(
     OperationGroup.create(`add new oneOf branch to ${diff.key}`, {
       op: 'add',
       path: jsonPointerHelpers.append(diff.propertyPath, '-'), // "-" indicates append to array
-      value: Schema.baseFromValue(diff.example),
+      value: Schema.baseFromValue(diff.example, openAPIVersion),
     })
   );
 

--- a/projects/optic/src/commands/oas/shapes/patches/generators/required.test.ts
+++ b/projects/optic/src/commands/oas/shapes/patches/generators/required.test.ts
@@ -26,7 +26,7 @@ describe('required shape patch generator', () => {
     const diffs = [...diffValueBySchema(input, jsonSchema)];
 
     const patches = diffs.flatMap((diff) => [
-      ...generateShapePatchesByDiff(diff, jsonSchema, {}),
+      ...generateShapePatchesByDiff(diff, jsonSchema, {}, '3.1.x'),
     ]);
 
     expect(patches).toMatchSnapshot();

--- a/projects/optic/src/commands/oas/shapes/patches/generators/required.ts
+++ b/projects/optic/src/commands/oas/shapes/patches/generators/required.ts
@@ -2,13 +2,14 @@ import { ShapeDiffResult, ShapeDiffResultKind } from '../../diffs';
 import { OperationGroup, PatchImpact, ShapePatch } from '..';
 import { SchemaObject } from '../../schema';
 import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
-import { JsonPath } from '@useoptic/openapi-io';
+import { JsonPath, SupportedOpenAPIVersions } from '@useoptic/openapi-io';
 import { ShapeLocation } from '../..';
 
 export function* requiredPatches(
   diff: ShapeDiffResult,
   schema: SchemaObject,
-  shapeContext: { location?: ShapeLocation }
+  shapeContext: { location?: ShapeLocation },
+  openAPIVersion: SupportedOpenAPIVersions
 ): IterableIterator<ShapePatch> {
   if (diff.kind !== ShapeDiffResultKind.MissingRequiredProperty) return;
 

--- a/projects/optic/src/commands/oas/shapes/patches/generators/type.test.ts
+++ b/projects/optic/src/commands/oas/shapes/patches/generators/type.test.ts
@@ -19,7 +19,7 @@ describe('type shape patch generator', () => {
     const diffs = [...diffValueBySchema(input, jsonSchema)];
 
     const patches = diffs.flatMap((diff) => [
-      ...generateShapePatchesByDiff(diff, jsonSchema, {}),
+      ...generateShapePatchesByDiff(diff, jsonSchema, {}, '3.1.x'),
     ]);
 
     expect(patches).toMatchSnapshot();
@@ -33,7 +33,7 @@ describe('type shape patch generator', () => {
     const diffs = [...diffValueBySchema(input, jsonSchema)];
 
     const patches = diffs.flatMap((diff) => [
-      ...generateShapePatchesByDiff(diff, jsonSchema, {}),
+      ...generateShapePatchesByDiff(diff, jsonSchema, {}, '3.1.x'),
     ]);
 
     expect(patches).toMatchSnapshot();
@@ -47,7 +47,7 @@ describe('type shape patch generator', () => {
     const diffs = [...diffValueBySchema(input, jsonSchema)];
 
     const patches = diffs.flatMap((diff) => [
-      ...generateShapePatchesByDiff(diff, jsonSchema, {}),
+      ...generateShapePatchesByDiff(diff, jsonSchema, {}, '3.1.x'),
     ]);
 
     expect(patches).toMatchSnapshot();
@@ -61,7 +61,7 @@ describe('type shape patch generator', () => {
     const diffs = [...diffValueBySchema(input, jsonSchema)];
 
     const patches = diffs.flatMap((diff) => [
-      ...generateShapePatchesByDiff(diff, jsonSchema, {}),
+      ...generateShapePatchesByDiff(diff, jsonSchema, {}, '3.1.x'),
     ]);
 
     expect(patches).toMatchSnapshot();

--- a/projects/optic/src/commands/oas/shapes/patches/index.ts
+++ b/projects/optic/src/commands/oas/shapes/patches/index.ts
@@ -12,14 +12,16 @@ export { PatchImpact, PatchOperationGroup as OperationGroup };
 
 import { diffShapePatchGenerators, newSchemaPatch } from './generators';
 import { OperationDiffResult } from '../../operations/diffs';
+import { SupportedOpenAPIVersions } from '@useoptic/openapi-io';
 
 export function* generateShapePatchesByDiff(
   diff: ShapeDiffResult,
   schema: SchemaObject,
-  shapeContext: { location?: ShapeLocation }
+  shapeContext: { location?: ShapeLocation },
+  openAPIVersion: SupportedOpenAPIVersions
 ): IterableIterator<ShapePatch> {
   for (let generator of diffShapePatchGenerators) {
-    yield* generator(diff, schema, shapeContext);
+    yield* generator(diff, schema, shapeContext, openAPIVersion);
   }
 }
 

--- a/projects/optic/src/commands/oas/specs/streams/patches.ts
+++ b/projects/optic/src/commands/oas/specs/streams/patches.ts
@@ -23,6 +23,7 @@ import {
 } from '../../operations';
 import { SchemaInventory } from '../../shapes/closeness/schema-inventory';
 import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
+import { SupportedOpenAPIVersions } from '@useoptic/openapi-io';
 
 export interface SpecPatches extends AsyncIterable<SpecPatch> {}
 
@@ -53,13 +54,14 @@ export class SpecPatches {
 
   static async *generateForNewSpec<T>(
     info: OpenAPIV3.InfoObject,
-    openAPIversion: string = '3.0.3'
+    openAPIVersion: string = '3.0.3'
   ): SpecPatches {
-    yield* newSpecPatches(info, openAPIversion);
+    yield* newSpecPatches(info, openAPIVersion);
   }
 
   static async *shapeAdditions(
-    documentedBodies: DocumentedBodies
+    documentedBodies: DocumentedBodies,
+    openAPIVersion: SupportedOpenAPIVersions
   ): SpecPatches {
     const updatedSchemasByPath: Map<string, SchemaObject> = new Map();
 
@@ -70,7 +72,10 @@ export class SpecPatches {
         documentedBody.schema = updatedSchemasByPath.get(specJsonPath)!;
       }
 
-      for (let patch of ShapePatches.generateBodyAdditions(documentedBody)) {
+      for (let patch of ShapePatches.generateBodyAdditions(
+        documentedBody,
+        openAPIVersion
+      )) {
         documentedBody = DocumentedBody.applyShapePatch(documentedBody, patch);
         yield SpecPatch.fromShapePatch(patch, specJsonPath, shapeLocation!);
       }

--- a/projects/optic/src/commands/oas/tests/shapes/__snapshots__/generate.test.ts.snap
+++ b/projects/optic/src/commands/oas/tests/shapes/__snapshots__/generate.test.ts.snap
@@ -483,6 +483,22 @@ exports[`generate shapes from bodies oneOfs are built correctly one of array or 
 }
 `;
 
+exports[`generate shapes from bodies primitives can become type null in 3.0 1`] = `
+{
+  "nullable": true,
+  "type": "string",
+}
+`;
+
+exports[`generate shapes from bodies primitives can become type null in 3.1 1`] = `
+{
+  "type": [
+    "string",
+    "null",
+  ],
+}
+`;
+
 exports[`generate shapes from bodies primitives can build JSON from a boolean 1`] = `
 {
   "type": "boolean",
@@ -491,7 +507,7 @@ exports[`generate shapes from bodies primitives can build JSON from a boolean 1`
 
 exports[`generate shapes from bodies primitives can build JSON from a null 1`] = `
 {
-  "type": "null",
+  "nullable": true,
 }
 `;
 

--- a/projects/optic/src/commands/oas/tests/shapes/extend.test.ts
+++ b/projects/optic/src/commands/oas/tests/shapes/extend.test.ts
@@ -11,7 +11,7 @@ function patchSchema(
   for (let input of inputs) {
     let body = DocumentedBodyFixtures.jsonBody(input);
     body.schema = schema;
-    let patches = ShapePatches.generateBodyAdditions(body);
+    let patches = ShapePatches.generateBodyAdditions(body, '3.1.x');
 
     for (let patch of patches) {
       schema = Schema.applyShapePatch(schema, patch);


### PR DESCRIPTION
## 🍗 Description
Optic was generating invalid schemas sometimes because `3.1` requires you supports a null type while `3.0` only supports `nullable`
## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
