### PR TITLE
remove unused components

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.45.1",
+  "version": "0.45.2",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/fastify-capture/package.json
+++ b/projects/fastify-capture/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/fastify-capture",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.45.1",
+  "version": "0.45.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.45.1",
+  "version": "0.45.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.45.1",
+  "version": "0.45.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.45.1",
+  "version": "0.45.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.45.1",
+  "version": "0.45.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.45.1",
+  "version": "0.45.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/src/__tests__/integration/__snapshots__/bundle.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/bundle.test.ts.snap
@@ -5,6 +5,33 @@ exports[`bundle bundles components together 1`] = `
 "info":
   "title": "TodoAPI"
   "version": "1.1"
+"components":
+  "schemas":
+    "schemas":
+      "type": "object"
+      "title": "Todo"
+      "properties":
+        "name":
+          "type": "string"
+        "status":
+          "type": "string"
+        "created_at":
+          "type": "string"
+        "firstTodo":
+          "$ref": "#/components/schemas/schemas"
+        "todos":
+          "type": "array"
+          "items":
+            "$ref": "#/components/schemas/schemas"
+      "required":
+        - "name"
+        - "status"
+    "anotherschema":
+      "type": "string"
+  "parameters": {}
+  "examples": {}
+  "requestBodies": {}
+  "responses": {}
 "paths":
   "/todos":
     "get":
@@ -33,34 +60,24 @@ exports[`bundle bundles components together 1`] = `
           "content":
             "application/json":
               "schema":
-                "$ref": "#/components/schemas/schemas"
-"components":
-  "schemas":
-    "schemas":
-      "type": "object"
-      "title": "Todo"
-      "properties":
-        "name":
-          "type": "string"
-        "status":
-          "type": "string"
-        "created_at":
-          "$ref": "#/components/schemas/anotherschema"
-        "firstTodo":
-          "$ref": "#/components/schemas/schemas"
-        "todos":
-          "type": "array"
-          "items":
-            "$ref": "#/components/schemas/schemas"
-      "required":
-        - "name"
-        - "status"
-    "anotherschema":
-      "type": "string"
-  "parameters": {}
-  "examples": {}
-  "requestBodies": {}
-  "responses": {}
+                "type": "object"
+                "title": "Todo"
+                "properties":
+                  "name":
+                    "type": "string"
+                  "status":
+                    "type": "string"
+                  "created_at":
+                    "type": "string"
+                  "firstTodo":
+                    "$ref": "#/components/schemas/schemas"
+                  "todos":
+                    "type": "array"
+                    "items":
+                      "$ref": "#/components/schemas/schemas"
+                "required":
+                  - "name"
+                  - "status"
 
 "
 `;

--- a/projects/optic/src/__tests__/integration/workspaces/bundle/specs/openapi.yml
+++ b/projects/optic/src/__tests__/integration/workspaces/bundle/specs/openapi.yml
@@ -2,6 +2,10 @@ openapi: 3.0.1
 info:
   title: TodoAPI
   version: "1.1"
+components:
+  schemas:
+    notUsed:
+      type: string
 paths:
   /todos:
     get:

--- a/projects/optic/src/commands/bundle/bundle.ts
+++ b/projects/optic/src/commands/bundle/bundle.ts
@@ -148,11 +148,10 @@ const bundleAction =
 
       //write tmp file
       const tmpOutput = path.join(
-        process.cwd(),
+        path.dirname(filePath),
         `tmp-openapi-${Date.now()}.json`
       );
       await fs.writeFile(tmpOutput, JSON.stringify(updatedSpec, null, 2));
-
       const spec = await getSpec(tmpOutput, config);
       updatedSpec = removeUnusedComponents(spec.jsonLike, spec.sourcemap);
       await fs.unlink(tmpOutput);
@@ -433,7 +432,9 @@ function removeUnusedComponents(
   testComponents('parameters');
   testComponents('headers');
 
-  return jsonpatch.applyPatch(spec, removals, true, true).newDocument;
+  const copied = JSON.parse(JSON.stringify(spec));
+
+  return jsonpatch.applyPatch(copied, removals, true, true).newDocument;
 }
 
 async function bundleMatchingRefsAsComponents<T>(

--- a/projects/optic/src/commands/bundle/bundle.ts
+++ b/projects/optic/src/commands/bundle/bundle.ts
@@ -93,10 +93,7 @@ const bundleAction =
     if (filePath) {
       parsedFile = await getSpec(filePath, config);
 
-      const updatedSpec = await bundle(
-        parsedFile.jsonLike,
-        parsedFile.sourcemap
-      );
+      let updatedSpec = await bundle(parsedFile.jsonLike, parsedFile.sourcemap);
 
       if (includeExtensions.length) {
         Object.entries(updatedSpec.paths).forEach(([path, operations]) => {
@@ -148,6 +145,17 @@ const bundleAction =
           });
         });
       }
+
+      //write tmp file
+      const tmpOutput = path.join(
+        process.cwd(),
+        `tmp-openapi-${Date.now()}.json`
+      );
+      await fs.writeFile(tmpOutput, JSON.stringify(updatedSpec, null, 2));
+
+      const spec = await getSpec(tmpOutput, config);
+      updatedSpec = removeUnusedComponents(spec.jsonLike, spec.sourcemap);
+      await fs.unlink(tmpOutput);
 
       const yamlOut = () =>
         yaml.stringify(updatedSpec, {
@@ -382,6 +390,50 @@ async function bundle(
   );
 
   return updatedSpec;
+}
+
+// assumes single file OpenAPI spec
+function removeUnusedComponents(
+  spec: OpenAPIV3.Document,
+  sourcemap: JsonSchemaSourcemap
+) {
+  const removals: Operation[] = [];
+
+  const usages = new Set(
+    Object.values(sourcemap.refMappings)
+      .map((i) => i[1])
+      .flat(1)
+  );
+
+  function testComponents(kind: keyof OpenAPIV3.ComponentsObject) {
+    const components = jsonPointerHelpers.tryGet(
+      spec,
+      jsonPointerHelpers.compile(['components', kind])
+    );
+    const componentNames = Object.keys(
+      components.match ? components.value : {}
+    );
+
+    componentNames.forEach((name) => {
+      const jsonPointer = jsonPointerHelpers.compile([
+        'components',
+        kind,
+        name,
+      ]);
+      if (!usages.has(jsonPointer)) {
+        removals.push({ op: 'remove', path: jsonPointer });
+      }
+    });
+  }
+
+  testComponents('schemas');
+  testComponents('requestBodies');
+  testComponents('responses');
+  testComponents('examples');
+  testComponents('parameters');
+  testComponents('headers');
+
+  return jsonpatch.applyPatch(spec, removals, true, true).newDocument;
 }
 
 async function bundleMatchingRefsAsComponents<T>(

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.45.1",
+  "version": "0.45.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.45.1",
+  "version": "0.45.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
## 🍗 Description
`bundle` command now removes unused components. 

It has to run in two passes
1.  insource remove URL and remote file refs. Pick names that don't conflict, update all usages to point to `components/`
2. save a tmp file to disk, parse it again
3. count reference usages for each component. If 0, add a `op: remove` patch. 

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
