### PR TITLE
Allow exit on backfill anytime for api add

### DIFF
--- a/projects/optic/src/__tests__/integration/__snapshots__/api-add.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/api-add.test.ts.snap
@@ -4,9 +4,13 @@ exports[`optic api add git - no cli interaction discover all files in a folder 1
 "
 
 [1m[90mLooking for OpenAPI specs in directory $workspace$/nested[39m[22m
-- Found OpenAPI at nested/speccopy2.yml
-[32m✔[39m [1m[34ma spec[39m[22m is now being tracked.
-  [1mView history: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
+[1m[32m✔[39m[22m [1m[34ma spec[39m[22m is now being tracked.
+  [1mView: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
+
+[34m[1mBackfilling API history, you can exit at any time (\`ctrl + c\`) and finish this later.[22m[39m
+
+[1m[90mBackfilling history for nested/speccopy2.yml[39m[22m
+[32m✔[39m [1m[34ma spec[39m[22m history backfilled
 
 [34m[1mx-optic-url has been added to newly tracked specs. You should commit these changes.[22m[39m
 
@@ -18,15 +22,23 @@ exports[`optic api add git - no cli interaction discover all files in repo 1`] =
 "
 
 [1m[90mLooking for OpenAPI specs in directory $workspace$[39m[22m
-- Found OpenAPI at example-api-v0.json
-[32m✔[39m [1m[34mEmpty[39m[22m is now being tracked.
-  [1mView history: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
-- Found OpenAPI at nested/speccopy2.yml
-[32m✔[39m [1m[34ma spec[39m[22m is now being tracked.
-  [1mView history: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
-- Found OpenAPI at spec.yml
-[32m✔[39m [1m[34ma spec[39m[22m is now being tracked.
-  [1mView history: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
+[1m[32m✔[39m[22m [1m[34mEmpty[39m[22m is now being tracked.
+  [1mView: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
+[1m[32m✔[39m[22m [1m[34ma spec[39m[22m is now being tracked.
+  [1mView: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
+[1m[32m✔[39m[22m [1m[34ma spec[39m[22m is now being tracked.
+  [1mView: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
+
+[34m[1mBackfilling API history, you can exit at any time (\`ctrl + c\`) and finish this later.[22m[39m
+
+[1m[90mBackfilling history for example-api-v0.json[39m[22m
+[32m✔[39m [1m[34mEmpty[39m[22m history backfilled
+
+[1m[90mBackfilling history for nested/speccopy2.yml[39m[22m
+[32m✔[39m [1m[34ma spec[39m[22m history backfilled
+
+[1m[90mBackfilling history for spec.yml[39m[22m
+[32m✔[39m [1m[34ma spec[39m[22m history backfilled
 
 [34m[1mx-optic-url has been added to newly tracked specs. You should commit these changes.[22m[39m
 
@@ -38,15 +50,23 @@ exports[`optic api add git - no cli interaction discover all files in repo using
 "
 
 [1m[90mLooking for OpenAPI specs in directory $workspace$[39m[22m
-- Found OpenAPI at example-api-v0.json
-[32m✔[39m [1m[34mEmpty[39m[22m is now being tracked.
-  [1mView history: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
-- Found OpenAPI at nested/speccopy2.yml
-[32m✔[39m [1m[34ma spec[39m[22m is now being tracked.
-  [1mView history: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
-- Found OpenAPI at spec.yml
-[32m✔[39m [1m[34ma spec[39m[22m is now being tracked.
-  [1mView history: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
+[1m[32m✔[39m[22m [1m[34mEmpty[39m[22m is now being tracked.
+  [1mView: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
+[1m[32m✔[39m[22m [1m[34ma spec[39m[22m is now being tracked.
+  [1mView: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
+[1m[32m✔[39m[22m [1m[34ma spec[39m[22m is now being tracked.
+  [1mView: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
+
+[34m[1mBackfilling API history, you can exit at any time (\`ctrl + c\`) and finish this later.[22m[39m
+
+[1m[90mBackfilling history for example-api-v0.json[39m[22m
+[32m✔[39m [1m[34mEmpty[39m[22m history backfilled
+
+[1m[90mBackfilling history for nested/speccopy2.yml[39m[22m
+[32m✔[39m [1m[34ma spec[39m[22m history backfilled
+
+[1m[90mBackfilling history for spec.yml[39m[22m
+[32m✔[39m [1m[34ma spec[39m[22m history backfilled
 
 [34m[1mx-optic-url has been added to newly tracked specs. You should commit these changes.[22m[39m
 
@@ -58,9 +78,13 @@ exports[`optic api add git - no cli interaction discover one file with history d
 "
 
 [1m[90mAdding API $workspace$/spec.yml[39m[22m
-- Found OpenAPI at spec.yml
-[32m✔[39m [1m[34ma spec[39m[22m is now being tracked.
-  [1mView history: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
+[1m[32m✔[39m[22m [1m[34ma spec[39m[22m is now being tracked.
+  [1mView: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
+
+[34m[1mBackfilling API history, you can exit at any time (\`ctrl + c\`) and finish this later.[22m[39m
+
+[1m[90mBackfilling history for spec.yml[39m[22m
+[32m✔[39m [1m[34ma spec[39m[22m history backfilled
 
 [34m[1mx-optic-url has been added to newly tracked specs. You should commit these changes.[22m[39m
 
@@ -98,9 +122,8 @@ exports[`optic api add no vcs - no cli interaction discover all files in a folde
 "
 
 [1m[90mLooking for OpenAPI specs in directory $workspace$/nested[39m[22m
-- Found OpenAPI at nested/speccopy2.yml
-[32m✔[39m [1m[34ma spec[39m[22m is now being tracked.
-  [1mView history: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
+[1m[32m✔[39m[22m [1m[34ma spec[39m[22m is now being tracked.
+  [1mView: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
 
 [34m[1mx-optic-url has been added to newly tracked specs. You should commit these changes.[22m[39m
 
@@ -112,15 +135,12 @@ exports[`optic api add no vcs - no cli interaction discover all files in repo 1`
 "
 
 [1m[90mLooking for OpenAPI specs in directory $workspace$[39m[22m
-- Found OpenAPI at example-api-v0.json
-[32m✔[39m [1m[34mEmpty[39m[22m is now being tracked.
-  [1mView history: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
-- Found OpenAPI at spec.yml
-[32m✔[39m [1m[34ma spec[39m[22m is now being tracked.
-  [1mView history: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
-- Found OpenAPI at nested/speccopy2.yml
-[32m✔[39m [1m[34ma spec[39m[22m is now being tracked.
-  [1mView history: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
+[1m[32m✔[39m[22m [1m[34mEmpty[39m[22m is now being tracked.
+  [1mView: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
+[1m[32m✔[39m[22m [1m[34ma spec[39m[22m is now being tracked.
+  [1mView: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
+[1m[32m✔[39m[22m [1m[34ma spec[39m[22m is now being tracked.
+  [1mView: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
 
 [34m[1mx-optic-url has been added to newly tracked specs. You should commit these changes.[22m[39m
 
@@ -132,15 +152,12 @@ exports[`optic api add no vcs - no cli interaction discover all files in repo us
 "
 
 [1m[90mLooking for OpenAPI specs in directory $workspace$[39m[22m
-- Found OpenAPI at example-api-v0.json
-[32m✔[39m [1m[34mEmpty[39m[22m is now being tracked.
-  [1mView history: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
-- Found OpenAPI at spec.yml
-[32m✔[39m [1m[34ma spec[39m[22m is now being tracked.
-  [1mView history: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
-- Found OpenAPI at nested/speccopy2.yml
-[32m✔[39m [1m[34ma spec[39m[22m is now being tracked.
-  [1mView history: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
+[1m[32m✔[39m[22m [1m[34mEmpty[39m[22m is now being tracked.
+  [1mView: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
+[1m[32m✔[39m[22m [1m[34ma spec[39m[22m is now being tracked.
+  [1mView: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
+[1m[32m✔[39m[22m [1m[34ma spec[39m[22m is now being tracked.
+  [1mView: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
 
 [34m[1mx-optic-url has been added to newly tracked specs. You should commit these changes.[22m[39m
 
@@ -152,9 +169,8 @@ exports[`optic api add no vcs - no cli interaction discover one file with histor
 "
 
 [1m[90mAdding API $workspace$/spec.yml[39m[22m
-- Found OpenAPI at spec.yml
-[32m✔[39m [1m[34ma spec[39m[22m is now being tracked.
-  [1mView history: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
+[1m[32m✔[39m[22m [1m[34ma spec[39m[22m is now being tracked.
+  [1mView: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
 
 [34m[1mx-optic-url has been added to newly tracked specs. You should commit these changes.[22m[39m
 

--- a/projects/optic/src/commands/api/add.ts
+++ b/projects/optic/src/commands/api/add.ts
@@ -78,7 +78,7 @@ type ApiAddActionOptions = {
   all: boolean;
 };
 
-async function crawlCandidateSpecs(
+async function initializeApi(
   orgId: string,
   [file_path, shas]: [string, string[]],
   config: OpticCliConfig,
@@ -90,7 +90,6 @@ async function crawlCandidateSpecs(
     web_url?: string;
   }
 ) {
-  const uploadedChecksums = new Set<string>();
   const pathRelativeToRoot = path.relative(config.root, file_path);
   let parseResult: ParseResult;
   try {
@@ -120,17 +119,13 @@ async function crawlCandidateSpecs(
     );
     return;
   }
-
-  const spinner = ora(`Found OpenAPI at ${pathRelativeToRoot}`);
-  spinner.start();
-  spinner.color = 'blue';
+  const specName = parseResult.jsonLike.info.title || pathRelativeToRoot;
 
   const existingOpticUrl: string | undefined =
     parseResult.jsonLike[OPTIC_URL_KEY];
   const maybeParsedUrl = existingOpticUrl
     ? getApiFromOpticUrl(existingOpticUrl)
     : null;
-  const specName = parseResult.jsonLike.info.title || pathRelativeToRoot;
 
   let alreadyTracked = false;
 
@@ -151,6 +146,77 @@ async function crawlCandidateSpecs(
       url: getApiUrl(config.client.getWebBase(), orgId, id),
     };
   }
+  await uploadSpec(api.id, {
+    spec: parseResult,
+    tags: [],
+    client: config.client,
+    orgId,
+  });
+
+  // Write to file only if optic-url is not set or is invalid
+  if (!existingOpticUrl || !maybeParsedUrl) {
+    if (/.json/i.test(file_path)) {
+      await writeJson(file_path, {
+        [OPTIC_URL_KEY]: api.url,
+      });
+    } else {
+      await writeYml(file_path, {
+        [OPTIC_URL_KEY]: api.url,
+      });
+    }
+    logger.debug(`Added spec ${pathRelativeToRoot} to ${api.url}`);
+
+    trackEvent('api.added', {
+      apiId: api.id,
+      orgId: orgId,
+      url: api.url,
+    });
+
+    if (options.web) {
+      await open(api.url, { wait: false });
+    }
+  } else {
+    logger.debug(
+      `Spec ${pathRelativeToRoot} has already been added at ${api.url}`
+    );
+  }
+
+  logger.info(
+    `${chalk.bold.green('✔')} ${chalk.bold.blue(specName)} ${
+      alreadyTracked ? 'is already being tracked' : 'is now being tracked'
+    }.\n  ${chalk.bold(`View: ${chalk.underline(api.url)}`)}`
+  );
+
+  return {
+    specName,
+    api,
+    candidate: [file_path, shas] as [string, string[]],
+  };
+}
+
+async function backfillHistory(
+  orgId: string,
+  apiDetails: NonNullable<Awaited<ReturnType<typeof initializeApi>>>,
+  config: OpticCliConfig,
+  options: {
+    path_to_spec: string | undefined;
+    web?: boolean;
+    default_branch: string;
+    default_tag?: string | undefined;
+    web_url?: string;
+  }
+) {
+  const {
+    api,
+    candidate: [file_path, shas],
+    specName,
+  } = apiDetails;
+  const uploadedChecksums = new Set<string>();
+  const pathRelativeToRoot = path.relative(config.root, file_path);
+
+  const spinner = ora(`Found OpenAPI at ${pathRelativeToRoot}`);
+  spinner.start();
+  spinner.color = 'blue';
 
   if (config.vcs?.type === VCS.Git) {
     const currentBranch = await Git.getCurrentBranchName();
@@ -167,16 +233,6 @@ async function crawlCandidateSpecs(
       branchToUseForTag = options.default_branch;
     }
 
-    // If the git workspace is dirty, we should upload the spec with changes
-    // such that first use of optic you will have a spec (even without tags)
-    if (specHasUncommittedChanges(parseResult.sourcemap, config.vcs.diffSet)) {
-      await uploadSpec(api.id, {
-        spec: parseResult,
-        tags: [],
-        client: config.client,
-        orgId,
-      });
-    }
     const specsToTag: [string, string, Date | undefined][] = [];
     for await (const sha of shas) {
       if (mergeBaseSha === sha) {
@@ -247,49 +303,7 @@ async function crawlCandidateSpecs(
       )} tagging`;
       await config.client.tagSpec(specId, tags, effective_at);
     }
-  } else {
-    // Outside of a git repo, we should just upload it as a spec without tags
-    await uploadSpec(api.id, {
-      spec: parseResult,
-      tags: [],
-      client: config.client,
-      orgId,
-    });
   }
-
-  // Write to file only if optic-url is not set or is invalid
-  if (!existingOpticUrl || !maybeParsedUrl) {
-    if (/.json/i.test(file_path)) {
-      await writeJson(file_path, {
-        [OPTIC_URL_KEY]: api.url,
-      });
-    } else {
-      await writeYml(file_path, {
-        [OPTIC_URL_KEY]: api.url,
-      });
-    }
-    logger.debug(`Added spec ${pathRelativeToRoot} to ${api.url}`);
-
-    trackEvent('api.added', {
-      apiId: api.id,
-      orgId: orgId,
-      url: api.url,
-    });
-
-    if (options.web) {
-      await open(api.url, { wait: false });
-    }
-  } else {
-    logger.debug(
-      `Spec ${pathRelativeToRoot} has already been added at ${api.url}`
-    );
-  }
-
-  spinner.succeed(
-    `${chalk.bold.blue(specName)} ${
-      alreadyTracked ? 'already being tracked' : 'is now being tracked'
-    }.\n  ${chalk.bold(`View history: ${chalk.underline(api.url)}`)}`
-  );
 }
 
 export const getApiAddAction =
@@ -433,22 +447,45 @@ export const getApiAddAction =
       candidates = new Map(files.map((f) => [f, []]));
     }
 
+    const apisToBackfill: NonNullable<
+      Awaited<ReturnType<typeof initializeApi>>
+    >[] = [];
     for await (const candidate of candidates) {
-      await crawlCandidateSpecs(orgRes.org.id, candidate, config, {
+      const api = await initializeApi(orgRes.org.id, candidate, config, {
         path_to_spec: file?.path,
         web: options.web,
         default_branch,
         default_tag,
         web_url,
       });
+
+      if (api && api.candidate[1].length > 0) {
+        apisToBackfill.push(api);
+      }
     }
 
-    logger.info('');
-    logger.info(
-      chalk.blue.bold(
-        `x-optic-url has been added to newly tracked specs. You should commit these changes.`
-      )
-    );
+    if (apisToBackfill.length > 0) {
+      logger.info(``);
+      logger.info(
+        chalk.blue.bold(
+          `x-optic-url has been added to newly tracked specs. You should commit these changes.`
+        )
+      );
+      logger.info(
+        chalk.blue.bold(
+          'Backfilling API history, you can exit at any time (`ctrl + c`) and fill history later by rerunning this command.'
+        )
+      );
+      for (const api of apisToBackfill) {
+        await backfillHistory(orgRes.org.id, api, config, {
+          path_to_spec: file?.path,
+          web: options.web,
+          default_branch,
+          default_tag,
+          web_url,
+        });
+      }
+    }
 
     logger.info('');
     logger.info(chalk.blue.bold(`Setup CI checks by running "optic ci setup"`));


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Updates optic api add to front load api creation so that a user can exit backfilling at any time.

In the future we should also update our backfilling so that we're backfilling reverse chronological order for every spec in the current working dir, but that'll take a little bit more work to do


```
➜  optic git:(allow-exit-anytime-for-api-add) ✗ OPTIC_ENV=local yarn run local:run api add specs/ --history-depth=10


Looking for OpenAPI specs in directory /projects/optic/specs
✔ Swagger Petstore is now being tracked.
  View: http://localhost:3001/organizations/b5ea9384-702c-4de1-ad55-75d45dc34295/apis/E1O4m8TGWmuteKlRV2EE5
✔ Swagger Petstore is now being tracked.
  View: http://localhost:3001/organizations/b5ea9384-702c-4de1-ad55-75d45dc34295/apis/2yLQdn08-Z55D5z5540zE
✔ a spec is now being tracked.
  View: http://localhost:3001/organizations/b5ea9384-702c-4de1-ad55-75d45dc34295/apis/HrIppzlIXt8hAwIAw9_em

Backfilling API history, you can exit at any time (`ctrl + c`) and finish this later.

Backfilling history for projects/optic/specs/smallpetstore0.json
✔ Swagger Petstore history backfilled

Backfilling history for projects/optic/specs/smallpetstore1.json
✔ Swagger Petstore history backfilled

Backfilling history for projects/optic/specs/test-spec.yml
✔ a spec history backfilled

x-optic-url has been added to newly tracked specs. You should commit these changes.

Setup CI checks by running "optic ci setup"
```

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
