### PR TITLE
Update uncommitted changes check to apply on a spec by spec basis

### DIFF
--- a/projects/optic/src/__tests__/integration/__snapshots__/spec-push.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/spec-push.test.ts.snap
@@ -9,9 +9,9 @@ Succesfully uploaded spec to Optic. View the spec here http://localhost:3001/org
 `;
 
 exports[`optic spec push does not automatically add git tags when not clean state 1`] = `
-"Not automatically including any git tags because the current working directory has uncommited changes.
+"Automatically adding the git sha 'git:COMMIT-HASH' and branch 'gitbranch:master' as tags
 
-Uploading spec for api at https://app.useoptic.com/organizations/org-id/apis/api-id 
+Uploading spec for api at https://app.useoptic.com/organizations/org-id/apis/api-id with tags git:COMMIT-HASH, gitbranch:master
 Succesfully uploaded spec to Optic. View the spec here http://localhost:3001/organizations/org-id/apis/api-id?specId=spec-id
 "
 `;

--- a/projects/optic/src/commands/api/add.ts
+++ b/projects/optic/src/commands/api/add.ts
@@ -1,11 +1,15 @@
 import { Command } from 'commander';
 import prompts from 'prompts';
 import open from 'open';
-import path from 'path';
+import path, { parse } from 'path';
 import fs from 'node:fs/promises';
 import ora from 'ora';
 import { OpticCliConfig, VCS } from '../../config';
-import { getFileFromFsOrGit, ParseResult } from '../../utils/spec-loaders';
+import {
+  getFileFromFsOrGit,
+  ParseResult,
+  specHasUncommittedChanges,
+} from '../../utils/spec-loaders';
 import { logger } from '../../logger';
 import { OPTIC_URL_KEY } from '../../constants';
 import chalk from 'chalk';
@@ -147,7 +151,7 @@ async function crawlCandidateSpecs(
   if (config.vcs?.type === VCS.Git) {
     // If the git workspace is dirty, we should upload the spec with changes
     // such that first use of optic you will have a spec (even without tags)
-    if (config.vcs.status === 'dirty') {
+    if (specHasUncommittedChanges(parseResult.sourcemap, config.vcs.diffSet)) {
       await uploadSpec(api.id, {
         spec: parseResult,
         tags: [],


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Updates the uncommitted changes check to only look on a per spec basis. This also includes references as part of the definition if a path changed (we read this from the sourcemap)

We do this by storing the set of changes in the git diff (as an absolute path)

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._
https://github.com/opticdev/optic/issues/1865

## 👹 QA
_How can other humans verify that this PR is correct?_
