### PR TITLE
feat(ci): build sea on mac ci hosts

### DIFF
--- a/.github/workflows/build-sea.yml
+++ b/.github/workflows/build-sea.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 16
           cache: yarn
 
       - name: Install Task

--- a/.github/workflows/build-sea.yml
+++ b/.github/workflows/build-sea.yml
@@ -1,0 +1,36 @@
+name: Build SEA
+on:
+  pull_request:
+  workflow_dispatch:
+  merge_group:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-sea:
+    runs-on: macos-13-xl
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: yarn
+
+      - name: Install Task
+        run: curl -sL https://taskfile.dev/install.sh | sudo bash -s -- -b /usr/local/bin/
+
+      - name: Build
+        run: task default
+
+      # build optic binaries. we don't do anything with them yet since theyre not being signed.
+      - name: Build packages
+        env:
+          # this is necessary while we build on intel macos hosts, since it can't generate arm64 bytecode
+          pkg_args: '--no-bytecode --public --public-packages "*"'
+        run: >
+          task pkg:build -- ${{ env.pkg_args }}
+
+      # sanity check
+      - run: ls -lah dist/
+      - run: dist/optic-macos-x64 --help

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,6 @@ on:
     branches:
       - main
 
-
 jobs:
   build:
     runs-on: ubuntu-latest-16-core

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,9 +23,3 @@ jobs:
 
       - name: Test
         run: task default test
-
-      # build optic binaries. we don't do anything with them yet, but we will soon. building them here
-      # to ensure the build process works. since this is a linux-host we only build for linux. eventually,
-      # we'll need something building on macos (and windows?) too.
-      - name: Build SEA
-        run: task pkg:build -- -t node18-linux-x64

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -125,7 +125,9 @@
       "node18-macos-arm64",
       "node18-macos-x64",
       "node18-linux-arm64",
-      "node18-linux-x64"
+      "node18-linux-x64",
+      "node18-win-arm64",
+      "node18-win-x64"
     ],
     "outputPath": "../../dist"
   }


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

adds a new workflow that builds binaries on a macOS host. this lets us cross-compile for arm64 and x64 for mac, linux, and windows. i was previously mistaken about not being able to be build for arm64 from intel macs, we just need to skip bytecode generation.

these executables are still for testing and the macOS builds aren't signed.

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._
- closes https://github.com/opticdev/monorail/issues/4261

## 👹 QA
_How can other humans verify that this PR is correct?_
