### PR TITLE
feat: add alpine linux targets for binaries

### DIFF
--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -126,6 +126,8 @@
       "node18-macos-x64",
       "node18-linux-arm64",
       "node18-linux-x64",
+      "node18-alpine-x64",
+      "node18-alpine-arm64",
       "node18-win-arm64",
       "node18-win-x64"
     ],


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

adds alpine linux build targets for the binaries.

```
➜ docker run --rm -v ./dist/:/dist -t alpine /dist/optic-alpine-arm64
Usage: optic [options] [command]
...
```

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
