### PR TITLE
Support base cloud ref in diff and diff-all

### DIFF
--- a/projects/optic/src/__tests__/integration/__snapshots__/diff-all.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/diff-all.test.ts.snap
@@ -1,5 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`diff-all diff all against a cloud tag 1`] = `
+"[34mDiffing cloud:main to spec.json[39m
+
+specification details:
+- /x-optic-url [32madded[39m
+- /openapi [33mchanged[39m
+
+[1mGET[22m /api/users: [31mremoved[39m
+  
+[1mGET[22m /example: [32madded[39m
+  
+[1mPOST[22m /example: [32madded[39m
+  
+[1mPUT[22m /example: [32madded[39m
+  
+[1mPATCH[22m /example: [32madded[39m
+  
+Checks
+
+  [1m[41m[37m FAIL [39m[49m[22m [1mGET[22m /api/users
+    removed rule[31m [error][39m: prevent operation removal
+      [31m[31mx[39m[31m cannot remove an operation. This is a breaking change.[39m
+      at paths > /api/users > get [4m(empty.json:1:45)[24m
+
+
+
+4 operations added, 1 removed
+[32m[1m0 passed[22m[39m
+[31m[1m1 errors[22m[39m
+
+"
+`;
+
 exports[`diff-all diff all not in the root of a repo 1`] = `
 "[34mDiffing HEAD~1:folder/in-folder.yml to in-folder.yml[39m
 No changes were detected
@@ -141,11 +174,12 @@ Checks
 [31m[1m2 errors[22m[39m
 
 [32m✔[39m Uploaded results of diff to http://localhost:3001/organizations/org-id/apis/api-id/runs/run-id
-[33mWarning - the following OpenAPI specs were detected but did not have valid x-optic-url keys. \`optic diff-all\` only runs on specs that include \`x-optic-url\` keys that point to specs uploaded to optic.[39m
+[33mWarning - the following OpenAPI specs were detected but did not have valid x-optic-url keys. 'optic diff-all --upload' can only runs on specs that have been added to optic[39m
+
 Run the \`optic api add\` command to add these specs to optic
-../spec-with-invalid-url.yml
-../specwithoutkey.json
-../specwithoutkey.yml
+../spec-with-invalid-url.yml [31m(untracked)[39m
+../specwithoutkey.json [31m(untracked)[39m
+../specwithoutkey.yml [31m(untracked)[39m
 
 "
 `;
