### PR TITLE
set cli name

### DIFF
--- a/projects/optic/src/init.ts
+++ b/projects/optic/src/init.ts
@@ -40,6 +40,7 @@ export const initCli = async (
     hideNotifier?: boolean;
   } = {}
 ): Promise<Command> => {
+  cli.name('optic');
   initSentry(process.env.SENTRY_URL, packageJson.version);
   initSegment(process.env.SEGMENT_KEY);
   cli.hook('preAction', async (command) => {


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Sets the cli name when the binary name is different to optic (e.g. local run, distributed packages)

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._
https://github.com/opticdev/monorail/issues/4266
## 👹 QA
_How can other humans verify that this PR is correct?_
