### PR TITLE
Clarify lint output

### DIFF
--- a/projects/optic/src/__tests__/integration/__snapshots__/lint.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/lint.test.ts.snap
@@ -22,7 +22,7 @@ exports[`lint fails on bad formatting 1`] = `
 
 exports[`lint fails on requirement rule errors 1`] = `
 "Linting spec spec-fails-requirement.yml...
-[32m[1m✔ Linting passed[22m[39m
+[32m[1m✔ OpenAPI is valid[22m[39m
 
 Running Optic Checks
 
@@ -55,7 +55,7 @@ exports[`lint fails on validation errors 1`] = `
 
 exports[`lint passes on valid specs 1`] = `
 "Linting spec spec-good-spec.yml...
-[32m[1m✔ Linting passed[22m[39m
+[32m[1m✔ OpenAPI is valid[22m[39m
 
 Running Optic Checks
 

--- a/projects/optic/src/__tests__/integration/__snapshots__/lint.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/lint.test.ts.snap
@@ -22,8 +22,9 @@ exports[`lint fails on bad formatting 1`] = `
 
 exports[`lint fails on requirement rule errors 1`] = `
 "Linting spec spec-fails-requirement.yml...
+[32m[1m✔ Linting passed[22m[39m
 
-Checks
+Running Optic Checks
 
   [1m[41m[37m FAIL [39m[49m[22m [1mPOST[22m /filler_route
     requirement rule[31m [error][39m: response property naming check
@@ -36,7 +37,7 @@ Checks
 [32m[1m0 passed[22m[39m
 [31m[1m1 errors[22m[39m
 
-[31m[1mLinting errors found with your OpenAPI spec.[22m[39m
+[31m[1mx Check failures detected with your OpenAPI spec.[22m[39m
 "
 `;
 
@@ -54,8 +55,9 @@ exports[`lint fails on validation errors 1`] = `
 
 exports[`lint passes on valid specs 1`] = `
 "Linting spec spec-good-spec.yml...
+[32m[1m✔ Linting passed[22m[39m
 
-Checks
+Running Optic Checks
 
   [1m[42m[37m PASS [39m[49m[22m [1mPOST[22m /filler_route
 
@@ -64,6 +66,6 @@ Checks
 [32m[1m1 passed[22m[39m
 [31m[1m0 errors[22m[39m
 
-[32m[1mLinting passed.[22m[39m
+[32m[1m✔ Checks passed.[22m[39m
 "
 `;

--- a/projects/optic/src/commands/lint/lint.ts
+++ b/projects/optic/src/commands/lint/lint.ts
@@ -71,37 +71,39 @@ const getLintAction =
       }
     );
 
-    logger.info('');
-    logger.info('Checks');
-    logger.info('');
+    logger.info(chalk.green.bold('✔ Linting passed'));
 
-    for (const log of generateComparisonLogsV2(
-      changelogData,
-      {
-        from: file.sourcemap,
-        to: file.sourcemap,
-      },
-      specResults,
-      {
-        output: 'pretty',
-        verbose: false,
-        severity: textToSev(options.severity),
+    if (checks.total > 0) {
+      logger.info('');
+      logger.info('Running Optic Checks');
+      logger.info('');
+
+      for (const log of generateComparisonLogsV2(
+        changelogData,
+        {
+          from: file.sourcemap,
+          to: file.sourcemap,
+        },
+        specResults,
+        {
+          output: 'pretty',
+          verbose: false,
+          severity: textToSev(options.severity),
+        }
+      )) {
+        logger.info(log);
       }
-    )) {
-      logger.info(log);
-    }
 
-    logger.info('');
-    const failures = checks.failed;
-    const failuresForSeverity =
-      options.severity === 'error'
-        ? failures.error
-        : options.severity === 'warn'
-        ? failures.warn + failures.error
-        : failures.warn + failures.error + failures.info;
+      logger.info('');
+      const failures = checks.failed;
+      const failuresForSeverity =
+        options.severity === 'error'
+          ? failures.error
+          : options.severity === 'warn'
+          ? failures.warn + failures.error
+          : failures.warn + failures.error + failures.info;
 
-    if (options.web) {
-      if (specResults.results.length > 0) {
+      if (options.web) {
         const analyticsData: Record<string, any> = {
           isInCi: config.isInCi,
         };
@@ -122,14 +124,14 @@ const getLintAction =
           wait: false,
         });
       }
-    }
 
-    if (failuresForSeverity > 0) {
-      logger.info(
-        chalk.red.bold('Linting errors found with your OpenAPI spec.')
-      );
-      process.exitCode = 1;
-    } else {
-      logger.info(chalk.green.bold('Linting passed.'));
+      if (failuresForSeverity > 0) {
+        logger.info(
+          chalk.red.bold('x Check failures detected with your OpenAPI spec.')
+        );
+        process.exitCode = 1;
+      } else {
+        logger.info(chalk.green.bold('✔ Checks passed.'));
+      }
     }
   };

--- a/projects/optic/src/commands/lint/lint.ts
+++ b/projects/optic/src/commands/lint/lint.ts
@@ -71,7 +71,7 @@ const getLintAction =
       }
     );
 
-    logger.info(chalk.green.bold('✔ Linting passed'));
+    logger.info(chalk.green.bold('✔ OpenAPI is valid'));
 
     if (checks.total > 0) {
       logger.info('');


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Lint is confusing - we have the output of:
```
Linting spec specs/test-spec.yml...

Checks


0 passed
0 errors

Linting passed.
```

I've updated this to:
- always show lint passed if we are able to parse + validate the spec
- only display the optic checks part if we have rule results that are run
- clarify the wording so we're showing optic rules below

e.g.
without checks
```
Linting spec specs/test-spec.yml...
✔ Linting passed
```

and with checks
```
Linting spec specs/test-spec.yml...
✔ Linting passed

Running Optic Checks

 PASS POST /filler_route



1 passed
0 errors

✔ Checks passed.

```




## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
