### PR TITLE
Update to run against URLs

### DIFF
--- a/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
@@ -689,3 +689,18 @@ Checks
 [32m✔[39m Uploaded results of diff to http://localhost:3001/organizations/org-id/apis/api-id/runs/run-id
 "
 `;
+
+exports[`diff with mock server with web url 1`] = `
+"[90mRerun this command with the [97m--web[39m[90m flag to open a visual changelog your browser[39m
+
+specification details:
+- /info/description [32madded[39m
+- /openapi, /info/version, /info/title [33mchanged[39m
+
+
+[32m[1m0 passed[22m[39m
+[31m[1m0 errors[22m[39m
+
+[34m[1mSee the full history of this API by running "optic api add empty.json --history-depth 0"[22m[39m
+"
+`;

--- a/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
@@ -397,7 +397,7 @@ Checks
 [32m[1m152 passed[22m[39m
 [31m[1m46 errors[22m[39m
 
-[34m[1mSee the full history of this API by running "optic api add petstore-base.json --history-depth 0"[22m[39m
+[34m[1mSee the full history of this API by running "optic api add petstore-updated.json --history-depth 0"[22m[39m
 "
 `;
 
@@ -448,7 +448,7 @@ Checks
 [32m[1m3 passed[22m[39m
 [31m[1m2 errors[22m[39m
 
-[34m[1mSee the full history of this API by running "optic api add example-api-v0.json --history-depth 0"[22m[39m
+[34m[1mSee the full history of this API by running "optic api add example-api-v1.json --history-depth 0"[22m[39m
 "
 `;
 
@@ -519,7 +519,7 @@ Checks
 [32m[1m3 passed[22m[39m
 [31m[1m2 errors[22m[39m
 
-[34m[1mSee the full history of this API by running "optic api add example-api-v0.json --history-depth 0"[22m[39m
+[34m[1mSee the full history of this API by running "optic api add example-api-v1.json --history-depth 0"[22m[39m
 "
 `;
 
@@ -573,7 +573,7 @@ Checks
 [32m[1m5 passed[22m[39m
 [31m[1m2 errors[22m[39m
 
-[34m[1mSee the full history of this API by running "optic api add example-api-v0.json --history-depth 0"[22m[39m
+[34m[1mSee the full history of this API by running "optic api add example-api-v1.json --history-depth 0"[22m[39m
 "
 `;
 
@@ -625,7 +625,7 @@ Checks
 [32m[1m3 passed[22m[39m
 [31m[1m2 errors[22m[39m
 
-[34m[1mSee the full history of this API by running "optic api add example-api-v0.json --history-depth 0"[22m[39m
+[34m[1mSee the full history of this API by running "optic api add example-api-v1.json --history-depth 0"[22m[39m
 "
 `;
 
@@ -663,7 +663,7 @@ Checks
 [32m[1m0 passed[22m[39m
 [31m[1m1 errors[22m[39m
 
-[34m[1mSee the full history of this API by running "optic api add example-api-v0.json --history-depth 0"[22m[39m
+[34m[1mSee the full history of this API by running "optic api add example-api-v1.json --history-depth 0"[22m[39m
 "
 `;
 
@@ -701,6 +701,5 @@ specification details:
 [32m[1m0 passed[22m[39m
 [31m[1m0 errors[22m[39m
 
-[34m[1mSee the full history of this API by running "optic api add empty.json --history-depth 0"[22m[39m
 "
 `;

--- a/projects/optic/src/__tests__/integration/diff.test.ts
+++ b/projects/optic/src/__tests__/integration/diff.test.ts
@@ -127,6 +127,13 @@ describe('diff', () => {
         return JSON.stringify({
           id: 'run-id',
         });
+      } else if (method === 'GET' && /my-spec\.yml$/.test(url)) {
+        return `openapi: 3.0.3
+info:
+  title: a spec
+  description: The API
+  version: 0.1.0
+paths: {}`;
       }
       return JSON.stringify({});
     });
@@ -194,6 +201,19 @@ describe('diff', () => {
       );
 
       expect(code).toBe(1);
+      expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
+    });
+
+    test('with web url', async () => {
+      const workspace = await setupWorkspace('diff/files-no-repo', {
+        repo: false,
+      });
+      const { combined, code } = await runOptic(
+        workspace,
+        `diff null: ${process.env.BWTS_HOST_OVERRIDE}/my-spec.yml --check`
+      );
+
+      expect(code).toBe(0);
       expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
     });
   });

--- a/projects/optic/src/commands/api/add.ts
+++ b/projects/optic/src/commands/api/add.ts
@@ -6,7 +6,7 @@ import fs from 'node:fs/promises';
 import ora from 'ora';
 import { OpticCliConfig, VCS } from '../../config';
 import {
-  getFileFromFsOrGit,
+  loadSpec,
   ParseResult,
   specHasUncommittedChanges,
 } from '../../utils/spec-loaders';
@@ -91,7 +91,7 @@ async function crawlCandidateSpecs(
   const pathRelativeToRoot = path.relative(config.root, file_path);
   let parseResult: ParseResult;
   try {
-    parseResult = await getFileFromFsOrGit(file_path, config, {
+    parseResult = await loadSpec(file_path, config, {
       strict: false,
       denormalize: true,
     });
@@ -163,14 +163,10 @@ async function crawlCandidateSpecs(
     for await (const sha of shas) {
       let parseResult: ParseResult;
       try {
-        parseResult = await getFileFromFsOrGit(
-          `${sha}:${pathRelativeToRoot}`,
-          config,
-          {
-            strict: false,
-            denormalize: true,
-          }
-        );
+        parseResult = await loadSpec(`${sha}:${pathRelativeToRoot}`, config, {
+          strict: false,
+          denormalize: true,
+        });
       } catch (e) {
         logger.debug(
           `${short(

--- a/projects/optic/src/commands/api/list.ts
+++ b/projects/optic/src/commands/api/list.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import path from 'path';
 import fs from 'node:fs/promises';
 import { OpticCliConfig } from '../../config';
-import { getFileFromFsOrGit, ParseResult } from '../../utils/spec-loaders';
+import { loadSpec, ParseResult } from '../../utils/spec-loaders';
 import { logger } from '../../logger';
 import { OPTIC_URL_KEY } from '../../constants';
 import chalk from 'chalk';
@@ -74,7 +74,7 @@ export const getApiAddAction =
       let parseResult: ParseResult;
       try {
         // TODO just fs read json or yml instead here - no need to load sourcemap
-        parseResult = await getFileFromFsOrGit(file_path, config, {
+        parseResult = await loadSpec(file_path, config, {
           strict: false,
           denormalize: true,
         });

--- a/projects/optic/src/commands/bundle/bundle.ts
+++ b/projects/optic/src/commands/bundle/bundle.ts
@@ -1,5 +1,5 @@
 import { Command, Option } from 'commander';
-import { ParseResult, getFileFromFsOrGit } from '../../utils/spec-loaders';
+import { ParseResult, loadSpec } from '../../utils/spec-loaders';
 import { OpticCliConfig } from '../../config';
 import {
   OpenAPIV3,
@@ -58,8 +58,7 @@ const getSpec = async (
   config: OpticCliConfig
 ): Promise<ParseResult> => {
   try {
-    // TODO update function to try download from spec-id cloud
-    return getFileFromFsOrGit(file1, config, {
+    return loadSpec(file1, config, {
       strict: false,
       denormalize: false,
     });

--- a/projects/optic/src/commands/dereference/dereference.ts
+++ b/projects/optic/src/commands/dereference/dereference.ts
@@ -1,5 +1,5 @@
 import { Command, Option } from 'commander';
-import { ParseResult, getFileFromFsOrGit } from '../../utils/spec-loaders';
+import { ParseResult, loadSpec } from '../../utils/spec-loaders';
 import { OpticCliConfig } from '../../config';
 import { UserError } from '@useoptic/openapi-utilities';
 import { isYaml, writeYaml } from '@useoptic/openapi-io';
@@ -47,8 +47,7 @@ const getDereferencedSpec = async (
   config: OpticCliConfig
 ): Promise<ParseResult> => {
   try {
-    // TODO update function to try download from spec-id cloud
-    return getFileFromFsOrGit(file1, config, {
+    return loadSpec(file1, config, {
       strict: false,
       denormalize: false,
     });

--- a/projects/optic/src/commands/diff/compute.ts
+++ b/projects/optic/src/commands/diff/compute.ts
@@ -6,7 +6,7 @@ import {
 import { generateRuleRunner } from './generate-rule-runner';
 import { OPTIC_STANDARD_KEY } from '../../constants';
 import {
-  getFileFromFsOrGit,
+  loadSpec,
   ParseResult,
   parseSpecVersion,
 } from '../../utils/spec-loaders';

--- a/projects/optic/src/commands/diff/diff-all.ts
+++ b/projects/optic/src/commands/diff/diff-all.ts
@@ -2,11 +2,7 @@ import { Command, Option } from 'commander';
 import pm from 'picomatch';
 import { OpticCliConfig, VCS } from '../../config';
 import { findOpenApiSpecsCandidates } from '../../utils/git-utils';
-import {
-  getFileFromFsOrGit,
-  loadRaw,
-  ParseResult,
-} from '../../utils/spec-loaders';
+import { loadSpec, loadRaw, ParseResult } from '../../utils/spec-loaders';
 import { logger } from '../../logger';
 import { OPTIC_URL_KEY } from '../../constants';
 import { compute } from './compute';
@@ -240,7 +236,7 @@ async function computeAll(
     let fromParseResults: ParseResult;
     let toParseResults: ParseResult;
     try {
-      fromParseResults = await getFileFromFsOrGit(candidate.from, config, {
+      fromParseResults = await loadSpec(candidate.from, config, {
         strict: false,
         denormalize: true,
       });
@@ -253,7 +249,7 @@ async function computeAll(
     }
 
     try {
-      toParseResults = await getFileFromFsOrGit(candidate.to, config, {
+      toParseResults = await loadSpec(candidate.to, config, {
         strict: options.validation === 'strict',
         denormalize: true,
       });

--- a/projects/optic/src/commands/diff/diff.ts
+++ b/projects/optic/src/commands/diff/diff.ts
@@ -207,13 +207,14 @@ const runDiff = async (
     }
 
     logger.info('');
-
-    if (!hasOpticUrl) {
+    if ((!hasOpticUrl && headFile.from === 'file') || headFile.from === 'git') {
+      const relativePath = path.relative(
+        process.cwd(),
+        headFile.sourcemap.rootFilePath
+      );
       logger.info(
         chalk.blue.bold(
-          `See the full history of this API by running "optic api add ${
-            path.parse(baseFile.sourcemap.rootFilePath).base
-          } --history-depth 0"`
+          `See the full history of this API by running "optic api add ${relativePath} --history-depth 0"`
         )
       );
     }

--- a/projects/optic/src/commands/diff/diff.ts
+++ b/projects/optic/src/commands/diff/diff.ts
@@ -12,7 +12,7 @@ import { generateComparisonLogsV2 } from '../../utils/diff-renderer';
 import {
   parseFilesFromRef,
   ParseResult,
-  getFileFromFsOrGit,
+  loadSpec,
 } from '../../utils/spec-loaders';
 import { OpticCliConfig, VCS } from '../../config';
 import chalk from 'chalk';
@@ -104,10 +104,9 @@ const getBaseAndHeadFromFiles = async (
   strict: boolean
 ): Promise<[ParseResult, ParseResult]> => {
   try {
-    // TODO update function to try download from spec-id cloud
     return await Promise.all([
-      getFileFromFsOrGit(file1, config, { strict, denormalize: true }),
-      getFileFromFsOrGit(file2, config, { strict, denormalize: true }),
+      loadSpec(file1, config, { strict, denormalize: true }),
+      loadSpec(file2, config, { strict, denormalize: true }),
     ]);
   } catch (e) {
     console.error(e instanceof Error ? e.message : e);

--- a/projects/optic/src/commands/lint/lint.ts
+++ b/projects/optic/src/commands/lint/lint.ts
@@ -2,7 +2,7 @@ import { Command, Option } from 'commander';
 import open from 'open';
 
 import { compute } from '../diff/compute';
-import { getFileFromFsOrGit, ParseResult } from '../../utils/spec-loaders';
+import { loadSpec, ParseResult } from '../../utils/spec-loaders';
 import { OpticCliConfig } from '../../config';
 import { errorHandler } from '../../error-handler';
 import { logger } from '../../logger';
@@ -52,7 +52,7 @@ const getLintAction =
     logger.info(`Linting spec ${path}...`);
     let file: ParseResult;
     try {
-      file = await getFileFromFsOrGit(path, config, {
+      file = await loadSpec(path, config, {
         strict: true,
         denormalize: true,
       });

--- a/projects/optic/src/commands/oas/verify.ts
+++ b/projects/optic/src/commands/oas/verify.ts
@@ -18,10 +18,7 @@ import { OpticCliConfig, VCS } from '../../config';
 import { OPTIC_URL_KEY } from '../../constants';
 import { getApiFromOpticUrl } from '../../utils/cloud-urls';
 import { uploadSpec, uploadSpecVerification } from '../../utils/cloud-specs';
-import {
-  getFileFromFsOrGit,
-  specHasUncommittedChanges,
-} from '../../utils/spec-loaders';
+import { loadSpec, specHasUncommittedChanges } from '../../utils/spec-loaders';
 import * as Git from '../../utils/git-utils';
 import { sanitizeGitTag } from '@useoptic/openapi-utilities';
 import { nextCommand } from './reporters/next-command';
@@ -92,7 +89,7 @@ export async function runVerify(
   const absoluteSpecPath = Path.resolve(specPath);
 
   /// Run to verify with the latest specification
-  const parseResult = await getFileFromFsOrGit(absoluteSpecPath, config, {
+  const parseResult = await loadSpec(absoluteSpecPath, config, {
     strict: false,
     denormalize: true,
   });

--- a/projects/optic/src/commands/spec/push.ts
+++ b/projects/optic/src/commands/spec/push.ts
@@ -1,10 +1,10 @@
 import { Command } from 'commander';
 import open from 'open';
-import { sanitizeGitTag, SPEC_TAG_REGEXP } from '@useoptic/openapi-utilities';
+import { sanitizeGitTag } from '@useoptic/openapi-utilities';
 
 import { OpticCliConfig, VCS } from '../../config';
 import {
-  getFileFromFsOrGit,
+  loadSpec,
   ParseResult,
   specHasUncommittedChanges,
 } from '../../utils/spec-loaders';
@@ -65,7 +65,7 @@ const getSpecPushAction =
 
     let parseResult: ParseResult;
     try {
-      parseResult = await getFileFromFsOrGit(spec_path, config, {
+      parseResult = await loadSpec(spec_path, config, {
         strict: false,
         denormalize: true,
       });

--- a/projects/optic/src/utils/spec-loaders.ts
+++ b/projects/optic/src/utils/spec-loaders.ts
@@ -30,6 +30,7 @@ export type ParseResultContext = {
 
 export type ParseResult = ParseOpenAPIResult & {
   isEmptySpec: boolean;
+  from: 'git' | 'file' | 'url' | 'empty';
   context: ParseResultContext;
 };
 
@@ -158,6 +159,7 @@ async function parseSpecAndDereference(
       return {
         jsonLike,
         sourcemap,
+        from: 'empty',
         isEmptySpec: true,
         context: null,
       };
@@ -176,6 +178,7 @@ async function parseSpecAndDereference(
           config.root,
           input.branch
         )),
+        from: 'git',
         isEmptySpec: false,
         context: {
           vcs: 'git',
@@ -191,6 +194,7 @@ async function parseSpecAndDereference(
       const parseResult = await parseOpenAPIWithSourcemap(input.url);
       return {
         ...parseResult,
+        from: 'url',
         isEmptySpec: false,
         context: null,
       };
@@ -219,6 +223,7 @@ async function parseSpecAndDereference(
 
       return {
         ...parseResult,
+        from: 'file',
         isEmptySpec: false,
         context,
       };

--- a/projects/optic/src/utils/spec-loaders.ts
+++ b/projects/optic/src/utils/spec-loaders.ts
@@ -199,16 +199,21 @@ function validateAndDenormalize(
   return options.denormalize ? denormalize(parseResult) : parseResult;
 }
 
-// filePathOrRef can be a path, or a gitref:path (delimited by `:`)
-export const getFileFromFsOrGit = async (
-  filePathOrRef: string | undefined,
+// Optic ref supports
+// - file paths (`./specs/openapi.yml`)
+// - git paths (`git:main`)
+// - public urls (`https://example.com/my-openapi-spec.yml`)
+// - empty files (`null:`)
+// - (in the future): cloud tags (`cloud:apiId@tag`)
+export const loadSpec = async (
+  opticRef: string | undefined,
   config: OpticCliConfig,
   options: {
     strict: boolean;
     denormalize: boolean;
   }
 ): Promise<ParseResult> => {
-  const file = await parseSpecAndDereference(filePathOrRef, config);
+  const file = await parseSpecAndDereference(opticRef, config);
 
   return validateAndDenormalize(file, options);
 };


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Updates to allow diff / other things against a URL (not a optic hosted spec - will be in a different PR).

Example usage - `optic diff null: https://raw.githubusercontent.com/opticdev/optic/main/projects/optic/specs/test-spec.yml --web`

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
