### PR TITLE
Allow rule error to throw a severity

### DIFF
--- a/projects/rulesets-base/src/__tests__/rule.test.ts
+++ b/projects/rulesets-base/src/__tests__/rule.test.ts
@@ -1,0 +1,73 @@
+import { test, expect, describe } from '@jest/globals';
+import { RuleRunner } from '../rule-runner';
+import { OperationRule } from '../rules';
+import { RuleError } from '../errors';
+import {
+  OpenAPIV3,
+  Severity,
+  defaultEmptySpec,
+} from '@useoptic/openapi-utilities';
+import { createRuleInputs } from '../test-helpers';
+
+describe('severity', () => {
+  const json: OpenAPIV3.Document = {
+    ...defaultEmptySpec,
+    paths: {
+      '/api/users': {
+        get: {
+          description: 'hello',
+          responses: {},
+        },
+      },
+    },
+  };
+
+  test('setting a severity on a rule', async () => {
+    const ruleName = 'operation description';
+    const ruleRunner = new RuleRunner([
+      new OperationRule({
+        name: ruleName,
+        severity: 'warn',
+        rule: (operationAssertions) => {
+          operationAssertions.requirement(() => {
+            throw new RuleError({
+              message: 'failed',
+            });
+          });
+        },
+      }),
+    ]);
+
+    const results = await ruleRunner.runRulesWithFacts(
+      createRuleInputs(json, json)
+    );
+    expect(results.length === 1).toBe(true);
+    expect(results[0].severity).toBe(Severity.Warn);
+    expect(results[0].error).toBeTruthy();
+  });
+
+  test('throwing severity in a rule implementation', async () => {
+    const ruleName = 'operation description';
+    const ruleRunner = new RuleRunner([
+      new OperationRule({
+        name: ruleName,
+        severity: 'warn',
+        rule: (operationAssertions) => {
+          operationAssertions.requirement(() => {
+            throw new RuleError({
+              message: 'failed',
+              severity: 'info',
+            });
+          });
+        },
+      }),
+    ]);
+
+    const results = await ruleRunner.runRulesWithFacts(
+      createRuleInputs(json, json)
+    );
+    expect(results.length === 1).toBe(true);
+    expect(results[0].severity).toBe(Severity.Info);
+    expect(results[0].error).toBeTruthy();
+  });
+});

--- a/projects/rulesets-base/src/errors.ts
+++ b/projects/rulesets-base/src/errors.ts
@@ -1,5 +1,8 @@
+import { Severity } from '@useoptic/openapi-utilities';
+
 type RuleConfig = {
   message: string;
+  severity?: Severity;
 } & (
   | {
       expected?: undefined;
@@ -13,9 +16,11 @@ type RuleConfig = {
 
 export class RuleError extends Error {
   public type: 'rule-error';
+  public severity?: Severity;
   constructor(public details: RuleConfig) {
     super(details.message);
     this.type = 'rule-error';
+    this.severity = details.severity;
     // https://github.com/Microsoft/TypeScript-wiki/blob/main/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
     Object.setPrototypeOf(this, RuleError.prototype);
   }

--- a/projects/rulesets-base/src/errors.ts
+++ b/projects/rulesets-base/src/errors.ts
@@ -1,8 +1,8 @@
-import { Severity } from '@useoptic/openapi-utilities';
+import { Severity, textToSev } from '@useoptic/openapi-utilities';
 
 type RuleConfig = {
   message: string;
-  severity?: Severity;
+  severity?: 'info' | 'warn' | 'error';
 } & (
   | {
       expected?: undefined;
@@ -20,7 +20,7 @@ export class RuleError extends Error {
   constructor(public details: RuleConfig) {
     super(details.message);
     this.type = 'rule-error';
-    this.severity = details.severity;
+    this.severity = details.severity && textToSev(details.severity);
     // https://github.com/Microsoft/TypeScript-wiki/blob/main/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
     Object.setPrototypeOf(this, RuleError.prototype);
   }

--- a/projects/rulesets-base/src/rule-runner/assertions.ts
+++ b/projects/rulesets-base/src/rule-runner/assertions.ts
@@ -212,7 +212,7 @@ class AssertionRunner<T extends AssertionType> implements Assertions<T> {
           if (RuleError.isInstance(e)) {
             results.push({
               passed: false,
-              severity: this.severity,
+              severity: e.severity ?? this.severity,
               exempted,
               changeOrFact: sanitizeChange(change),
               error: e.toString(),
@@ -254,7 +254,7 @@ class AssertionRunner<T extends AssertionType> implements Assertions<T> {
           if (RuleError.isInstance(e)) {
             results.push({
               passed: false,
-              severity: this.severity,
+              severity: e.severity ?? this.severity,
               exempted,
               changeOrFact: sanitizeFact(after),
               received: JSON.stringify(e.details.received),
@@ -290,7 +290,7 @@ class AssertionRunner<T extends AssertionType> implements Assertions<T> {
           if (RuleError.isInstance(e)) {
             results.push({
               passed: false,
-              severity: this.severity,
+              severity: e.severity ?? this.severity,
               exempted,
               changeOrFact: sanitizeChange(change),
               received: JSON.stringify(e.details.received),
@@ -327,7 +327,7 @@ class AssertionRunner<T extends AssertionType> implements Assertions<T> {
           if (RuleError.isInstance(e)) {
             results.push({
               passed: false,
-              severity: this.severity,
+              severity: e.severity ?? this.severity,
               exempted,
               changeOrFact: sanitizeChange(change),
               received: JSON.stringify(e.details.received),


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Support throwing a severity depending on condition for rule assertion - this would be used in something like:
```javascript
new OperationRule({
  name: ruleName,
  rule: (operationAssertions) => {
    operationAssertions.requirement(
      (operation) => {
        if (!operation.value['description']) {
          throw new RuleError({
            message: 'operation does not have `description`',
            severity: 'error',
          });
        } else if (operation.value['description'].startsWith(...)) {
          throw new RuleError({
            message: 'operation has some other thing that we want to warn on',
            severity: 'warn',
          });
        }
      }
    );
  },
})

```

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
