### PR TITLE
implement history command

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.46.1",
+  "version": "0.47.0",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",
@@ -28,6 +28,5 @@
     "**/*.+(js|jsx|ts|tsx|json|css)": [
       "yarn prettier --write"
     ]
-  },
-  "stableVersion": "0.46.0"
+  }
 }

--- a/projects/fastify-capture/package.json
+++ b/projects/fastify-capture/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/fastify-capture",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.46.1",
+  "version": "0.47.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -37,6 +37,5 @@
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
     "typescript": "^5.0.4"
-  },
-  "stableVersion": "0.46.0"
+  }
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.46.1",
+  "version": "0.47.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -33,6 +33,5 @@
   "dependencies": {
     "jsonpointer": "^5.0.1",
     "minimatch": "9.0.1"
-  },
-  "stableVersion": "0.46.0"
+  }
 }

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.46.1",
+  "version": "0.47.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -58,6 +58,5 @@
     "upath": "^2.0.1",
     "yaml": "^2.2.2",
     "yaml-ast-parser": "^0.0.43"
-  },
-  "stableVersion": "0.46.0"
+  }
 }

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.46.1",
+  "version": "0.47.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -57,6 +57,5 @@
     "openapi-types": "^12.0.2",
     "ts-invariant": "^0.9.3",
     "yaml-ast-parser": "^0.0.43"
-  },
-  "stableVersion": "0.46.0"
+  }
 }

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.46.1",
+  "version": "0.47.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -64,6 +64,5 @@
     "picomatch": "^2.3.1",
     "url-join": "^4.0.1",
     "uuid": "^9.0.0"
-  },
-  "stableVersion": "0.46.0"
+  }
 }

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.46.1",
+  "version": "0.47.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -132,6 +132,5 @@
       "node18-win-x64"
     ],
     "outputPath": "../../dist"
-  },
-  "stableVersion": "0.46.0"
+  }
 }

--- a/projects/optic/src/__tests__/integration/__snapshots__/history.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/history.test.ts.snap
@@ -12,7 +12,7 @@ exports[`optic history writes changelog 1`] = `
   - removed \`requestBody\` \`required\`.\`2\`
   - added \`requestBody\` \`required\`.\`2\`
 - \`GET\` \`/user/{username}\`:
-  - added \`404\` response 
+  - added \`404\` response
   - removed \`200\` response \`phone\` property
   - added \`200\` response \`bio\` property
   - changed \`200\` response \`userStatus\`.\`type\`
@@ -21,8 +21,8 @@ exports[`optic history writes changelog 1`] = `
   - removed \`200\` response \`required\`.\`2\`
   - added \`200\` response \`required\`.\`2\`
 - \`GET\` \`/user/login\`:
-  - removed \`200\` response 
-  - added \`200\` response 
+  - removed \`200\` response
+  - added \`200\` response
   - changed \`200\` response \`type\`
   - added \`200\` response \`format\`
 - \`POST\` \`/user/createWithList\`:
@@ -49,9 +49,9 @@ exports[`optic history writes changelog 1`] = `
   - added \`requestBody\` \`userStatus\`.\`enum\`
   - removed \`requestBody\` \`required\`.\`2\`
   - added \`requestBody\` \`required\`.\`2\`
-- \`DELETE\` \`/store/order/{orderId}\`: added \`404\` response 
+- \`DELETE\` \`/store/order/{orderId}\`: added \`404\` response
 - \`GET\` \`/store/order/{orderId}\`:
-  - added \`404\` response 
+  - added \`404\` response
   - added \`200\` response \`summary\` property
   - removed \`200\` response \`status\`.\`enum\`.\`1\`
   - added \`200\` response \`status\`.\`enum\`.\`2\`
@@ -65,15 +65,15 @@ exports[`optic history writes changelog 1`] = `
   - removed \`requestBody\` \`status\`.\`enum\`.\`1\`
   - added \`requestBody\` \`status\`.\`enum\`.\`2\`
 - \`POST\` \`/pet/{petId}/uploadImage\`:
-  - removed \`200\` response 
-  - added \`201\` response 
-  - added \`404\` response 
+  - removed \`200\` response
+  - added \`201\` response
+  - added \`404\` response
   - changed \`default\` response \`type\`.\`type\`
   - added \`debug\` cookie parameter
 - removed \`GET\` \`/pet\`
 - \`PUT\` \`/pet\`:
-  - removed \`400\` response 
-  - removed \`requestBody\` 
+  - removed \`400\` response
+  - removed \`requestBody\`
   - removed \`requestBody\` \`name\` property
   - added \`requestBody\` \`number\` property
   - removed \`requestBody\` \`required\`.\`0\`

--- a/projects/optic/src/__tests__/integration/__snapshots__/history.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/history.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`optic history writes changelog 1`] = `
 "# Swagger Petstore Updated
-### Wed Jun 21 2023
+### Sun Jan 01 2023
 - \`PUT\` \`/user/{username}\`:
   - removed \`requestBody\` \`phone\` property
   - added \`requestBody\` \`bio\` property
@@ -71,7 +71,6 @@ exports[`optic history writes changelog 1`] = `
   - changed \`default\` response \`type\`.\`type\`
   - added \`debug\` cookie parameter
 - removed \`GET\` \`/pet\`
-- \`POST\` \`/pet\`: 
 - \`PUT\` \`/pet\`:
   - removed \`400\` response 
   - removed \`requestBody\` 

--- a/projects/optic/src/__tests__/integration/__snapshots__/history.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/history.test.ts.snap
@@ -1,0 +1,106 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`optic history writes changelog 1`] = `
+"# Swagger Petstore Updated
+### Wed Jun 21 2023
+- \`PUT\` \`/user/{username}\`:
+  - removed \`requestBody\` \`phone\` property
+  - added \`requestBody\` \`bio\` property
+  - changed \`requestBody\` \`userStatus\`.\`type\`
+  - removed \`requestBody\` \`userStatus\`.\`format\`
+  - added \`requestBody\` \`userStatus\`.\`enum\`
+  - removed \`requestBody\` \`required\`.\`2\`
+  - added \`requestBody\` \`required\`.\`2\`
+- \`GET\` \`/user/{username}\`:
+  - added \`404\` response 
+  - removed \`200\` response \`phone\` property
+  - added \`200\` response \`bio\` property
+  - changed \`200\` response \`userStatus\`.\`type\`
+  - removed \`200\` response \`userStatus\`.\`format\`
+  - added \`200\` response \`userStatus\`.\`enum\`
+  - removed \`200\` response \`required\`.\`2\`
+  - added \`200\` response \`required\`.\`2\`
+- \`GET\` \`/user/login\`:
+  - removed \`200\` response 
+  - added \`200\` response 
+  - changed \`200\` response \`type\`
+  - added \`200\` response \`format\`
+- \`POST\` \`/user/createWithList\`:
+  - removed \`requestBody\` \`items\`.\`phone\` property
+  - added \`requestBody\` \`items\`.\`bio\` property
+  - changed \`requestBody\` \`items\`.\`userStatus\`.\`type\`
+  - removed \`requestBody\` \`items\`.\`userStatus\`.\`format\`
+  - added \`requestBody\` \`items\`.\`userStatus\`.\`enum\`
+  - removed \`requestBody\` \`items\`.\`required\`.\`2\`
+  - added \`requestBody\` \`items\`.\`required\`.\`2\`
+- \`POST\` \`/user/createWithArray\`:
+  - removed \`requestBody\` \`items\`.\`phone\` property
+  - added \`requestBody\` \`items\`.\`bio\` property
+  - changed \`requestBody\` \`items\`.\`userStatus\`.\`type\`
+  - removed \`requestBody\` \`items\`.\`userStatus\`.\`format\`
+  - added \`requestBody\` \`items\`.\`userStatus\`.\`enum\`
+  - removed \`requestBody\` \`items\`.\`required\`.\`2\`
+  - added \`requestBody\` \`items\`.\`required\`.\`2\`
+- \`POST\` \`/user\`:
+  - removed \`requestBody\` \`phone\` property
+  - added \`requestBody\` \`bio\` property
+  - changed \`requestBody\` \`userStatus\`.\`type\`
+  - removed \`requestBody\` \`userStatus\`.\`format\`
+  - added \`requestBody\` \`userStatus\`.\`enum\`
+  - removed \`requestBody\` \`required\`.\`2\`
+  - added \`requestBody\` \`required\`.\`2\`
+- \`DELETE\` \`/store/order/{orderId}\`: added \`404\` response 
+- \`GET\` \`/store/order/{orderId}\`:
+  - added \`404\` response 
+  - added \`200\` response \`summary\` property
+  - removed \`200\` response \`status\`.\`enum\`.\`1\`
+  - added \`200\` response \`status\`.\`enum\`.\`2\`
+  - removed \`200\` response \`required\`.\`1\`
+- \`POST\` \`/store/order\`:
+  - added \`200\` response \`example\`
+  - added \`200\` response \`summary\` property
+  - removed \`200\` response \`status\`.\`enum\`.\`1\`
+  - added \`200\` response \`status\`.\`enum\`.\`2\`
+  - added \`requestBody\` \`summary\` property
+  - removed \`requestBody\` \`status\`.\`enum\`.\`1\`
+  - added \`requestBody\` \`status\`.\`enum\`.\`2\`
+- \`POST\` \`/pet/{petId}/uploadImage\`:
+  - removed \`200\` response 
+  - added \`201\` response 
+  - added \`404\` response 
+  - changed \`default\` response \`type\`.\`type\`
+  - added \`debug\` cookie parameter
+- removed \`GET\` \`/pet\`
+- \`POST\` \`/pet\`: 
+- \`PUT\` \`/pet\`:
+  - removed \`400\` response 
+  - removed \`requestBody\` 
+  - removed \`requestBody\` \`name\` property
+  - added \`requestBody\` \`number\` property
+  - removed \`requestBody\` \`required\`.\`0\`
+  - added \`requestBody\` \`required\`.\`0\`
+- \`GET\` \`/parameters_at_path\`: added \`undefined\` undefined parameter
+- \`POST\` \`/example\`: removed \`somethingelse\` query parameter
+- \`GET\` \`/example\`:
+  - changed \`200\` response \`toTypeArrays\`.\`type\`
+  - changed \`200\` response \`fromTypeArrays\`.\`type\`
+  - removed \`200\` response \`requiredKeys\`.\`required\`.\`0\`
+  - removed \`200\` response \`requiredKeys\`.\`required\`.\`1\`
+  - added \`200\` response \`requiredKeys\`.\`required\`.\`0\`
+  - added \`200\` response \`requiredKeys\`.\`required\`.\`1\`
+  - removed \`200\` response \`requiredKeys\`.\`deletedRequiredKey\` property
+  - added \`200\` response \`requiredKeys\`.\`addedRequiredKey\` property
+  - added \`200\` response \`expandableObject\`.\`anyOf\`.\`1\`
+  - changed \`200\` response \`composedObject\`.\`orderId\`.\`type\`
+  - removed \`200\` response \`stringOrNumberOrObject\`.\`oneOf\`.\`2\`
+  - removed \`deletedQueryParameter\` query parameter
+  - added \`addedQueryParameter\` query parameter
+  - removed \`requiredToOptional\` query parameter
+  - added \`optionalToRequired\` query parameter
+- added \`GET\` \`/pet/findByStatus\`
+- added \`GET\` \`/pet/findByTags\`
+- added \`GET\` \`/pet/{petId}\`
+- added \`POST\` \`/pet/{petId}\`
+- added \`DELETE\` \`/pet/{petId}\`
+"
+`;

