### PR TITLE
adapt ci setup to open source flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.44.3",
+  "version": "0.45.0",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/fastify-capture/package.json
+++ b/projects/fastify-capture/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/fastify-capture",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.44.3",
+  "version": "0.45.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.44.3",
+  "version": "0.45.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.44.3",
+  "version": "0.45.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.44.3",
+  "version": "0.45.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.44.3",
+  "version": "0.45.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/ci/configs/github.yml
+++ b/projects/optic/ci/configs/github.yml
@@ -24,3 +24,7 @@ jobs:
           # If false, standard check failures will show in PR comments and
           # in Optic Cloud but will not cause the action to fail
           standards_fail: %standards_fail
+
+          # If you have more than one spec, separate matches with commas
+          # (openapi.yml,other.yml)
+          additional_args: --match %match

--- a/projects/optic/ci/configs/github_generated_spec.yml
+++ b/projects/optic/ci/configs/github_generated_spec.yml
@@ -13,8 +13,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Generate Spec
-        # TODO: Replace this line with your generation script
-        run: generate-spec.sh
+        run: %generate_script
 
       - uses: opticdev/action@v1
         with:
@@ -29,8 +28,9 @@ jobs:
           # in Optic Cloud but will not cause the action to fail
           standards_fail: %standards_fail
 
-          # TODO: Modify the match argument to be the name of your spec. If you have
-          # more than one spec, separate them with commas (openapi.yml,other.yml)
-          additional_args: --generated --match openapi-spec.yml
+          # If you have more than one spec, separate matches with commas
+          # (openapi.yml,other.yml)
+          additional_args: --generated --match %match
+
           compare_from_pr: cloud:default
           compare_from_push: cloud:default

--- a/projects/optic/ci/configs/gitlab.yml
+++ b/projects/optic/ci/configs/gitlab.yml
@@ -17,7 +17,7 @@ optic-diff-push:
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_REF_NAME == $CI_DEFAULT_BRANCH
   script:
     - npm install -g @useoptic/optic
-    - optic diff-all --check --upload --head-tag "gitbranch:$CI_COMMIT_REF_NAME"
+    - optic diff-all --check --upload --head-tag "gitbranch:$CI_COMMIT_REF_NAME" --match %match
 
 # on merge request, diff with the base and post a comment
 optic-diff-merge-request:
@@ -29,7 +29,7 @@ optic-diff-merge-request:
     - git fetch origin --depth=1 $CI_MERGE_REQUEST_DIFF_BASE_SHA
 
     # run optic diff and record the result, but don't fail if optic fails
-    - export OPTIC_RESULT=0; optic diff-all --check --upload --head-tag "gitbranch:$CI_COMMIT_REF_NAME" --compare-from $CI_MERGE_REQUEST_DIFF_BASE_SHA || export OPTIC_RESULT=$?
+    - export OPTIC_RESULT=0; optic diff-all --check --upload --head-tag "gitbranch:$CI_COMMIT_REF_NAME" --compare-from $CI_MERGE_REQUEST_DIFF_BASE_SHA --match %match || export OPTIC_RESULT=$?
 
     # add a comment on the merge request
     - if [ -n "${OPTIC_GITLAB_TOKEN}" ]; then GITLAB_TOKEN=$OPTIC_GITLAB_TOKEN optic ci comment --provider gitlab --project-id $CI_PROJECT_ID --merge-request-id $CI_MERGE_REQUEST_IID --sha $CI_COMMIT_SHA; fi;

--- a/projects/optic/ci/configs/gitlab_generated_spec.yml
+++ b/projects/optic/ci/configs/gitlab_generated_spec.yml
@@ -16,12 +16,10 @@ optic-diff-push:
   rules:
     - if: $CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_REF_NAME == $CI_DEFAULT_BRANCH
   script:
-    # TODO: Replace this line with your generation script
-    - generate_spec.sh
+    - %generate_script
     - npm install -g @useoptic/optic
 
-    # TODO: Update --match options to be a comma separated list of your generated specs
-    - optic diff-all --check --upload --head-tag "gitbranch:$CI_COMMIT_REF_NAME"  --compare-from cloud:default --generated --match openapi-spec.yml
+    - optic diff-all --check --upload --head-tag "gitbranch:$CI_COMMIT_REF_NAME"  --compare-from cloud:default --generated --match %match
 
 # on merge request, diff with the base and post a comment
 optic-diff-merge-request:
@@ -29,14 +27,12 @@ optic-diff-merge-request:
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event" && $OPTIC_TOKEN
   script:
