### PR TITLE
chore(ci): fix set-output deprecation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
         run: |
           v=$(jq -r .version < package.json)
           echo "VERSION=$v" >> $GITHUB_ENV
-          echo "::set-output name=optic_version::$v"
+          echo "optic_version=${v}" >> $GITHUB_OUTPUT
 
       - name: Publish NPM
         run: |


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._
closes https://github.com/opticdev/optic/issues/1915

## 👹 QA
_How can other humans verify that this PR is correct?_
