### PR TITLE
Git links in ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.46.1-0",
+  "version": "0.46.1-1",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.46.0",
+  "version": "0.46.1-0",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",
@@ -28,5 +28,6 @@
     "**/*.+(js|jsx|ts|tsx|json|css)": [
       "yarn prettier --write"
     ]
-  }
+  },
+  "stableVersion": "0.46.0"
 }

--- a/projects/fastify-capture/package.json
+++ b/projects/fastify-capture/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/fastify-capture",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.46.1-0",
+  "version": "0.46.1-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/fastify-capture/package.json
+++ b/projects/fastify-capture/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/fastify-capture",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.46.0",
+  "version": "0.46.1-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -37,5 +37,6 @@
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
     "typescript": "^5.0.4"
-  }
+  },
+  "stableVersion": "0.46.0"
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.46.0",
+  "version": "0.46.1-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -33,5 +33,6 @@
   "dependencies": {
     "jsonpointer": "^5.0.1",
     "minimatch": "9.0.1"
-  }
+  },
+  "stableVersion": "0.46.0"
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.46.1-0",
+  "version": "0.46.1-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.46.0",
+  "version": "0.46.1-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -58,5 +58,6 @@
     "upath": "^2.0.1",
     "yaml": "^2.2.2",
     "yaml-ast-parser": "^0.0.43"
-  }
+  },
+  "stableVersion": "0.46.0"
 }

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.46.1-0",
+  "version": "0.46.1-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.46.0",
+  "version": "0.46.1-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -57,5 +57,6 @@
     "openapi-types": "^12.0.2",
     "ts-invariant": "^0.9.3",
     "yaml-ast-parser": "^0.0.43"
-  }
+  },
+  "stableVersion": "0.46.0"
 }

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.46.1-0",
+  "version": "0.46.1-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.46.0",
+  "version": "0.46.1-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -64,5 +64,6 @@
     "picomatch": "^2.3.1",
     "url-join": "^4.0.1",
     "uuid": "^9.0.0"
-  }
+  },
+  "stableVersion": "0.46.0"
 }

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.46.1-0",
+  "version": "0.46.1-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.46.0",
+  "version": "0.46.1-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -132,5 +132,6 @@
       "node18-win-x64"
     ],
     "outputPath": "../../dist"
