### PR TITLE
Fix diff-all error rendering to hide stacktrace of user error

### DIFF
--- a/projects/optic/src/commands/diff/diff-all.ts
+++ b/projects/optic/src/commands/diff/diff-all.ts
@@ -512,7 +512,7 @@ function handleWarnings(
 
     for (const unparseableFrom of warnings.unparseableFromSpec) {
       logger.error(`spec: ${unparseableFrom.path}`);
-      logger.error(unparseableFrom.error);
+      logger.error((unparseableFrom.error as Error).message);
       logger.error('');
     }
   }
@@ -530,7 +530,7 @@ function handleWarnings(
 
     for (const unparseableTo of warnings.unparseableToSpec) {
       logger.error(`spec: ${unparseableTo.path}`);
-      logger.error(unparseableTo.error);
+      logger.error((unparseableTo.error as Error).message);
       logger.error('');
     }
     process.exitCode = 1;


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

In these sorts of errors:
```
Error - the following specs could not be parsed from the current working directory
spec: specs/test-spec.yml
ValidationError: invalid openapi: paths > /filler_route > post > responses > 201 must NOT have additional properties
10 | responses:
11 |   "201":
12 |     description: Created successfully
13 |     application/json:
14 |       schema:
15 |         type: object
16 |         properties:
/Users/nicholaslim/Desktop/repos/optic/projects/optic/specs/test-spec.yml
    at new ValidationError (/Users/nicholaslim/Desktop/repos/optic/projects/openapi-io/src/validation/errors.ts:3:5)
    at validateOpenApiV3Document (/Users/nicholaslim/Desktop/repos/optic/projects/openapi-io/src/validation/validator.ts:154:11)
    at validateAndDenormalize (/Users/nicholaslim/Desktop/repos/optic/projects/optic/src/utils/spec-loaders.ts:285:28)
    at /Users/nicholaslim/Desktop/repos/optic/projects/optic/src/utils/spec-loaders.ts:311:10
    at step (/Users/nicholaslim/Desktop/repos/optic/projects/optic/src/utils/spec-loaders.ts:67:23)
    at Object.next (/Users/nicholaslim/Desktop/repos/optic/projects/optic/src/utils/spec-loaders.ts:48:53)
    at fulfilled (/Users/nicholaslim/Desktop/repos/optic/projects/optic/src/utils/spec-loaders.ts:39:58)
```

Hide the stack trace, this isn't useful for the user since it's generated from our code (i.e. there's a user error they need to fix)

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
