### PR TITLE
Update diff-all to pull from file system instead of git

### DIFF
--- a/projects/optic/src/commands/api/get-file-candidates.ts
+++ b/projects/optic/src/commands/api/get-file-candidates.ts
@@ -2,15 +2,17 @@ import fs from 'node:fs/promises';
 import path from 'path';
 
 export async function getFileCandidates(opts: {
-  startsWith: string;
+  root?: string;
+  startsWith?: string;
 }): Promise<string[]> {
+  const root = opts.root || process.cwd();
   const files: string[] = [];
-  const stack: string[] = [process.cwd()];
+  const stack: string[] = [root];
   while (stack.length > 0) {
     const dir: string = stack.pop()!;
     for (const file of await fs.readdir(dir, { withFileTypes: true })) {
       const absolutePath = path.join(dir, file.name);
-      if (!absolutePath.startsWith(opts.startsWith)) {
+      if (opts.startsWith && !absolutePath.startsWith(opts.startsWith)) {
         continue;
       }
 

--- a/projects/optic/src/commands/diff/diff-all.ts
+++ b/projects/optic/src/commands/diff/diff-all.ts
@@ -28,6 +28,7 @@ import path from 'path';
 import { getApiUrl } from '../../utils/cloud-urls';
 import { getDetailsForGeneration } from '../../utils/generated';
 import * as Types from '../../client/optic-backend-types';
+import { getFileCandidates } from '../api/get-file-candidates';
 
 const usage = () => `
   optic diff-all
@@ -622,7 +623,14 @@ const getDiffAllAction =
     let candidateMap: CandidateMap;
     let compareToCandidates: string[];
     try {
-      compareToCandidates = await findOpenApiSpecsCandidates(options.compareTo);
+      if (options.compareTo) {
+        compareToCandidates = await findOpenApiSpecsCandidates(
+          options.compareTo
+        );
+      } else {
+        const paths = await getFileCandidates({ root: config.root });
+        compareToCandidates = paths.map((p) => path.relative(process.cwd(), p));
+      }
     } catch (e) {
       logger.error(
         `Error reading files from git history for --compare-to ${options.compareTo}`


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Updates diff-all to pull from the file system instead of git. This means we will now pick up diff-all candidates outside of your git repository, specifically for the `--generated` flow when you don't want your generated spec to be part of your git repository

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
