### PR TITLE
allow additional properties for openapi 3_1

### DIFF
--- a/projects/openapi-io/src/validation/validation-schemas.ts
+++ b/projects/openapi-io/src/validation/validation-schemas.ts
@@ -3,7 +3,6 @@ const openapi3_0_schema_object = {
   'x-custom-validator': 'validateSchema',
   description:
     'The Schema Object allows the definition of input and output data types. These types can be objects, but also primitives and arrays. This object is an extended subset of the JSON Schema Specification Wright Draft 00.  For more information about the properties, see JSON Schema Core and JSON Schema Validation. Unless stated otherwise, the property definitions follow the JSON Schema.',
-  // additionalProperties: false,
   additionalProperties: true,
   patternProperties: {
     '^x-': {
@@ -161,7 +160,7 @@ const openapi3_1_schema_object = {
   'x-custom-validator': 'validateSchema',
   description:
     'The Schema Object allows the definition of input and output data types. These types can be objects, but also primitives and arrays. This object is an extended subset of the JSON Schema Specification Wright Draft 00.  For more information about the properties, see JSON Schema Core and JSON Schema Validation. Unless stated otherwise, the property definitions follow the JSON Schema.',
-  additionalProperties: false,
+  additionalProperties: true,
   patternProperties: {
     '^x-': {
       $ref: '#/definitions/specificationExtension',


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

additional properties is false on 3_1 but true on 3 - this breaks cases like `webhooks`

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
