### PR TITLE
Support --include-uncommitted-changes and upload with cloud spec

### DIFF
--- a/projects/optic/src/commands/api/add.ts
+++ b/projects/optic/src/commands/api/add.ts
@@ -194,7 +194,11 @@ async function crawlCandidateSpecs(
         orgId,
         forward_effective_at_to_tags: true,
       });
-      specsToTag.push([specId, sha, parseResult.context?.effective_at]);
+      const effective_at =
+        parseResult.context?.vcs === 'git'
+          ? parseResult.context.effective_at
+          : undefined;
+      specsToTag.push([specId, sha, effective_at]);
     }
 
     if (!alreadyTracked) {

--- a/projects/optic/src/commands/diff/diff-all.ts
+++ b/projects/optic/src/commands/diff/diff-all.ts
@@ -98,6 +98,11 @@ comma separated values (e.g. "**/*.yml,**/*.json")'
     .option('--web', 'view the diff in the optic changelog web view', false)
     .option('--json', 'output as json', false)
     .option(
+      '--include-uncommited-changes',
+      'include uncommitted changes and tag it against this spec. Use this if you generate specs in CI to upload. This option is generally not recommended for other cases as it means your uploaded spec may not match your git history.',
+      false
+    )
+    .option(
       '--fail-on-untracked-openapi',
       'fail with exit code 1 if there are detected untracked apis',
       false
@@ -113,6 +118,7 @@ type DiffAllActionOptions = {
   ignore?: string;
   headTag?: string;
   check: boolean;
+  includeUncommittedChanges: boolean;
   web: boolean;
   upload: boolean;
   json: boolean;
@@ -252,6 +258,7 @@ async function computeAll(
       toParseResults = await loadSpec(candidate.to, config, {
         strict: options.validation === 'strict',
         denormalize: true,
+        includeUncommittedChanges: options.includeUncommittedChanges,
       });
     } catch (e) {
       allWarnings.unparseableToSpec.push({

--- a/projects/optic/src/config.ts
+++ b/projects/optic/src/config.ts
@@ -10,6 +10,7 @@ import { logger } from './logger';
 
 export enum VCS {
   Git = 'git',
+  Cloud = 'cloud', // hosted in optic cloud
 }
 
 export const OPTIC_YML_NAME = 'optic.yml';

--- a/projects/optic/src/utils/cloud-specs.ts
+++ b/projects/optic/src/utils/cloud-specs.ts
@@ -3,7 +3,6 @@ import {
   CompareSpecResults,
   UserError,
   ApiCoverage,
-  sourcemapReader,
 } from '@useoptic/openapi-utilities';
 import { OpticBackendClient } from '../client';
 import { computeChecksumForAws } from './checksum';
@@ -24,6 +23,9 @@ export async function downloadSpec(
 ): Promise<{
   jsonLike: ParseResult['jsonLike'];
   sourcemap: ParseResult['sourcemap'];
+  spec: {
+    id: string;
+  };
 }> {
   const response = await opts.client.getSpec(spec.apiId, spec.tag);
 
@@ -34,6 +36,9 @@ export async function downloadSpec(
     return {
       jsonLike: spec,
       sourcemap,
+      spec: {
+        id: response.id,
+      },
     };
   } else {
     // fetch from cloud
@@ -46,6 +51,9 @@ export async function downloadSpec(
       sourcemap: JsonSchemaSourcemap.fromSerializedSourcemap(
         JSON.parse(sourcemapStr)
       ),
+      spec: {
+        id: response.id,
+      },
     };
   }
 }
@@ -99,10 +107,19 @@ export async function uploadSpec(
       }),
     ]);
 
-    const effective_at = opts.spec.context?.effective_at;
-    const git_name = opts.spec.context?.name;
-    const git_email = opts.spec.context?.email;
-    const commit_message = opts.spec.context?.message;
+    let effective_at: Date | undefined = undefined;
+    let git_name: string | undefined = undefined;
+    let git_email: string | undefined = undefined;
+    let commit_message: string | undefined = undefined;
+
+    if (opts.spec.context?.vcs === 'git') {
+      ({
+        effective_at,
+        name: git_name,
+        email: git_email,
+        message: commit_message,
+      } = opts.spec.context);
+    }
 
     const { id } = await opts.client.createSpec({
       upload_id: result.upload_id,

--- a/projects/optic/src/utils/spec-loaders.ts
+++ b/projects/optic/src/utils/spec-loaders.ts
@@ -22,14 +22,20 @@ import { OpticBackendClient } from '../client';
 
 const exec = promisify(callbackExec);
 
-export type ParseResultContext = {
-  vcs: 'git';
-  sha: string;
-  effective_at?: Date;
-  name: string;
-  email: string;
-  message: string;
-} | null;
+export type ParseResultContext =
+  | {
+      vcs: 'git';
+      sha: string;
+      effective_at?: Date;
+      name: string;
+      email: string;
+      message: string;
+    }
+  | {
+      vcs: 'cloud';
+      specId: string;
+    }
+  | null;
 
 export type ParseResult = ParseOpenAPIResult & {
   isEmptySpec: boolean;
@@ -183,7 +189,7 @@ async function parseSpecAndDereference(
     case 'cloud': {
       // try fetch from cloud, if 404 return an error
       // todo handle empty spec case
-      const { jsonLike, sourcemap } = await downloadSpec(
+      const { jsonLike, sourcemap, spec } = await downloadSpec(
         { apiId: input.apiId, tag: input.tag },
         config
       );
@@ -192,7 +198,10 @@ async function parseSpecAndDereference(
         sourcemap,
         from: 'cloud',
         isEmptySpec: false,
-        context: null,
+        context: {
+          vcs: 'cloud',
+          specId: spec.id,
+        },
       };
     }
     case 'git': {


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Two fixes:
- add an `--include-uncommitted-changes` flag to diff and diff-all
- the upload flow to handle cloud specs (i.e. we don't upload them, but instead we'll point at the already uploaded spec)

TODO
- [ ] write a test for this upload flow after https://github.com/opticdev/optic/pull/1882 lands

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
