### PR TITLE
generate request body with empty schema

### DIFF
--- a/projects/optic/src/commands/oas/operations/patches/generators/__snapshots__/request-body.test.ts.snap
+++ b/projects/optic/src/commands/oas/operations/patches/generators/__snapshots__/request-body.test.ts.snap
@@ -119,7 +119,9 @@ exports[`requestBodyPatches generates a patch for an unspecified request body 1`
           {
             "op": "add",
             "path": "/requestBody/content/application~1json",
-            "value": {},
+            "value": {
+              "schema": {},
+            },
           },
         ],
       },
@@ -138,7 +140,9 @@ exports[`requestBodyPatches generates a patch for an unspecified request body 2`
   "pathPattern": "/some-path",
   "requestBody": {
     "content": {
-      "application/json": {},
+      "application/json": {
+        "schema": {},
+      },
     },
   },
   "responses": {

--- a/projects/optic/src/commands/oas/operations/patches/generators/__snapshots__/request-body.test.ts.snap
+++ b/projects/optic/src/commands/oas/operations/patches/generators/__snapshots__/request-body.test.ts.snap
@@ -60,7 +60,9 @@ exports[`requestBodyPatches generates a patch for a unmatched request body conte
           {
             "op": "add",
             "path": "/requestBody/content/text~1csv",
-            "value": {},
+            "value": {
+              "schema": {},
+            },
           },
         ],
       },
@@ -80,7 +82,9 @@ exports[`requestBodyPatches generates a patch for a unmatched request body conte
   "requestBody": {
     "content": {
       "application/json": {},
-      "text/csv": {},
+      "text/csv": {
+        "schema": {},
+      },
     },
     "required": true,
   },

--- a/projects/optic/src/commands/oas/operations/patches/generators/request-body.ts
+++ b/projects/optic/src/commands/oas/operations/patches/generators/request-body.ts
@@ -72,7 +72,9 @@ function* unmatchedRequestBodyPatches(
     PatchOperationGroup.create(`add ${contentType} as content type`, {
       op: 'add',
       path: jsonPointerHelpers.compile(['requestBody', 'content', contentType]),
-      value: {},
+      value: {
+        schema: {},
+      },
     })
   );
 


### PR DESCRIPTION
## 🍗 Description
fixes https://github.com/opticdev/optic/issues/1860 by adding ` schema: {}` to documented request bodies

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
