### PR TITLE
fix capture pass in folder

### DIFF
--- a/projects/optic/src/commands/oas/capture.ts
+++ b/projects/optic/src/commands/oas/capture.ts
@@ -67,8 +67,10 @@ export async function captureCommand(config: OpticCliConfig): Promise<Command> {
         const specFile = createNewSpecFile('3.1.0');
         if (isJson(filePath)) {
           logger.info(`Initializing OpenAPI file at ${filePath}`);
+          await fs.mkdir(path.dirname(filePath), { recursive: true });
           await fs.writeFile(filePath, JSON.stringify(specFile, null, 2));
         } else if (isYaml(filePath)) {
+          await fs.mkdir(path.dirname(filePath), { recursive: true });
           logger.info(`Initializing OpenAPI file at ${filePath}`);
           await fs.writeFile(filePath, writeYaml(specFile));
         } else {


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

`optic capture spec-that-doesnt-exist` will create the file if not there

`optic capture specs/test-spec.yml localhost:3030` will crash because we won't create a DIR - updates to create a dir as part file creation in optic capture

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