-    # TODO: Replace this line with your generation script
-    - generate_spec.sh
+    - %generate_script
     - npm install -g @useoptic/optic
     - git fetch origin --depth=1 $CI_MERGE_REQUEST_DIFF_BASE_SHA
 
     # run optic diff and record the result, but don't fail if optic fails
-    # TODO: Update --match options to be a comma separated list of your generated specs
-    - export OPTIC_RESULT=0; optic diff-all --check --upload --head-tag "gitbranch:$CI_COMMIT_REF_NAME" --compare-from cloud:default --generated --match openapi-spec.yml || export OPTIC_RESULT=$?
+    - export OPTIC_RESULT=0; optic diff-all --check --upload --head-tag "gitbranch:$CI_COMMIT_REF_NAME" --compare-from cloud:default --generated --match %match || export OPTIC_RESULT=$?
 
     # add a comment on the merge request
     - if [ -n "${OPTIC_GITLAB_TOKEN}" ]; then GITLAB_TOKEN=$OPTIC_GITLAB_TOKEN optic ci comment --provider gitlab --project-id $CI_PROJECT_ID --merge-request-id $CI_MERGE_REQUEST_IID --sha $CI_COMMIT_SHA; fi;

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.44.3",
+  "version": "0.45.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/src/commands/ci/setup.ts
+++ b/projects/optic/src/commands/ci/setup.ts
@@ -133,7 +133,7 @@ async function setupGitHub(config: OpticCliConfig, answers: PromptAnswers) {
   console.log('Next:');
   if (!answers.match)
     console.log(
-      `- Replace "${matchPlaceholder}" with your OpenAPI paths in the generated file (ex: openapi.yml,other.yml).`
+      `- Replace "${matchPlaceholder}" with your OpenAPI paths in the generated file (examples: "first-spec.yml,second-spec.yml" or "**/spec.yml").`
     );
   if (answers.generatedSpecs && !answers.generateScript)
     console.log(
@@ -144,7 +144,7 @@ async function setupGitHub(config: OpticCliConfig, answers: PromptAnswers) {
     '- Configure your standards and authorize Optic to comment on your PRs: https://useoptic.com/docs/setup-ci, then change your OpenAPI files and submit a PR to see Optic in action!'
   );
   console.log(
-    '- Visit https://www.useoptic.com/docs/cloud-get-started to learn about integrating your CI setup with Optic cloud.'
+    '- Check Optic cloud to get hosted preview documentation, visual changelogs and API history: https://www.useoptic.com/docs/cloud-get-started'
   );
 }
 

--- a/projects/optic/src/commands/ci/setup.ts
+++ b/projects/optic/src/commands/ci/setup.ts
@@ -81,7 +81,7 @@ const getCiSetupAction = (config: OpticCliConfig) => async () => {
         type: 'text',
         name: 'match',
         message:
-          'List your OpenAPI spec files, comma separated (ex: openapi.yml,other.yml)',
+          'Path to your OpenAPI spec files (examples: "first-spec.yml,second-spec.yml" or "**/spec.yml")',
       },
     ],
     { onCancel: () => process.exit(1) }
@@ -144,7 +144,7 @@ async function setupGitHub(config: OpticCliConfig, answers: PromptAnswers) {
     '- Configure your standards and authorize Optic to comment on your PRs: https://useoptic.com/docs/setup-ci, then change your OpenAPI files and submit a PR to see Optic in action!'
   );
   console.log(
-    '- Visit https://www.useoptic.com/cloud to learn about integrating your CI setup with Optic cloud.'
+    '- Visit https://www.useoptic.com/docs/cloud-get-started to learn about integrating your CI setup with Optic cloud.'
   );
 }
 

--- a/projects/optic/src/commands/ci/setup.ts
+++ b/projects/optic/src/commands/ci/setup.ts
@@ -4,18 +4,17 @@ import prompts from 'prompts';
 import fs from 'fs/promises';
 import path from 'path';
 import chalk from 'chalk';
-import open from 'open';
 import { guessRemoteOrigin } from '../../utils/git-utils';
 import { errorHandler } from '../../error-handler';
-import { getCiSetupUrl } from '../../utils/cloud-urls';
-
-type MaybeProvider = Awaited<ReturnType<typeof guessRemoteOrigin>>;
 
 const configsPath = path.join(__dirname, '..', '..', '..', 'ci', 'configs');
 
 const usage = () => `
   optic ci setup
 `;