--- a/projects/optic/src/__tests__/integration/history.test.ts
+++ b/projects/optic/src/__tests__/integration/history.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect } from '@jest/globals';
+import {
+  runOptic,
+  setupWorkspace,
+  normalizeWorkspace,
+  run,
+} from './integration';
+
+function sanitizeOutput(out: string) {
+  return out.replace(/[a-zA-Z0-9]{8}:/g, 'COMMIT-HASH:');
+}
+
+describe('optic history', () => {
+  test('writes changelog', async () => {
+    process.env.OPTIC_TOKEN = 'something';
+    const workspace = await setupWorkspace('history/petstore', {
+      repo: true,
+      commit: true,
+    });
+
+    await run(
+      `cp petstore-updated.json petstore-base.json && git add . && git commit -m 'update petstore'`,
+      false,
+      workspace
+    );
+
+    const { combined, code } = await runOptic(
+      workspace,
+      'history petstore-base.json'
+    );
+
+    expect(code).toBe(0);
+    expect(
+      normalizeWorkspace(workspace, sanitizeOutput(combined))
+    ).toMatchSnapshot();
+  }, 20000);
+});

--- a/projects/optic/src/__tests__/integration/workspaces/history/petstore/petstore-base.json
+++ b/projects/optic/src/__tests__/integration/workspaces/history/petstore/petstore-base.json
@@ -1,0 +1,1049 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Swagger Petstore",
+    "description": "This is a sample server Petstore server.  You can find out more about     Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).      For this sample, you can use the api key `special-key` to test the authorization     filters.",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": { "email": "apiteam@swagger.io" },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    },
+    "version": "1.0.0"
+  },
+  "externalDocs": {
+    "description": "Find out more about Swagger",
+    "url": "http://swagger.io"
+  },
+  "servers": [
+    { "url": "https://petstore.swagger.io/v2" },
+    { "url": "http://petstore.swagger.io/v2" }
+  ],
+  "tags": [
+    {
+      "name": "pet",
+      "description": "Everything about your Pets",
+      "externalDocs": {
+        "description": "Find out more",
+        "url": "http://swagger.io"
+      }
+    },
+    { "name": "store", "description": "Access to Petstore orders" },
+    {
+      "name": "user",
+      "description": "Operations about user",
+      "externalDocs": {
+        "description": "Find out more about our store",
+        "url": "http://swagger.io"
+      }
+    }
+  ],
+  "paths": {
+    "/example": {
+      "get": {
+        "operationId": "getExamples",
+        "parameters": [
+          {
+            "name": "optionalToRequired",
+            "in": "query",
+            "description": "The user name for login",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "requiredToOptional",
+            "in": "query",
+            "description": "The user name for login",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "deletedQueryParameter",
+            "in": "query",
+            "description": "The user name for login",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "succesful",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "stringOrNumberOrObject": {
+                      "oneOf": [
+                        { "type": "string" },
+                        { "type": "number" },
+                        {
+                          "type": "object",
+                          "properties": { "orderId": { "type": "string" } }
+                        }
+                      ]
+                    },
+                    "composedObject": {
+                      "allOf": [
+                        {
+                          "type": "object",
+                          "properties": { "orderId": { "type": "string" } }
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "fulfillmentId": { "type": "string" }
+                          }
+                        }
+                      ]
+                    },
+                    "expandableObject": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": { "orderId": { "type": "string" } }
+                        }
+                      ]
+                    },
+                    "requiredKeys": {
+                      "type": "object",
+                      "properties": {
+                        "optionalToRequired": { "type": "string" },
+                        "requiredToOptional": { "type": "string" },
+                        "deletedRequiredKey": { "type": "string" }
+                      },
+                      "required": ["requiredToOptional", "deletedRequiredKey"]
+                    },
+                    "fromTypeArrays": { "type": ["string", "number"] },
+                    "toTypeArrays": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "seomthing",
+            "in": "query",
+            "description": "something",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "somethingelse",
+            "in": "query",
+            "description": "something",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/parameters_at_path": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Invalid input",
+            "content": {
+              "application/json": { "schema": { "type": "string" } }
+            }
+          }
+        }
+      }
+    },
+    "/pet": {
+      "get": {
+        "responses": {
+          "404": { "description": "Pet not found", "content": {} },
+          "405": { "description": "Validation exception", "content": {} }
+        }
+      },
+      "put": {
+        "requestBody": {
+          "description": "Pet object that needs to be added to the store",
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": ["name", "photoUrls"],
+                "type": "object",
+                "properties": {
+                  "id": { "type": "integer", "format": "int64" },
+                  "category": {
+                    "type": "object",
+                    "properties": {
+                      "id": { "type": "integer", "format": "int64" },
+                      "name": { "type": "string" }
+                    },
+                    "xml": { "name": "Category" }
+                  },
+                  "name": { "type": "string", "example": "doggie" },
+                  "photoUrls": {
+                    "type": "array",
+                    "xml": { "name": "photoUrl", "wrapped": true },
+                    "items": { "type": "string" }
+                  },
+                  "tags": {
+                    "type": "array",
+                    "xml": { "name": "tag", "wrapped": true },
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": { "type": "integer", "format": "int64" },
+                        "name": { "type": "string" }
+                      },
+                      "xml": { "name": "Tag" }
+                    }
+                  },
+                  "status": {
+                    "type": "string",
+                    "description": "pet status in the store",
+                    "enum": ["available", "pending", "sold"]
+                  }
+                },
+                "xml": { "name": "Pet" }
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "required": ["name", "photoUrls"],
+                "type": "object",
+                "properties": {
+                  "id": { "type": "integer", "format": "int64" },
+                  "category": {
+                    "type": "object",
+                    "properties": {
+                      "id": { "type": "integer", "format": "int64" },
+                      "name": { "type": "string" }
+                    },
+                    "xml": { "name": "Category" }
+                  },
+                  "name": { "type": "string", "example": "doggie" },
+                  "photoUrls": {
+                    "type": "array",
+                    "xml": { "name": "photoUrl", "wrapped": true },
+                    "items": { "type": "string" }
+                  },
+                  "tags": {
+                    "type": "array",
+                    "xml": { "name": "tag", "wrapped": true },
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": { "type": "integer", "format": "int64" },
+                        "name": { "type": "string" }
+                      },
+                      "xml": { "name": "Tag" }
+                    }
+                  },
+                  "status": {
+                    "type": "string",
+                    "description": "pet status in the store",
+                    "enum": ["available", "pending", "sold"]
+                  }
+                },
+                "xml": { "name": "Pet" }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "400": { "description": "Invalid ID supplied", "content": {} },
+          "404": { "description": "Pet not found", "content": {} },
+          "405": { "description": "Validation exception", "content": {} }
+        }
+      },
+      "post": {
+        "tags": ["pet"],
+        "summary": "Add a new pet to the store",
+        "operationId": "addPet",
+        "requestBody": {
+          "description": "Pet object that needs to be added to the store",
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": ["name", "photoUrls"],
+                "type": "object",
+                "properties": {
+                  "id": { "type": "integer", "format": "int64" },
+                  "category": {
+                    "type": "object",
+                    "properties": {
+                      "id": { "type": "integer", "format": "int64" },
+                      "name": { "type": "string" }
+                    },
+                    "xml": { "name": "Category" }
+                  },
+                  "name": { "type": "string", "example": "doggie" },
+                  "photoUrls": {
+                    "type": "array",
+                    "xml": { "name": "photoUrl", "wrapped": true },
+                    "items": { "type": "string" }
+                  },
+                  "tags": {
+                    "type": "array",
+                    "xml": { "name": "tag", "wrapped": true },
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": { "type": "integer", "format": "int64" },
+                        "name": { "type": "string" }
+                      },
+                      "xml": { "name": "Tag" }
+                    }
+                  },
+                  "status": {
+                    "type": "string",
+                    "description": "pet status in the store",
+                    "enum": ["available", "pending", "sold"]
+                  }
+                },
+                "xml": { "name": "Pet" }
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "required": ["name", "photoUrls"],
+                "type": "object",
+                "properties": {
+                  "id": { "type": "integer", "format": "int64" },
+                  "category": {
+                    "type": "object",
+                    "properties": {
+                      "id": { "type": "integer", "format": "int64" },
+                      "name": { "type": "string" }
+                    },
+                    "xml": { "name": "Category" }
+                  },
+                  "name": { "type": "string", "example": "doggie" },
+                  "photoUrls": {
+                    "type": "array",
+                    "xml": { "name": "photoUrl", "wrapped": true },
+                    "items": { "type": "string" }
+                  },
+                  "tags": {
+                    "type": "array",
+                    "xml": { "name": "tag", "wrapped": true },
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": { "type": "integer", "format": "int64" },
+                        "name": { "type": "string" }
+                      },
+                      "xml": { "name": "Tag" }
+                    }
+                  },
+                  "status": {
+                    "type": "string",
+                    "description": "pet status in the store",
+                    "enum": ["available", "pending", "sold"]
+                  }
+                },
+                "xml": { "name": "Pet" }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "405": { "description": "Invalid input", "content": {} }
+        },
+        "security": [{ "petstore_auth": ["write:pets", "read:pets"] }],
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/pet/{petId}/uploadImage": {
+      "post": {
+        "tags": ["pet"],
+        "summary": "uploads an image",
+        "operationId": "uploadFile",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to update",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          },
+          {
+            "name": "debug",
+            "in": "cookie",
+            "description": "A debug token",
+            "required": false,
+            "schema": { "type": "integer" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "additionalMetadata": {
+                    "type": "string",
+                    "description": "Additional data to pass to server"
+                  },
+                  "file": {
+                    "type": "string",
+                    "description": "file to upload",
+                    "format": "binary"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "integer", "format": "int32" },
+                    "type": { "type": "string" },
+                    "message": { "type": "string" }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "integer", "format": "int32" },
+                    "type": { "type": "string" },
+                    "message": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [{ "petstore_auth": ["write:pets", "read:pets"] }]
+      }
+    },
+    "/store/inventory": {
+      "get": {
+        "tags": ["store"],
+        "summary": "Returns pet inventories by status",
+        "description": "Returns a map of status codes to quantities",
+        "operationId": "getInventory",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "integer",
+                    "format": "int32"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [{ "api_key": [] }]
+      }
+    },
+    "/store/order": {
+      "post": {
+        "tags": ["store"],
+        "summary": "Place an order for a pet",
+        "operationId": "placeOrder",
+        "requestBody": {
+          "description": "order placed for purchasing the pet",
+          "content": {
+            "*/*": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": { "type": "integer", "format": "int64" },
+                  "petId": { "type": "integer", "format": "int64" },
+                  "quantity": { "type": "integer", "format": "int32" },
+                  "shipDate": { "type": "string", "format": "date-time" },
+                  "status": {
+                    "type": "string",
+                    "description": "Order Status",
+                    "enum": ["placed", "approved", "delivered"]
+                  },
+                  "complete": { "type": "boolean", "default": false }
+                },
+                "xml": { "name": "Order" }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer", "format": "int64" },
+                    "petId": { "type": "integer", "format": "int64" },
+                    "quantity": { "type": "integer", "format": "int32" },
+                    "shipDate": { "type": "string", "format": "date-time" },
+                    "status": {
+                      "type": "string",
+                      "description": "Order Status",
+                      "enum": ["placed", "approved", "delivered"]
+                    },
+                    "complete": { "type": "boolean", "default": false }
+                  },
+                  "xml": { "name": "Order" }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer", "format": "int64" },
+                    "petId": { "type": "integer", "format": "int64" },
+                    "quantity": { "type": "integer", "format": "int32" },
+                    "shipDate": { "type": "string", "format": "date-time" },
+                    "status": {
+                      "type": "string",
+                      "description": "Order Status",
+                      "enum": ["placed", "approved", "delivered"]
+                    },
+                    "complete": { "type": "boolean", "default": false }
+                  },
+                  "xml": { "name": "Order" }
+                }
+              }
+            }
+          },
+          "400": { "description": "Invalid Order", "content": {} }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/store/order/{orderId}": {
+      "get": {
+        "tags": ["store"],
+        "summary": "Find purchase order by ID",
+        "description": "For valid response try integer IDs with value >= 1 and <= 10.         Other values will generated exceptions",
+        "operationId": "getOrderById",
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of pet that needs to be fetched",
+            "required": true,
+            "schema": {
+              "maximum": 10,
+              "minimum": 1,
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "object",
+                  "required": ["id", "petId"],
+                  "properties": {
+                    "id": { "type": "integer", "format": "int64" },
+                    "petId": { "type": "integer", "format": "int64" },
+                    "quantity": { "type": "integer", "format": "int32" },
+                    "shipDate": { "type": "string", "format": "date-time" },
+                    "status": {
+                      "type": "string",
+                      "description": "Order Status",
+                      "enum": ["placed", "approved", "delivered"]
+                    },
+                    "complete": { "type": "boolean", "default": false }
+                  },
+                  "xml": { "name": "Order" }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer", "format": "int64" },
+                    "petId": { "type": "integer", "format": "int64" },
+                    "quantity": { "type": "integer", "format": "int32" },
+                    "shipDate": { "type": "string", "format": "date-time" },
+                    "status": {
+                      "type": "string",
+                      "description": "Order Status",
+                      "enum": ["placed", "approved", "delivered"]
+                    },
+                    "complete": { "type": "boolean", "default": false }
+                  },
+                  "xml": { "name": "Order" }
+                }
+              }
+            }
+          },
+          "400": { "description": "Invalid ID supplied", "content": {} },
+          "404": { "description": "Order not found", "content": {} }
+        }
+      },
+      "delete": {
+        "tags": ["store"],
+        "summary": "Delete purchase order by ID",
+        "description": "For valid response try integer IDs with positive integer value.         Negative or non-integer values will generate API errors",
+        "operationId": "deleteOrder",
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of the order that needs to be deleted",
+            "required": true,
+            "schema": { "minimum": 1, "type": "integer", "format": "int64" }
+          }
+        ],
+        "responses": {
+          "400": { "description": "Invalid ID supplied", "content": {} },
+          "404": { "description": "Order not found", "content": {} }
+        }
+      }
+    },
+    "/user": {
+      "post": {
+        "tags": ["user"],
+        "summary": "Create user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "createUser",
+        "requestBody": {
+          "description": "Created user object",
+          "content": {
+            "*/*": {
+              "schema": {
+                "type": "object",
+                "required": ["id", "email", "lastName", "userStatus"],
+                "properties": {
+                  "id": { "type": "integer", "format": "int64" },
+                  "username": { "type": "string" },
+                  "firstName": { "type": "string" },
+                  "lastName": { "type": "string" },
+                  "email": { "type": "string" },
+                  "password": { "type": "string" },
+                  "phone": { "type": "string" },
+                  "userStatus": {
+                    "type": "integer",
+                    "description": "User Status",
+                    "format": "int32"
+                  }
+                },
+                "xml": { "name": "User" }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "default": { "description": "successful operation", "content": {} }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/user/createWithArray": {
+      "post": {
+        "tags": ["user"],
+        "summary": "Creates list of users with given input array",
+        "operationId": "createUsersWithArrayInput",
+        "requestBody": {
+          "description": "List of user object",
+          "content": {
+            "*/*": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["id", "email", "lastName", "userStatus"],
+                  "properties": {
+                    "id": { "type": "integer", "format": "int64" },
+                    "username": { "type": "string" },
+                    "firstName": { "type": "string" },
+                    "lastName": { "type": "string" },
+                    "email": { "type": "string" },
+                    "password": { "type": "string" },
+                    "phone": { "type": "string" },
+                    "userStatus": {
+                      "type": "integer",
+                      "description": "User Status",
+                      "format": "int32"
+                    }
+                  },
+                  "xml": { "name": "User" }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "default": { "description": "successful operation", "content": {} }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/user/createWithList": {
+      "post": {
+        "tags": ["user"],
+        "summary": "Creates list of users with given input array",
+        "operationId": "createUsersWithListInput",
+        "requestBody": {
+          "description": "List of user object",
+          "content": {
+            "*/*": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["id", "email", "lastName", "userStatus"],
+                  "properties": {
+                    "id": { "type": "integer", "format": "int64" },
+                    "username": { "type": "string" },
+                    "firstName": { "type": "string" },
+                    "lastName": { "type": "string" },
+                    "email": { "type": "string" },
+                    "password": { "type": "string" },
+                    "phone": { "type": "string" },
+                    "userStatus": {
+                      "type": "integer",
+                      "description": "User Status",
+                      "format": "int32"
+                    }
+                  },
+                  "xml": { "name": "User" }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "default": { "description": "successful operation", "content": {} }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/user/login": {
+      "get": {
+        "tags": ["user"],
+        "summary": "Logs user into the system",
+        "operationId": "loginUser",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "query",
+            "description": "The user name for login",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "password",
+            "in": "query",
+            "description": "The password for login in clear text",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "headers": {
+              "X-Expires-After": {
+                "description": "date in UTC when token expires",
+                "schema": { "type": "number" }
+              },
+              "content-type": {
+                "description": "the description goes here",
+                "schema": { "type": "string" }
+              }
+            },
+            "content": {
+              "application/xml": { "schema": { "type": "string" } },
+              "application/json": { "schema": { "type": "string" } }
+            }
+          },
+          "400": {
+            "description": "Invalid username/password supplied",
+            "content": {}
+          }
+        }
+      }
+    },
+    "/user/logout": {
+      "get": {
+        "tags": ["user"],
+        "summary": "Logs out current logged in user session",
+        "operationId": "logoutUser",
+        "responses": {
+          "default": { "description": "successful operation", "content": {} }
+        }
+      }
+    },
+    "/user/{username}": {
+      "get": {
+        "tags": ["user"],
+        "summary": "Get user by user name",
+        "operationId": "getUserByName",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be fetched. Use user1 for testing. ",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "object",
+                  "required": ["id", "email", "lastName", "userStatus"],
+                  "properties": {
+                    "id": { "type": "integer", "format": "int64" },
+                    "username": { "type": "string" },
+                    "firstName": { "type": "string" },
+                    "lastName": { "type": "string" },
+                    "email": { "type": "string" },
+                    "password": { "type": "string" },
+                    "phone": { "type": "string" },
+                    "userStatus": {
+                      "type": "integer",
+                      "description": "User Status",
+                      "format": "int32"
+                    }
+                  },
+                  "xml": { "name": "User" }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["id", "email", "lastName", "userStatus"],
+                  "properties": {
+                    "id": { "type": "integer", "format": "int64" },
+                    "username": { "type": "string" },
+                    "firstName": { "type": "string" },
+                    "lastName": { "type": "string" },
+                    "email": { "type": "string" },
+                    "password": { "type": "string" },
+                    "phone": { "type": "string" },
+                    "userStatus": {
+                      "type": "integer",
+                      "description": "User Status",
+                      "format": "int32"
+                    }
+                  },
+                  "xml": { "name": "User" }
+                }
+              }
+            }
+          },
+          "400": { "description": "Invalid username supplied", "content": {} },
+          "404": { "description": "User not found", "content": {} }
+        }
+      },
+      "put": {
+        "tags": ["user"],
+        "summary": "Updated user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "updateUser",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "name that need to be updated",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "description": "Updated user object",
+          "content": {
+            "*/*": {
+              "schema": {
+                "type": "object",
+                "required": ["id", "email", "lastName", "userStatus"],
+                "properties": {
+                  "id": { "type": "integer", "format": "int64" },
+                  "username": { "type": "string" },
+                  "firstName": { "type": "string" },
+                  "lastName": { "type": "string" },
+                  "email": { "type": "string" },
+                  "password": { "type": "string" },
+                  "phone": { "type": "string" },
+                  "userStatus": {
+                    "type": "integer",
+                    "description": "User Status",
+                    "format": "int32"
+                  }
+                },
+                "xml": { "name": "User" }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "400": { "description": "Invalid user supplied", "content": {} },
+          "404": { "description": "User not found", "content": {} }
+        },
+        "x-codegen-request-body-name": "body"
+      },
+      "delete": {
+        "tags": ["user"],
+        "summary": "Delete user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "deleteUser",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be deleted",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "400": { "description": "Invalid username supplied", "content": {} },
+          "404": { "description": "User not found", "content": {} }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Order": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "format": "int64" },
+          "petId": { "type": "integer", "format": "int64" },
+          "quantity": { "type": "integer", "format": "int32" },
+          "shipDate": { "type": "string", "format": "date-time" },
+          "status": {
+            "type": "string",
+            "description": "Order Status",
+            "enum": ["placed", "approved", "delivered"]
+          },
+          "complete": { "type": "boolean", "default": false }
+        },
+        "xml": { "name": "Order" }
+      },
+      "Category": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "format": "int64" },
+          "name": { "type": "string" }
+        },
+        "xml": { "name": "Category" }
+      },
+      "User": {
+        "type": "object",
+        "required": ["id", "email", "lastName", "userStatus"],
+        "properties": {
+          "id": { "type": "integer", "format": "int64" },
+          "username": { "type": "string" },
+          "firstName": { "type": "string" },
+          "lastName": { "type": "string" },
+          "email": { "type": "string" },
+          "password": { "type": "string" },
+          "phone": { "type": "string" },
+          "userStatus": {
+            "type": "integer",
+            "description": "User Status",
+            "format": "int32"
+          }
+        },
+        "xml": { "name": "User" }
+      },
+      "Tag": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "format": "int64" },
+          "name": { "type": "string" }
+        },
+        "xml": { "name": "Tag" }
+      },
+      "Pet": {
+        "required": ["name", "photoUrls"],
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "format": "int64" },
+          "category": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "integer", "format": "int64" },
+              "name": { "type": "string" }
+            },
+            "xml": { "name": "Category" }
+          },
+          "name": { "type": "string", "example": "doggie" },
+          "photoUrls": {
+            "type": "array",
+            "xml": { "name": "photoUrl", "wrapped": true },
+            "items": { "type": "string" }
+          },
+          "tags": {
+            "type": "array",
+            "xml": { "name": "tag", "wrapped": true },
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "integer", "format": "int64" },
+                "name": { "type": "string" }
+              },
+              "xml": { "name": "Tag" }
+            }
+          },
+          "status": {
+            "type": "string",
+            "description": "pet status in the store",
+            "enum": ["available", "pending", "sold"]
+          }
+        },
+        "xml": { "name": "Pet" }
+      },
+      "ApiResponse": {
+        "type": "object",
+        "properties": {
+          "code": { "type": "integer", "format": "int32" },
+          "type": { "type": "string" },
+          "message": { "type": "string" }
+        }
+      }
+    },
+    "securitySchemes": {
+      "petstore_auth": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      },
+      "api_key": { "type": "apiKey", "name": "api_key", "in": "header" }
+    }
+  }
+}

