### PR TITLE
Fix diff-all --generated when no paths are fetched

### DIFF
--- a/projects/optic/src/commands/diff/diff-all.ts
+++ b/projects/optic/src/commands/diff/diff-all.ts
@@ -27,6 +27,7 @@ import { generateComparisonLogsV2 } from '../../utils/diff-renderer';
 import path from 'path';
 import { getApiUrl } from '../../utils/cloud-urls';
 import { getDetailsForGeneration } from '../../utils/generated';
+import * as Types from '../../client/optic-backend-types';
 
 const usage = () => `
   optic diff-all
@@ -283,10 +284,13 @@ async function computeAll(
           pathToUrl[p] = null;
         }
       }
-      const { apis } = await config.client.getApis(
-        Object.keys(pathToUrl),
-        web_url
-      );
+      let apis: (Types.Api | null)[] = [];
+      if (Object.keys(pathToUrl).length > 0) {
+        ({ apis } = await config.client.getApis(
+          Object.keys(pathToUrl),
+          web_url
+        ));
+      }
 
       for (const api of apis) {
         if (api) {


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

If no paths are fetched the endpoint returns a 400, we don't need to fetch anything here

TODO
- [ ] Bump version

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
