### PR TITLE
add a server + server ready check to capture

### DIFF
--- a/projects/optic/src/commands/oas/captures/run-command.ts
+++ b/projects/optic/src/commands/oas/captures/run-command.ts
@@ -1,59 +1,54 @@
 import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
 import { createCommandFeedback } from '../reporters/feedback';
-import url from 'url';
 
 export class RunCommand {
   constructor(
-    private proxyUrl: string,
     private feedback: ReturnType<typeof createCommandFeedback>,
-    private options: { reverseProxy: boolean }
+    private feedbackLevel: 'info' | 'error' | 'silent' = 'info',
+    private env: { [key: string]: string | undefined } = {}
   ) {}
 
   completed: boolean = false;
   process: ChildProcessWithoutNullStreams | undefined = undefined;
 
   async run(command: string): Promise<{ exitCode: number }> {
-    const { port, hostname } = url.parse(this.proxyUrl);
-
     const [commandStart] = command.split(/ +/);
 
     const commandProcess = spawn(command, {
       cwd: process.cwd(),
       env: {
         ...process.env,
-        ...(this.options.reverseProxy
-          ? {
-              OPTIC_HOST: this.proxyUrl,
-            }
-          : {
-              http_proxy: `http://${hostname}:${port}`,
-              https_proxy: `https://${hostname}:${port}`,
-            }),
+        ...this.env,
       },
       shell: true,
     });
 
-    this.feedback.notable('Running command: ' + command);
+    if (this.feedbackLevel === 'info')
+      this.feedback.notable('Running command: ' + command);
 
     this.process = commandProcess;
 
     commandProcess.stdout.setEncoding('utf8');
 
-    commandProcess.stdout.on('data', (data) => {
-      const str = data.toString(),
-        lines = str.split(/(\r?\n)/g);
-      lines.forEach(
-        (line) => line.trim() && this.feedback.logChild(commandStart, line)
-      );
-    });
+    if (this.feedbackLevel === 'info') {
+      commandProcess.stdout.on('data', (data) => {
+        const str = data.toString(),
+          lines = str.split(/(\r?\n)/g);
+        lines.forEach(
+          (line) => line.trim() && this.feedback.logChild(commandStart, line)
+        );
+      });
+    }
 
-    commandProcess.stderr.on('data', (data) => {
-      const str = data.toString(),
-        lines = str.split(/(\r?\n)/g);
-      lines.forEach(
-        (line) => line.trim() && this.feedback.logChild(commandStart, line)
-      );
-    });
+    if (this.feedbackLevel !== 'silent') {
+      commandProcess.stderr.on('data', (data) => {
+        const str = data.toString(),
+          lines = str.split(/(\r?\n)/g);
+        lines.forEach(
+          (line) => line.trim() && this.feedback.logChild(commandStart, line)
+        );
+      });
+    }
 
     return new Promise((resolve) => {
       const endIt = (code: number | undefined) => {
@@ -69,9 +64,9 @@ export class RunCommand {
     });
   }
 
-  async kill() {
-    if (!this.completed && this.process) {
-      this.process.kill(1);
+  kill() {
+    if (this.process) {
+      this.process.kill('SIGKILL');
     }
   }
 }


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Adds a server + server ready check command to optic capture - useful when you want this to run in CI and run this code against a server that pulls traffic

Usage:
`optic capture oas.yml http://localhost:3030 --command "npm run test" --server "npm run start --server-ready-check "curl http://localhost:3030/healthcheck`

TODO
- [ ] Update documentation
- [ ] Update website tutorials

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