-  }
+  },
+  "stableVersion": "0.46.0"
 }

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.46.1-0",
+  "version": "0.46.1-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/src/__tests__/integration/__snapshots__/diff-all.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/diff-all.test.ts.snap
@@ -15,7 +15,7 @@ specification details:
 [31mx [1mGET[22m /api/users[39m: [31mremoved[39m
   
   [31m[1mx [prevent operation removal][22m cannot remove an operation. This is a breaking change.[39m
-  at https://github.com/User/UserRepo/tree/b92fc9cd38a1e4b98febf8ee612c54380e179f8f/empty.json#L1
+  at https://github.com/User/UserRepo/tree/COMMIT-HASH/empty.json#L1
   
 
 [32m✔ [1mGET[22m /example[39m: [32madded[39m
@@ -55,7 +55,7 @@ specification details:
 [31mx [1mGET[22m /api/users[39m: [31mremoved[39m
   
   [31m[1mx [prevent operation removal][22m cannot remove an operation. This is a breaking change.[39m
-  at https://github.com/User/UserRepo/tree/a0d6d1bfb9fe0b1b737616f77d262ca3f4e98a29/empty.json#L1
+  at https://github.com/User/UserRepo/tree/COMMIT-HASH/empty.json#L1
   
 
 [32m✔ [1mGET[22m /example[39m: [32madded[39m
@@ -87,7 +87,7 @@ specification details:
 [31mx [1mGET[22m /api/users[39m: [31mremoved[39m
   
   [31m[1mx [prevent operation removal][22m cannot remove an operation. This is a breaking change.[39m
-  at https://github.com/User/UserRepo/tree/a0d6d1bfb9fe0b1b737616f77d262ca3f4e98a29/empty.json#L1
+  at https://github.com/User/UserRepo/tree/COMMIT-HASH/empty.json#L1
   
 
 [32m✔ [1mGET[22m /example[39m: [32madded[39m
@@ -118,12 +118,12 @@ exports[`diff-all diff all not in the root of a repo 1`] = `
 
 [31mx [1mPOST[22m /filler_route[39m: 
   [31m[1mx [operation path component naming check][22m filler_route is not camelCase[39m
-  at https://github.com/User/UserRepo/tree/a7314df4aab74f8eb9e7b00bb5f6422a14fe037d/folder/in-folder.yml#L9
+  at https://github.com/User/UserRepo/tree/COMMIT-HASH/folder/in-folder.yml#L9
   
 
 [31mx [1mPOST[22m /api/filler-route[39m: 
   [31m[1mx [operation path component naming check][22m filler-route is not camelCase[39m
-  at https://github.com/User/UserRepo/tree/a7314df4aab74f8eb9e7b00bb5f6422a14fe037d/folder/in-folder.yml#L24
+  at https://github.com/User/UserRepo/tree/COMMIT-HASH/folder/in-folder.yml#L24
   
 
 ...and 2 other endpoints
@@ -142,33 +142,33 @@ specification details:
 [31mx [1mPOST[22m /filler_route[39m: [31mremoved[39m
   
   [31m[1mx [prevent operation removal][22m cannot remove an operation. This is a breaking change.[39m
-  at https://github.com/User/UserRepo/tree/a7314df4aab74f8eb9e7b00bb5f6422a14fe037d/mvspec.yml#L9
+  at https://github.com/User/UserRepo/tree/COMMIT-HASH/mvspec.yml#L9
   
   - response [1m201[22m: 
     [31m[1mx [prevent response status code removal][22m must not remove response status code 201. This is a breaking change.[39m
-    at https://github.com/User/UserRepo/tree/a7314df4aab74f8eb9e7b00bb5f6422a14fe037d/mvspec.yml#L12
+    at https://github.com/User/UserRepo/tree/COMMIT-HASH/mvspec.yml#L12
     
     - body [1mapplication/json[22m: 
       - property [1m/schema/properties/id[22m: 
       
         [31m[1mx [prevent removing response property][22m cannot remove response property 'id'. This is a breaking change.[39m
-        at https://github.com/User/UserRepo/tree/a7314df4aab74f8eb9e7b00bb5f6422a14fe037d/mvspec.yml#L19
+        at https://github.com/User/UserRepo/tree/COMMIT-HASH/mvspec.yml#L19
         
 
 [31mx [1mPOST[22m /api/filler-route[39m: [31mremoved[39m
   
   [31m[1mx [prevent operation removal][22m cannot remove an operation. This is a breaking change.[39m
-  at https://github.com/User/UserRepo/tree/a7314df4aab74f8eb9e7b00bb5f6422a14fe037d/mvspec.yml#L24
+  at https://github.com/User/UserRepo/tree/COMMIT-HASH/mvspec.yml#L24
   
   - response [1m201[22m: 
     [31m[1mx [prevent response status code removal][22m must not remove response status code 201. This is a breaking change.[39m
-    at https://github.com/User/UserRepo/tree/a7314df4aab74f8eb9e7b00bb5f6422a14fe037d/mvspec.yml#L27
+    at https://github.com/User/UserRepo/tree/COMMIT-HASH/mvspec.yml#L27
     
     - body [1mapplication/json[22m: 
       - property [1m/schema/properties/id[22m: 
       
         [31m[1mx [prevent removing response property][22m cannot remove response property 'id'. This is a breaking change.[39m
-        at https://github.com/User/UserRepo/tree/a7314df4aab74f8eb9e7b00bb5f6422a14fe037d/mvspec.yml#L34
+        at https://github.com/User/UserRepo/tree/COMMIT-HASH/mvspec.yml#L34
         
 
 
@@ -200,7 +200,7 @@ specification details:
 
 [31mx [1mPOST[22m /filler_route[39m: 
   [31m[1mx [operation path component naming check][22m filler_route is not camelCase[39m
-  at https://github.com/User/UserRepo/tree/a7314df4aab74f8eb9e7b00bb5f6422a14fe037d/specwithkey.yml#L9
+  at https://github.com/User/UserRepo/tree/COMMIT-HASH/specwithkey.yml#L9
   
 
 ...and 1 other endpoint
@@ -220,13 +220,13 @@ specification details:
 [31mx [1mPOST[22m /filler_route[39m: [32madded[39m
   
   [31m[1mx [operation path component naming check][22m filler_route is not camelCase[39m
-  at https://github.com/User/UserRepo/tree/a7314df4aab74f8eb9e7b00bb5f6422a14fe037d/movedspec.yml#L9
+  at https://github.com/User/UserRepo/tree/COMMIT-HASH/movedspec.yml#L9
   
 
 [31mx [1mPOST[22m /api/filler-route[39m: [32madded[39m
   
   [31m[1mx [operation path component naming check][22m filler-route is not camelCase[39m
-  at https://github.com/User/UserRepo/tree/a7314df4aab74f8eb9e7b00bb5f6422a14fe037d/movedspec.yml#L24
+  at https://github.com/User/UserRepo/tree/COMMIT-HASH/movedspec.yml#L24
   
 
 ...and 2 other endpoints
@@ -256,17 +256,17 @@ specification details:
 [31mx [1mPOST[22m /filler_route[39m: [31mremoved[39m
   
   [31m[1mx [prevent operation removal][22m cannot remove an operation. This is a breaking change.[39m
-  at https://github.com/User/UserRepo/tree/a39e34b47677c1abf1184de1c90530a6e5606cd7/folder-to-run/should-run.yml#L9
+  at https://github.com/User/UserRepo/tree/COMMIT-HASH/folder-to-run/should-run.yml#L9
   
   - response [1m201[22m: 
     [31m[1mx [prevent response status code removal][22m must not remove response status code 201. This is a breaking change.[39m
-    at https://github.com/User/UserRepo/tree/a39e34b47677c1abf1184de1c90530a6e5606cd7/folder-to-run/should-run.yml#L12
+    at https://github.com/User/UserRepo/tree/COMMIT-HASH/folder-to-run/should-run.yml#L12
     
     - body [1mapplication/json[22m: 
       - property [1m/schema/properties/id[22m: 
       
         [31m[1mx [prevent removing response property][22m cannot remove response property 'id'. This is a breaking change.[39m
-        at https://github.com/User/UserRepo/tree/a39e34b47677c1abf1184de1c90530a6e5606cd7/folder-to-run/should-run.yml#L19
+        at https://github.com/User/UserRepo/tree/COMMIT-HASH/folder-to-run/should-run.yml#L19
         
 
 
@@ -300,12 +300,12 @@ exports[`diff-all diffs all files in a workspace with x-optic-url keys with --up
 
 [31mx [1mPOST[22m /filler_route[39m: 
   [31m[1mx [operation path component naming check][22m filler_route is not camelCase[39m
-  at https://github.com/User/UserRepo/tree/75cba4a4b0e17a2e0ea5a99f1169d19eb13ed114/folder/in-folder.yml#L9
+  at https://github.com/User/UserRepo/tree/COMMIT-HASH/folder/in-folder.yml#L9
   
 
 [31mx [1mPOST[22m /api/filler-route[39m: 
   [31m[1mx [operation path component naming check][22m filler-route is not camelCase[39m
-  at https://github.com/User/UserRepo/tree/75cba4a4b0e17a2e0ea5a99f1169d19eb13ed114/folder/in-folder.yml#L24
+  at https://github.com/User/UserRepo/tree/COMMIT-HASH/folder/in-folder.yml#L24
   
 
 ...and 2 other endpoints
@@ -324,33 +324,33 @@ specification details:
 [31mx [1mPOST[22m /filler_route[39m: [31mremoved[39m
   
   [31m[1mx [prevent operation removal][22m cannot remove an operation. This is a breaking change.[39m
-  at https://github.com/User/UserRepo/tree/75cba4a4b0e17a2e0ea5a99f1169d19eb13ed114/mvspec.yml#L9
+  at https://github.com/User/UserRepo/tree/COMMIT-HASH/mvspec.yml#L9
   
   - response [1m201[22m: 
     [31m[1mx [prevent response status code removal][22m must not remove response status code 201. This is a breaking change.[39m
-    at https://github.com/User/UserRepo/tree/75cba4a4b0e17a2e0ea5a99f1169d19eb13ed114/mvspec.yml#L12
+    at https://github.com/User/UserRepo/tree/COMMIT-HASH/mvspec.yml#L12
     
     - body [1mapplication/json[22m: 
       - property [1m/schema/properties/id[22m: 
       
         [31m[1mx [prevent removing response property][22m cannot remove response property 'id'. This is a breaking change.[39m
-        at https://github.com/User/UserRepo/tree/75cba4a4b0e17a2e0ea5a99f1169d19eb13ed114/mvspec.yml#L19
+        at https://github.com/User/UserRepo/tree/COMMIT-HASH/mvspec.yml#L19
         
 
 [31mx [1mPOST[22m /api/filler-route[39m: [31mremoved[39m
   
   [31m[1mx [prevent operation removal][22m cannot remove an operation. This is a breaking change.[39m
-  at https://github.com/User/UserRepo/tree/75cba4a4b0e17a2e0ea5a99f1169d19eb13ed114/mvspec.yml#L24
+  at https://github.com/User/UserRepo/tree/COMMIT-HASH/mvspec.yml#L24
   
   - response [1m201[22m: 
     [31m[1mx [prevent response status code removal][22m must not remove response status code 201. This is a breaking change.[39m
-    at https://github.com/User/UserRepo/tree/75cba4a4b0e17a2e0ea5a99f1169d19eb13ed114/mvspec.yml#L27
+    at https://github.com/User/UserRepo/tree/COMMIT-HASH/mvspec.yml#L27
     
     - body [1mapplication/json[22m: 
       - property [1m/schema/properties/id[22m: 
       
         [31m[1mx [prevent removing response property][22m cannot remove response property 'id'. This is a breaking change.[39m
-        at https://github.com/User/UserRepo/tree/75cba4a4b0e17a2e0ea5a99f1169d19eb13ed114/mvspec.yml#L34
+        at https://github.com/User/UserRepo/tree/COMMIT-HASH/mvspec.yml#L34
         
 
 
@@ -382,7 +382,7 @@ specification details:
 
 [31mx [1mPOST[22m /filler_route[39m: 
   [31m[1mx [operation path component naming check][22m filler_route is not camelCase[39m
-  at https://github.com/User/UserRepo/tree/75cba4a4b0e17a2e0ea5a99f1169d19eb13ed114/specwithkey.yml#L9
+  at https://github.com/User/UserRepo/tree/COMMIT-HASH/specwithkey.yml#L9
   
 
 ...and 1 other endpoint
@@ -402,13 +402,13 @@ specification details:
 [31mx [1mPOST[22m /filler_route[39m: [32madded[39m
   
   [31m[1mx [operation path component naming check][22m filler_route is not camelCase[39m
-  at https://github.com/User/UserRepo/tree/75cba4a4b0e17a2e0ea5a99f1169d19eb13ed114/movedspec.yml#L9
+  at https://github.com/User/UserRepo/tree/COMMIT-HASH/movedspec.yml#L9
   
 
 [31mx [1mPOST[22m /api/filler-route[39m: [32madded[39m
   
   [31m[1mx [operation path component naming check][22m filler-route is not camelCase[39m
-  at https://github.com/User/UserRepo/tree/75cba4a4b0e17a2e0ea5a99f1169d19eb13ed114/movedspec.yml#L24
+  at https://github.com/User/UserRepo/tree/COMMIT-HASH/movedspec.yml#L24
   
 
 ...and 2 other endpoints
@@ -1237,33 +1237,33 @@ specification details:
 [31mx [1mPOST[22m /filler_route[39m: [31mremoved[39m
   
   [31m[1mx [prevent operation removal][22m cannot remove an operation. This is a breaking change.[39m
-  at https://github.com/User/UserRepo/tree/df9277cd263f33d6dde36fc5244d80816be5465c/mvspec.yml#L8
+  at https://github.com/User/UserRepo/tree/COMMIT-HASH/mvspec.yml#L8
   
   - response [1m201[22m: 
     [31m[1mx [prevent response status code removal][22m must not remove response status code 201. This is a breaking change.[39m
-    at https://github.com/User/UserRepo/tree/df9277cd263f33d6dde36fc5244d80816be5465c/mvspec.yml#L11
+    at https://github.com/User/UserRepo/tree/COMMIT-HASH/mvspec.yml#L11
     
     - body [1mapplication/json[22m: 
       - property [1m/schema/properties/id[22m: 
       
         [31m[1mx [prevent removing response property][22m cannot remove response property 'id'. This is a breaking change.[39m
-        at https://github.com/User/UserRepo/tree/df9277cd263f33d6dde36fc5244d80816be5465c/mvspec.yml#L18
+        at https://github.com/User/UserRepo/tree/COMMIT-HASH/mvspec.yml#L18
         
 
 [31mx [1mPOST[22m /api/filler-route[39m: [31mremoved[39m
   
   [31m[1mx [prevent operation removal][22m cannot remove an operation. This is a breaking change.[39m
-  at https://github.com/User/UserRepo/tree/df9277cd263f33d6dde36fc5244d80816be5465c/mvspec.yml#L23
+  at https://github.com/User/UserRepo/tree/COMMIT-HASH/mvspec.yml#L23
   
   - response [1m201[22m: 
     [31m[1mx [prevent response status code removal][22m must not remove response status code 201. This is a breaking change.[39m
-    at https://github.com/User/UserRepo/tree/df9277cd263f33d6dde36fc5244d80816be5465c/mvspec.yml#L26
+    at https://github.com/User/UserRepo/tree/COMMIT-HASH/mvspec.yml#L26
     
     - body [1mapplication/json[22m: 
       - property [1m/schema/properties/id[22m: 
       
         [31m[1mx [prevent removing response property][22m cannot remove response property 'id'. This is a breaking change.[39m
-        at https://github.com/User/UserRepo/tree/df9277cd263f33d6dde36fc5244d80816be5465c/mvspec.yml#L33
+        at https://github.com/User/UserRepo/tree/COMMIT-HASH/mvspec.yml#L33
         
 
 

--- a/projects/optic/src/__tests__/integration/__snapshots__/diff-all.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/diff-all.test.ts.snap
@@ -15,7 +15,7 @@ specification details:
 [31mx [1mGET[22m /api/users[39m: [31mremoved[39m
   
   [31m[1mx [prevent operation removal][22m cannot remove an operation. This is a breaking change.[39m
-  at [4mempty.json:1:45[24m
+  at https://github.com/User/UserRepo/tree/b92fc9cd38a1e4b98febf8ee612c54380e179f8f/empty.json#L1
   
 
 [32m✔ [1mGET[22m /example[39m: [32madded[39m
@@ -55,7 +55,7 @@ specification details:
 [31mx [1mGET[22m /api/users[39m: [31mremoved[39m
   
   [31m[1mx [prevent operation removal][22m cannot remove an operation. This is a breaking change.[39m
-  at [4mempty.json:1:45[24m
+  at https://github.com/User/UserRepo/tree/a0d6d1bfb9fe0b1b737616f77d262ca3f4e98a29/empty.json#L1
   
 
 [32m✔ [1mGET[22m /example[39m: [32madded[39m
@@ -87,7 +87,7 @@ specification details:
 [31mx [1mGET[22m /api/users[39m: [31mremoved[39m
   
   [31m[1mx [prevent operation removal][22m cannot remove an operation. This is a breaking change.[39m
-  at [4mempty.json:1:45[24m
+  at https://github.com/User/UserRepo/tree/a0d6d1bfb9fe0b1b737616f77d262ca3f4e98a29/empty.json#L1
   
 
 [32m✔ [1mGET[22m /example[39m: [32madded[39m
@@ -118,12 +118,12 @@ exports[`diff-all diff all not in the root of a repo 1`] = `
 
 [31mx [1mPOST[22m /filler_route[39m: 
   [31m[1mx [operation path component naming check][22m filler_route is not camelCase[39m
-  at [4min-folder.yml:9:178[24m
+  at https://github.com/User/UserRepo/tree/a7314df4aab74f8eb9e7b00bb5f6422a14fe037d/folder/in-folder.yml#L9
   
 
 [31mx [1mPOST[22m /api/filler-route[39m: 
   [31m[1mx [operation path component naming check][22m filler-route is not camelCase[39m
-  at [4min-folder.yml:24:593[24m
+  at https://github.com/User/UserRepo/tree/a7314df4aab74f8eb9e7b00bb5f6422a14fe037d/folder/in-folder.yml#L24
   
 
 ...and 2 other endpoints
@@ -142,33 +142,33 @@ specification details:
 [31mx [1mPOST[22m /filler_route[39m: [31mremoved[39m
   
   [31m[1mx [prevent operation removal][22m cannot remove an operation. This is a breaking change.[39m
-  at [4m../mvspec.yml:9:178[24m
+  at https://github.com/User/UserRepo/tree/a7314df4aab74f8eb9e7b00bb5f6422a14fe037d/mvspec.yml#L9
   
   - response [1m201[22m: 
     [31m[1mx [prevent response status code removal][22m must not remove response status code 201. This is a breaking change.[39m
-    at [4m../mvspec.yml:12:235[24m
+    at https://github.com/User/UserRepo/tree/a7314df4aab74f8eb9e7b00bb5f6422a14fe037d/mvspec.yml#L12
     
     - body [1mapplication/json[22m: 
       - property [1m/schema/properties/id[22m: 
       
         [31m[1mx [prevent removing response property][22m cannot remove response property 'id'. This is a breaking change.[39m
-        at [4m../mvspec.yml:19:432[24m
+        at https://github.com/User/UserRepo/tree/a7314df4aab74f8eb9e7b00bb5f6422a14fe037d/mvspec.yml#L19
         
 
 [31mx [1mPOST[22m /api/filler-route[39m: [31mremoved[39m
   
   [31m[1mx [prevent operation removal][22m cannot remove an operation. This is a breaking change.[39m
-  at [4m../mvspec.yml:24:593[24m
+  at https://github.com/User/UserRepo/tree/a7314df4aab74f8eb9e7b00bb5f6422a14fe037d/mvspec.yml#L24
   
   - response [1m201[22m: 
     [31m[1mx [prevent response status code removal][22m must not remove response status code 201. This is a breaking change.[39m
-    at [4m../mvspec.yml:27:650[24m
+    at https://github.com/User/UserRepo/tree/a7314df4aab74f8eb9e7b00bb5f6422a14fe037d/mvspec.yml#L27
     
     - body [1mapplication/json[22m: 
       - property [1m/schema/properties/id[22m: 
       
         [31m[1mx [prevent removing response property][22m cannot remove response property 'id'. This is a breaking change.[39m
-        at [4m../mvspec.yml:34:847[24m
+        at https://github.com/User/UserRepo/tree/a7314df4aab74f8eb9e7b00bb5f6422a14fe037d/mvspec.yml#L34
         
 
 
@@ -200,7 +200,7 @@ specification details:
 
 [31mx [1mPOST[22m /filler_route[39m: 
   [31m[1mx [operation path component naming check][22m filler_route is not camelCase[39m
-  at [4m../specwithkey.yml:9:178[24m
+  at https://github.com/User/UserRepo/tree/a7314df4aab74f8eb9e7b00bb5f6422a14fe037d/specwithkey.yml#L9
   
 
 ...and 1 other endpoint
@@ -220,13 +220,13 @@ specification details:
 [31mx [1mPOST[22m /filler_route[39m: [32madded[39m
   
   [31m[1mx [operation path component naming check][22m filler_route is not camelCase[39m
-  at [4m../movedspec.yml:9:178[24m
+  at https://github.com/User/UserRepo/tree/a7314df4aab74f8eb9e7b00bb5f6422a14fe037d/movedspec.yml#L9
   
 
 [31mx [1mPOST[22m /api/filler-route[39m: [32madded[39m
   
   [31m[1mx [operation path component naming check][22m filler-route is not camelCase[39m
-  at [4m../movedspec.yml:24:593[24m
+  at https://github.com/User/UserRepo/tree/a7314df4aab74f8eb9e7b00bb5f6422a14fe037d/movedspec.yml#L24
   
 
 ...and 2 other endpoints
@@ -256,17 +256,17 @@ specification details:
 [31mx [1mPOST[22m /filler_route[39m: [31mremoved[39m
   
   [31m[1mx [prevent operation removal][22m cannot remove an operation. This is a breaking change.[39m
-  at [4mfolder-to-run/should-run.yml:9:178[24m
+  at https://github.com/User/UserRepo/tree/a39e34b47677c1abf1184de1c90530a6e5606cd7/folder-to-run/should-run.yml#L9
   
   - response [1m201[22m: 
     [31m[1mx [prevent response status code removal][22m must not remove response status code 201. This is a breaking change.[39m
-    at [4mfolder-to-run/should-run.yml:12:235[24m
+    at https://github.com/User/UserRepo/tree/a39e34b47677c1abf1184de1c90530a6e5606cd7/folder-to-run/should-run.yml#L12
     
     - body [1mapplication/json[22m: 
       - property [1m/schema/properties/id[22m: 
       
         [31m[1mx [prevent removing response property][22m cannot remove response property 'id'. This is a breaking change.[39m
-        at [4mfolder-to-run/should-run.yml:19:432[24m
+        at https://github.com/User/UserRepo/tree/a39e34b47677c1abf1184de1c90530a6e5606cd7/folder-to-run/should-run.yml#L19
         
 
 
@@ -300,12 +300,12 @@ exports[`diff-all diffs all files in a workspace with x-optic-url keys with --up
 
 [31mx [1mPOST[22m /filler_route[39m: 
   [31m[1mx [operation path component naming check][22m filler_route is not camelCase[39m
-  at [4mfolder/in-folder.yml:9:178[24m
+  at https://github.com/User/UserRepo/tree/75cba4a4b0e17a2e0ea5a99f1169d19eb13ed114/folder/in-folder.yml#L9
   
 
 [31mx [1mPOST[22m /api/filler-route[39m: 
   [31m[1mx [operation path component naming check][22m filler-route is not camelCase[39m
-  at [4mfolder/in-folder.yml:24:593[24m
+  at https://github.com/User/UserRepo/tree/75cba4a4b0e17a2e0ea5a99f1169d19eb13ed114/folder/in-folder.yml#L24
   
 
 ...and 2 other endpoints
@@ -324,33 +324,33 @@ specification details:
 [31mx [1mPOST[22m /filler_route[39m: [31mremoved[39m
   
   [31m[1mx [prevent operation removal][22m cannot remove an operation. This is a breaking change.[39m
-  at [4mmvspec.yml:9:178[24m
+  at https://github.com/User/UserRepo/tree/75cba4a4b0e17a2e0ea5a99f1169d19eb13ed114/mvspec.yml#L9
   
   - response [1m201[22m: 
     [31m[1mx [prevent response status code removal][22m must not remove response status code 201. This is a breaking change.[39m
-    at [4mmvspec.yml:12:235[24m
+    at https://github.com/User/UserRepo/tree/75cba4a4b0e17a2e0ea5a99f1169d19eb13ed114/mvspec.yml#L12
     
     - body [1mapplication/json[22m: 
       - property [1m/schema/properties/id[22m: 
       
         [31m[1mx [prevent removing response property][22m cannot remove response property 'id'. This is a breaking change.[39m
-        at [4mmvspec.yml:19:432[24m
+        at https://github.com/User/UserRepo/tree/75cba4a4b0e17a2e0ea5a99f1169d19eb13ed114/mvspec.yml#L19
         
 
 [31mx [1mPOST[22m /api/filler-route[39m: [31mremoved[39m
   
   [31m[1mx [prevent operation removal][22m cannot remove an operation. This is a breaking change.[39m
-  at [4mmvspec.yml:24:593[24m
+  at https://github.com/User/UserRepo/tree/75cba4a4b0e17a2e0ea5a99f1169d19eb13ed114/mvspec.yml#L24
   
   - response [1m201[22m: 
     [31m[1mx [prevent response status code removal][22m must not remove response status code 201. This is a breaking change.[39m
-    at [4mmvspec.yml:27:650[24m
+    at https://github.com/User/UserRepo/tree/75cba4a4b0e17a2e0ea5a99f1169d19eb13ed114/mvspec.yml#L27
     
     - body [1mapplication/json[22m: 
       - property [1m/schema/properties/id[22m: 
       
         [31m[1mx [prevent removing response property][22m cannot remove response property 'id'. This is a breaking change.[39m
-        at [4mmvspec.yml:34:847[24m
+        at https://github.com/User/UserRepo/tree/75cba4a4b0e17a2e0ea5a99f1169d19eb13ed114/mvspec.yml#L34
         
 
 
@@ -382,7 +382,7 @@ specification details:
 
 [31mx [1mPOST[22m /filler_route[39m: 
   [31m[1mx [operation path component naming check][22m filler_route is not camelCase[39m
-  at [4mspecwithkey.yml:9:178[24m
+  at https://github.com/User/UserRepo/tree/75cba4a4b0e17a2e0ea5a99f1169d19eb13ed114/specwithkey.yml#L9
   
 
 ...and 1 other endpoint
@@ -402,13 +402,13 @@ specification details:
 [31mx [1mPOST[22m /filler_route[39m: [32madded[39m
   
   [31m[1mx [operation path component naming check][22m filler_route is not camelCase[39m
-  at [4mmovedspec.yml:9:178[24m
+  at https://github.com/User/UserRepo/tree/75cba4a4b0e17a2e0ea5a99f1169d19eb13ed114/movedspec.yml#L9
   
 
 [31mx [1mPOST[22m /api/filler-route[39m: [32madded[39m
   
   [31m[1mx [operation path component naming check][22m filler-route is not camelCase[39m
-  at [4mmovedspec.yml:24:593[24m
+  at https://github.com/User/UserRepo/tree/75cba4a4b0e17a2e0ea5a99f1169d19eb13ed114/movedspec.yml#L24
   
 
 ...and 2 other endpoints
@@ -1237,33 +1237,33 @@ specification details:
 [31mx [1mPOST[22m /filler_route[39m: [31mremoved[39m
   
   [31m[1mx [prevent operation removal][22m cannot remove an operation. This is a breaking change.[39m
-  at [4mmvspec.yml:8:105[24m
+  at https://github.com/User/UserRepo/tree/df9277cd263f33d6dde36fc5244d80816be5465c/mvspec.yml#L8
   
   - response [1m201[22m: 
     [31m[1mx [prevent response status code removal][22m must not remove response status code 201. This is a breaking change.[39m
-    at [4mmvspec.yml:11:162[24m
+    at https://github.com/User/UserRepo/tree/df9277cd263f33d6dde36fc5244d80816be5465c/mvspec.yml#L11
     
     - body [1mapplication/json[22m: 
       - property [1m/schema/properties/id[22m: 
       
         [31m[1mx [prevent removing response property][22m cannot remove response property 'id'. This is a breaking change.[39m
-        at [4mmvspec.yml:18:359[24m
+        at https://github.com/User/UserRepo/tree/df9277cd263f33d6dde36fc5244d80816be5465c/mvspec.yml#L18
         
 
 [31mx [1mPOST[22m /api/filler-route[39m: [31mremoved[39m
   
   [31m[1mx [prevent operation removal][22m cannot remove an operation. This is a breaking change.[39m
-  at [4mmvspec.yml:23:520[24m
+  at https://github.com/User/UserRepo/tree/df9277cd263f33d6dde36fc5244d80816be5465c/mvspec.yml#L23
   
   - response [1m201[22m: 
     [31m[1mx [prevent response status code removal][22m must not remove response status code 201. This is a breaking change.[39m
-    at [4mmvspec.yml:26:577[24m
+    at https://github.com/User/UserRepo/tree/df9277cd263f33d6dde36fc5244d80816be5465c/mvspec.yml#L26
     
     - body [1mapplication/json[22m: 
       - property [1m/schema/properties/id[22m: 
       
         [31m[1mx [prevent removing response property][22m cannot remove response property 'id'. This is a breaking change.[39m
-        at [4mmvspec.yml:33:774[24m
+        at https://github.com/User/UserRepo/tree/df9277cd263f33d6dde36fc5244d80816be5465c/mvspec.yml#L33
         
 
 

--- a/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
@@ -621,7 +621,7 @@ exports[`diff with mock server uploads specs if authenticated and --upload 1`] =
       - property : [33mchanged[39m
       
         [31m[1mx [prevent response property type changes][22m expected response body application/json root shape to not change type. This is a breaking change.[39m
-        at [4mspec.json:24:565[24m
+        at https://github.com/User/UserRepo/tree/adf8074aa23a7a79509af21762db128012ed5e0b/spec.json#L24
         
 
 ...and 4 other endpoints

--- a/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
@@ -621,7 +621,7 @@ exports[`diff with mock server uploads specs if authenticated and --upload 1`] =
       - property : [33mchanged[39m
       
         [31m[1mx [prevent response property type changes][22m expected response body application/json root shape to not change type. This is a breaking change.[39m
-        at https://github.com/User/UserRepo/tree/adf8074aa23a7a79509af21762db128012ed5e0b/spec.json#L24
+        at https://github.com/User/UserRepo/tree/COMMIT-HASH/spec.json#L24
         
 
 ...and 4 other endpoints

--- a/projects/optic/src/__tests__/integration/diff-all.test.ts
+++ b/projects/optic/src/__tests__/integration/diff-all.test.ts
@@ -58,6 +58,10 @@ setupTestServer(({ url, method }) => {
   return JSON.stringify({});
 });
 
+function sanitizeOutput(out: string) {
+  return out.replace(/tree\/[a-zA-Z0-9]{40}/g, 'tree/COMMIT-HASH');
+}
+
 describe('diff-all', () => {
   let oldEnv: any;
   beforeEach(() => {
@@ -84,7 +88,9 @@ describe('diff-all', () => {
     );
     const { combined, code } = await runOptic(workspace, 'diff-all --check');
 
-    expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
+    expect(
+      normalizeWorkspace(workspace, sanitizeOutput(combined))
+    ).toMatchSnapshot();
     expect(code).toBe(1);
   });
 
@@ -101,7 +107,9 @@ describe('diff-all', () => {
     );
     const { combined, code } = await runOptic(workspace, 'diff-all --check');
 
-    expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
+    expect(
+      normalizeWorkspace(workspace, sanitizeOutput(combined))
+    ).toMatchSnapshot();
     expect(code).toBe(1);
   });
 
@@ -123,7 +131,9 @@ describe('diff-all', () => {
       'diff-all --check --upload'
     );
 
-    expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
+    expect(
+      normalizeWorkspace(workspace, sanitizeOutput(combined))
+    ).toMatchSnapshot();
     expect(
       JSON.parse(
         await fs.readFile(path.join(workspace, 'ci-run-details.json'), 'utf-8')
@@ -150,7 +160,9 @@ describe('diff-all', () => {
       'diff-all --check --json --upload'
     );
 
-    expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
+    expect(
+      normalizeWorkspace(workspace, sanitizeOutput(combined))
+    ).toMatchSnapshot();
     expect(code).toBe(1);
   });
 
@@ -172,7 +184,9 @@ describe('diff-all', () => {
       'diff-all --check --upload --match "folder-to-run/**" --ignore "folder-to-run/ignore/**"'
     );
 
-    expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
+    expect(
+      normalizeWorkspace(workspace, sanitizeOutput(combined))
+    ).toMatchSnapshot();
     expect(code).toBe(1);
   });
 
@@ -194,7 +208,9 @@ describe('diff-all', () => {
       'diff-all --check --upload'
     );
 
-    expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
+    expect(
+      normalizeWorkspace(workspace, sanitizeOutput(combined))
+    ).toMatchSnapshot();
     expect(code).toBe(1);
   });
 
@@ -211,7 +227,9 @@ describe('diff-all', () => {
     );
 
     expect(code).toBe(1);
-    expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
+    expect(
+      normalizeWorkspace(workspace, sanitizeOutput(combined))
+    ).toMatchSnapshot();
   });
 
   test('diff all in --generated', async () => {
@@ -233,6 +251,8 @@ describe('diff-all', () => {
     );
 
     expect(code).toBe(1);
-    expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
+    expect(
+      normalizeWorkspace(workspace, sanitizeOutput(combined))
+    ).toMatchSnapshot();
   });
 });

--- a/projects/optic/src/__tests__/integration/diff.test.ts
+++ b/projects/optic/src/__tests__/integration/diff.test.ts
@@ -18,6 +18,10 @@ import {
 
 jest.setTimeout(30000);
 
+function sanitizeOutput(out: string) {
+  return out.replace(/tree\/[a-zA-Z0-9]{40}/g, 'tree/COMMIT-HASH');
+}
+
 let oldEnv: any;
 beforeEach(() => {
   oldEnv = { ...process.env };
@@ -169,7 +173,9 @@ paths: {}`;
       );
 
       expect(code).toBe(1);
-      expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
+      expect(
+        normalizeWorkspace(workspace, sanitizeOutput(combined))
+      ).toMatchSnapshot();
     });
 
     test('ruleset key on api spec', async () => {

--- a/projects/optic/src/commands/diff/diff.ts
+++ b/projects/optic/src/commands/diff/diff.ts
@@ -16,7 +16,10 @@ import {
   flushEvents,
   trackEvent,
 } from '@useoptic/openapi-utilities/build/utilities/segment';
-import { terminalChangelog } from './changelog-renderers/terminal-changelog';
+import {
+  SourcemapOptions,
+  terminalChangelog,
+} from './changelog-renderers/terminal-changelog';
 import { jsonChangelog } from './changelog-renderers/json-changelog';
 import { compute } from './compute';
 import { compressDataV2 } from './compressResults';
@@ -316,11 +319,26 @@ const getDiffAction =
 
       logger.info('');
 
+      let sourcemapOptions: SourcemapOptions = {
+        ciProvider: undefined,
+      };
+      if (config.isInCi && config.vcs?.type === VCS.Git) {
+        const remote = await Git.guessRemoteOrigin();
+        if (remote) {
+          sourcemapOptions = {
+            ciProvider: remote.provider,
+            remote: remote.web_url,
+            sha: config.vcs.sha,
+            root: config.root,
+          };
+        }
+      }
       for (const log of terminalChangelog(
         { from: baseParseResult, to: headParseResult },
         diffResult.changelogData,
         diffResult.specResults,
         {
+          ...sourcemapOptions,
           path: file1,
           check: options.check,
           inCi: config.isInCi,

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.46.0",
+  "version": "0.46.1-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -40,5 +40,6 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
-  }
+  },
+  "stableVersion": "0.46.0"
 }

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.46.1-0",
+  "version": "0.46.1-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.46.0",
+  "version": "0.46.1-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -39,5 +39,6 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
-  }
+  },
+  "stableVersion": "0.46.0"
 }

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.46.1-0",
+  "version": "0.46.1-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

renders the git links for sourcemap when running in CI

e.g.

```bash
# local
src/__tests__/integration/workspaces/diff/petstore/petstore-base.json:81:2600
# ci
https://github.com/opticdev/optic/tree/fbe3df088881e0748d46b4b4e0472509c6c15436/projects/optic/src/__tests__/integration/workspaces/diff/petstore/petstore-base.json#L81
```

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
