### PR TITLE
Allow specifying --verbose on `optic ci comment`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.47.2",
+  "version": "0.47.3",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/fastify-capture/package.json
+++ b/projects/fastify-capture/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/fastify-capture",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.47.2",
+  "version": "0.47.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.47.2",
+  "version": "0.47.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.47.2",
+  "version": "0.47.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.47.2",
+  "version": "0.47.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-utilities/src/index.ts
+++ b/projects/openapi-utilities/src/index.ts
@@ -90,6 +90,7 @@ export {
   getOperationsModifsLabel,
   countOperationsModifications,
   getLabel,
+  getOperationsChanged,
   getOperationsChangedLabel,
 } from './utilities/count-changed-operations';
 

--- a/projects/openapi-utilities/src/utilities/count-changed-operations.ts
+++ b/projects/openapi-utilities/src/utilities/count-changed-operations.ts
@@ -74,14 +74,18 @@ export const getLabel = (
 export const getOperationsModifsLabel = (changes: IChange[]) =>
   getLabel(countOperationsModifications(changes));
 
-export const getOperationsChangedLabel = (
+export const getOperationsChanged = (
   groupedDiffs: GroupedDiffs
-): string => {
-  const addedOps = new Set();
-  const changedOps = new Set();
-  const removedOps = new Set();
+): {
+  added: Set<string>;
+  changed: Set<string>;
+  removed: Set<string>;
+} => {
+  const addedOps = new Set<string>();
+  const changedOps = new Set<string>();
+  const removedOps = new Set<string>();
   for (const endpoint of Object.values(groupedDiffs.endpoints)) {
-    const id = `${endpoint.path}${endpoint.method}`;
+    const id = `${endpoint.method.toUpperCase()} ${endpoint.path}`;
     const diffs = getEndpointDiffs(endpoint);
     const typeofDiffs = typeofV3Diffs(endpoint.diffs);
     if (typeofDiffs === 'added') {
@@ -93,9 +97,21 @@ export const getOperationsChangedLabel = (
     }
   }
 
+  return {
+    added: addedOps,
+    changed: changedOps,
+    removed: removedOps,
+  };
+};
+
+export const getOperationsChangedLabel = (
+  groupedDiffs: GroupedDiffs
+): string => {
+  const { added, changed, removed } = getOperationsChanged(groupedDiffs);
+
   return getLabel({
-    added: addedOps.size,
-    changed: changedOps.size,
-    removed: removedOps.size,
+    added: added.size,
+    changed: changed.size,
+    removed: removed.size,
   });
 };

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.47.2",
+  "version": "0.47.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.47.2",
+  "version": "0.47.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/src/commands/ci/comment/__tests__/__snapshots__/common.test.ts.snap
+++ b/projects/optic/src/commands/ci/comment/__tests__/__snapshots__/common.test.ts.snap
@@ -27,7 +27,83 @@ completed ([preview](https://app.useoptic.com/docs))
 </td>
 <td>
 
-1 operation added ([view changelog](https://app.useoptic.com/changelog))
+2 operations added ([view changelog](https://app.useoptic.com/changelog))
+
+  
+
+
+</td>
+<td>
+
+ℹ️ No automated checks have run
+
+</td>
+
+</tr>
+</tbody>
+</table>
+
+### Errors running optic
+
+<table>
+<thead>
+<tr>
+<th>API</th>
+<th>Error</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>failed</td>
+<td>
+
+\`\`\`
+blahblahblah
+\`\`\`
+
+</td>
+</tr>
+</tbody>
+</table>
+
+
+Summary of API changes for commit (123)
+
+1 API had no changes."
+`;
+
+exports[`generateCompareSummaryMarkdown generates md output for passed, failed and noop for verbose 1`] = `
+"
+<!--
+DO NOT MODIFY
+app_id: optic-comment-3UsoJCz_Z0SpGLo5Vjw6o
+commit_sha: 123
+-->
+### APIs Changed
+
+<table>
+<thead>
+<tr>
+<th>API</th>
+<th>Operation Changes</th>
+<th>Checks</th>
+
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+
+completed ([preview](https://app.useoptic.com/docs))
+
+</td>
+<td>
+
+2 operations added ([view changelog](https://app.useoptic.com/changelog))
+
+  \`GET /api\` (added)
+\`POST /api\` (added)
+
 
 </td>
 <td>
@@ -148,7 +224,10 @@ completed ([preview](https://app.useoptic.com/docs))
 </td>
 <td>
 
-1 operation added ([view changelog](https://app.useoptic.com/changelog))
+2 operations added ([view changelog](https://app.useoptic.com/changelog))
+
+  
+
 
 </td>
 <td>
@@ -195,7 +274,10 @@ no-optic-cloud ([setup preview](https://useoptic.com/docs/cloud-get-started))
 </td>
 <td>
 
-1 operation added ([setup changelog](https://useoptic.com/docs/cloud-get-started))
+2 operations added ([setup changelog](https://useoptic.com/docs/cloud-get-started))
+
+  
+
 
 </td>
 <td>

--- a/projects/optic/src/commands/ci/comment/__tests__/common.test.ts
+++ b/projects/optic/src/commands/ci/comment/__tests__/common.test.ts
@@ -19,6 +19,13 @@ const to = {
           },
         },
       },
+      post: {
+        responses: {
+          '200': {
+            description: 'hello',
+          },
+        },
+      },
     },
   },
 };
@@ -59,7 +66,17 @@ const input: CiRunDetails = {
 describe('generateCompareSummaryMarkdown', () => {
   test('generates md output for passed, failed and noop', () => {
     expect(
-      generateCompareSummaryMarkdown({ sha: '123' }, input)
+      generateCompareSummaryMarkdown({ sha: '123' }, input, {
+        verbose: false,
+      })
+    ).toMatchSnapshot();
+  });
+
+  test('generates md output for passed, failed and noop for verbose', () => {
+    expect(
+      generateCompareSummaryMarkdown({ sha: '123' }, input, {
+        verbose: true,
+      })
     ).toMatchSnapshot();
   });
 
@@ -72,6 +89,9 @@ describe('generateCompareSummaryMarkdown', () => {
           failed: [],
           noop: [],
           severity: 2,
+        },
+        {
+          verbose: false,
         }
       )
     ).toMatchSnapshot();
@@ -86,6 +106,9 @@ describe('generateCompareSummaryMarkdown', () => {
           failed: input.failed,
           noop: [],
           severity: 2,
+        },
+        {
+          verbose: false,
         }
       )
     ).toMatchSnapshot();
@@ -100,6 +123,9 @@ describe('generateCompareSummaryMarkdown', () => {
           failed: [],
           noop: input.noop,
           severity: 2,
+        },
+        {
+          verbose: false,
         }
       )
     ).toMatchSnapshot();
@@ -130,6 +156,9 @@ describe('generateCompareSummaryMarkdown', () => {
           failed: [],
           noop: [],
           severity: 2,
+        },
+        {
+          verbose: false,
         }
       )
     ).toMatchSnapshot();

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.47.2",
+  "version": "0.47.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.47.2",
+  "version": "0.47.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

#1887 - support specifying a verbose mode on `optic ci comment` - right now we can just render out the operations, but i think we could also render more things in this comment. Example comment below...

Thoughts?

I don't think github / gitlab supports color in markdown text, otherwise I think that would be ideal

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
