### PR TITLE
fix: build docker after binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,17 +150,20 @@ jobs:
         with:
           args: '{{ GITHUB_ACTOR }}: 🚫 optic v{{ VERSION }} failed to publish.'
 
-  publish-container-image:
-    needs: release
-    if: github.event.release.prerelease == false
-    uses: ./.github/workflows/release-container-image.yml
-    with:
-      optic_version: ${{ needs.release.outputs.optic_version }}
-    secrets: inherit
-
   publish-binaries:
     needs: release
     uses: ./.github/workflows/release-binaries.yml
     with:
       release_tag_name: ${{ github.event.release.tag_name }}
     secrets: inherit
+
+  publish-container-image:
+    needs:
+      - release
+      - publish-binaries
+    if: github.event.release.prerelease == false
+    uses: ./.github/workflows/release-container-image.yml
+    with:
+      optic_version: ${{ needs.release.outputs.optic_version }}
+    secrets: inherit
+


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

recently, i changed the docker image to install optic binaries. when making a release today i spotted that we're attempting to produce the binaries and the docker images in parallel. that obviously don't work since the latter depends on artifacts from the former. https://github.com/opticdev/optic/actions/runs/5211864701/workflow

this changes the release flow so that binaries build first, then docker.

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
