### PR TITLE
add fallback for open with large url

### DIFF
--- a/.github/workflows/release-container-image.yml
+++ b/.github/workflows/release-container-image.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Login to Amazon ECR Public
         id: login-ecr-public
-        uses: aws-actions/amazon-ecr-login@e407df249e6c155d03c0e4375f34bc2385f52d65 # v1.6.1
+        uses: aws-actions/amazon-ecr-login@fc3959cb4cf5a821ab7a5a636ea4f1e855b05180 # v1.6.2
         with:
           registry-type: public
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.47.4-0",
+  "version": "0.47.4",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",
@@ -28,6 +28,5 @@
     "**/*.+(js|jsx|ts|tsx|json|css)": [
       "yarn prettier --write"
     ]
-  },
-  "stableVersion": "0.47.3"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.47.3",
+  "version": "0.47.4-0",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",
@@ -28,5 +28,6 @@
     "**/*.+(js|jsx|ts|tsx|json|css)": [
       "yarn prettier --write"
     ]
-  }
+  },
+  "stableVersion": "0.47.3"
 }

--- a/projects/fastify-capture/package.json
+++ b/projects/fastify-capture/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/fastify-capture",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.47.4-0",
+  "version": "0.47.4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -37,6 +37,5 @@
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
     "typescript": "^5.0.4"
-  },
-  "stableVersion": "0.47.3"
+  }
 }

--- a/projects/fastify-capture/package.json
+++ b/projects/fastify-capture/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/fastify-capture",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.47.3",
+  "version": "0.47.4-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -37,5 +37,6 @@
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
     "typescript": "^5.0.4"
-  }
+  },
+  "stableVersion": "0.47.3"
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.47.4-0",
+  "version": "0.47.4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -33,6 +33,5 @@
   "dependencies": {
     "jsonpointer": "^5.0.1",
     "minimatch": "9.0.2"
-  },
-  "stableVersion": "0.47.3"
+  }
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.47.3",
+  "version": "0.47.4-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -33,5 +33,6 @@
   "dependencies": {
     "jsonpointer": "^5.0.1",
     "minimatch": "9.0.2"
-  }
+  },
+  "stableVersion": "0.47.3"
 }

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.47.3",
+  "version": "0.47.4-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -58,5 +58,6 @@
     "upath": "^2.0.1",
     "yaml": "^2.2.2",
     "yaml-ast-parser": "^0.0.43"
-  }
+  },
+  "stableVersion": "0.47.3"
 }

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.47.4-0",
+  "version": "0.47.4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -58,6 +58,5 @@
     "upath": "^2.0.1",
     "yaml": "^2.2.2",
     "yaml-ast-parser": "^0.0.43"
-  },
-  "stableVersion": "0.47.3"
+  }
 }

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.47.4-0",
+  "version": "0.47.4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -57,6 +57,5 @@
     "openapi-types": "^12.0.2",
     "ts-invariant": "^0.9.3",
     "yaml-ast-parser": "^0.0.43"
-  },
-  "stableVersion": "0.47.3"
+  }
 }

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.47.3",
+  "version": "0.47.4-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -57,5 +57,6 @@
     "openapi-types": "^12.0.2",
     "ts-invariant": "^0.9.3",
     "yaml-ast-parser": "^0.0.43"
-  }
+  },
+  "stableVersion": "0.47.3"
 }

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.47.3",
+  "version": "0.47.4-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -64,5 +64,6 @@
     "picomatch": "^2.3.1",
     "url-join": "^4.0.1",
     "uuid": "^9.0.0"
-  }
+  },
+  "stableVersion": "0.47.3"
 }

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.47.4-0",
+  "version": "0.47.4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -64,6 +64,5 @@
     "picomatch": "^2.3.1",
     "url-join": "^4.0.1",
     "uuid": "^9.0.0"
-  },
-  "stableVersion": "0.47.3"
+  }
 }

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.47.4-0",
+  "version": "0.47.4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -132,6 +132,5 @@
       "node18-win-x64"
     ],
     "outputPath": "../../dist"
-  },
-  "stableVersion": "0.47.3"
+  }
 }

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.47.3",
+  "version": "0.47.4-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -132,5 +132,6 @@
       "node18-win-x64"
     ],
     "outputPath": "../../dist"
-  }
+  },
+  "stableVersion": "0.47.3"
 }

--- a/projects/optic/src/commands/diff/diff-all.ts
+++ b/projects/optic/src/commands/diff/diff-all.ts
@@ -12,7 +12,6 @@ import {
   flushEvents,
   trackEvent,
 } from '@useoptic/openapi-utilities/build/utilities/segment';
