### PR TITLE
chore(ci): remove exe from archive filenames

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -147,7 +147,13 @@ tasks:
           name=$(basename "$bin")
           tar -czvf ./dist/archives/${name}.tar.gz -C dist $name
         done
+      # rename windows archives from `optic-windows-amd64.exe.tar.gz` to `optic-windows-amd64.tar.gz`
+      - |
+        for file in ./dist/archives/*; do
+          [[ "$file" =~ "\.exe" ]] && mv "$file" "${file/\.exe/}"
+        done
       - bash .github/scripts/create-checksums.sh
+      - ls -la ./dist/archives
 
   pkg:upload:
     cmds:


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

- removes the "exe" bit from the windows archive filename. this will line up the asset naming with what the install script expects.

before: `optic-windows-arm64.exe.tar.gz`
after: `optic-windows-arm64.tar.gz` 

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._
- closes https://github.com/opticdev/monorail/issues/4344

## 👹 QA
_How can other humans verify that this PR is correct?_
