### PR TITLE
fix: binary builds did not include ci templates, breaking `ci setup`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.44.2",
+  "version": "0.44.3",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/fastify-capture/package.json
+++ b/projects/fastify-capture/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/fastify-capture",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.44.2",
+  "version": "0.44.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.44.2",
+  "version": "0.44.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.44.2",
+  "version": "0.44.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.44.2",
+  "version": "0.44.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.44.2",
+  "version": "0.44.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -120,7 +120,11 @@
     ],
     "assets": [
       "../../node_modules/open/xdg-open",
-      "../../node_modules/vm2/lib/setup-sandbox.js"
+      "../../node_modules/vm2/lib/setup-sandbox.js",
+      "ci/configs/github.yml",
+      "ci/configs/github_generated_spec.yml",
+      "ci/configs/gitlab.yml",
+      "ci/configs/gitlab_generated_spec.yml"
     ],
     "targets": [
       "node18-macos-arm64",

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -121,10 +121,7 @@
     "assets": [
       "../../node_modules/open/xdg-open",
       "../../node_modules/vm2/lib/setup-sandbox.js",
-      "ci/configs/github.yml",
-      "ci/configs/github_generated_spec.yml",
-      "ci/configs/gitlab.yml",
-      "ci/configs/gitlab_generated_spec.yml"
+      "ci/configs/*"
     ],
     "targets": [
       "node18-macos-arm64",

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.44.2",
+  "version": "0.44.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.44.2",
+  "version": "0.44.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.44.2",
+  "version": "0.44.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

fixes https://github.com/opticdev/monorail/issues/4459, verified with a local build


we weren't including the ci templates into the binary builds, so `ci setup` was broken:
```
➜ optic ci setup
✔ What CI provider would you like to configure? › GitHub Actions
✔ Should failing standards fail CI? › No
✔ Do you use a script to generate your OpenAPI specs? › Yes
File '/**/optic/projects/optic/ci/configs/github_generated_spec.yml' was not included into executable at compilation stage. Please recompile adding it as asset or script.
```

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
