### PR TITLE
Fix system proxy host case

### DIFF
--- a/projects/optic/src/commands/oas/captures/streams/sources/proxy.ts
+++ b/projects/optic/src/commands/oas/captures/streams/sources/proxy.ts
@@ -39,7 +39,7 @@ export class ProxyInteractions {
       targetCA?: Array<{ cert: Buffer | string }>;
     } = {}
   ): Promise<[ProxyInteractions, string, string]> {
-    let { host, protocol, origin: targetOrigin } = new URL(targetHost);
+    let { host, protocol } = new URL(targetHost);
     if (targetHost.includes('/')) {
       // accept urls to be passed in rather than pure hosts
       targetHost = host;
@@ -61,7 +61,7 @@ export class ProxyInteractions {
       },
     });
 
-    let forwardedHosts = [targetOrigin];
+    let forwardedHosts = [targetHost];
     await capturingProxy
       .forAnyRequest()
       .always()
@@ -94,7 +94,7 @@ export class ProxyInteractions {
       .thenPassThrough({
         beforeRequest: onTargetedRequest,
         forwarding: {
-          targetHost: targetOrigin,
+          targetHost: targetHost,
           // bug: updateHostHeader isn't rewriting the request header - we're manually rewriting this in `beforeRequest`
           updateHostHeader: true,
         },


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

One of the recent fixes to the `--reverse-proxy` mode broke the system proxy - turns out this was a red herring when debugging and we can remove it (https redirects weren't working because the host wasn't being forwarded, not because we were using the right origin).

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
