### PR TITLE
Fix patch logic invalid reference token

### DIFF
--- a/projects/optic/src/commands/oas/shapes/patches/generators/additionalProperties.ts
+++ b/projects/optic/src/commands/oas/shapes/patches/generators/additionalProperties.ts
@@ -94,5 +94,6 @@ export function* additionalPropertiesPatches(
         : PatchImpact.BackwardsIncompatible,
     ],
     groupedOperations,
+    shouldRegeneratePatches: false,
   };
 }

--- a/projects/optic/src/commands/oas/shapes/patches/generators/newSchema.ts
+++ b/projects/optic/src/commands/oas/shapes/patches/generators/newSchema.ts
@@ -26,5 +26,6 @@ export function newSchemaPatch(
         : PatchImpact.BackwardsIncompatible, // @acunnife, adding a new body to an existing request is backwards-incompatible, right?
     ],
     groupedOperations,
+    shouldRegeneratePatches: false,
   };
 }

--- a/projects/optic/src/commands/oas/shapes/patches/generators/oneOf.ts
+++ b/projects/optic/src/commands/oas/shapes/patches/generators/oneOf.ts
@@ -47,5 +47,6 @@ export function* oneOfPatches(
         : PatchImpact.BackwardsIncompatible,
     ],
     groupedOperations,
+    shouldRegeneratePatches: false,
   };
 }

--- a/projects/optic/src/commands/oas/shapes/patches/generators/required.ts
+++ b/projects/optic/src/commands/oas/shapes/patches/generators/required.ts
@@ -67,6 +67,7 @@ export function* requiredPatches(
     groupedOperations: [
       ...makeOptionalOperations(requiredArray.indexOf(diff.key)),
     ],
+    shouldRegeneratePatches: false,
   };
   if (makeOptionalPatch.groupedOperations.length > 0) {
     yield makeOptionalPatch;
@@ -87,5 +88,6 @@ export function* requiredPatches(
       ...makeOptionalOperations(requiredArray.indexOf(diff.key)),
       ...removePropertyOperations(diff.parentObjectPath, diff.key),
     ],
+    shouldRegeneratePatches: false,
   };
 }

--- a/projects/optic/src/commands/oas/shapes/patches/generators/type.ts
+++ b/projects/optic/src/commands/oas/shapes/patches/generators/type.ts
@@ -105,6 +105,7 @@ export function* typePatches(
             value: true,
           }),
         ],
+        shouldRegeneratePatches: false,
       };
     } else {
       // option one: convert to a one-off
@@ -120,6 +121,7 @@ export function* typePatches(
             : PatchImpact.BackwardsIncompatible,
         ],
         groupedOperations: makeOneOfOperations(),
+        shouldRegeneratePatches: true,
       };
 
       // option two: change the type
@@ -128,6 +130,7 @@ export function* typePatches(
         description: `change type of ${diff.key}`,
         impact: [PatchImpact.BackwardsIncompatible],
         groupedOperations: changeTypeOperations(),
+        shouldRegeneratePatches: false,
       };
     }
   } else if (openAPIVersion === '3.1.x') {
@@ -157,6 +160,7 @@ export function* typePatches(
             value: schemaType,
           }),
         ],
+        shouldRegeneratePatches: false,
       };
     } else {
       yield {
@@ -171,6 +175,7 @@ export function* typePatches(
             : PatchImpact.BackwardsIncompatible,
         ],
         groupedOperations: makeOneOfOperations(),
+        shouldRegeneratePatches: true,
       };
 
       // option two: change the type
@@ -179,6 +184,7 @@ export function* typePatches(
         description: `change type of ${diff.key}`,
         impact: [PatchImpact.BackwardsIncompatible],
         groupedOperations: changeTypeOperations(),
+        shouldRegeneratePatches: false,
       };
     }
   }

--- a/projects/optic/src/commands/oas/shapes/patches/index.ts
+++ b/projects/optic/src/commands/oas/shapes/patches/index.ts
@@ -32,6 +32,7 @@ export interface ShapePatch {
   diff: ShapeDiffResult | OperationDiffResult | undefined;
   impact: PatchImpact[];
   groupedOperations: PatchOperationGroup[];
+  shouldRegeneratePatches?: boolean;
 }
 
 export class ShapePatch {

--- a/projects/optic/src/commands/oas/shapes/streams/patches.ts
+++ b/projects/optic/src/commands/oas/shapes/streams/patches.ts
@@ -37,10 +37,9 @@ export class ShapePatches {
       let shapeDiffs = diffBodyBySchema(body, schema);
 
       let patchCount = 0;
+      let shouldRegenerate = false;
 
       for (let shapeDiff of shapeDiffs) {
-        // consuming Result<ShapeDiffs> directly ignores any schema compilation errors
-        // TODO: consider making this more explicit
         let diffPatches = generateShapePatchesByDiff(
           shapeDiff,
           schema,
@@ -57,7 +56,10 @@ export class ShapePatches {
 
           schema = Schema.applyShapePatch(schema, patch);
           yield patch;
+          // If the patch changes the structure of the schema (e.g. removes / replaces with oneOf), we need to regenerate the patches because the target json path could have moved
+          if (patch.shouldRegeneratePatches) shouldRegenerate = true;
         }
+        if (shouldRegenerate) break;
       }
       patchesExhausted = patchCount === 0;
     }


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

What a journey, this is caused when our patch engine has multiple patches from a diff from data it see, where one of it will refactor / rewrite a path that we've generated a json path for.

Consider this example:
- we have an object with property `key` which generates the patches convert to `oneOf` and make key optional
- when we apply the patch convert to `oneOf`, the make key optional patch has the incorrect jsonKey, which means we need to regenerate the subsequent patch.

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

https://github.com/opticdev/optic/issues/1929

## 👹 QA
_How can other humans verify that this PR is correct?_

```
yarn run local:run new openapi.yml
yarn run local:run update openapi.yml --all --har (har from issue)
```
