### PR TITLE
Fix/match matching non yml and null error

### DIFF
--- a/projects/optic/src/commands/diff/diff-all.ts
+++ b/projects/optic/src/commands/diff/diff-all.ts
@@ -577,7 +577,8 @@ async function matchSpecCandidates(
   const matches = matchesOption?.split(',').filter((g) => g !== '') ?? [];
   const ignores = ignoresOption?.split(',').filter((g) => g !== '') ?? [];
 
-  return await fg(matches, { ignore: ignores });
+  const candidates = await fg(matches, { ignore: ignores });
+  return candidates.filter((c) => /\.(json|ya?ml)$/i.test(c));
 }
 
 function applyGlobFilter(

--- a/projects/optic/src/utils/spec-loaders.ts
+++ b/projects/optic/src/utils/spec-loaders.ts
@@ -144,6 +144,10 @@ export async function loadRaw(
     return createNullSpec();
   }
 
+  if (rawString === '') {
+    throw new Error('file is empty');
+  }
+
   if (format === 'unknown') {
     // try json, then yml
     try {


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

small fixes for diff-all:
- fix non .yml or .json files get pulled out with `--match`
- fix `cannot read x-optic-url of null` - caused by loadYaml running on an empty string - this returns `null`

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
