### PR TITLE
Allow spec to refer to cloud specs

### DIFF
--- a/projects/openapi-io/src/parser/sourcemap.ts
+++ b/projects/openapi-io/src/parser/sourcemap.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import { createHash } from 'crypto';
 
 import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
+import { SerializedSourcemap } from '@useoptic/openapi-utilities';
 
 export type JsonPath = string;
 export type FileReference = number;
@@ -17,6 +18,15 @@ function getsha256(contents: string): string {
 }
 
 export class JsonSchemaSourcemap {
+  static fromSerializedSourcemap(
+    serialized: SerializedSourcemap
+  ): JsonSchemaSourcemap {
+    const sourcemap = new JsonSchemaSourcemap(serialized.rootFilePath);
+    sourcemap.files = serialized.files;
+    sourcemap.refMappings = serialized.refMappings;
+    return sourcemap;
+  }
+
   constructor(public rootFilePath: string) {}
 
   public files: Array<{

--- a/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
@@ -690,6 +690,18 @@ Checks
 "
 `;
 
+exports[`diff with mock server with cloud tag ref 1`] = `
+"[90mRerun this command with the [97m--web[39m[90m flag to open a visual changelog your browser[39m
+
+[1mGET[22m /api/users: [32madded[39m
+  
+1 operation added
+[32m[1m0 passed[22m[39m
+[31m[1m0 errors[22m[39m
+
+"
+`;
+
 exports[`diff with mock server with web url 1`] = `
 "[90mRerun this command with the [97m--web[39m[90m flag to open a visual changelog your browser[39m
 

--- a/projects/optic/src/__tests__/integration/diff.test.ts
+++ b/projects/optic/src/__tests__/integration/diff.test.ts
@@ -134,6 +134,16 @@ info:
   description: The API
   version: 0.1.0
 paths: {}`;
+      } else if (method === 'GET' && /spec$/.test(url)) {
+        return `{"openapi":"3.1.0","paths":{ "/api/users": { "get": { "responses":{} }}},"info":{"version":"0.0.0","title":"Empty"}}`;
+      } else if (method === 'GET' && /sourcemap$/.test(url)) {
+        return `{"rootFilePath":"empty.json","files":[{"path":"empty.json","index":0,"contents":{"openapi": "3.1.0","paths": {},"info": {"version": "0.0.0","title": "Empty"},"x-optic-ci-empty-spec": true},"sha256":"841ad837d9488cb03837e695fd2d7dfacacc708465ba8b4e3d2d811428915016"}],"refMappings":{}}`;
+      } else if (method === 'GET' && /api\/apis\/.*\/specs\/.*$/.test(url)) {
+        return JSON.stringify({
+          id: 'run-id',
+          specUrl: `${process.env.BWTS_HOST_OVERRIDE}/spec`,
+          sourcemapUrl: `${process.env.BWTS_HOST_OVERRIDE}/sourcemap`,
+        });
       }
       return JSON.stringify({});
     });
@@ -211,6 +221,19 @@ paths: {}`;
       const { combined, code } = await runOptic(
         workspace,
         `diff null: ${process.env.BWTS_HOST_OVERRIDE}/my-spec.yml --check`
+      );
+
+      expect(code).toBe(0);
+      expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
+    });
+
+    test('with cloud tag ref', async () => {
+      const workspace = await setupWorkspace('diff/files-no-repo', {
+        repo: false,
+      });
+      const { combined, code } = await runOptic(
+        workspace,
+        `diff null: cloud:api-id@main --check`
       );
 
       expect(code).toBe(0);

--- a/projects/optic/src/client/optic-backend.ts
+++ b/projects/optic/src/client/optic-backend.ts
@@ -129,6 +129,17 @@ export class OpticBackendClient extends JsonHttpClient {
     return this.postJson(`/api/specs/prepare`, body);
   }
 
+  public async getSpec(
+    apiId: string,
+    tag: string
+  ): Promise<{
+    id: string;
+    specUrl: string | null;
+    sourcemapUrl: string | null;
+  }> {
+    return this.getJson(`/api/apis/${apiId}/specs/tag:${tag}`);
+  }
+
   public async createSpec(spec: {
     tags: string[];
     upload_id: string;

--- a/projects/optic/src/commands/api/list.ts
+++ b/projects/optic/src/commands/api/list.ts
@@ -75,7 +75,7 @@ export const getApiAddAction =
       const relativePath = path.relative(process.cwd(), file_path);
       let spec: OpenAPIV3.Document;
       try {
-        spec = await loadRaw(file_path);
+        spec = await loadRaw(file_path, config);
         // Checks that the document looks like an openapi document (i.e. has paths, etc )
         validateOpenApiV3Document(spec, undefined, { strictOpenAPI: false });
       } catch (e) {

--- a/projects/optic/src/commands/diff/compute.ts
+++ b/projects/optic/src/commands/diff/compute.ts
@@ -5,11 +5,7 @@ import {
 } from '@useoptic/openapi-utilities';
 import { generateRuleRunner } from './generate-rule-runner';
 import { OPTIC_STANDARD_KEY } from '../../constants';
-import {
-  loadSpec,
-  ParseResult,
-  parseSpecVersion,
-} from '../../utils/spec-loaders';
+import { ParseResult, parseOpticRef } from '../../utils/spec-loaders';
 import { OpticCliConfig } from '../../config';
 import { trackEvent } from '@useoptic/openapi-utilities/build/utilities/segment';
 import { logger } from '../../logger';
@@ -53,7 +49,7 @@ export async function compute(
       logger.error(e);
     }
   } else {
-    const parsed = parseSpecVersion(options.path);
+    const parsed = parseOpticRef(options.path);
     const filePath =
       parsed.from === 'git'
         ? parsed.name

--- a/projects/optic/src/commands/diff/diff-all.ts
+++ b/projects/optic/src/commands/diff/diff-all.ts
@@ -196,7 +196,7 @@ async function computeAll(
 
     let rawSpec;
     try {
-      rawSpec = await loadRaw(specPathToLoad);
+      rawSpec = await loadRaw(specPathToLoad, config);
     } catch (e) {
       if (e instanceof Error && e['probablySpec']) {
         logger.error(`Error parsing ${specPathToLoad}:`);

--- a/projects/optic/src/utils/cloud-specs.ts
+++ b/projects/optic/src/utils/cloud-specs.ts
@@ -14,6 +14,7 @@ import { logger } from '../logger';
 import { NotFoundError } from '../client/errors';
 import chalk from 'chalk';
 import { createNullSpec, createNullSpecSourcemap } from './specs';
+import { JsonSchemaSourcemap } from '@useoptic/openapi-io';
 
 export const EMPTY_SPEC_ID = 'EMPTY';
 
@@ -42,7 +43,9 @@ export async function downloadSpec(
     ]);
     return {
       jsonLike: JSON.parse(specStr),
-      sourcemap: JSON.parse(sourcemapStr), // TODO construct sourcemap
+      sourcemap: JsonSchemaSourcemap.fromSerializedSourcemap(
+        JSON.parse(sourcemapStr)
+      ),
     };
   }
 }

--- a/projects/optic/src/utils/s3.ts
+++ b/projects/optic/src/utils/s3.ts
@@ -19,3 +19,21 @@ export const uploadFileToS3 = async (
     }
   });
 };
+
+export const downloadFileFromS3 = async (
+  signedUrl: string,
+  additionalHeaders: Record<string, string> = {}
+) => {
+  return await fetch(signedUrl, {
+    method: 'GET',
+    headers: {
+      ...additionalHeaders,
+    },
+  }).then(async (response) => {
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`${response.status} ${response.statusText} \n${text}`);
+    }
+    return response.text();
+  });
+};

--- a/projects/optic/src/utils/spec-loaders.ts
+++ b/projects/optic/src/utils/spec-loaders.ts
@@ -3,7 +3,7 @@ import fetch from 'node-fetch';
 import path from 'path';
 import { promisify } from 'util';
 import { exec as callbackExec } from 'child_process';
-import { defaultEmptySpec, OpenAPIV3 } from '@useoptic/openapi-utilities';
+import { OpenAPIV3 } from '@useoptic/openapi-utilities';
 import {
   validateOpenApiV3Document,
   filePathToGitPath,
@@ -16,7 +16,9 @@ import {
 } from '@useoptic/openapi-io';
 import { OpticCliConfig, VCS } from '../config';
 import * as Git from './git-utils';
-import { OPTIC_EMPTY_SPEC_KEY } from '../constants';
+import { createNullSpec, createNullSpecSourcemap } from './specs';
+import { downloadSpec } from './cloud-specs';
+import { OpticBackendClient } from '../client';
 
 const exec = promisify(callbackExec);
 
@@ -31,11 +33,16 @@ export type ParseResultContext = {
 
 export type ParseResult = ParseOpenAPIResult & {
   isEmptySpec: boolean;
-  from: 'git' | 'file' | 'url' | 'empty';
+  from: 'git' | 'file' | 'url' | 'empty' | 'cloud';
   context: ParseResultContext;
 };
 
 type SpecFromInput =
+  | {
+      from: 'cloud';
+      apiId: string;
+      tag: string;
+    }
   | {
       from: 'file';
       filePath: string;
@@ -47,16 +54,16 @@ type SpecFromInput =
     }
   | {
       from: 'empty';
-      value: OpenAPIV3.Document;
     }
   | {
       from: 'url';
       url: string;
     };
 
-export function parseSpecVersion(raw?: string | null): SpecFromInput {
+export function parseOpticRef(raw?: string | null): SpecFromInput {
   raw = raw ?? 'null:';
   let isUrl = false;
+  const maybeCloudMatch = raw.match(/^cloud:(?<apiId>.+)@(?<tag>.+)$/);
 
   try {
     new URL(raw);
@@ -66,15 +73,17 @@ export function parseSpecVersion(raw?: string | null): SpecFromInput {
   if (raw === 'null:') {
     return {
       from: 'empty',
-      value: {
-        ...defaultEmptySpec,
-        [OPTIC_EMPTY_SPEC_KEY]: true,
-      } as OpenAPIV3.Document,
     };
   } else if (isUrl) {
     return {
       from: 'url',
       url: raw,
+    };
+  } else if (maybeCloudMatch?.groups?.apiId && maybeCloudMatch?.groups?.tag) {
+    return {
+      from: 'cloud',
+      apiId: maybeCloudMatch.groups.apiId,
+      tag: maybeCloudMatch.groups.tag,
     };
   } else if (
     raw.includes(':') &&
@@ -98,8 +107,11 @@ export function parseSpecVersion(raw?: string | null): SpecFromInput {
 }
 
 // Loads spec without dereferencing
-export async function loadRaw(opticRef: string): Promise<OpenAPIV3.Document> {
-  const input = parseSpecVersion(opticRef);
+export async function loadRaw(
+  opticRef: string,
+  config: { client: OpticBackendClient }
+): Promise<OpenAPIV3.Document> {
+  const input = parseOpticRef(opticRef);
   let format: 'json' | 'yml' | 'unknown';
   let rawString: string;
   if (input.from === 'file') {
@@ -111,8 +123,14 @@ export async function loadRaw(opticRef: string): Promise<OpenAPIV3.Document> {
   } else if (input.from === 'url') {
     rawString = await fetch(input.url).then((res) => res.text());
     format = 'unknown';
+  } else if (input.from === 'cloud') {
+    const spec = await downloadSpec(
+      { apiId: input.apiId, tag: input.tag },
+      config
+    );
+    return spec.jsonLike;
   } else {
-    return input.value;
+    return createNullSpec();
   }
 
   if (format === 'unknown') {
@@ -144,23 +162,32 @@ async function parseSpecAndDereference(
   config: OpticCliConfig
 ): Promise<ParseResult> {
   const workingDir = process.cwd();
-  const input = parseSpecVersion(filePathOrRef);
+  const input = parseOpticRef(filePathOrRef);
 
   switch (input.from) {
     case 'empty': {
-      const emptySpecName = 'empty.json';
-      const sourcemap = new JsonSchemaSourcemap(emptySpecName);
-      sourcemap.addFileIfMissingFromContents(
-        emptySpecName,
-        JSON.stringify(input.value, null, 2),
-        0
-      );
-
+      const spec = createNullSpec();
+      const sourcemap = createNullSpecSourcemap(spec);
       return {
-        jsonLike: input.value,
+        jsonLike: spec,
         sourcemap,
         from: 'empty',
         isEmptySpec: true,
+        context: null,
+      };
+    }
+    case 'cloud': {
+      // try fetch from cloud, if 404 return an error
+      // todo handle empty spec case
+      const { jsonLike, sourcemap } = await downloadSpec(
+        { apiId: input.apiId, tag: input.tag },
+        config
+      );
+      return {
+        jsonLike,
+        sourcemap,
+        from: 'cloud',
+        isEmptySpec: false,
         context: null,
       };
     }
@@ -249,7 +276,7 @@ function validateAndDenormalize(
 // - git paths (`git:main`)
 // - public urls (`https://example.com/my-openapi-spec.yml`)
 // - empty files (`null:`)
-// - (in the future): cloud tags (`cloud:apiId@tag`)
+// - cloud tags (`cloud:apiId@tag`)
 export const loadSpec = async (
   opticRef: string | undefined,
   config: OpticCliConfig,

--- a/projects/optic/src/utils/specs.ts
+++ b/projects/optic/src/utils/specs.ts
@@ -1,4 +1,6 @@
-import { OpenAPIV3 } from '@useoptic/openapi-utilities';
+import { OpenAPIV3, defaultEmptySpec } from '@useoptic/openapi-utilities';
+import { OPTIC_EMPTY_SPEC_KEY } from '../constants';
+import { JsonSchemaSourcemap } from '@useoptic/openapi-io';
 
 export function createNewSpecFile(version: string): OpenAPIV3.Document {
   return {
@@ -9,4 +11,24 @@ export function createNewSpecFile(version: string): OpenAPIV3.Document {
     openapi: version,
     paths: {},
   };
+}
+
+export function createNullSpec(): OpenAPIV3.Document {
+  return {
+    ...defaultEmptySpec,
+    [OPTIC_EMPTY_SPEC_KEY]: true,
+  } as OpenAPIV3.Document;
+}
+
+export function createNullSpecSourcemap(
+  nullSpec: OpenAPIV3.Document
+): JsonSchemaSourcemap {
+  const emptySpecName = 'empty.json';
+  const sourcemap = new JsonSchemaSourcemap(emptySpecName);
+  sourcemap.addFileIfMissingFromContents(
+    emptySpecName,
+    JSON.stringify(nullSpec, null, 2),
+    0
+  );
+  return sourcemap;
 }


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Update to support functionality like...

`optic lint cloud:_cQglr_1M77d9lf7DQUef@gitbranch:main`

Coming up in a future PR is allowing `diff` or `diff-all` to specify a `--compare-from cloud:default` which will use this underlying logic

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
