### PR TITLE
log openapi version when not supported

### DIFF
--- a/projects/openapi-io/src/index.ts
+++ b/projects/openapi-io/src/index.ts
@@ -10,7 +10,7 @@ import { ExternalRefHandler } from './parser/types';
 import { JsonPath, JsonSchemaSourcemap } from './parser/sourcemap';
 import { loadYaml, isYaml, isJson, writeYaml } from './write';
 import { validateOpenApiV3Document } from './validation/validator';
-import { ValidationError } from './validation/errors';
+import { ValidationError, OpenAPIVersionError } from './validation/errors';
 import {
   checkOpenAPIVersion,
   SupportedOpenAPIVersions,

--- a/projects/openapi-io/src/validation/errors.ts
+++ b/projects/openapi-io/src/validation/errors.ts
@@ -4,3 +4,20 @@ export class ValidationError extends Error {
     Object.setPrototypeOf(this, ValidationError.prototype);
   }
 }
+
+export class OpenAPIVersionError extends Error {
+  public type: 'oas-version-error';
+  public version: '2.x.x' | undefined;
+
+  constructor(message?: string, version?: '2.x.x') {
+    super(message);
+    this.type = 'oas-version-error';
+    this.version = version;
+
+    Object.setPrototypeOf(this, ValidationError.prototype);
+  }
+
+  static isInstance(v: any): v is OpenAPIVersionError {
+    return v?.type === 'oas-version-error';
+  }
+}

--- a/projects/openapi-io/src/validation/openapi-versions.ts
+++ b/projects/openapi-io/src/validation/openapi-versions.ts
@@ -1,14 +1,17 @@
 import semver from 'semver';