-import open from 'open';
 import { compressDataV2 } from './compressResults';
 import { textToSev } from '@useoptic/openapi-utilities';
 import { uploadDiff } from './upload-diff';
@@ -29,6 +28,7 @@ import {
 } from './changelog-renderers/terminal-changelog';
 import { jsonChangelog } from './changelog-renderers/json-changelog';
 import * as Types from '../../client/optic-backend-types';
+import { openUrl } from '../../utils/open-url';
 
 const usage = () => `
   optic diff-all
@@ -564,7 +564,7 @@ async function openWebpage(
   }
   trackEvent('optic.diff_all.view_web', analyticsData);
 
-  await open(url, { wait: false });
+  await openUrl(url);
 }
 
 function sanitizeRef(maybeGitRef: string): string {

--- a/projects/optic/src/commands/diff/diff.ts
+++ b/projects/optic/src/commands/diff/diff.ts
@@ -1,6 +1,4 @@
 import { Command, Option } from 'commander';
-import open from 'open';
-
 import { UserError, textToSev } from '@useoptic/openapi-utilities';
 
 import {
@@ -34,6 +32,7 @@ import ora from 'ora';
 import * as GitCandidates from '../api/git-get-file-candidates';
 import stableStringify from 'json-stable-stringify';
 import { computeChecksumForAws } from '../../utils/checksum';
+import { openUrl } from '../../utils/open-url';
 
 type DiffActionOptions = {
   base: string;
@@ -490,9 +489,7 @@ const getDiffAction =
           await flushEvents();
         }
         trackEvent('optic.diff.view_web', analyticsData);
-        await open(maybeChangelogUrl, {
-          wait: false,
-        });
+        await openUrl(maybeChangelogUrl);
       }
     }
 

--- a/projects/optic/src/commands/lint/lint.ts
+++ b/projects/optic/src/commands/lint/lint.ts
@@ -1,5 +1,4 @@
 import { Command, Option } from 'commander';
-import open from 'open';
 
 import { compute } from '../diff/compute';
 import { loadSpec, ParseResult } from '../../utils/spec-loaders';
@@ -14,6 +13,7 @@ import {
   flushEvents,
   trackEvent,
 } from '@useoptic/openapi-utilities/build/utilities/segment';
+import { openUrl } from '../../utils/open-url';
 
 const description = `lints and validates an OpenAPI file`;
 
@@ -120,9 +120,9 @@ const getLintAction =
 
         trackEvent('optic.lint.view_web', analyticsData);
         await flushEvents();
-        await open(`${config.client.getWebBase()}/cli/diff#${compressedData}`, {
-          wait: false,
-        });
+        await openUrl(
+          `${config.client.getWebBase()}/cli/diff#${compressedData}`
+        );
       }
 
       if (failuresForSeverity > 0) {

--- a/projects/optic/src/utils/open-url.ts
+++ b/projects/optic/src/utils/open-url.ts
@@ -1,0 +1,26 @@
+import fs from 'node:fs/promises';
+import open from 'open';
+import os from 'os';
+import path from 'path';
+
+const tmpDirectory = os.tmpdir();
+
+export const openUrl = async (url: string) => {
+  try {
+    await open(url, {
+      wait: false,
+    });
+  } catch (e) {
+    if (e instanceof Error && /ENAMETOOLONG/i.test(e.message)) {
+      const tmpHtmlPath = path.join(tmpDirectory, 'optic', 'tmp-web.html');
+      await fs.mkdir(path.dirname(tmpHtmlPath), { recursive: true });
+
+      await fs.writeFile(
+        tmpHtmlPath,
+        `<!DOCTYPE html><html><body><script type="text/javascript">window.location.replace("${url}")</script></body></html>`
+      );
+
+      await open(tmpHtmlPath);
+    }
+  }
+};

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.47.4-0",
+  "version": "0.47.4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -40,6 +40,5 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
-  },
-  "stableVersion": "0.47.3"
+  }
 }

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.47.3",
+  "version": "0.47.4-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -40,5 +40,6 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
-  }
+  },
+  "stableVersion": "0.47.3"
 }

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.47.3",
+  "version": "0.47.4-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -39,5 +39,6 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
-  }
+  },
+  "stableVersion": "0.47.3"
 }

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.47.4-0",
+  "version": "0.47.4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -39,6 +39,5 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
-  },
-  "stableVersion": "0.47.3"
+  }
 }


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Windows terminals have trouble opening the web url (long url encoded via a hash) - trying to work around this by writing a html file that redirects to the original url and writing that to a tmp dir.

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

https://github.com/opticdev/optic/issues/2039

## 👹 QA
_How can other humans verify that this PR is correct?_

`0.47.4-0` prerelease version can be used for testing
