### PR TITLE
feat(ci): release macOS binaries

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,96 @@
+name: release-binaries
+
+on:
+  workflow_dispatch: {}
+  release:
+    types:
+      - published
+
+env:
+  SKIP_ANNOUNCE: 'false'
+  SKIP_PUBLISH: 'false'
+
+jobs:
+  verify-prerelease-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Verify prerelease has a prerelease tag
+        if: github.event.release.prerelease
+        run: |
+          if ! [[ "${{ github.event.release.tag_name }}" =~ ^v[0-9]+.[0-9]+.[0-9]+\-.+ ]]
+          then
+            echo "ERROR: '${{ github.event.release.tag_name }}' is not a valid prerelease tag"
+            exit 1
+          fi
+
+  verify-versions-agree:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Confirm GH release and package.json agree on version
+        if: github.event_name == 'release'
+        run: |
+          # add a 'v' prefix to match the Git tag
+          package_version=v$(jq -r '.version' < package.json)
+
+          if [ "${package_version}" != "${{ github.event.release.tag_name }}" ]
+          then
+            echo "ERROR: package.json version (${package_version}) does not match GitHub release tag (${{ github.event.release.tag_name }})"
+            exit 1
+          fi
+      - name: Confirm all package.json files have the same version
+        run: .github/scripts/version-sync
+
+  verify-version-unpublished:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Confirm release version is unpublished
+        run: |
+          package_version=$(jq -r '.version' < package.json)
+          is_published=$(
+            yarn npm info "@useoptic/openapi-utilities" --json \
+            | jq -rs '.[0]' \
+            | jq ".versions // []" \
+            | jq -r "any(.[]; . == \"$package_version\")"
+          )
+
+          if [ "${is_published}" == "true" ]
+          then
+            echo "ERROR: @useoptic/openapi-utilities@$package_version is already published"
+            exit 1
+          fi
+
+  release:
+    runs-on: macos-latest-xl
+    needs:
+      - verify-prerelease-tag
+      - verify-versions-agree
+      - verify-version-unpublished
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: yarn
+
+      - name: Install Task
+        run: curl -sL https://taskfile.dev/install.sh | sudo bash -s -- -b /usr/local/bin/
+
+      - name: Build
+        env:
+          NODE_ENV: production
+        run: |
+          set -a
+          source projects/optic-ci/.env.production
+          task default
+
+      - name: Release binaries
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          task pkg:build -- --no-bytecode --public --public-packages "*"
+          task pkg:archive pkg:upload

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,73 +1,24 @@
 name: release-binaries
 
 on:
-  workflow_dispatch: {}
-  release:
-    types:
-      - published
-
-env:
-  SKIP_ANNOUNCE: 'false'
-  SKIP_PUBLISH: 'false'
+  workflow_dispatch:
+    inputs:
+      release_tag_name:
+        required: true
+        type: string
+        description: >
+          The tag that a release has been previously created from. Binaries will be attached to this release.
+  workflow_call:
+    inputs:
+      release_tag_name:
+        required: true
+        type: string
+        description: >
+          The tag that a release has been previously created from. Binaries will be attached to this release.
 
 jobs:
-  verify-prerelease-tag:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Verify prerelease has a prerelease tag
-        if: github.event.release.prerelease
-        run: |
-          if ! [[ "${{ github.event.release.tag_name }}" =~ ^v[0-9]+.[0-9]+.[0-9]+\-.+ ]]
-          then
-            echo "ERROR: '${{ github.event.release.tag_name }}' is not a valid prerelease tag"
-            exit 1
-          fi
-
-  verify-versions-agree:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Confirm GH release and package.json agree on version
-        if: github.event_name == 'release'
-        run: |
-          # add a 'v' prefix to match the Git tag
-          package_version=v$(jq -r '.version' < package.json)
-
-          if [ "${package_version}" != "${{ github.event.release.tag_name }}" ]
-          then
-            echo "ERROR: package.json version (${package_version}) does not match GitHub release tag (${{ github.event.release.tag_name }})"
-            exit 1
-          fi
-      - name: Confirm all package.json files have the same version
-        run: .github/scripts/version-sync
-
-  verify-version-unpublished:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Confirm release version is unpublished
-        run: |
-          package_version=$(jq -r '.version' < package.json)
-          is_published=$(
-            yarn npm info "@useoptic/openapi-utilities" --json \
-            | jq -rs '.[0]' \
-            | jq ".versions // []" \
-            | jq -r "any(.[]; . == \"$package_version\")"
-          )
-
-          if [ "${is_published}" == "true" ]
-          then
-            echo "ERROR: @useoptic/openapi-utilities@$package_version is already published"
-            exit 1
-          fi
-
   release:
     runs-on: macos-latest-xl
-    needs:
-      - verify-prerelease-tag
-      - verify-versions-agree
-      - verify-version-unpublished
     steps:
       - uses: actions/checkout@v3
 
@@ -79,18 +30,13 @@ jobs:
       - name: Install Task
         run: curl -sL https://taskfile.dev/install.sh | sudo bash -s -- -b /usr/local/bin/
 
-      - name: Build
+      - name: Release binaries
         env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag_name }}
           NODE_ENV: production
         run: |
           set -a
           source projects/optic-ci/.env.production
-          task default
-
-      - name: Release binaries
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: |
           task pkg:build -- --no-bytecode --public --public-packages "*"
           task pkg:archive pkg:upload

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,16 +128,6 @@ jobs:
             echo "Would publish $VERSION to the "$RELEASE_CHANNEL" channel"
           fi
 
-      - name: Release binaries
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: |
-          task pkg:build -- \
-            -t node18-linuxstatic-arm64,node18-linuxstatic-x64,node18-win-arm64,node18-win-x64 \
-            --no-bytecode --public --public-packages "*"
-          task pkg:archive pkg:upload
-
       - name: Announce success
         uses: Ilshidur/action-slack@689ad44a9c9092315abd286d0e3a9a74d31ab78a # v2.1.0
         if: >

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,3 +157,10 @@ jobs:
     with:
       optic_version: ${{ needs.release.outputs.optic_version }}
     secrets: inherit
+
+  publish-binaries:
+    needs: release
+    uses: ./.github/workflows/release-binaries.yml
+    with:
+      release_tag_name: ${{ github.event.release.tag_name }}
+    secrets: inherit


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

while we aren't set up to sign and notarize our macOS builds yet, we're going to start attaching them to releases anyway. this pr adds a dedicated workflow for building/releasing the binaries. it runs on macOS runners, which can build all the platforms in question.

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_

hard to test this from a branch. after merging i'll ship a prerelease and fix up any issues.