### PR TITLE
Update feedback in optic capture / verify flows

### DIFF
--- a/projects/optic/src/commands/oas/capture.ts
+++ b/projects/optic/src/commands/oas/capture.ts
@@ -241,7 +241,7 @@ export async function captureCommand(config: OpticCliConfig): Promise<Command> {
                   feedback.success(`Wrote har traffic to ${completedName}`);
                   feedback.log(
                     `\nRun "${chalk.bold(
-                      `optic oas verify ${filePath}`
+                      `optic verify ${filePath}`
                     )}" to diff the captured traffic`
                   );
                 }

--- a/projects/optic/src/commands/oas/diffing/patch.ts
+++ b/projects/optic/src/commands/oas/diffing/patch.ts
@@ -53,6 +53,7 @@ export async function patchOperationsAsNeeded(
 }
 
 export async function renderDiffs(
+  specPath: string,
   sourcemap: JsonSchemaSourcemap,
   spec: OpenAPIV3.Document,
   patches: SpecPatches,
@@ -92,7 +93,7 @@ export async function renderDiffs(
           ? `${diff.statusCode} Response ${diff.contentType}`
           : '';
 
-      renderBodyDiff(description, method, pathPattern);
+      renderBodyDiff(specPath, description, method, pathPattern);
     } else if (diff.kind === 'AdditionalProperty') {
       // filter out dependent diffs
       if (
@@ -105,6 +106,7 @@ export async function renderDiffs(
 
       stats.shapeDiff++;
       renderShapeDiff(
+        specPath,
         diff,
         jsonPointerHelpers.join(path, diff.parentObjectPath),
         `Undocumented '${diff.key}'`,
@@ -124,6 +126,7 @@ export async function renderDiffs(
 
       stats.shapeDiff++;
       renderShapeDiff(
+        specPath,
         diff,
         jsonPointerHelpers.join(path, diff.propertyPath),
         `[Actual] ${JSON.stringify(diff.example)}`,
@@ -143,6 +146,7 @@ export async function renderDiffs(
 
       stats.shapeDiff++;
       renderShapeDiff(
+        specPath,
         diff,
         jsonPointerHelpers.join(path, diff.propertyPath),
         `missing`,
@@ -159,6 +163,7 @@ export async function renderDiffs(
 }
 
 function renderShapeDiff(
+  specPath: string,
   diff: ShapeDiffResult,
   pathToHighlight: string,
   error: string,
@@ -172,18 +177,25 @@ ${logger.log(pathToHighlight, {
   highlightColor: 'yellow',
   observation: error,
 })}
-${nextCommand(`fix schema by running`, `optic update `)}\n`;
+${nextCommand(
+  `fix schema by running`,
+  `optic update ${specPath} "${method} ${pathPattern}"`
+)}\n`;
   console.log(lines);
 }
 
 function renderBodyDiff(
+  specPath: string,
   description: string,
   method: string,
   pathPattern: string
 ) {
   const lines = `${chalk.bgYellow('  Undocumented  ')} ${description}
   operation: ${chalk.bold(`${method} ${pathPattern}`)}  
-${nextCommand(`document new body by running`, `optic update `)}\n`;
+${nextCommand(
+  `document new body by running`,
+  `optic update ${specPath} "${method} ${pathPattern}"`
+)}\n`;
   console.log(lines);
 }
 

--- a/projects/optic/src/commands/oas/verify.ts
+++ b/projects/optic/src/commands/oas/verify.ts
@@ -108,7 +108,7 @@ export async function runVerify(
             existingCaptures.toString()
           )} capture${existingCaptures === 1 ? '' : 's'}. ${nextCommand(
             'Reset captures',
-            `optic oas capture clear ${path.relative(process.cwd(), specPath)}`
+            `optic capture clear ${path.relative(process.cwd(), specPath)}`
           )}\``
     } \n`
   );
@@ -168,7 +168,7 @@ export async function runVerify(
       specHasUncommittedChanges(parseResult.sourcemap, config.vcs.diffSet)
     ) {
       console.error(
-        'optic oas verify --upload can only be run in a git repository without uncommitted changes. That ensures reports are properly tagged.'
+        'optic verify --upload can only be run in a git repository without uncommitted changes. That ensures reports are properly tagged.'
       );
       process.exitCode = 1;
       return;

--- a/projects/optic/src/commands/oas/verify.ts
+++ b/projects/optic/src/commands/oas/verify.ts
@@ -16,7 +16,7 @@ import { renderDiffs, updateByInteractions } from './diffing/patch';
 import { specToOperations } from './operations/queries';
 import { OpticCliConfig, VCS } from '../../config';
 import { OPTIC_URL_KEY } from '../../constants';
-import { getApiFromOpticUrl } from '../../utils/cloud-urls';
+import { getApiFromOpticUrl, getSpecUrl } from '../../utils/cloud-urls';
 import { uploadSpec, uploadSpecVerification } from '../../utils/cloud-specs';
 import { loadSpec, specHasUncommittedChanges } from '../../utils/spec-loaders';
 import * as Git from '../../utils/git-utils';
@@ -203,6 +203,15 @@ export async function runVerify(
       verificationData: coverage.coverage,
       message: options.message,
     });
+
+    console.log(
+      `Successfully uploaded verification data. View your spec at ${getSpecUrl(
+        config.client.getWebBase(),
+        orgId,
+        apiId,
+        specId
+      )}`
+    );
   }
 
   analytics.forEach((event) => trackEvent(event.event, event.properties));

--- a/projects/optic/src/commands/oas/verify.ts
+++ b/projects/optic/src/commands/oas/verify.ts
@@ -128,6 +128,7 @@ export async function runVerify(
   );
 
   const diffResults = await renderDiffs(
+    specPath,
     sourcemap,
     spec,
     updatePatches,


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

- Remove hints that use deprecated `optic oas ...`
- Added more specific optic update commands (i.e. optic update specname method/path)
- add feedback for optic verify upload

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
