### PR TITLE
Improve optic api add performance and allow --all --history_depth > 1

### DIFF
--- a/projects/optic/specs/test-spec.yml
+++ b/projects/optic/specs/test-spec.yml
@@ -19,4 +19,4 @@ paths:
                     type: number
                     format: uuid
                     example: d5b640e5-d88c-4c17-9bf0-93597b7a1ce2
-x-optic-url: https://app.o3c.info/organizations/88c4a2a7-b90f-431e-8017-fddcb0d78b46/apis/fuW9bqmOqqYayXYoPpy4B
+

--- a/projects/optic/src/commands/api/add.ts
+++ b/projects/optic/src/commands/api/add.ts
@@ -311,16 +311,6 @@ export const getApiAddAction =
       return;
     }
 
-    if (file.isDir && options.historyDepth !== '1') {
-      logger.error(
-        chalk.red(
-          'Invalid argument combination: Cannot set a history-depth !== 1 when no spec path is provided'
-        )
-      );
-      process.exitCode = 1;
-      return;
-    }
-
     const orgRes = await getOrganizationFromToken(
       config.client,
       'Select the organization you want to add APIs to'
@@ -397,6 +387,7 @@ export const getApiAddAction =
           )
         : await GitCandidates.getPathCandidatesForSha(config.vcs.sha, {
             startsWith: file.path,
+            depth: options.historyDepth,
           });
     } else {
       const files = !file.isDir

--- a/projects/optic/src/commands/api/add.ts
+++ b/projects/optic/src/commands/api/add.ts
@@ -221,16 +221,14 @@ async function crawlCandidateSpecs(
       specsToTag.push([specId, sha, effective_at]);
     }
 
-    if (!alreadyTracked) {
-      const branch = await Git.getCurrentBranchName();
-      const tag = [sanitizeGitTag(`gitbranch:${branch}`)];
-      for (const [specId, sha, effective_at] of [...specsToTag].reverse()) {
-        spinner.text = `${chalk.bold.blue(specName)} version ${sha.substring(
-          0,
-          6
-        )} tagging`;
-        await config.client.tagSpec(specId, tag, effective_at);
-      }
+    const branch = await Git.getCurrentBranchName();
+    const tag = [sanitizeGitTag(`gitbranch:${branch}`)];
+    for (const [specId, sha, effective_at] of [...specsToTag].reverse()) {
+      spinner.text = `${chalk.bold.blue(specName)} version ${sha.substring(
+        0,
+        6
+      )} tagging`;
+      await config.client.tagSpec(specId, tag, effective_at);
     }
   } else {
     // Outside of a git repo, we should just upload it as a spec without tags

--- a/projects/optic/src/utils/cloud-specs.ts
+++ b/projects/optic/src/utils/cloud-specs.ts
@@ -75,12 +75,24 @@ export async function uploadSpec(
     orgId: string;
     // Sets spec_tag.effective_at to spec.effective_at instead of current date
     forward_effective_at_to_tags?: boolean;
+    precomputed?: {
+      specString?: string;
+      specChecksum?: string;
+      sourcemapString?: string;
+      sourcemapChecksum?: string;
+    };
   }
 ): Promise<string> {
-  const stableSpecString = stableStringify(opts.spec.jsonLike);
-  const stableSourcemapString = stableStringify(opts.spec.sourcemap);
-  const spec_checksum = computeChecksumForAws(stableSpecString);
-  const sourcemap_checksum = computeChecksumForAws(stableSourcemapString);
+  const stableSpecString =
+    opts.precomputed?.specString ?? stableStringify(opts.spec.jsonLike);
+  const stableSourcemapString =
+    opts.precomputed?.specChecksum ?? stableStringify(opts.spec.sourcemap);
+  const spec_checksum =
+    opts.precomputed?.sourcemapString ??
+    computeChecksumForAws(stableSpecString);
+  const sourcemap_checksum =
+    opts.precomputed?.sourcemapChecksum ??
+    computeChecksumForAws(stableSourcemapString);
   let result: Awaited<ReturnType<typeof opts.client.prepareSpecUpload>>;
   const tags = opts.tags.filter((tag, ndx) => opts.tags.indexOf(tag) === ndx);
 

--- a/projects/optic/src/utils/cloud-specs.ts
+++ b/projects/optic/src/utils/cloud-specs.ts
@@ -86,10 +86,9 @@ export async function uploadSpec(
   const stableSpecString =
     opts.precomputed?.specString ?? stableStringify(opts.spec.jsonLike);
   const stableSourcemapString =
-    opts.precomputed?.specChecksum ?? stableStringify(opts.spec.sourcemap);
+    opts.precomputed?.sourcemapString ?? stableStringify(opts.spec.sourcemap);
   const spec_checksum =
-    opts.precomputed?.sourcemapString ??
-    computeChecksumForAws(stableSpecString);
+    opts.precomputed?.specChecksum ?? computeChecksumForAws(stableSpecString);
   const sourcemap_checksum =
     opts.precomputed?.sourcemapChecksum ??
     computeChecksumForAws(stableSourcemapString);

--- a/projects/optic/src/utils/git-utils.ts
+++ b/projects/optic/src/utils/git-utils.ts
@@ -72,6 +72,21 @@ export const getCurrentBranchName = async (): Promise<string> =>
     exec(command, cb);
   });
 
+export const getMergeBase = async (
+  branch1: string,
+  branch2: string
+): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const cb = (err: unknown, stdout: string, stderr: string) => {
+      if (err || stderr || !stdout) reject();
+      resolve(stdout.trim());
+    };
+
+    const command = `git merge-base ${branch1} ${branch2}`;
+    exec(command, cb);
+  });
+};
+
 export const getRootPath = async (): Promise<string> =>
   new Promise((resolve, reject) => {
     const cb = (err: unknown, stdout: string, stderr: string) => {


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Couple of things
- Removes the constraint to add `optic api add --all` and `history_depth > 1`
- Skips specs that have identical checksums
- Tags the branch with the default branch rather than the current branch

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