@@ -337,11 +371,12 @@ Checks
 [31m[1m2 errors[22m[39m
 
 [32m✔[39m Uploaded results of diff to http://localhost:3001/organizations/org-id/apis/api-id/runs/run-id
-[33mWarning - the following OpenAPI specs were detected but did not have valid x-optic-url keys. \`optic diff-all\` only runs on specs that include \`x-optic-url\` keys that point to specs uploaded to optic.[39m
+[33mWarning - the following OpenAPI specs were detected but did not have valid x-optic-url keys. 'optic diff-all --upload' can only runs on specs that have been added to optic[39m
+
 Run the \`optic api add\` command to add these specs to optic
-spec-with-invalid-url.yml
-specwithoutkey.json
-specwithoutkey.yml
+spec-with-invalid-url.yml [31m(untracked)[39m
+specwithoutkey.json [31m(untracked)[39m
+specwithoutkey.yml [31m(untracked)[39m
 
 "
 `;

--- a/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
@@ -690,6 +690,39 @@ Checks
 "
 `;
 
+exports[`diff with mock server with --base cloud:tag 1`] = `
+"[90mRerun this command with the [97m--web[39m[90m flag to open a visual changelog your browser[39m
+
+specification details:
+- /x-optic-url [32madded[39m
+- /openapi [33mchanged[39m
+
+[1mGET[22m /api/users: [31mremoved[39m
+  
+[1mGET[22m /example: [32madded[39m
+  
+[1mPOST[22m /example: [32madded[39m
+  
+[1mPUT[22m /example: [32madded[39m
+  
+[1mPATCH[22m /example: [32madded[39m
+  
+Checks
+
+  [1m[41m[37m FAIL [39m[49m[22m [1mGET[22m /api/users
+    removed rule[31m [error][39m: prevent operation removal
+      [31m[31mx[39m[31m cannot remove an operation. This is a breaking change.[39m
+      at paths > /api/users > get [4m(empty.json:1:45)[24m
+
+
+
+4 operations added, 1 removed
+[32m[1m0 passed[22m[39m
+[31m[1m1 errors[22m[39m
+
+"
+`;
+
 exports[`diff with mock server with cloud tag ref 1`] = `
 "[90mRerun this command with the [97m--web[39m[90m flag to open a visual changelog your browser[39m
 

--- a/projects/optic/src/__tests__/integration/diff.test.ts
+++ b/projects/optic/src/__tests__/integration/diff.test.ts
@@ -137,7 +137,7 @@ paths: {}`;
       } else if (method === 'GET' && /spec$/.test(url)) {
         return `{"openapi":"3.1.0","paths":{ "/api/users": { "get": { "responses":{} }}},"info":{"version":"0.0.0","title":"Empty"}}`;
       } else if (method === 'GET' && /sourcemap$/.test(url)) {
-        return `{"rootFilePath":"empty.json","files":[{"path":"empty.json","index":0,"contents":{"openapi": "3.1.0","paths": {},"info": {"version": "0.0.0","title": "Empty"},"x-optic-ci-empty-spec": true},"sha256":"841ad837d9488cb03837e695fd2d7dfacacc708465ba8b4e3d2d811428915016"}],"refMappings":{}}`;
+        return `{"rootFilePath":"empty.json","files":[{"path":"empty.json","sha256":"815b8e5491a1f491765084f236c741d5073e10fcece23436f2db84a8c788db09","contents":"{'openapi':'3.1.0','paths':{ '/api/users': { 'get': { 'responses':{} }}},'info':{'version':'0.0.0','title':'Empty'}}","index":0}],"refMappings":{}}`;
       } else if (method === 'GET' && /api\/apis\/.*\/specs\/.*$/.test(url)) {
         return JSON.stringify({
           id: 'run-id',
@@ -237,6 +237,19 @@ paths: {}`;
       );
 
       expect(code).toBe(0);
+      expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
+    });
+
+    test('with --base cloud:tag', async () => {
+      const workspace = await setupWorkspace('diff/upload', {
+        repo: false,
+      });
+      const { combined, code } = await runOptic(
+        workspace,
+        `diff spec.json --base cloud:main --check`
+      );
+
+      expect(code).toBe(1);
       expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
     });
   });

--- a/projects/optic/src/__tests__/integration/workspaces/diff-all/cloud-diff/spec.json
+++ b/projects/optic/src/__tests__/integration/workspaces/diff-all/cloud-diff/spec.json
@@ -1,0 +1,40 @@
+{
+  "openapi": "3.0.1",
+  "x-optic-url": "https://app.useoptic.com/organizations/org-id/apis/api-id",
+  "paths": {
+    "/example": {
+      "get": {
+        "operationId": "my-op",
+        "responses": {}
+      },
+      "post": {
+        "operationId": "postOriginalaa",
+        "responses": {}
+      },
+      "put": {
+        "operationId": "putOriginalaa",
+        "responses": {}
+      },
+      "patch": {
+        "operationId": "putOriginaaal",
+        "responses": {
+          "200": {
+            "description": "hello",
+            "content": {
+              "application/json": {
+                "example": "hello",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "info": {
+    "version": "0.0.0",
+    "title": "Empty"
+  }
+}

--- a/projects/optic/src/commands/diff/diff-all.ts
+++ b/projects/optic/src/commands/diff/diff-all.ts
@@ -56,7 +56,7 @@ export const registerDiffAll = (cli: Command, config: OpticCliConfig) => {
     )
     .option(
       '--compare-from <compare-from>',
-      'the base ref to compare against. Defaults to HEAD~1',
+      'the base ref to compare against. Defaults to HEAD~1. Also supports optic cloud tags (cloud:tag_name)',
       'HEAD~1'
     )
     .option(

--- a/projects/optic/src/utils/cloud-urls.ts
+++ b/projects/optic/src/utils/cloud-urls.ts
@@ -7,8 +7,9 @@ const PATH_NAME_REGEXP =
   /^\/organizations\/([a-zA-Z0-9-_]+)\/apis\/([a-zA-Z0-9-_]+)$/i;
 
 export function getApiFromOpticUrl(
-  opticUrl: string
+  opticUrl: string | undefined
 ): { apiId: string; orgId: string } | null {
+  if (!opticUrl) return null;
   try {
     const url = new URL(opticUrl);
     const match = url.pathname.match(PATH_NAME_REGEXP);

--- a/projects/optic/src/utils/spec-loaders.ts
+++ b/projects/optic/src/utils/spec-loaders.ts
@@ -21,6 +21,7 @@ import { downloadSpec } from './cloud-specs';
 import { OpticBackendClient } from '../client';
 import { getApiFromOpticUrl } from './cloud-urls';
 import { OPTIC_URL_KEY } from '../constants';
+import chalk from 'chalk';
 
 const exec = promisify(callbackExec);
 
@@ -366,7 +367,11 @@ export const parseFilesFromCloud = async (
 
   if (!maybeApi) {
     throw new Error(
-      'Must have an `x-optic-url` set on the head spec to be able to compare against a cloud base'
+      `${chalk.bold.red(
+        "Must have an 'x-optic-url' in your OpenAPI spec file to be able to compare against a cloud base."
+      )}.
+
+${chalk.gray(`Get started by running 'optic api add ${filePath}'`)}`
     );
   }
 


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Updates diff + diff-all to diff against a ref. This looks like:
- `optic diff spec.yml --base cloud:gitbranch:main`
- `optic diff-all --compare-from cloud:gitbranch:main`

This requires specs to have `x-optic-url` set - we construct a `cloud:apiId@tag` format and use that to request the spec (i.e. latest spec on specified tag)

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
