### PR TITLE
chore: only build linuxstatic for linux, rename binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           task pkg:build -- \
-            -t node18-linux-arm64,node18-linux-x64,node18-alpine-arm64,node18-alpine-x64,node18-win-arm64,node18-win-x64 \
+            -t node18-linuxstatic-arm64,node18-linuxstatic-x64,node18-win-arm64,node18-win-x64 \
             --no-bytecode --public --public-packages "*"
           task pkg:archive pkg:upload
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -105,6 +105,35 @@ tasks:
     cmds:
       - task: build
       - npx --yes pkg package.json {{.CLI_ARGS}}
+      - task: pkg:rename
+
+  pkg:rename:
+    cmds:
+      # rename linuxstatic to linux
+      - |
+        for file in $(find ./dist -maxdepth 1 -iname '*linuxstatic*'); do
+          new_name=${file//linuxstatic/linux}
+          mv "$file" "$new_name"
+        done
+      # rename macos to darwin
+      - |
+        for file in $(find ./dist -maxdepth 1 -iname '*macos*'); do
+          new_name=${file//macos/darwin}
+          mv "$file" "$new_name"
+        done
+      # rename win to windows
+      - |
+        for file in $(find ./dist -maxdepth 1 -iname '*-win-*'); do
+          new_name=${file//win/windows}
+          mv "$file" "$new_name"
+        done
+      # rename x64 to amd64
+      - |
+        for file in $(find ./dist -maxdepth 1 -iname '*x64*'); do
+          new_name=${file//x64/amd64}
+          mv "$file" "$new_name"
+        done
+      - ls -l dist
 
   pkg:clean:
     cmds:
@@ -114,7 +143,7 @@ tasks:
     cmds:
       - mkdir -p dist/archives
       - |
-        for bin in $(find ./dist -maxdepth 1 -iregex '.*-win-.*' -or -iregex '.*-linux-.*' -or -iregex '.*-alpine-.*'); do
+        for bin in $(find ./dist -maxdepth 1 -type f); do
           name=$(basename "$bin")
           tar -czvf ./dist/archives/${name}.tar.gz -C dist $name
         done

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -124,10 +124,8 @@
     "targets": [
       "node18-macos-arm64",
       "node18-macos-x64",
-      "node18-linux-arm64",
-      "node18-linux-x64",
-      "node18-alpine-x64",
-      "node18-alpine-arm64",
+      "node18-linuxstatic-arm64",
+      "node18-linuxstatic-x64",
       "node18-win-arm64",
       "node18-win-x64"
     ],


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

- linux: rather than producing one statically and one dynamically linked binary, just build the former. it should run everywhere.
    ```
    ➜ docker run -it --rm -v ./dist/:/dist -t alpine /dist/optic-linux-arm64 --help &>/dev/null ; echo $status
    0

    ➜ docker run -it --rm -v ./dist/:/dist -t ubuntu /dist/optic-linux-arm64 --help &>/dev/null ; echo $status
    0
    ```
- renames binaries so that the arch and OS matches valid GOARCH/GOOS values. this might seem like an odd choice, but Go has well established and widely used defaults for these values. additionally, there's a good set of open-source shell functions that also uses those defaults for platform detection.

ultimately, both of these changes will make it simpler to create an install script that does platform detection.

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