-import { ValidationError } from './errors';
+import { OpenAPIVersionError } from './errors';
 
 export type SupportedOpenAPIVersions = '3.1.x' | '3.0.x';
 
 export function checkOpenAPIVersion(spec: {
   openapi: string;
+  swagger?: string;
 }): SupportedOpenAPIVersions {
   if (semver.satisfies(spec.openapi, '3.1.x')) return '3.1.x';
   if (semver.satisfies(spec.openapi, '3.0.x')) return '3.0.x';
-  throw new ValidationError(
-    `Unsupported OpenAPI version ${spec.openapi}. Optic supports OpenAPI 3.1.x and 3.0.x`
+  const isSwagger = spec.swagger && semver.satisfies(spec.swagger, '2.x.x');
+  throw new OpenAPIVersionError(
+    `Unsupported OpenAPI version ${spec.openapi}. Optic supports OpenAPI 3.1.x and 3.0.x`,
+    isSwagger ? '2.x.x' : undefined
   );
 }

--- a/projects/optic/src/commands/api/add.ts
+++ b/projects/optic/src/commands/api/add.ts
@@ -65,7 +65,7 @@ export const registerApiAdd = (cli: Command, config: OpticCliConfig) => {
     )
     .option('--all', 'add all', false)
     .option('--web', 'open to the added API in Optic Cloud', false)
-    .action(errorHandler(getApiAddAction(config)));
+    .action(errorHandler(getApiAddAction(config), { command: 'api-add' }));
 };
 
 type ApiAddActionOptions = {

--- a/projects/optic/src/commands/api/create.ts
+++ b/projects/optic/src/commands/api/create.ts
@@ -27,7 +27,9 @@ export const registerApiCreate = (cli: Command, config: OpticCliConfig) => {
     .addHelpText('after', helpText)
     .description('Generate an optic url to add to your specs')
     .argument('<name>', 'the name of the api')
-    .action(errorHandler(getApiCreateAction(config)));
+    .action(
+      errorHandler(getApiCreateAction(config), { command: 'api-create' })
+    );
 };
 
 const getApiCreateAction = (config: OpticCliConfig) => async (name: string) => {

--- a/projects/optic/src/commands/api/list.ts
+++ b/projects/optic/src/commands/api/list.ts
@@ -28,7 +28,7 @@ export const registerApiList = (cli: Command, config: OpticCliConfig) => {
       'path to directory for spec list (defaults to the git root or current working directory)'
     )
     .description('List specs within a directory')
-    .action(errorHandler(getApiListAction(config)));
+    .action(errorHandler(getApiListAction(config), { command: 'api-list' }));
 };
 
 type ApiActionOptions = {};

--- a/projects/optic/src/commands/bundle/bundle.ts
+++ b/projects/optic/src/commands/bundle/bundle.ts
@@ -53,7 +53,7 @@ export const registerBundle = (cli: Command, config: OpticCliConfig) => {
     .option('-o [output]', 'output file name')
     .addOption(filterXExtensions)
     .addOption(includeXExtensions)
-    .action(errorHandler(bundleAction(config)));
+    .action(errorHandler(bundleAction(config), { command: 'bundle' }));
 };
 
 const getSpec = async (

--- a/projects/optic/src/commands/ci/comment/comment.ts
+++ b/projects/optic/src/commands/ci/comment/comment.ts
@@ -52,7 +52,9 @@ export const registerCiComment = (cli: Command, config: OpticCliConfig) => {
       '(only for enterprise versions of github or gitlab) - the base url to your enterprise github / gitlab instance'
     )
     .description('comment on a pull request / merge request')
-    .action(errorHandler(getCiCommentAction(config)));
+    .action(
+      errorHandler(getCiCommentAction(config), { command: 'ci-comment' })
+    );
 };
 
 type UnvalidatedOptions = {

--- a/projects/optic/src/commands/ci/setup.ts
+++ b/projects/optic/src/commands/ci/setup.ts
@@ -25,7 +25,7 @@ export const registerCiSetup = (cli: Command, config: OpticCliConfig) => {
     .description(
       'Answer a series of prompts to generate CI configuration for Optic'
     )
-    .action(errorHandler(getCiSetupAction(config)));
+    .action(errorHandler(getCiSetupAction(config), { command: 'ci-setup' }));
 };
 
 type PromptAnswers = {

--- a/projects/optic/src/commands/dereference/dereference.ts
+++ b/projects/optic/src/commands/dereference/dereference.ts
@@ -40,7 +40,7 @@ export const registerDereference = (cli: Command, config: OpticCliConfig) => {
     .option('-o [output]', 'output file name')
     .addOption(filterXExtensions)
     .addOption(includeXExtensions)
-    .action(errorHandler(deferenceAction(config)));
+    .action(errorHandler(deferenceAction(config), { command: 'dereference' }));
 };
 
 const getDereferencedSpec = async (

--- a/projects/optic/src/commands/diff/diff-all.ts
+++ b/projects/optic/src/commands/diff/diff-all.ts
@@ -104,7 +104,7 @@ comma separated values (e.g. "**/*.yml,**/*.json")'
       'fail with exit code 1 if there are detected untracked apis',
       false
     )
-    .action(errorHandler(getDiffAllAction(config)));
+    .action(errorHandler(getDiffAllAction(config), { command: 'diff-all' }));
 };
 
 type DiffAllActionOptions = {

--- a/projects/optic/src/commands/diff/diff.ts
+++ b/projects/optic/src/commands/diff/diff.ts
@@ -96,7 +96,7 @@ export const registerDiff = (cli: Command, config: OpticCliConfig) => {
     .option('--web', 'view the diff in the optic changelog web view', false)
     .option('--json', 'output as json', false)
     .option('--generated', 'use with --upload with a generated spec', false)
-    .action(errorHandler(getDiffAction(config)));
+    .action(errorHandler(getDiffAction(config), { command: 'diff' }));
 };
 
 type SpecDetails = { apiId: string; orgId: string } | null;

--- a/projects/optic/src/commands/lint/lint.ts
+++ b/projects/optic/src/commands/lint/lint.ts
@@ -38,7 +38,7 @@ export const registerLint = (cli: Command, config: OpticCliConfig) => {
     .option('--web', 'view the lint results in the optic web view', false)
     .description(description)
     .argument('<file_path>', 'path to file to lint')
-    .action(errorHandler(getLintAction(config)));
+    .action(errorHandler(getLintAction(config), { command: 'lint' }));
 };
 
 type LintActionOptions = {

--- a/projects/optic/src/commands/login/login.ts
+++ b/projects/optic/src/commands/login/login.ts
@@ -20,7 +20,7 @@ export const registerLogin = (cli: Command, config: OpticCliConfig) => {
   cli
     .command('login')
     .description('Login to Optic')
-    .action(errorHandler(getLoginAction(config)));
+    .action(errorHandler(getLoginAction(config), { command: 'login' }));
 };
 
 const getLoginAction = (config: OpticCliConfig) => async () => {

--- a/projects/optic/src/commands/ruleset/init.ts
+++ b/projects/optic/src/commands/ruleset/init.ts
@@ -18,7 +18,7 @@ export const registerRulesetInit = (cli: Command, config: OpticCliConfig) => {
     .command('init')
     .description('Initializes a new ruleset project')
     .argument('[name]', 'the name of the new ruleset project')
-    .action(errorHandler(getInitAction()));
+    .action(errorHandler(getInitAction(), { command: 'ruleset-init' }));
 };
 
 const getInitAction = () => async (name?: string) => {

--- a/projects/optic/src/commands/ruleset/upload.ts
+++ b/projects/optic/src/commands/ruleset/upload.ts
@@ -41,7 +41,9 @@ This command also requires a token to be provided via the environment variable O
       '--organization-id <organization-id>',
       'specify an organization to add this to'
     )
-    .action(errorHandler(getUploadAction(config)));
+    .action(
+      errorHandler(getUploadAction(config), { command: 'ruleset-upload' })
+    );
 };
 
 type UploadActionOptions = {

--- a/projects/optic/src/commands/spec/add-api-url.ts
+++ b/projects/optic/src/commands/spec/add-api-url.ts
@@ -25,7 +25,9 @@ export const registerSpecAddApiUrl = (cli: Command, config: OpticCliConfig) => {
     .description('Add Optic API URL to a spec file')
     .argument('<spec_path>', 'path to spec file')
     .argument('<api_url>', 'api url to add to spec file')
-    .action(errorHandler(getAddApiUrlAction(config)));
+    .action(
+      errorHandler(getAddApiUrlAction(config), { command: 'spec-add-api-url' })
+    );
 };
 
 const getAddApiUrlAction =

--- a/projects/optic/src/commands/spec/push.ts
+++ b/projects/optic/src/commands/spec/push.ts
@@ -44,7 +44,7 @@ export const registerSpecPush = (cli: Command, config: OpticCliConfig) => {
       'Adds additional tags to the spec version. In git repositories with a clean working directory, a git tag will automatically be included. Tags must be alphanumeric or the - _ : characters'
     )
     .option('--web', 'open to the push spec in Optic Cloud', false)
-    .action(errorHandler(getSpecPushAction(config)));
+    .action(errorHandler(getSpecPushAction(config), { command: 'spec-push' }));
 };
 
 type SpecPushActionOptions = {


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

logs analytics when someone runs openapi versions that aren't supported (i.e. swagger versions)

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