+
+const matchPlaceholder = 'replace-me-openapi.yml';
+const generatePlaceholder = 'replace-me-generate.sh';
 
 export const registerCiSetup = (cli: Command, config: OpticCliConfig) => {
   cli
@@ -33,6 +32,8 @@ type PromptAnswers = {
   provider: 'GitHub' | 'GitLab';
   standardsFail: boolean;
   generatedSpecs: boolean;
+  generateScript: string;
+  match: string;
 };
 
 const getCiSetupAction = (config: OpticCliConfig) => async () => {
@@ -70,22 +71,30 @@ const getCiSetupAction = (config: OpticCliConfig) => async () => {
         ],
         initial: 1,
       },
+      {
+        type: (prev) => (prev === true ? 'text' : null),
+        name: 'generateScript',
+        message:
+          'The script or command you use to genrate your specs (ex: generate.sh)',
+      },
+      {
+        type: 'text',
+        name: 'match',
+        message:
+          'List your OpenAPI spec files, comma separated (ex: openapi.yml,other.yml)',
+      },
     ],
     { onCancel: () => process.exit(1) }
   );
 
   if (answers.provider === 'GitHub') {
-    await setupGitHub(config, maybeProvider, answers);
+    await setupGitHub(config, answers);
   } else if (answers.provider === 'GitLab') {
-    await setupGitLab(config, maybeProvider, answers);
+    await setupGitLab(config, answers);
   }
 };
 
