### PR TITLE
Allow specifying capture port

### DIFF
--- a/projects/optic/src/commands/oas/capture.ts
+++ b/projects/optic/src/commands/oas/capture.ts
@@ -144,8 +144,13 @@ export async function captureCommand(config: OpticCliConfig): Promise<Command> {
       if (!runningCommand && !options.reverseProxy) {
         await systemProxy.start(undefined);
       } else {
-        feedback.notable(
-          `Optic proxy is running at ${proxyUrl} - send traffic to this host. Traffic will be forwarded to ${targetUrl} and will be recorded`
+        logger.info(
+          `${chalk.blue.bold('Proxy URL:')} ${proxyUrl} (send traffic here)`
+        );
+        logger.info(
+          `${chalk.blue.bold(
+            'Forwarding URL:'
+          )} ${targetUrl} (traffic will be forwarded here)`
         );
       }
 

--- a/projects/optic/src/commands/oas/capture.ts
+++ b/projects/optic/src/commands/oas/capture.ts
@@ -50,6 +50,10 @@ export async function captureCommand(config: OpticCliConfig): Promise<Command> {
       'run optic capture in reverse proxy mode - send traffic to a port that gets forwarded to your server'
     )
     .option(
+      '--proxy-port <proxy-port>',
+      'specify the port the proxy should be running on'
+    )
+    .option(
       '--command <command>',
       'command to run with the http_proxy and http_proxy configured'
     )
@@ -91,6 +95,14 @@ export async function captureCommand(config: OpticCliConfig): Promise<Command> {
 
       const options = command.opts();
 
+      if (options.proxyPort && isNaN(Number(options.proxyPort))) {
+        logger.error(
+          `--proxy-port must be a number - received ${options.proxyPort}`
+        );
+        process.exitCode = 1;
+        return;
+      }
+
       if (options.debug) {
         logNode();
       }
@@ -119,7 +131,11 @@ export async function captureCommand(config: OpticCliConfig): Promise<Command> {
       let [proxyInteractions, proxyUrl] = await ProxyInteractions.create(
         targetUrl,
         sourcesController.signal,
-        { ca, mode: options.reverseProxy ? 'reverse-proxy' : 'system-proxy' }
+        {
+          ca,
+          mode: options.reverseProxy ? 'reverse-proxy' : 'system-proxy',
+          proxyPort: options.proxyPort && Number(options.proxyPort),
+        }
       );
 
       const runningCommand = Boolean(options.command);

--- a/projects/optic/src/commands/oas/capture.ts
+++ b/projects/optic/src/commands/oas/capture.ts
@@ -211,7 +211,11 @@ export async function captureCommand(config: OpticCliConfig): Promise<Command> {
       const renderingStats = renderCaptureProgress(
         feedback,
         observationsFork.fork(),
-        { interactiveCapture, debug: options.debug }
+        {
+          interactiveCapture,
+          debug: options.debug,
+          reverseProxy: options.reverseProxy,
+        }
       );
       const trackingStats = trackStats(
         observationsFork.fork(),
@@ -350,7 +354,7 @@ export interface CaptureObservations
 async function renderCaptureProgress(
   feedback: ReturnType<typeof createCommandFeedback>,
   observations: CaptureObservations,
-  config: { interactiveCapture: boolean; debug: boolean }
+  config: { interactiveCapture: boolean; debug: boolean; reverseProxy: boolean }
 ) {
   const ora = (await import('ora')).default;
 
@@ -366,7 +370,7 @@ async function renderCaptureProgress(
   spinner.start();
 
   let timer;
-  if (config.interactiveCapture) {
+  if (config.interactiveCapture && !config.reverseProxy) {
     timer = setTimeout(() => {
       if (interactionCount === 0) {
         spinner.clear();

--- a/projects/optic/src/commands/oas/captures/streams/sources/proxy.ts
+++ b/projects/optic/src/commands/oas/captures/streams/sources/proxy.ts
@@ -38,6 +38,7 @@ export class ProxyInteractions {
       ca?: ProxyCertAuthority;
       targetCA?: Array<{ cert: Buffer | string }>;
       mode: 'reverse-proxy' | 'system-proxy';
+      proxyPort?: number;
     }
   ): Promise<[ProxyInteractions, string, string]> {
     let { host, protocol, origin } = new URL(targetHost);
@@ -185,10 +186,12 @@ export class ProxyInteractions {
       interactions.onCompleted();
     }
 
-    let transparentPort = await portfinder.getPortPromise({
-      port: 8000,
-      stopPort: 8999,
-    });
+    let transparentPort = options.proxyPort
+      ? options.proxyPort
+      : await portfinder.getPortPromise({
+          port: 8000,
+          stopPort: 8999,
+        });
     await capturingProxy.start({
       startPort: transparentPort + 1,
       endPort: transparentPort + 999,


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Allow someone to specify `--proxy-port 8050` which will start the proxy port on a specific server

also did a small update to our logging for proxy + forward url

```
$ optic capture specs/test-spec.yml https://api.github.com --reverse-proxy --proxy-port 8050
Proxy URL: https://localhost:8050 (send traffic here)
Forwarding URL: https://api.github.com (traffic will be forwarded here)
 help  Press [ Enter ] to finish capturing requests
⠙ 0 requests captured
```

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
