### PR TITLE
mapping component bundle fix

### DIFF
--- a/projects/optic/src/commands/bundle/bundle.ts
+++ b/projects/optic/src/commands/bundle/bundle.ts
@@ -660,7 +660,7 @@ async function bundleMatchingRefsAsComponents<T>(
               {
                 op: 'replace',
                 path: obj.pointer,
-                value: refFound.componentPath,
+                value: '#' + refFound.componentPath,
               },
             ]);
           }


### PR DESCRIPTION
## 🍗 Description
fixes a bug with mapping bundling. Was missing a `#` before the pointer. Wasn't caught by lint or tests since these aren't really $refs

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