-async function setupGitHub(
-  config: OpticCliConfig,
-  provider: MaybeProvider,
-  answers: PromptAnswers
-) {
+async function setupGitHub(config: OpticCliConfig, answers: PromptAnswers) {
   const target = '.github/workflows/optic.yml';
   const targetPath = path.join(config.root, target);
   const targetDir = path.dirname(targetPath);
@@ -106,46 +115,40 @@ async function setupGitHub(
   const standardsValue = answers.standardsFail ? 'true' : 'false';
   configContent = configContent.replace('%standards_fail', standardsValue);
 
+  const generateScript = answers.generateScript || generatePlaceholder;
+  configContent = configContent.replace('%generate_script', generateScript);
+
+  const match = answers.match || matchPlaceholder;
+  configContent = configContent.replace('%match', match);
+
   await fs.writeFile(path.join(config.root, target), configContent);
 
-  console.log();
   console.log(
     `${chalk.green('✔')} Wrote ${
       answers.provider
     } CI configuration to ${target}`
   );
 
-  const instructionsUrl = getCiSetupUrl(
-    config.client.getWebBase(),
-    provider?.provider,
-    provider?.web_url
+  console.log('');
+  console.log('Next:');
+  if (!answers.match)
+    console.log(
+      `- Replace "${matchPlaceholder}" with your OpenAPI paths in the generated file (ex: openapi.yml,other.yml).`
+    );
+  if (answers.generatedSpecs && !answers.generateScript)
+    console.log(
+      `- Replace "${generatePlaceholder}" with your generate command or script in the generated file.`
+    );
+  console.log('- Commit the generated CI file.');
+  console.log(
+    '- Configure your standards and authorize Optic to comment on your PRs: https://useoptic.com/docs/setup-ci, then change your OpenAPI files and submit a PR to see Optic in action!'
   );
-
-  console.log();
-  console.log(chalk.red("Wait, you're not finished yet"));
-  if (answers.generatedSpecs) {
-    console.log(
-      `Before pushing your new GitHub Actions workflow, review the commented sections marked TODO in ${target}.`
-    );
-    console.log(
-      `Then, follow the instructions at ${instructionsUrl} to set up the required secrets in your repository.`
-    );
-  } else {
-    console.log(
-      `Before pushing your new GitHub Actions workflow, follow the instructions at ${instructionsUrl} to set up the required secrets in your repository.`
-    );
-  }
-
-  console.log();
-
-  await openUrlPrompt(instructionsUrl);
+  console.log(
+    '- Visit https://www.useoptic.com/cloud to learn about integrating your CI setup with Optic cloud.'
+  );
 }
 
-async function setupGitLab(
-  config: OpticCliConfig,
-  provider: MaybeProvider,
-  answers: PromptAnswers
-) {
+async function setupGitLab(config: OpticCliConfig, answers: PromptAnswers) {
   const target = '.gitlab-ci.yml';
   const targetPath = path.join(config.root, target);
   const targetDir = path.dirname(targetPath);
@@ -164,14 +167,19 @@ async function setupGitLab(
   );
   let configContent = await fs.readFile(fromConfig, 'utf-8');
   const standardsValue = answers.standardsFail ? '' : '# ';
-  configContent = configContent.replace('%standards_fail', standardsValue);
+  configContent = configContent.replaceAll('%standards_fail', standardsValue);
+
+  const generateScript = answers.generateScript || generatePlaceholder;
+  configContent = configContent.replaceAll('%generate_script', generateScript);
+
+  const match = answers.match || matchPlaceholder;
+  configContent = configContent.replaceAll('%match', match);
 
   if (!exists) {
     await fs.mkdir(targetDir, { recursive: true });
 
     await fs.writeFile(targetPath, configContent);
 
-    console.log();
     console.log(
       `${chalk.green('✔')} Wrote ${
         answers.provider
@@ -190,33 +198,30 @@ async function setupGitLab(
     console.log('-----------------------');
   }
 
-  const instructionsUrl = getCiSetupUrl(
-    config.client.getWebBase(),
-    provider?.provider,
-    provider?.web_url
+  console.log('');
+  console.log('Next:');
+  if (!answers.match)
+    console.log(
+      `- Replace "${matchPlaceholder}" with your OpenAPI paths in the generated file (ex: openapi.yml,other.yml).`
+    );
+  if (answers.generatedSpecs && !answers.generateScript)
+    console.log(
+      `- Replace "${generatePlaceholder}" with your generate command or script in the generated file.`
+    );
+
+  console.log('- Commit the generated file.');
+  console.log(
+    '- Configure your standards and authorize Optic to comment on your MRs: https://useoptic.com/docs/setup-ci, then change your OpenAPI files and submit a MR to see Optic in action!'
   );
-
-  console.log();
-  console.log(chalk.red("Wait, you're not finished yet"));
-  if (answers.generatedSpecs) {
-    console.log(
-      `Before pushing your new GitLab CI/CD pipeline, review the commented sections marked TODO in ${target}.`
-    );
-    console.log(
-      `Then, follow the instructions at ${instructionsUrl} to set up the required secrets in your repository.`
-    );
-  } else {
-    console.log(
-      'Before pushing your new GitLab CI/CD pipeline, follow the instructions at\n' +
-        `${instructionsUrl} to set up the required secrets in your repository.`
-    );
-  }
-  console.log();
-
-  await openUrlPrompt(instructionsUrl);
+  console.log(
+    `- Change your OpenAPI files and submit a MR to see Optic in action!`
+  );
+  console.log(
+    '- Visit https://www.useoptic.com/cloud to learn about integrating your CI setup with Optic cloud.'
+  );
 }
 
-async function verifyPath(root: string, target: string): Promise<boolean> {
+async function verifyPath(_root: string, target: string): Promise<boolean> {
   let exists = false;
   try {
     await fs.access(target);
@@ -239,22 +244,4 @@ async function verifyPath(root: string, target: string): Promise<boolean> {
   }
 
   return true;
-}
-
-async function openUrlPrompt(url: string) {
-  const answer = await prompts(
-    {
-      type: 'confirm',
-      name: 'open',
-      message: `Open setup instructions in your browser?`,
-      initial: true,
-    },
-    { onCancel: () => process.exit(1) }
-  );
-
-  if (answer.open) {
-    await open(url, { wait: false });
-  }
-
-  return;
 }

--- a/projects/optic/src/commands/ci/setup.ts
+++ b/projects/optic/src/commands/ci/setup.ts
@@ -214,10 +214,7 @@ async function setupGitLab(config: OpticCliConfig, answers: PromptAnswers) {
     '- Configure your standards and authorize Optic to comment on your MRs: https://useoptic.com/docs/setup-ci, then change your OpenAPI files and submit a MR to see Optic in action!'
   );
   console.log(
-    `- Change your OpenAPI files and submit a MR to see Optic in action!`
-  );
-  console.log(
-    '- Visit https://www.useoptic.com/cloud to learn about integrating your CI setup with Optic cloud.'
+    '- Check Optic cloud to get hosted preview documentation, visual changelogs and API history: https://www.useoptic.com/docs/cloud-get-started'
   );
 }
 

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.44.3",
+  "version": "0.45.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.44.3",
+  "version": "0.45.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Update the `ci setup` command for the new open source flow. I added two new prompts to ask for the OpenAPI file paths and the generate command. Also we're always asking for the match option now: I think we can have this as the default, then tell users they can remove the match option once they move to cloud.

If the user lets the match and script prompts empty we put a placeholder and tell them to update it.

I also removed the optic token instructions.
<img width="1267" alt="image" src="https://github.com/opticdev/optic/assets/2964863/c7af8da7-f3a4-4bcc-943b-9a765a5a0c3a">



## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
