### PR TITLE
add cloud setup links to comment when no cloud

### DIFF
--- a/projects/optic/src/commands/ci/comment/__tests__/__snapshots__/common.test.ts.snap
+++ b/projects/optic/src/commands/ci/comment/__tests__/__snapshots__/common.test.ts.snap
@@ -167,3 +167,50 @@ Summary of API changes for commit (123)
 
 "
 `;
+
+exports[`generateCompareSummaryMarkdown when run without optic cloud 1`] = `
+"
+<!--
+DO NOT MODIFY
+app_id: optic-comment-3UsoJCz_Z0SpGLo5Vjw6o
+commit_sha: 123
+-->
+### APIs Changed
+
+<table>
+<thead>
+<tr>
+<th>API</th>
+<th>Operation Changes</th>
+<th>Checks</th>
+
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+
+no-optic-cloud ([setup preview](https://useoptic.com/docs/cloud-get-started))
+
+</td>
+<td>
+
+1 operation added ([setup changelog](https://useoptic.com/docs/cloud-get-started))
+
+</td>
+<td>
+
+ℹ️ No automated checks have run
+
+</td>
+
+</tr>
+</tbody>
+</table>
+
+
+
+Summary of API changes for commit (123)
+
+"
+`;

--- a/projects/optic/src/commands/ci/comment/__tests__/common.test.ts
+++ b/projects/optic/src/commands/ci/comment/__tests__/common.test.ts
@@ -103,4 +103,33 @@ describe('generateCompareSummaryMarkdown', () => {
       )
     ).toMatchSnapshot();
   });
+
+  test('when run without optic cloud', () => {
+    expect(
+      generateCompareSummaryMarkdown(
+        { sha: '123' },
+        {
+          completed: [
+            {
+              apiName: 'no-optic-cloud',
+              warnings: [],
+              comparison: {
+                groupedDiffs: groupDiffsByEndpoint(
+                  {
+                    from,
+                    to,
+                  },
+                  diff(from, to)
+                ),
+                results: [],
+              },
+            },
+          ],
+          failed: [],
+          noop: [],
+          severity: 2,
+        }
+      )
+    ).toMatchSnapshot();
+  });
 });

--- a/projects/optic/src/commands/ci/comment/common.ts
+++ b/projects/optic/src/commands/ci/comment/common.ts
@@ -66,13 +66,19 @@ ${results.completed
       `<tr>
 <td>
 
-${s.apiName} ${s.specUrl ? `([preview](${s.specUrl}))` : ''}
+${s.apiName} ${
+        s.specUrl
+          ? `([preview](${s.specUrl}))`
+          : '([setup preview](https://useoptic.com/docs/cloud-get-started))'
+      }
 
 </td>
 <td>
 
 ${getOperationsChangedLabel(s.comparison.groupedDiffs)} ${
-        s.opticWebUrl ? `([view changelog](${s.opticWebUrl}))` : ''
+        s.opticWebUrl
+          ? `([view changelog](${s.opticWebUrl}))`
+          : '([setup changelog](https://useoptic.com/docs/cloud-get-started))'
       }
 
 </td>


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Adds a comment with links to setup if commenting but not in CI

Comment example
----

<!--
DO NOT MODIFY
app_id: optic-comment-3UsoJCz_Z0SpGLo5Vjw6o
commit_sha: 123
-->
### APIs Changed

<table>
<thead>
<tr>
<th>API</th>
<th>Operation Changes</th>
<th>Checks</th>

</tr>
</thead>
<tbody>
<tr>
<td>

no-optic-cloud ([setup preview](https://useoptic.com/docs/cloud-get-started))

</td>
<td>

1 operation added ([setup changelog](https://useoptic.com/docs/cloud-get-started))

</td>
<td>

ℹ️ No automated checks have run

</td>

</tr>
</tbody>
</table>



Summary of API changes for commit (f6b81eff774d4bf62a1e0536d2e09892ee67931d)


## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