--- a/projects/optic/src/__tests__/integration/workspaces/history/petstore/petstore-updated.json
+++ b/projects/optic/src/__tests__/integration/workspaces/history/petstore/petstore-updated.json
@@ -1,0 +1,1508 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Swagger Petstore Updated",
+    "description": "This is a sample server Petstore server.  You can find out more about     Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).      For this sample, you can use the api key `special-key` to test the authorization     filters.",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": { "email": "apiteam@swagger.io" },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    },
+    "version": "1.0.0"
+  },
+  "externalDocs": {
+    "description": "Find out more about Swagger",
+    "url": "http://swagger.io"
+  },
+  "servers": [
+    { "url": "https://petstore.swagger.io/v2" },
+    { "url": "http://petstore.swagger.io/v2" },
+    { "url": "http://petstore.swagger.io/v3" }
+  ],
+  "tags": [
+    {
+      "name": "pet",
+      "description": "Everything about your Pets",
+      "externalDocs": {
+        "description": "Find out more",
+        "url": "http://swagger.io"
+      }
+    },
+    { "name": "store", "description": "Access to Petstore orders" },
+    {
+      "name": "user",
+      "description": "Operations about user",
+      "externalDocs": {
+        "description": "Find out more about our store",
+        "url": "http://swagger.io"
+      }
+    }
+  ],
+  "paths": {
+    "/example": {
+      "get": {
+        "operationId": "getExamples",
+        "parameters": [
+          {
+            "name": "optionalToRequired",
+            "in": "query",
+            "description": "The user name for login",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "requiredToOptional",
+            "in": "query",
+            "description": "The user name for login",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "addedQueryParameter",
+            "in": "query",
+            "description": "The user name for login",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "succesful",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "stringOrNumberOrObject": {
+                      "oneOf": [{ "type": "string" }, { "type": "number" }]
+                    },
+                    "composedObject": {
+                      "allOf": [
+                        {
+                          "type": "object",
+                          "properties": { "orderId": { "type": "number" } }
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "fulfillmentId": { "type": "string" }
+                          }
+                        }
+                      ]
+                    },
+                    "expandableObject": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": { "orderId": { "type": "string" } }
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "order": {
+                              "type": "object",
+                              "properties": { "id": { "type": "string" } }
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "requiredKeys": {
+                      "type": "object",
+                      "properties": {
+                        "optionalToRequired": { "type": "string" },
+                        "requiredToOptional": { "type": "string" },
+                        "addedRequiredKey": { "type": "string" }
+                      },
+                      "required": ["optionalToRequired", "addedRequiredKey"]
+                    },
+                    "toTypeArrays": { "type": ["string", "number"] },
+                    "fromTypeArrays": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "seomthing",
+            "in": "query",
+            "description": "something",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/parameters_at_path": {
+      "parameters": [
+        {
+          "name": "query_in_path",
+          "in": "query",
+          "description": "asada",
+          "required": true,
+          "schema": { "type": "string" }
+        }
+      ],
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Invalid input",
+            "content": {
+              "application/json": { "schema": { "type": "string" } }
+            }
+          }
+        }
+      }
+    },
+    "/pet": {
+      "put": {
+        "requestBody": {
+          "description": "Pet object that needs to be added to the store",
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": ["number", "photoUrls"],
+                "type": "object",
+                "properties": {
+                  "id": { "type": "integer", "format": "int64" },
+                  "number": { "type": "string" },
+                  "category": {
+                    "type": "object",
+                    "properties": {
+                      "id": { "type": "integer", "format": "int64" },
+                      "name": { "type": "string" }
+                    },
+                    "xml": { "name": "Category" }
+                  },
+                  "photoUrls": {
+                    "type": "array",
+                    "xml": { "name": "photoUrl", "wrapped": true },
+                    "items": { "type": "string" }
+                  },
+                  "tags": {
+                    "type": "array",
+                    "xml": { "name": "tag", "wrapped": true },
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": { "type": "integer", "format": "int64" },
+                        "name": { "type": "string" }
+                      },
+                      "xml": { "name": "Tag" }
+                    }
+                  },
+                  "status": {
+                    "type": "string",
+                    "description": "pet status in the store",
+                    "enum": ["available", "pending", "sold"]
+                  }
+                },
+                "xml": { "name": "Pet" }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "404": { "description": "Pet not found", "content": {} },
+          "405": { "description": "Validation exception", "content": {} }
+        }
+      },
+      "post": {
+        "tags": ["pet"],
+        "summary": "Add a new pet to the store",
+        "operationId": "addPet-change",
+        "requestBody": {
+          "description": "Pet object that needs to be added to the store",
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": ["name", "photoUrls"],
+                "type": "object",
+                "properties": {
+                  "id": { "type": "integer", "format": "int64" },
+                  "category": {
+                    "type": "object",
+                    "properties": {
+                      "id": { "type": "integer", "format": "int64" },
+                      "name": { "type": "string" }
+                    },
+                    "xml": { "name": "Category" }
+                  },
+                  "name": { "type": "string", "example": "doggie" },
+                  "photoUrls": {
+                    "type": "array",
+                    "xml": { "name": "photoUrl", "wrapped": true },
+                    "items": { "type": "string" }
+                  },
+                  "tags": {
+                    "type": "array",
+                    "xml": { "name": "tag", "wrapped": true },
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": { "type": "integer", "format": "int64" },
+                        "name": { "type": "string" }
+                      },
+                      "xml": { "name": "Tag" }
+                    }
+                  },
+                  "status": {
+                    "type": "string",
+                    "description": "pet status in the store",
+                    "enum": ["available", "pending", "sold"]
+                  }
+                },
+                "xml": { "name": "Pet" }
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "required": ["name", "photoUrls"],
+                "type": "object",
+                "properties": {
+                  "id": { "type": "integer", "format": "int64" },
+                  "category": {
+                    "type": "object",
+                    "properties": {
+                      "id": { "type": "integer", "format": "int64" },
+                      "name": { "type": "string" }
+                    },
+                    "xml": { "name": "Category" }
+                  },
+                  "name": { "type": "string", "example": "doggie" },
+                  "photoUrls": {
+                    "type": "array",
+                    "xml": { "name": "photoUrl", "wrapped": true },
+                    "items": { "type": "string" }
+                  },
+                  "tags": {
+                    "type": "array",
+                    "xml": { "name": "tag", "wrapped": true },
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": { "type": "integer", "format": "int64" },
+                        "name": { "type": "string" }
+                      },
+                      "xml": { "name": "Tag" }
+                    }
+                  },
+                  "status": {
+                    "type": "string",
+                    "description": "pet status in the store",
+                    "enum": ["available", "pending", "sold"]
+                  }
+                },
+                "xml": { "name": "Pet" }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "405": { "description": "Invalid input", "content": {} }
+        },
+        "security": [{ "petstore_auth": ["write:pets", "read:pets"] }],
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/pet/findByStatus": {
+      "get": {
+        "tags": ["pet"],
+        "summary": "Finds Pets by status",
+        "description": "Multiple status values can be provided with comma separated strings",
+        "operationId": "findPetsByStatus",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Status values that need to be considered for filter",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "default": "available",
+                "enum": ["available", "pending", "sold"]
+              }
+            }
+          },
+          {
+            "name": "debug",
+            "in": "cookie",
+            "description": "A debug token",
+            "required": false,
+            "schema": { "type": "integer", "enum": [0, 1] }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "required": ["name", "photoUrls"],
+                    "type": "object",
+                    "properties": {
+                      "id": { "type": "integer", "format": "int64" },
+                      "category": {
+                        "type": "object",
+                        "properties": {
+                          "id": { "type": "integer", "format": "int64" },
+                          "name": { "type": "string" }
+                        },
+                        "xml": { "name": "Category" }
+                      },
+                      "name": { "type": "string", "example": "doggie" },
+                      "photoUrls": {
+                        "type": "array",
+                        "xml": { "name": "photoUrl", "wrapped": true },
+                        "items": { "type": "string" }
+                      },
+                      "tags": {
+                        "type": "array",
+                        "xml": { "name": "tag", "wrapped": true },
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": { "type": "integer", "format": "int64" },
+                            "name": { "type": "string" }
+                          },
+                          "xml": { "name": "Tag" }
+                        }
+                      },
+                      "status": {
+                        "type": "string",
+                        "description": "pet status in the store",
+                        "enum": ["available", "pending", "sold"]
+                      }
+                    },
+                    "xml": { "name": "Pet" }
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "required": ["name", "photoUrls"],
+                    "type": "object",
+                    "properties": {
+                      "id": { "type": "integer", "format": "int64" },
+                      "category": {
+                        "type": "object",
+                        "properties": {
+                          "id": { "type": "integer", "format": "int64" },
+                          "name": { "type": "string" }
+                        },
+                        "xml": { "name": "Category" }
+                      },
+                      "name": { "type": "string", "example": "doggie" },
+                      "photoUrls": {
+                        "type": "array",
+                        "xml": { "name": "photoUrl", "wrapped": true },
+                        "items": { "type": "string" }
+                      },
+                      "tags": {
+                        "type": "array",
+                        "xml": { "name": "tag", "wrapped": true },
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": { "type": "integer", "format": "int64" },
+                            "name": { "type": "string" }
+                          },
+                          "xml": { "name": "Tag" }
+                        }
+                      },
+                      "status": {
+                        "type": "string",
+                        "description": "pet status in the store",
+                        "enum": ["available", "pending", "sold"]
+                      }
+                    },
+                    "xml": { "name": "Pet" }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "description": "Invalid status value", "content": {} }
+        },
+        "security": [{ "petstore_auth": ["write:pets", "read:pets"] }]
+      }
+    },
+    "/pet/findByTags": {
+      "get": {
+        "tags": ["pet"],
+        "summary": "Finds Pets by tags",
+        "description": "Muliple tags can be provided with comma separated strings. Use         tag1, tag2, tag3 for testing.",
+        "operationId": "findPetsByTags",
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "Tags to filter by",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": { "type": "array", "items": { "type": "string" } }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "required": ["name", "photoUrls"],
+                    "type": "object",
+                    "properties": {
+                      "id": { "type": "integer", "format": "int64" },
+                      "category": {
+                        "type": "object",
+                        "properties": {
+                          "id": { "type": "integer", "format": "int64" },
+                          "name": { "type": "string" }
+                        },
+                        "xml": { "name": "Category" }
+                      },
+                      "name": { "type": "string", "example": "doggie" },
+                      "photoUrls": {
+                        "type": "array",
+                        "xml": { "name": "photoUrl", "wrapped": true },
+                        "items": { "type": "string" }
+                      },
+                      "tags": {
+                        "type": "array",
+                        "xml": { "name": "tag", "wrapped": true },
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": { "type": "integer", "format": "int64" },
+                            "name": { "type": "string" }
+                          },
+                          "xml": { "name": "Tag" }
+                        }
+                      },
+                      "status": {
+                        "type": "string",
+                        "description": "pet status in the store",
+                        "enum": ["available", "pending", "sold"]
+                      }
+                    },
+                    "xml": { "name": "Pet" }
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "required": ["name", "photoUrls"],
+                    "type": "object",
+                    "properties": {
+                      "id": { "type": "integer", "format": "int64" },
+                      "category": {
+                        "type": "object",
+                        "properties": {
+                          "id": { "type": "integer", "format": "int64" },
+                          "name": { "type": "string" }
+                        },
+                        "xml": { "name": "Category" }
+                      },
+                      "name": { "type": "string", "example": "doggie" },
+                      "photoUrls": {
+                        "type": "array",
+                        "xml": { "name": "photoUrl", "wrapped": true },
+                        "items": { "type": "string" }
+                      },
+                      "tags": {
+                        "type": "array",
+                        "xml": { "name": "tag", "wrapped": true },
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": { "type": "integer", "format": "int64" },
+                            "name": { "type": "string" }
+                          },
+                          "xml": { "name": "Tag" }
+                        }
+                      },
+                      "status": {
+                        "type": "string",
+                        "description": "pet status in the store",
+                        "enum": ["available", "pending", "sold"]
+                      }
+                    },
+                    "xml": { "name": "Pet" }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "description": "Invalid tag value", "content": {} }
+        },
+        "deprecated": true,
+        "security": [{ "petstore_auth": ["write:pets", "read:pets"] }]
+      }
+    },
+    "/pet/{petId}": {
+      "get": {
+        "tags": ["pet"],
+        "summary": "Find pet by ID",
+        "description": "Returns a single pet",
+        "operationId": "getPetById",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to return",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "required": ["name", "photoUrls"],
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer", "format": "int64" },
+                    "category": {
+                      "type": "object",
+                      "properties": {
+                        "id": { "type": "integer", "format": "int64" },
+                        "name": { "type": "string" }
+                      },
+                      "xml": { "name": "Category" }
+                    },
+                    "name": { "type": "string", "example": "doggie" },
+                    "photoUrls": {
+                      "type": "array",
+                      "xml": { "name": "photoUrl", "wrapped": true },
+                      "items": { "type": "string" }
+                    },
+                    "tags": {
+                      "type": "array",
+                      "xml": { "name": "tag", "wrapped": true },
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": { "type": "integer", "format": "int64" },
+                          "name": { "type": "string" }
+                        },
+                        "xml": { "name": "Tag" }
+                      }
+                    },
+                    "status": {
+                      "type": "string",
+                      "description": "pet status in the store",
+                      "enum": ["available", "pending", "sold"]
+                    }
+                  },
+                  "xml": { "name": "Pet" }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "required": ["name", "photoUrls"],
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer", "format": "int64" },
+                    "category": {
+                      "type": "object",
+                      "properties": {
+                        "id": { "type": "integer", "format": "int64" },
+                        "name": { "type": "string" }
+                      },
+                      "xml": { "name": "Category" }
+                    },
+                    "name": { "type": "string", "example": "doggie" },
+                    "photoUrls": {
+                      "type": "array",
+                      "xml": { "name": "photoUrl", "wrapped": true },
+                      "items": { "type": "string" }
+                    },
+                    "tags": {
+                      "type": "array",
+                      "xml": { "name": "tag", "wrapped": true },
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": { "type": "integer", "format": "int64" },
+                          "name": { "type": "string" }
+                        },
+                        "xml": { "name": "Tag" }
+                      }
+                    },
+                    "status": {
+                      "type": "string",
+                      "description": "pet status in the store",
+                      "enum": ["available", "pending", "sold"]
+                    }
+                  },
+                  "xml": { "name": "Pet" }
+                }
+              }
+            }
+          },
+          "400": { "description": "Invalid ID supplied", "content": {} },
+          "404": { "description": "Pet not found", "content": {} }
+        },
+        "security": [{ "api_key": [] }]
+      },
+      "post": {
+        "tags": ["pet"],
+        "summary": "Updates a pet in the store with form data",
+        "operationId": "updatePetWithForm",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet that needs to be updated",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Updated name of the pet"
+                  },
+                  "status": {
+                    "type": "string",
+                    "description": "Updated status of the pet"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "405": { "description": "Invalid input", "content": {} }
+        },
+        "security": [{ "petstore_auth": ["write:pets", "read:pets"] }]
+      },
+      "delete": {
+        "tags": ["pet"],
+        "summary": "Deletes a pet",
+        "operationId": "deletePet",
+        "parameters": [
+          { "name": "api_key", "in": "header", "schema": { "type": "string" } },
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "Pet id to delete",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          }
+        ],
+        "responses": {
+          "400": { "description": "Invalid ID supplied", "content": {} },
+          "404": { "description": "Pet not found", "content": {} }
+        },
+        "security": [{ "petstore_auth": ["write:pets", "read:pets"] }]
+      }
+    },
+    "/pet/{petId}/uploadImage": {
+      "post": {
+        "tags": ["pet"],
+        "summary": "uploads an image",
+        "operationId": "uploadFile",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to update",
+            "required": true,
+            "schema": { "type": "integer", "format": "int64" }
+          },
+          {
+            "name": "debug",
+            "in": "cookie",
+            "description": "A debug token",
+            "required": false,
+            "schema": { "type": "integer", "enum": [0, 1] }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "additionalMetadata": {
+                    "type": "string",
+                    "description": "Additional data to pass to server"
+                  },
+                  "file": {
+                    "type": "string",
+                    "description": "file to upload",
+                    "format": "binary"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "integer", "format": "int32" },
+                    "type": { "type": "string" },
+                    "message": { "type": "string" }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Pet not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "integer", "format": "int32" },
+                    "type": { "type": "string" },
+                    "message": { "type": "string" }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "integer", "format": "int32" },
+                    "type": { "type": "integer" },
+                    "message": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [{ "petstore_auth": ["write:pets", "read:pets"] }]
+      }
+    },
+    "/store/inventory": {
+      "get": {
+        "tags": ["store"],
+        "summary": "Returns pet inventories by status",
+        "description": "Returns a map of status codes to quantities",
+        "operationId": "getInventory",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "integer",
+                    "format": "int32"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [{ "api_key": [] }]
+      }
+    },
+    "/store/order": {
+      "post": {
+        "tags": ["store"],
+        "summary": "Place an order for a pet",
+        "operationId": "placeOrder",
+        "requestBody": {
+          "description": "order placed for purchasing the pet",
+          "content": {
+            "*/*": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": { "type": "integer", "format": "int64" },
+                  "petId": { "type": "integer", "format": "int64" },
+                  "quantity": { "type": "integer", "format": "int32" },
+                  "shipDate": { "type": "string", "format": "date-time" },
+                  "status": {
+                    "type": "string",
+                    "description": "Order Status",
+                    "enum": ["placed", "delivered", "canceled"]
+                  },
+                  "summary": {
+                    "type": "string",
+                    "description": "Human readable summary of order"
+                  },
+                  "complete": { "type": "boolean", "default": false }
+                },
+                "xml": { "name": "Order" }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer", "format": "int64" },
+                    "petId": { "type": "integer", "format": "int64" },
+                    "quantity": { "type": "integer", "format": "int32" },
+                    "shipDate": { "type": "string", "format": "date-time" },
+                    "status": {
+                      "type": "string",
+                      "description": "Order Status",
+                      "enum": ["placed", "delivered", "canceled"]
+                    },
+                    "summary": {
+                      "type": "string",
+                      "description": "Human readable summary of order"
+                    },
+                    "complete": { "type": "boolean", "default": false }
+                  },
+                  "xml": { "name": "Order" }
+                }
+              },
+              "application/json": {
+                "example": {
+                  "id": 458102,
+                  "petId": 581231,
+                  "quantity": 31,
+                  "shipDate": "2022-03-04T22:54:32.631Z",
+                  "status": "delivered",
+                  "summary": "31 boxes of dog food",
+                  "complete": false
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer", "format": "int64" },
+                    "petId": { "type": "integer", "format": "int64" },
+                    "quantity": { "type": "integer", "format": "int32" },
+                    "shipDate": { "type": "string", "format": "date-time" },
+                    "status": {
+                      "type": "string",
+                      "description": "Order Status",
+                      "enum": ["placed", "delivered", "canceled"]
+                    },
+                    "summary": {
+                      "type": "string",
+                      "description": "Human readable summary of order"
+                    },
+                    "complete": { "type": "boolean", "default": false }
+                  },
+                  "xml": { "name": "Order" }
+                }
+              }
+            }
+          },
+          "400": { "description": "Invalid Order", "content": {} }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/store/order/{orderId}": {
+      "get": {
+        "tags": ["store"],
+        "summary": "Find purchase order by ID",
+        "description": "For valid response try integer IDs with value >= 1 and <= 10.         Other values will generated exceptions",
+        "operationId": "getOrderById",
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of pet that needs to be fetched",
+            "required": true,
+            "schema": {
+              "maximum": 10,
+              "minimum": 1,
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "object",
+                  "required": ["id"],
+                  "properties": {
+                    "id": { "type": "integer", "format": "int64" },
+                    "petId": { "type": "integer", "format": "int64" },
+                    "quantity": { "type": "integer", "format": "int32" },
+                    "shipDate": { "type": "string", "format": "date-time" },
+                    "status": {
+                      "type": "string",
+                      "description": "Order Status",
+                      "enum": ["placed", "delivered", "canceled"]
+                    },
+                    "summary": {
+                      "type": "string",
+                      "description": "Human readable summary of order"
+                    },
+                    "complete": { "type": "boolean", "default": false }
+                  },
+                  "xml": { "name": "Order" }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer", "format": "int64" },
+                    "petId": { "type": "integer", "format": "int64" },
+                    "quantity": { "type": "integer", "format": "int32" },
+                    "shipDate": { "type": "string", "format": "date-time" },
+                    "status": {
+                      "type": "string",
+                      "description": "Order Status",
+                      "enum": ["placed", "delivered", "canceled"]
+                    },
+                    "summary": {
+                      "type": "string",
+                      "description": "Human readable summary of order"
+                    },
+                    "complete": { "type": "boolean", "default": false }
+                  },
+                  "xml": { "name": "Order" }
+                }
+              }
+            }
+          },
+          "400": { "description": "Invalid ID supplied", "content": {} },
+          "404": {
+            "description": "Order not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "integer", "format": "int32" },
+                    "type": { "type": "string" },
+                    "message": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["store"],
+        "summary": "Delete purchase order by ID",
+        "description": "For valid response try integer IDs with positive integer value.         Negative or non-integer values will generate API errors",
+        "operationId": "deleteOrder",
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of the order that needs to be deleted",
+            "required": true,
+            "schema": { "minimum": 1, "type": "integer", "format": "int64" }
+          }
+        ],
+        "responses": {
+          "400": { "description": "Invalid ID supplied", "content": {} },
+          "404": {
+            "description": "Order not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "integer", "format": "int32" },
+                    "type": { "type": "string" },
+                    "message": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user": {
+      "post": {
+        "tags": ["user"],
+        "summary": "Create user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "createUser",
+        "requestBody": {
+          "description": "Created user object",
+          "content": {
+            "*/*": {
+              "schema": {
+                "type": "object",
+                "required": ["id", "email", "username", "userStatus"],
+                "properties": {
+                  "id": { "type": "integer", "format": "int64" },
+                  "username": { "type": "string" },
+                  "firstName": { "type": "string" },
+                  "lastName": { "type": "string" },
+                  "email": { "type": "string" },
+                  "password": { "type": "string" },
+                  "userStatus": {
+                    "type": "string",
+                    "description": "User Status",
+                    "enum": ["activation-pending", "activated", "blocked"]
+                  },
+                  "bio": { "type": "string" }
+                },
+                "xml": { "name": "User" }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "default": { "description": "successful operation", "content": {} }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/user/createWithArray": {
+      "post": {
+        "tags": ["user"],
+        "summary": "Creates list of users with given input array",
+        "operationId": "createUsersWithArrayInput",
+        "requestBody": {
+          "description": "List of user object",
+          "content": {
+            "*/*": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["id", "email", "username", "userStatus"],
+                  "properties": {
+                    "id": { "type": "integer", "format": "int64" },
+                    "username": { "type": "string" },
+                    "firstName": { "type": "string" },
+                    "lastName": { "type": "string" },
+                    "email": { "type": "string" },
+                    "password": { "type": "string" },
+                    "userStatus": {
+                      "type": "string",
+                      "description": "User Status",
+                      "enum": ["activation-pending", "activated", "blocked"]
+                    },
+                    "bio": { "type": "string" }
+                  },
+                  "xml": { "name": "User" }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "default": { "description": "successful operation", "content": {} }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/user/createWithList": {
+      "post": {
+        "tags": ["user"],
+        "summary": "Creates list of users with given input array",
+        "operationId": "createUsersWithListInput",
+        "requestBody": {
+          "description": "List of user object",
+          "content": {
+            "*/*": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["id", "email", "username", "userStatus"],
+                  "properties": {
+                    "id": { "type": "integer", "format": "int64" },
+                    "username": { "type": "string" },
+                    "firstName": { "type": "string" },
+                    "lastName": { "type": "string" },
+                    "email": { "type": "string" },
+                    "password": { "type": "string" },
+                    "userStatus": {
+                      "type": "string",
+                      "description": "User Status",
+                      "enum": ["activation-pending", "activated", "blocked"]
+                    },
+                    "bio": { "type": "string" }
+                  },
+                  "xml": { "name": "User" }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "default": { "description": "successful operation", "content": {} }
+        },
+        "x-codegen-request-body-name": "body"
+      }
+    },
+    "/user/login": {
+      "get": {
+        "tags": ["user"],
+        "summary": "Logs user into the system",
+        "operationId": "loginUser",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "query",
+            "description": "The user name for login",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "password",
+            "in": "query",
+            "description": "The password for login in clear text",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "headers": {
+              "X-Rate-Limit": {
+                "description": "calls per hour allowed by the user",
+                "schema": { "type": "integer", "format": "int32" }
+              },
+              "X-Expires-After": {
+                "description": "date in UTC when token expires",
+                "schema": { "type": "string", "format": "date-time" }
+              }
+            },
+            "content": {
+              "application/xml": { "schema": { "type": "string" } },
+              "application/json": { "schema": { "type": "string" } }
+            }
+          },
+          "400": {
+            "description": "Invalid username/password supplied",
+            "content": {}
+          }
+        }
+      }
+    },
+    "/user/logout": {
+      "get": {
+        "tags": ["user"],
+        "summary": "Logs out current logged in user session",
+        "operationId": "logoutUser",
+        "responses": {
+          "default": { "description": "successful operation", "content": {} }
+        }
+      }
+    },
+    "/user/{username}": {
+      "get": {
+        "tags": ["user"],
+        "summary": "Get user by user name",
+        "operationId": "getUserByName",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be fetched. Use user1 for testing. ",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "object",
+                  "required": ["id", "email", "username", "userStatus"],
+                  "properties": {
+                    "id": { "type": "integer", "format": "int64" },
+                    "username": { "type": "string" },
+                    "firstName": { "type": "string" },
+                    "lastName": { "type": "string" },
+                    "email": { "type": "string" },
+                    "password": { "type": "string" },
+                    "userStatus": {
+                      "type": "string",
+                      "description": "User Status",
+                      "enum": ["activation-pending", "activated", "blocked"]
+                    },
+                    "bio": { "type": "string" }
+                  },
+                  "xml": { "name": "User" }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["id", "email", "username", "userStatus"],
+                  "properties": {
+                    "id": { "type": "integer", "format": "int64" },
+                    "username": { "type": "string" },
+                    "firstName": { "type": "string" },
+                    "lastName": { "type": "string" },
+                    "email": { "type": "string" },
+                    "password": { "type": "string" },
+                    "userStatus": {
+                      "type": "string",
+                      "description": "User Status",
+                      "enum": ["activation-pending", "activated", "blocked"]
+                    },
+                    "bio": { "type": "string" }
+                  },
+                  "xml": { "name": "User" }
+                }
+              }
+            }
+          },
+          "400": { "description": "Invalid username supplied", "content": {} },
+          "404": {
+            "description": "User not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "integer", "format": "int32" },
+                    "type": { "type": "string" },
+                    "message": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": ["user"],
+        "summary": "Updated user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "updateUser",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "name that need to be updated",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "description": "Updated user object",
+          "content": {
+            "*/*": {
+              "schema": {
+                "type": "object",
+                "required": ["id", "email", "username", "userStatus"],
+                "properties": {
+                  "id": { "type": "integer", "format": "int64" },
+                  "username": { "type": "string" },
+                  "firstName": { "type": "string" },
+                  "lastName": { "type": "string" },
+                  "email": { "type": "string" },
+                  "password": { "type": "string" },
+                  "userStatus": {
+                    "type": "string",
+                    "description": "User Status",
+                    "enum": ["activation-pending", "activated", "blocked"]
+                  },
+                  "bio": { "type": "string" }
+                },
+                "xml": { "name": "User" }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "400": { "description": "Invalid user supplied", "content": {} },
+          "404": { "description": "User not found", "content": {} }
+        },
+        "x-codegen-request-body-name": "body"
+      },
+      "delete": {
+        "tags": ["user"],
+        "summary": "Delete user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "deleteUser",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be deleted",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "400": { "description": "Invalid username supplied", "content": {} },
+          "404": { "description": "User not found", "content": {} }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Order": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "format": "int64" },
+          "petId": { "type": "integer", "format": "int64" },
+          "quantity": { "type": "integer", "format": "int32" },
+          "shipDate": { "type": "string", "format": "date-time" },
+          "status": {
+            "type": "string",
+            "description": "Order Status",
+            "enum": ["placed", "delivered", "canceled"]
+          },
+          "summary": {
+            "type": "string",
+            "description": "Human readable summary of order"
+          },
+          "complete": { "type": "boolean", "default": false }
+        },
+        "xml": { "name": "Order" }
+      },
+      "Category": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "format": "int64" },
+          "name": { "type": "string" }
+        },
+        "xml": { "name": "Category" }
+      },
+      "User": {
+        "type": "object",
+        "required": ["id", "email", "username", "userStatus"],
+        "properties": {
+          "id": { "type": "integer", "format": "int64" },
+          "username": { "type": "string" },
+          "firstName": { "type": "string" },
+          "lastName": { "type": "string" },
+          "email": { "type": "string" },
+          "password": { "type": "string" },
+          "userStatus": {
+            "type": "string",
+            "description": "User Status",
+            "enum": ["activation-pending", "activated", "blocked"]
+          },
+          "bio": { "type": "string" }
+        },
+        "xml": { "name": "User" }
+      },
+      "Tag": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "format": "int64" },
+          "name": { "type": "string" }
+        },
+        "xml": { "name": "Tag" }
+      },
+      "Pet": {
+        "required": ["name", "photoUrls"],
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "format": "int64" },
+          "category": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "integer", "format": "int64" },
+              "name": { "type": "string" }
+            },
+            "xml": { "name": "Category" }
+          },
+          "name": { "type": "string", "example": "doggie" },
+          "photoUrls": {
+            "type": "array",
+            "xml": { "name": "photoUrl", "wrapped": true },
+            "items": { "type": "string" }
+          },
+          "tags": {
+            "type": "array",
+            "xml": { "name": "tag", "wrapped": true },
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "integer", "format": "int64" },
+                "name": { "type": "string" }
+              },
+              "xml": { "name": "Tag" }
+            }
+          },
+          "status": {
+            "type": "string",
+            "description": "pet status in the store",
+            "enum": ["available", "pending", "sold"]
+          }
+        },
+        "xml": { "name": "Pet" }
+      },
+      "ApiResponse": {
+        "type": "object",
+        "properties": {
+          "code": { "type": "integer", "format": "int32" },
+          "type": { "type": "string" },
+          "message": { "type": "string" }
+        }
+      }
+    },
+    "securitySchemes": {
+      "petstore_auth": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      },
+      "api_key": { "type": "apiKey", "name": "api_key", "in": "header" }
+    }
+  }
+}

