### PR TITLE
Update `optic api add` to do a breadth first backfill instead of dept…

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.43.5-2",
+  "version": "0.43.5",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",
@@ -27,6 +27,5 @@
     "**/*.+(js|jsx|ts|tsx|json|css)": [
       "yarn prettier --write"
     ]
-  },
-  "stableVersion": "0.43.4"
+  }
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@3.5.1",
-  "version": "0.43.5-2",
+  "version": "0.43.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -33,6 +33,5 @@
   "dependencies": {
     "jsonpointer": "^5.0.1",
     "minimatch": "9.0.1"
-  },
-  "stableVersion": "0.43.4"
+  }
 }

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@3.5.1",
-  "version": "0.43.5-2",
+  "version": "0.43.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -58,6 +58,5 @@
     "upath": "^2.0.1",
     "yaml": "^2.2.2",
     "yaml-ast-parser": "^0.0.43"
-  },
-  "stableVersion": "0.43.4"
+  }
 }

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@3.5.1",
-  "version": "0.43.5-2",
+  "version": "0.43.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -57,6 +57,5 @@
     "openapi-types": "^12.0.2",
     "ts-invariant": "^0.9.3",
     "yaml-ast-parser": "^0.0.43"
-  },
-  "stableVersion": "0.43.4"
+  }
 }

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.5.1",
-  "version": "0.43.5-2",
+  "version": "0.43.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -64,6 +64,5 @@
     "picomatch": "^2.3.1",
     "url-join": "^4.0.1",
     "uuid": "^9.0.0"
-  },
-  "stableVersion": "0.43.4"
+  }
 }

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.5.1",
-  "version": "0.43.5-2",
+  "version": "0.43.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -130,6 +130,5 @@
       "node18-win-x64"
     ],
     "outputPath": "../../dist"
-  },
-  "stableVersion": "0.43.4"
+  }
 }

--- a/projects/optic/src/__tests__/integration/__snapshots__/api-add.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/api-add.test.ts.snap
@@ -7,10 +7,9 @@ exports[`optic api add git - no cli interaction discover all files in a folder 1
 [1m[32m✔[39m[22m [1m[34ma spec[39m[22m is now being tracked.
   [1mView: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
 
-[34m[1mBackfilling API history, you can exit at any time (\`ctrl + c\`) and finish this later.[22m[39m
+[33mHint: add \`--history-depth=0\` to backfill the entire history of your API[39m
 
-[1m[90mBackfilling history for nested/speccopy2.yml[39m[22m
-[32m✔[39m [1m[34ma spec[39m[22m history backfilled
+[32m✔[39m Successfully backfilled history
 
 [34m[1mx-optic-url has been added to newly tracked specs. You should commit these changes.[22m[39m
 
@@ -29,16 +28,9 @@ exports[`optic api add git - no cli interaction discover all files in repo 1`] =
 [1m[32m✔[39m[22m [1m[34ma spec[39m[22m is now being tracked.
   [1mView: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
 
-[34m[1mBackfilling API history, you can exit at any time (\`ctrl + c\`) and finish this later.[22m[39m
+[33mHint: add \`--history-depth=0\` to backfill the entire history of your API[39m
 
-[1m[90mBackfilling history for example-api-v0.json[39m[22m
-[32m✔[39m [1m[34mEmpty[39m[22m history backfilled
-
-[1m[90mBackfilling history for nested/speccopy2.yml[39m[22m
-[32m✔[39m [1m[34ma spec[39m[22m history backfilled
-
-[1m[90mBackfilling history for spec.yml[39m[22m
-[32m✔[39m [1m[34ma spec[39m[22m history backfilled
+[32m✔[39m Successfully backfilled history
 
 [34m[1mx-optic-url has been added to newly tracked specs. You should commit these changes.[22m[39m
 
@@ -57,16 +49,9 @@ exports[`optic api add git - no cli interaction discover all files in repo using
 [1m[32m✔[39m[22m [1m[34ma spec[39m[22m is now being tracked.
   [1mView: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
 
-[34m[1mBackfilling API history, you can exit at any time (\`ctrl + c\`) and finish this later.[22m[39m
+[33mHint: add \`--history-depth=0\` to backfill the entire history of your API[39m
 
-[1m[90mBackfilling history for example-api-v0.json[39m[22m
-[32m✔[39m [1m[34mEmpty[39m[22m history backfilled
-
-[1m[90mBackfilling history for nested/speccopy2.yml[39m[22m
-[32m✔[39m [1m[34ma spec[39m[22m history backfilled
-
-[1m[90mBackfilling history for spec.yml[39m[22m
-[32m✔[39m [1m[34ma spec[39m[22m history backfilled
+[32m✔[39m Successfully backfilled history
 
 [34m[1mx-optic-url has been added to newly tracked specs. You should commit these changes.[22m[39m
 
@@ -81,10 +66,9 @@ exports[`optic api add git - no cli interaction discover one file with history d
 [1m[32m✔[39m[22m [1m[34ma spec[39m[22m is now being tracked.
   [1mView: [4mhttps://app.useoptic.com/organizations/org-id/apis/api-id[24m[22m
 
-[34m[1mBackfilling API history, you can exit at any time (\`ctrl + c\`) and finish this later.[22m[39m
+[33mHint: add \`--history-depth=0\` to backfill the entire history of your API[39m
 
-[1m[90mBackfilling history for spec.yml[39m[22m
-[32m✔[39m [1m[34ma spec[39m[22m history backfilled
+[32m✔[39m Successfully backfilled history
 
 [34m[1mx-optic-url has been added to newly tracked specs. You should commit these changes.[22m[39m
 

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.5.1",
-  "version": "0.43.5-2",
+  "version": "0.43.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -40,6 +40,5 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
-  },
-  "stableVersion": "0.43.4"
+  }
 }

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.5.1",
-  "version": "0.43.5-2",
+  "version": "0.43.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -39,6 +39,5 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
-  },
-  "stableVersion": "0.43.4"
+  }
 }


### PR DESCRIPTION
…h first

## 🍗 Description
_What does this PR do? Anything folks should know?_

Updates the optic api add command to backfill breadth first (i.e. reverse chronological order by sha backfilling the entire sha first, before continuing)

Needs a new backend deployment to fix a bug with reverse chronological tagging

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