--- a/projects/optic/src/commands/history.ts
+++ b/projects/optic/src/commands/history.ts
@@ -244,15 +244,15 @@ const logEndpointsChanges = (
   };
 
   const getRequestBodyChange = (segments: string[], changeType: string) => {
-    return `${changeType} \`requestBody\` ${getChangeDescription(
-      segments.slice(6)
-    )}`;
+    let changeDescription = getChangeDescription(segments.slice(6));
+    changeDescription = changeDescription ? ` ${changeDescription}` : '';
+    return `${changeType} \`requestBody\`${changeDescription}`;
   };
 
   const getResponseChange = (segments: string[], changeType: string) => {
-    return `${changeType} \`${segments[4]}\` response ${getChangeDescription(
-      segments.slice(7)
-    )}`;
+    let changeDescription = getChangeDescription(segments.slice(7));
+    changeDescription = changeDescription ? ` ${changeDescription}` : '';
+    return `${changeType} \`${segments[4]}\` response${changeDescription}`;
   };
 
   const getChange = (segments: string[], changeType: string) => {

--- a/projects/optic/src/commands/history.ts
+++ b/projects/optic/src/commands/history.ts
@@ -37,7 +37,7 @@ export const registerHistory = (cli: Command, config: OpticCliConfig) => {
       'Sets the depth of how far to crawl through to historic API data. history-depth=0 will crawl the entire history',
       '0'
     )
-    .action(errorHandler(getHistoryAction(config)));
+    .action(errorHandler(getHistoryAction(config), { command: 'history' }));
 };
 
 type HistoryOptions = {

--- a/projects/optic/src/commands/history.ts
+++ b/projects/optic/src/commands/history.ts
@@ -1,0 +1,329 @@
+import { OpticCliConfig, VCS } from '../config';
+import { Command } from 'commander';
+import { errorHandler } from '../error-handler';
+import { logger } from '../logger';
+import chalk from 'chalk';
+import * as GitCandidates from './api/git-get-file-candidates';
+import fs from 'fs';
+import path from 'path';
+import { loadSpec } from '../utils/spec-loaders';
+import stableStringify from 'json-stable-stringify';
+import { computeChecksumForAws } from '../utils/checksum';
+import { compareSpecs, ObjectDiff } from '@useoptic/openapi-utilities';
+import { RuleRunner } from '@useoptic/rulesets-base';
+import { BreakingChangesRuleset } from '@useoptic/standard-rulesets';
+import { OpenAPIV3 } from 'openapi-types';
+import { HttpMethods } from './oas/operations';
+import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
+import { exec } from 'child_process';
+
+const usage = () => `
+  optic history <path_to_spec.yml>`;
+
+const helpText = `
+Example usage:
+  Export api history to changelog.md file
+  $ optic history <path_to_spec.yml> > changelog.md`;
+
+export const registerHistory = (cli: Command, config: OpticCliConfig) => {
+  cli
+    .command('history')
+    .configureHelp({ commandUsage: usage })
+    .addHelpText('after', helpText)
+    .description('Browse spec history and create a text changelog')
+    .argument('[path_to_spec]', 'path to OpenAPI file')
+    .option(
+      '-D, --history-depth <history-depth>',
+      'Sets the depth of how far to crawl through to historic API data. history-depth=0 will crawl the entire history',
+      '0'
+    )
+    .action(errorHandler(getHistoryAction(config)));
+};
+
+type HistoryOptions = {
+  historyDepth: string;
+};
+
+type CommitInfo = {
+  commitDate: Date;
+};
+
+const getCommitInfo = (sha: string): Promise<CommitInfo> => {
+  return new Promise((resolve, reject) => {
+    exec(`git show --format="%cd" ${sha} -s`, (error, stdout, stderr) => {
+      if (error || stderr) reject(error || stderr);
+      resolve({
+        commitDate: new Date(stdout),
+      });
+    });
+  });
+};
+
+const isSameDay = (date1?: Date, date2?: Date) => {
+  if (!date1 || !date2) return false;
+  const utcDate1 = Date.UTC(
+    date1.getUTCFullYear(),
+    date1.getUTCMonth(),
+    date1.getUTCDate()
+  );
+  const utcDate2 = Date.UTC(
+    date2.getUTCFullYear(),
+    date2.getUTCMonth(),
+    date2.getUTCDate()
+  );
+  return utcDate1 == utcDate2;
+};
+
+const logDiffs = async (baseSpec: any, headSpec: any, headDate?: Date) => {
+  const rulesRunner = new RuleRunner([new BreakingChangesRuleset()]);
+  const comparison = await compareSpecs(baseSpec, headSpec, rulesRunner, {});
+  console.log(`### ${headDate?.toDateString()}`);
+  logEndpointsChanges(baseSpec.jsonLike, headSpec.jsonLike, comparison.diffs);
+};
+
+export const getHistoryAction =
+  (config: OpticCliConfig) =>
+  async (path_to_spec: string | undefined, options: HistoryOptions) => {
+    if (config.vcs?.type !== VCS.Git) {
+      logger.error(
+        chalk.red(
+          'the history command must be called from inside a git repository'
+        )
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    if (!path_to_spec) {
+      logger.error(chalk.red('path_to_spec is undefined.'));
+      process.exitCode = 1;
+      return;
+    }
+
+    const absolutePath = path.resolve(path_to_spec);
+    if (!absolutePath.startsWith(config.root)) {
+      logger.error(
+        chalk.red('path_to_spec must belong to the current git repository')
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    const stats = fs.statSync(path_to_spec, { throwIfNoEntry: false });
+    const isFile = stats?.isFile();
+    if (!isFile) {
+      logger.error(
+        chalk.red('path_to_spec is not a valid specification file path')
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    if (isNaN(Number(options.historyDepth))) {
+      logger.error(
+        chalk.red(
+          '--history-depth, -D is not a number. history-depth must be a number'
+        )
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    const candidates = await GitCandidates.getShasCandidatesForPath(
+      path_to_spec,
+      options.historyDepth
+    );
+
+    const pathRelativeToRoot = path.relative(config.root, absolutePath);
+
+    let headChecksum: string | undefined = undefined;
+    let headSpec: any;
+    let headDate: Date | undefined = undefined;
+
+    for (const [ix, baseSha] of candidates.shas.entries()) {
+      const baseSpec = await loadSpec(
+        `${baseSha}:${pathRelativeToRoot}`,
+        config,
+        {
+          strict: false,
+          denormalize: true,
+        }
+      );
+      const stableSpecString = stableStringify(baseSpec.jsonLike);
+      const baseChecksum = computeChecksumForAws(stableSpecString);
+      const { commitDate: baseDate } = await getCommitInfo(baseSha);
+      const sameDay = isSameDay(headDate, baseDate);
+      const sameChecksum = baseChecksum === headChecksum;
+      const lastCandidate = ix === candidates.shas.length - 1;
+
+      if (lastCandidate && !sameChecksum) {
+        await logDiffs(baseSpec, headSpec, headDate);
+        continue;
+      }
+
+      if (sameChecksum) continue;
+
+      if (!headSpec) {
+        headSpec = baseSpec;
+        headDate = baseDate;
+        const title = baseSpec.jsonLike.info.title;
+        console.log(`# ${title}`);
+        continue;
+      }
+
+      if (sameDay) continue;
+
+      await logDiffs(baseSpec, headSpec, headDate);
+
+      headChecksum = baseChecksum;
+      headDate = baseDate;
+      headSpec = baseSpec;
+    }
+  };
+
+const getChangeType = (diff: ObjectDiff) => {
+  return diff.after && diff.before
+    ? 'changed'
+    : diff.after
+    ? 'added'
+    : 'removed';
+};
+
+const isPathChange = (segments: string[]) => segments[0] === 'paths';
+
+const isPathExactChange = (segments: string[]) =>
+  isPathChange(segments) && segments.length === 2;
+
+const isMethodChange = (segments: string[]) =>
+  isPathChange(segments) &&
+  segments.length >= 3 &&
+  segments[2].toUpperCase() in HttpMethods;
+
+const isMethodExactChange = (segments: string[]) =>
+  isMethodChange(segments) && segments.length === 3;
+
+const isRequestChange = (segments: string[]) =>
+  isMethodChange(segments) && segments[3] === 'requestBody';
+
+const isResponseChange = (segments: string[]) =>
+  isMethodChange(segments) && segments[3] === 'responses';
+
+const isMethodParameterChange = (segments: string[]) =>
+  isMethodChange(segments) && segments[3] === 'parameters';
+
+const getParameterValue = (segements: string[], spec: OpenAPIV3.Document) => {
+  return jsonPointerHelpers.get(spec, segements);
+};
+
+const logEndpointsChanges = (
+  baseSpec: OpenAPIV3.Document,
+  headSpec: OpenAPIV3.Document,
+  diffs: ObjectDiff[]
+) => {
+  const paths = new Map<string, Map<string, Set<string>>>();
+
+  const getChangeDescription = (segments: string[]) => {
+    const parentSegment = segments[segments.length - 2];
+    const qualifier = parentSegment === 'properties' ? ' property' : '';
+    let outPaths = segments.filter(
+      (s) => ['schema', 'properties', 'content', 'paths'].indexOf(s) < 0
+    );
+    return outPaths.map((s) => `\`${s}\``).join('.') + `${qualifier}`;
+  };
+
+  const getParameterChange = (segments: string[], changeType: string) => {
+    const param = getParameterValue(
+      segments.slice(0, 5),
+      changeType === 'removed' ? baseSpec : headSpec
+    );
+    return changeType === 'added' || changeType === 'removed'
+      ? `${changeType} \`${param?.name}\` ${param?.in} parameter`
+      : `${changeType} \`${param?.name}\` ${
+          param?.in
+        } parameter ${getChangeDescription(segments.slice(5))}`;
+  };
+
+  const getRequestBodyChange = (segments: string[], changeType: string) => {
+    return `${changeType} \`requestBody\` ${getChangeDescription(
+      segments.slice(6)
+    )}`;
+  };
+
+  const getResponseChange = (segments: string[], changeType: string) => {
+    return `${changeType} \`${segments[4]}\` response ${getChangeDescription(
+      segments.slice(7)
+    )}`;
+  };
+
+  const getChange = (segments: string[], changeType: string) => {
+    return isRequestChange(segments)
+      ? getRequestBodyChange(segments, changeType)
+      : isResponseChange(segments)
+      ? getResponseChange(segments, changeType)
+      : isMethodParameterChange(segments)
+      ? getParameterChange(segments, changeType)
+      : isMethodExactChange(segments)
+      ? `${changeType}`
+      : '';
+  };
+
+  for (const diff of diffs) {
+    const changeType = getChangeType(diff);
+    const segments =
+      changeType === 'removed'
+        ? jsonPointerHelpers.decode(diff.before!)
+        : jsonPointerHelpers.decode(diff.after!);
+
+    if (isPathExactChange(segments)) {
+      const path = jsonPointerHelpers.get(
+        changeType === 'removed' ? baseSpec : headSpec,
+        segments
+      );
+      const methods: string[] = [];
+      for (const method in HttpMethods) {
+        if (method.toLowerCase() in path) {
+          methods.push(method);
+        }
+      }
+      for (const method of methods) {
+        diffs.push({
+          ...diff,
+          ...(diff.before ? { before: diff.before + `/${method}` } : {}),
+          ...(diff.after ? { after: diff.after + `/${method}` } : {}),
+        } as any);
+      }
+      continue;
+    }
+
+    if (!isMethodChange(segments)) continue;
+
+    const [, path, method] = segments;
+
+    if (!paths.get(path)) paths.set(path, new Map());
+    const prevPath = paths.get(path)!;
+    const prevMethod = prevPath.get(method) ?? new Set();
+
+    const change = getChange(segments, changeType);
+    prevMethod.add(change);
+    prevPath.set(method, prevMethod);
+  }
+
+  for (const [path, methods] of paths.entries()) {
+    for (const [method, changes] of methods.entries()) {
+      if (changes.size > 1) {
+        console.log(`- \`${method.toUpperCase()}\` \`${path}\`:`);
+        for (const change of changes) {
+          console.log(`  - ${change}`);
+        }
+      } else {
+        const change = changes[Symbol.iterator]().next()?.value;
+        const addedOrRemoved = change === 'added' || change === 'removed';
+        const suffix = addedOrRemoved ? `` : `: ${change}`;
+        const prefix = addedOrRemoved ? `${change} ` : '';
+        console.log(
+          `- ${prefix}\`${method.toUpperCase()}\` \`${path}\`${suffix}`
+        );
+      }
+    }
+  }
+};

--- a/projects/optic/src/commands/history.ts
+++ b/projects/optic/src/commands/history.ts
@@ -304,12 +304,13 @@ const logEndpointsChanges = (
     const prevMethod = prevPath.get(method) ?? new Set();
 
     const change = getChange(segments, changeType);
-    prevMethod.add(change);
+    if (change) prevMethod.add(change);
     prevPath.set(method, prevMethod);
   }
 
   for (const [path, methods] of paths.entries()) {
     for (const [method, changes] of methods.entries()) {
+      if (!changes.size) continue;
       if (changes.size > 1) {
         console.log(`- \`${method.toUpperCase()}\` \`${path}\`:`);
         for (const change of changes) {

--- a/projects/optic/src/init.ts
+++ b/projects/optic/src/init.ts
@@ -31,6 +31,7 @@ import { registerLint } from './commands/lint/lint';
 import { registerBundle } from './commands/bundle/bundle';
 import { updateCommand } from './commands/oas/update';
 import { registerApiList } from './commands/api/list';
+import { registerHistory } from './commands/history';
 import path from 'path';
 
 const packageJson = require('../package.json');
@@ -162,6 +163,8 @@ export const initCli = async (
   const ciSubcommands = cli.command('ci').addHelpCommand(false);
   registerCiComment(ciSubcommands, cliConfig);
   registerCiSetup(ciSubcommands, cliConfig);
+
+  registerHistory(cli, cliConfig);
 
   return cli;
 };

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.46.1",
+  "version": "0.47.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -40,6 +40,5 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
-  },
-  "stableVersion": "0.46.0"
+  }
 }

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.46.1",
+  "version": "0.47.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -39,6 +39,5 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
-  },
-  "stableVersion": "0.46.0"
+  }
 }


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

implement history command.

```
(base) ➜  optic git:(history-command) ✗ yarn run local:run history --help                                           
Usage: 
  optic history <path_to_spec.yml>

Browse spec history and creates a text changelog

Arguments:
  path_to_spec                         path to OpenAPI file

Options:
  -D, --history-depth <history-depth>  Sets the depth of how far to crawl through to historic API data. history-depth=0 will crawl the entire history (default: "0")
  -h, --help                           display help for command

Example usage:
  Export api history to changelog.md file
  $ optic history <path_to_spec.yml> > changelog.md
```

Example:

```
(base) ➜  optic git:(main) ✗ yarn run local:run history ../openapi-io/inputs/openapi3/petstore0.json -D 10
# Swagger Petstore
### Wed Jun 21 2023
- `POST` `/pet/{petId}/uploadImage/{gz}`: added `200` response `z` property
- `PUT` `/pet/{petId}/uploadImage/{gz}`:
  - added `200` response `z` property
  - changed `requestBody` `file`.`description`
### Tue Jun 20 2023
- `POST` `/pet/{petId}/uploadImage/{gz}`: added `petIdzoxx` path parameter
- `PUT` `/pet/{petId}/uploadImage/{gz}`:
  - added `requestBody` `test` property
  - removed `petIdz` path parameter
  - added `petIdzoxx` path parameter
  - changed `petId` path parameter `description`
  - removed `petId` path parameter
```
<img width="731" alt="image" src="https://github.com/opticdev/optic/assets/2964863/8b0a8810-7add-456c-ac41-5f380caddff2">

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
