### PR TITLE
Fix `optic update` interactions + add tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.47.3",
+  "version": "0.47.4-0",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",
@@ -28,5 +28,6 @@
     "**/*.+(js|jsx|ts|tsx|json|css)": [
       "yarn prettier --write"
     ]
-  }
+  },
+  "stableVersion": "0.47.3"
 }

--- a/projects/fastify-capture/package.json
+++ b/projects/fastify-capture/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/fastify-capture",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.47.3",
+  "version": "0.47.4-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -37,5 +37,6 @@
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
     "typescript": "^5.0.4"
-  }
+  },
+  "stableVersion": "0.47.3"
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.47.3",
+  "version": "0.47.4-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -33,5 +33,6 @@
   "dependencies": {
     "jsonpointer": "^5.0.1",
     "minimatch": "9.0.2"
-  }
+  },
+  "stableVersion": "0.47.3"
 }

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.47.3",
+  "version": "0.47.4-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -58,5 +58,6 @@
     "upath": "^2.0.1",
     "yaml": "^2.2.2",
     "yaml-ast-parser": "^0.0.43"
-  }
+  },
+  "stableVersion": "0.47.3"
 }

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.47.3",
+  "version": "0.47.4-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -57,5 +57,6 @@
     "openapi-types": "^12.0.2",
     "ts-invariant": "^0.9.3",
     "yaml-ast-parser": "^0.0.43"
-  }
+  },
+  "stableVersion": "0.47.3"
 }

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.47.3",
+  "version": "0.47.4-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -64,5 +64,6 @@
     "picomatch": "^2.3.1",
     "url-join": "^4.0.1",
     "uuid": "^9.0.0"
-  }
+  },
+  "stableVersion": "0.47.3"
 }

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.47.3",
+  "version": "0.47.4-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -132,5 +132,6 @@
       "node18-win-x64"
     ],
     "outputPath": "../../dist"
-  }
+  },
+  "stableVersion": "0.47.3"
 }

--- a/projects/optic/src/__tests__/integration/__snapshots__/update.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/update.test.ts.snap
@@ -17,6 +17,171 @@ Share a link to documentation with your team ([1moptic api add openapi.yml)[22
 
 exports[`update update an existing spec with prefixed server 2`] = `
 {
+  "components": {
+    "schemas": {
+      "GetBooksBook200ResponseBody": {
+        "properties": {
+          "author_id": {
+            "type": "string",
+          },
+          "created_at": {
+            "type": "string",
+          },
+          "id": {
+            "type": "string",
+          },
+          "name": {
+            "type": "string",
+          },
+          "updated_at": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "id",
+          "name",
+          "author_id",
+          "created_at",
+          "updated_at",
+        ],
+        "type": "object",
+      },
+      "GetSomeExample200ResponseBody": {
+        "properties": {
+          "something": {
+            "items": {
+              "properties": {
+                "another": {
+                  "oneOf": [
+                    {
+                      "items": {
+                        "properties": {
+                          "max": {
+                            "type": "number",
+                          },
+                          "min": {
+                            "type": "number",
+                          },
+                          "path": {
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "path",
+                          "max",
+                          "min",
+                        ],
+                        "type": "object",
+                      },
+                      "type": [
+                        "object",
+                        "null",
+                      ],
+                    },
+                    {
+                      "items": {
+                        "properties": {
+                          "max": {
+                            "type": "number",
+                          },
+                          "min": {
+                            "type": "number",
+                          },
+                          "path": {
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "path",
+                          "max",
+                          "min",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  ],
+                },
+                "name": {
+                  "type": "string",
+                },
+              },
+              "required": [
+                "name",
+                "another",
+              ],
+              "type": "object",
+            },
+            "type": "array",
+          },
+        },
+        "required": [
+          "something",
+        ],
+        "type": "object",
+      },
+      "PostAuthors201ResponseBody": {
+        "properties": {
+          "id": {
+            "type": "string",
+          },
+          "name": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "id",
+          "name",
+        ],
+        "type": "object",
+      },
+      "PostAuthorsRequestBody": {
+        "properties": {
+          "name": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "name",
+        ],
+        "type": "object",
+      },
+      "PostBooks201ResponseBody": {
+        "properties": {
+          "author_id": {
+            "type": "string",
+          },
+          "id": {
+            "type": "string",
+          },
+          "name": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "id",
+          "name",
+          "author_id",
+        ],
+        "type": "object",
+      },
+      "PostBooksRequestBody": {
+        "properties": {
+          "author_id": {
+            "type": "string",
+          },
+          "name": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "name",
+          "author_id",
+        ],
+        "type": "object",
+      },
+    },
+  },
   "info": {
     "description": "The API",
     "title": "a spec",
@@ -26,12 +191,43 @@ exports[`update update an existing spec with prefixed server 2`] = `
   "paths": {
     "/authors": {
       "post": {
-        "responses": {},
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PostAuthorsRequestBody",
+              },
+            },
+          },
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/PostAuthors201ResponseBody",
+                },
+              },
+            },
+            "description": "201 response",
+          },
+        },
       },
     },
     "/authors/{author}": {
       "get": {
-        "responses": {},
+        "responses": {
+          "200": {
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetBooksBook200ResponseBody",
+                },
+              },
+            },
+            "description": "200 response",
+          },
+        },
       },
       "parameters": [
         {
@@ -46,15 +242,76 @@ exports[`update update an existing spec with prefixed server 2`] = `
     },
     "/books": {
       "get": {
-        "responses": {},
+        "responses": {
+          "200": {
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "$ref": "#/components/schemas/GetBooksBook200ResponseBody",
+                      },
+                      "type": "array",
+                    },
+                    "has_more_data": {
+                      "type": "boolean",
+                    },
+                    "next": {
+                      "type": "null",
+                    },
+                  },
+                  "required": [
+                    "data",
+                    "next",
+                    "has_more_data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "200 response",
+          },
+        },
       },
       "post": {
-        "responses": {},
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PostBooksRequestBody",
+              },
+            },
+          },
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/PostBooks201ResponseBody",
+                },
+              },
+            },
+            "description": "201 response",
+          },
+        },
       },
     },
     "/books/{book}": {
       "get": {
-        "responses": {},
+        "responses": {
+          "200": {
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetBooksBook200ResponseBody",
+                },
+              },
+            },
+            "description": "200 response",
+          },
+        },
       },
       "parameters": [
         {
@@ -69,14 +326,25 @@ exports[`update update an existing spec with prefixed server 2`] = `
     },
     "/some/example": {
       "get": {
-        "responses": {},
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetSomeExample200ResponseBody",
+                },
+              },
+            },
+            "description": "200 response",
+          },
+        },
       },
     },
   },
   "servers": [
     {
       "name": "book server",
-      "url": "http://localhost:3030/books",
+      "url": "http://localhost:3030/api",
     },
   ],
 }

--- a/projects/optic/src/__tests__/integration/__snapshots__/update.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/update.test.ts.snap
@@ -217,6 +217,17 @@ exports[`update updates an empty spec 2`] = `
         ],
         "type": "object",
       },
+      "PostAuthorsRequestBody": {
+        "properties": {
+          "name": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "name",
+        ],
+        "type": "object",
+      },
       "PostBooks201ResponseBody": {
         "properties": {
           "author_id": {
@@ -236,6 +247,21 @@ exports[`update updates an empty spec 2`] = `
         ],
         "type": "object",
       },
+      "PostBooksRequestBody": {
+        "properties": {
+          "author_id": {
+            "type": "string",
+          },
+          "name": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "name",
+          "author_id",
+        ],
+        "type": "object",
+      },
     },
   },
   "info": {
@@ -250,7 +276,9 @@ exports[`update updates an empty spec 2`] = `
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {},
+              "schema": {
+                "$ref": "#/components/schemas/PostAuthorsRequestBody",
+              },
             },
           },
         },
@@ -332,7 +360,9 @@ exports[`update updates an empty spec 2`] = `
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {},
+              "schema": {
+                "$ref": "#/components/schemas/PostBooksRequestBody",
+              },
             },
           },
         },
@@ -531,6 +561,17 @@ exports[`update updates an existing spec 2`] = `
         ],
         "type": "object",
       },
+      "PostAuthorsRequestBody": {
+        "properties": {
+          "name": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "name",
+        ],
+        "type": "object",
+      },
       "PostBooks201ResponseBody": {
         "properties": {
           "author_id": {
@@ -550,6 +591,21 @@ exports[`update updates an existing spec 2`] = `
         ],
         "type": "object",
       },
+      "PostBooksRequestBody": {
+        "properties": {
+          "author_id": {
+            "type": "string",
+          },
+          "name": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "name",
+          "author_id",
+        ],
+        "type": "object",
+      },
     },
   },
   "info": {
@@ -564,7 +620,9 @@ exports[`update updates an existing spec 2`] = `
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {},
+              "schema": {
+                "$ref": "#/components/schemas/PostAuthorsRequestBody",
+              },
             },
           },
         },
@@ -646,7 +704,9 @@ exports[`update updates an existing spec 2`] = `
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {},
+              "schema": {
+                "$ref": "#/components/schemas/PostBooksRequestBody",
+              },
             },
           },
         },

--- a/projects/optic/src/__tests__/integration/__snapshots__/update.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/update.test.ts.snap
@@ -1,0 +1,711 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`update update an existing spec with prefixed server 1`] = `
+"[94m» [39mDocumenting new operations...
+  [32madded[39m  post /books
+  [32madded[39m  get /books
+  [32madded[39m  post /authors
+  [32madded[39m  get /some/example
+  [32madded[39m  get /books/{book}
+  [32madded[39m  get /authors/{author}
+[94m» [39mUpdating operations...
+
+[1G[1A[0K[1G[1B
+Share a link to documentation with your team ([1moptic api add openapi.yml)[22m
+"
+`;
+
+exports[`update update an existing spec with prefixed server 2`] = `
+{
+  "info": {
+    "description": "The API",
+    "title": "a spec",
+    "version": "0.1.0",
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/authors": {
+      "post": {
+        "responses": {},
+      },
+    },
+    "/authors/{author}": {
+      "get": {
+        "responses": {},
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "author",
+          "required": true,
+          "schema": {
+            "type": "string",
+          },
+        },
+      ],
+    },
+    "/books": {
+      "get": {
+        "responses": {},
+      },
+      "post": {
+        "responses": {},
+      },
+    },
+    "/books/{book}": {
+      "get": {
+        "responses": {},
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "book",
+          "required": true,
+          "schema": {
+            "type": "string",
+          },
+        },
+      ],
+    },
+    "/some/example": {
+      "get": {
+        "responses": {},
+      },
+    },
+  },
+  "servers": [
+    {
+      "name": "book server",
+      "url": "http://localhost:3030/books",
+    },
+  ],
+}
+`;
+
+exports[`update updates an empty spec 1`] = `
+"[94m» [39mDocumenting new operations...
+  [32madded[39m  post /books
+  [32madded[39m  get /books
+  [32madded[39m  post /authors
+  [32madded[39m  get /some/example
+  [32madded[39m  get /books/{book}
+  [32madded[39m  get /authors/{author}
+[94m» [39mUpdating operations...
+
+[1G[1A[0K[1G[1B
+Share a link to documentation with your team ([1moptic api add openapi.yml)[22m
+"
+`;
+
+exports[`update updates an empty spec 2`] = `
+{
+  "components": {
+    "schemas": {
+      "GetBooksBook200ResponseBody": {
+        "properties": {
+          "author_id": {
+            "type": "string",
+          },
+          "created_at": {
+            "type": "string",
+          },
+          "id": {
+            "type": "string",
+          },
+          "name": {
+            "type": "string",
+          },
+          "updated_at": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "id",
+          "name",
+          "author_id",
+          "created_at",
+          "updated_at",
+        ],
+        "type": "object",
+      },
+      "GetSomeExample200ResponseBody": {
+        "properties": {
+          "something": {
+            "items": {
+              "properties": {
+                "another": {
+                  "oneOf": [
+                    {
+                      "items": {
+                        "properties": {
+                          "max": {
+                            "type": "number",
+                          },
+                          "min": {
+                            "type": "number",
+                          },
+                          "path": {
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "path",
+                          "max",
+                          "min",
+                        ],
+                        "type": "object",
+                      },
+                      "type": [
+                        "object",
+                        "null",
+                      ],
+                    },
+                    {
+                      "items": {
+                        "properties": {
+                          "max": {
+                            "type": "number",
+                          },
+                          "min": {
+                            "type": "number",
+                          },
+                          "path": {
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "path",
+                          "max",
+                          "min",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  ],
+                },
+                "name": {
+                  "type": "string",
+                },
+              },
+              "required": [
+                "name",
+                "another",
+              ],
+              "type": "object",
+            },
+            "type": "array",
+          },
+        },
+        "required": [
+          "something",
+        ],
+        "type": "object",
+      },
+      "PostAuthors201ResponseBody": {
+        "properties": {
+          "id": {
+            "type": "string",
+          },
+          "name": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "id",
+          "name",
+        ],
+        "type": "object",
+      },
+      "PostBooks201ResponseBody": {
+        "properties": {
+          "author_id": {
+            "type": "string",
+          },
+          "id": {
+            "type": "string",
+          },
+          "name": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "id",
+          "name",
+          "author_id",
+        ],
+        "type": "object",
+      },
+    },
+  },
+  "info": {
+    "description": "The API",
+    "title": "a spec",
+    "version": "0.1.0",
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/authors": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {},
+            },
+          },
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/PostAuthors201ResponseBody",
+                },
+              },
+            },
+            "description": "201 response",
+          },
+        },
+      },
+    },
+    "/authors/{author}": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetBooksBook200ResponseBody",
+                },
+              },
+            },
+            "description": "200 response",
+          },
+        },
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "author",
+          "required": true,
+          "schema": {
+            "type": "string",
+          },
+        },
+      ],
+    },
+    "/books": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "$ref": "#/components/schemas/GetBooksBook200ResponseBody",
+                      },
+                      "type": "array",
+                    },
+                    "has_more_data": {
+                      "type": "boolean",
+                    },
+                    "next": {
+                      "type": "null",
+                    },
+                  },
+                  "required": [
+                    "data",
+                    "next",
+                    "has_more_data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "200 response",
+          },
+        },
+      },
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {},
+            },
+          },
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/PostBooks201ResponseBody",
+                },
+              },
+            },
+            "description": "201 response",
+          },
+        },
+      },
+    },
+    "/books/{book}": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetBooksBook200ResponseBody",
+                },
+              },
+            },
+            "description": "200 response",
+          },
+        },
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "book",
+          "required": true,
+          "schema": {
+            "type": "string",
+          },
+        },
+      ],
+    },
+    "/some/example": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetSomeExample200ResponseBody",
+                },
+              },
+            },
+            "description": "200 response",
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`update updates an existing spec 1`] = `
+"[94m» [39mDocumenting new operations...
+  [32madded[39m  post /books
+  [32madded[39m  get /books
+  [32madded[39m  post /authors
+  [32madded[39m  get /some/example
+  [32madded[39m  get /books/{book}
+  [32madded[39m  get /authors/{author}
+[94m» [39mUpdating operations...
+
+[1G[1A[0K[1G[1B
+Share a link to documentation with your team ([1moptic api add openapi.yml)[22m
+"
+`;
+
+exports[`update updates an existing spec 2`] = `
+{
+  "components": {
+    "schemas": {
+      "GetBooksBook200ResponseBody": {
+        "properties": {
+          "author_id": {
+            "type": "string",
+          },
+          "created_at": {
+            "type": "string",
+          },
+          "id": {
+            "type": "string",
+          },
+          "name": {
+            "type": "string",
+          },
+          "updated_at": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "id",
+          "name",
+          "author_id",
+          "created_at",
+          "updated_at",
+        ],
+        "type": "object",
+      },
+      "GetSomeExample200ResponseBody": {
+        "properties": {
+          "something": {
+            "items": {
+              "properties": {
+                "another": {
+                  "oneOf": [
+                    {
+                      "items": {
+                        "properties": {
+                          "max": {
+                            "type": "number",
+                          },
+                          "min": {
+                            "type": "number",
+                          },
+                          "path": {
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "path",
+                          "max",
+                          "min",
+                        ],
+                        "type": "object",
+                      },
+                      "type": [
+                        "object",
+                        "null",
+                      ],
+                    },
+                    {
+                      "items": {
+                        "properties": {
+                          "max": {
+                            "type": "number",
+                          },
+                          "min": {
+                            "type": "number",
+                          },
+                          "path": {
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "path",
+                          "max",
+                          "min",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  ],
+                },
+                "name": {
+                  "type": "string",
+                },
+              },
+              "required": [
+                "name",
+                "another",
+              ],
+              "type": "object",
+            },
+            "type": "array",
+          },
+        },
+        "required": [
+          "something",
+        ],
+        "type": "object",
+      },
+      "PostAuthors201ResponseBody": {
+        "properties": {
+          "id": {
+            "type": "string",
+          },
+          "name": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "id",
+          "name",
+        ],
+        "type": "object",
+      },
+      "PostBooks201ResponseBody": {
+        "properties": {
+          "author_id": {
+            "type": "string",
+          },
+          "id": {
+            "type": "string",
+          },
+          "name": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "id",
+          "name",
+          "author_id",
+        ],
+        "type": "object",
+      },
+    },
+  },
+  "info": {
+    "description": "The API",
+    "title": "a spec",
+    "version": "0.1.0",
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/authors": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {},
+            },
+          },
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/PostAuthors201ResponseBody",
+                },
+              },
+            },
+            "description": "201 response",
+          },
+        },
+      },
+    },
+    "/authors/{author}": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetBooksBook200ResponseBody",
+                },
+              },
+            },
+            "description": "200 response",
+          },
+        },
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "author",
+          "required": true,
+          "schema": {
+            "type": "string",
+          },
+        },
+      ],
+    },
+    "/books": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "$ref": "#/components/schemas/GetBooksBook200ResponseBody",
+                      },
+                      "type": "array",
+                    },
+                    "has_more_data": {
+                      "type": "boolean",
+                    },
+                    "next": {
+                      "type": "null",
+                    },
+                  },
+                  "required": [
+                    "data",
+                    "next",
+                    "has_more_data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "200 response",
+          },
+        },
+      },
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {},
+            },
+          },
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/PostBooks201ResponseBody",
+                },
+              },
+            },
+            "description": "201 response",
+          },
+        },
+      },
+    },
+    "/books/{book}": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json; charset=utf-8": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetBooksBook200ResponseBody",
+                },
+              },
+            },
+            "description": "200 response",
+          },
+        },
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "book",
+          "required": true,
+          "schema": {
+            "type": "string",
+          },
+        },
+      ],
+    },
+    "/some/example": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetSomeExample200ResponseBody",
+                },
+              },
+            },
+            "description": "200 response",
+          },
+        },
+      },
+    },
+  },
+}
+`;

--- a/projects/optic/src/__tests__/integration/update.test.ts
+++ b/projects/optic/src/__tests__/integration/update.test.ts
@@ -1,0 +1,70 @@
+import {
+  test,
+  expect,
+  describe,
+  jest,
+  beforeEach,
+  afterEach,
+} from '@jest/globals';
+import { runOptic, setupWorkspace, normalizeWorkspace } from './integration';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import yaml from 'js-yaml';
+
+jest.setTimeout(30000);
+
+let oldEnv: any;
+beforeEach(() => {
+  oldEnv = { ...process.env };
+  process.env.LOG_LEVEL = 'info';
+  process.env.OPTIC_ENV = 'local';
+  process.env.CI = 'false';
+});
+
+afterEach(() => {
+  process.env = { ...oldEnv };
+});
+
+describe('update', () => {
+  test('updates an empty spec', async () => {
+    const workspace = await setupWorkspace('update/empty-spec');
+    const { combined, code } = await runOptic(
+      workspace,
+      'update openapi.yml --har har.har --all'
+    );
+    expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
+    expect(code).toBe(0);
+
+    expect(
+      yaml.load(await fs.readFile(path.join(workspace, 'openapi.yml'), 'utf-8'))
+    ).toMatchSnapshot();
+  });
+
+  test('updates an existing spec', async () => {
+    const workspace = await setupWorkspace('update/existing-spec');
+    const { combined, code } = await runOptic(
+      workspace,
+      'update openapi.yml --har har.har --all'
+    );
+    expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
+    expect(code).toBe(0);
+
+    expect(
+      yaml.load(await fs.readFile(path.join(workspace, 'openapi.yml'), 'utf-8'))
+    ).toMatchSnapshot();
+  });
+
+  test('update an existing spec with prefixed server', async () => {
+    const workspace = await setupWorkspace('update/prefix-server-spec');
+    const { combined, code } = await runOptic(
+      workspace,
+      'update openapi.yml --har har.har --all'
+    );
+    expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
+    expect(code).toBe(0);
+
+    expect(
+      yaml.load(await fs.readFile(path.join(workspace, 'openapi.yml'), 'utf-8'))
+    ).toMatchSnapshot();
+  });
+});

--- a/projects/optic/src/__tests__/integration/workspaces/update/empty-spec/har.har
+++ b/projects/optic/src/__tests__/integration/workspaces/update/empty-spec/har.har
@@ -1,0 +1,349 @@
+{
+  "log": {
+    "version": "1.3",
+    "creator": "Optic capture command",
+    "entries": [
+      {
+        "request": {
+          "method": "GET",
+          "url": "http://localhost:3030/books/NjpTwgmENj11rGdUgpCQ9",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "bodySize": 0,
+          "cookies": [],
+          "queryString": []
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "cookies": [],
+          "redirectURL": "",
+          "bodySize": 175,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 236,
+            "text": "eyJpZCI6Ik5qcFR3Z21FTmoxMXJHZFVncENROSIsIm5hbWUiOiJQcmlkZSBhbmQgUHJlanVkaWNlIiwiYXV0aG9yX2lkIjoiNm5UeEFGTTVjazRIb2I3N2hHUW9MIiwiY3JlYXRlZF9hdCI6IjIwMjMtMDUtMjJUMTc6MTc6NDEuMzI2WiIsInVwZGF0ZWRfYXQiOiIyMDIzLTA1LTIyVDE3OjE3OjQxLjMyNloifQ==",
+            "encoding": "base64"
+          }
+        },
+        "cache": {},
+        "timings": { "send": 100, "wait": 100, "receive": 100 },
+        "startedDateTime": "1970-01-01T00:00:18.682Z",
+        "time": 300
+      },
+      {
+        "request": {
+          "method": "GET",
+          "url": "http://localhost:3030/authors/NjpTwgmENj11rGdUgpCQ9",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "bodySize": 0,
+          "cookies": [],
+          "queryString": []
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "cookies": [],
+          "redirectURL": "",
+          "bodySize": 139,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 188,
+            "text": "eyJpZCI6Ik5qcFR3Z21FTmoxMXJHZFVncENROSIsIm5hbWUiOiJGLiBTY290dCBGaXR6Z2VyYWxkIiwiY3JlYXRlZF9hdCI6IjIwMjMtMDMtMjJUMTA6MTE6NTEuNDIxWiIsInVwZGF0ZWRfYXQiOiIyMDIzLTAzLTIyVDEwOjExOjUxLjQyMVoifQ==",
+            "encoding": "base64"
+          }
+        },
+        "cache": {},
+        "timings": { "send": 100, "wait": 100, "receive": 100 },
+        "startedDateTime": "1970-01-01T00:00:24.052Z",
+        "time": 300
+      },
+
+      {
+        "request": {
+          "method": "GET",
+          "url": "http://localhost:3030/some/example",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "bodySize": 0,
+          "cookies": [],
+          "queryString": []
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "cookies": [],
+          "redirectURL": "",
+          "bodySize": 240,
+          "content": {
+            "mimeType": "application/json",
+            "size": 240,
+            "text": "eyJzb21ldGhpbmciOlt7Im5hbWUiOiJhYWRzYXNkIiwiYW5vdGhlciI6W3sicGF0aCI6IjEyMzQiLCJtYXgiOjAsIm1pbiI6MX1dfSx7Im5hbWUiOiJxd2VyZ2giLCJhbm90aGVyIjpudWxsfSx7Im5hbWUiOiJhYWRzYXNkIiwiYW5vdGhlciI6W3sicGF0aCI6IjEyMTIzNDUzNCIsIm1heCI6MCwibWluIjoxfV19XX0=",
+            "encoding": "base64"
+          }
+        },
+        "cache": {},
+        "timings": { "send": 100, "wait": 100, "receive": 100 },
+        "startedDateTime": "1970-01-01T00:00:07.607Z",
+        "time": 300
+      },
+      {
+        "request": {
+          "method": "POST",
+          "url": "http://localhost:3030/books",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" },
+            { "name": "Content-Type", "value": "application/json" },
+            { "name": "Content-Length", "value": "61" }
+          ],
+          "headersSize": -1,
+          "bodySize": 61,
+          "cookies": [],
+          "queryString": [],
+          "postData": {
+            "mimeType": "application/json",
+            "text": "eyJuYW1lIjogIkFuaW1hbCBGYXJtIiwgImF1dGhvcl9pZCI6ICI2blR4QUZNNWNrNEhvYjc3aEdRb0wifQ==",
+            "encoding": "base64",
+            "params": []
+          }
+        },
+        "response": {
+          "status": 201,
+          "statusText": "Created",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" },
+            { "name": "Content-Type", "value": "application/json" },
+            { "name": "Content-Length", "value": "61" }
+          ],
+          "headersSize": -1,
+          "cookies": [],
+          "redirectURL": "",
+          "bodySize": 87,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 116,
+            "text": "eyJpZCI6Il8talZNQXBHeFVOWmo5akVtcGNqSSIsIm5hbWUiOiJBbmltYWwgRmFybSIsImF1dGhvcl9pZCI6IjZuVHhBRk01Y2s0SG9iNzdoR1FvTCJ9",
+            "encoding": "base64"
+          }
+        },
+        "cache": {},
+        "timings": { "send": 100, "wait": 100, "receive": 100 },
+        "startedDateTime": "1970-01-01T00:00:28.497Z",
+        "time": 300
+      },
+      {
+        "request": {
+          "method": "GET",
+          "url": "http://localhost:3030/books",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "bodySize": 0,
+          "cookies": [],
+          "queryString": []
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "cookies": [],
+          "redirectURL": "",
+          "bodySize": 748,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1000,
+            "text": "eyJkYXRhIjpbeyJpZCI6IldqRTlPMWQ4RUxDYjhQT2lPdzRwbiIsIm5hbWUiOiJQcmlkZSBhbmQgUHJlanVkaWNlIiwiYXV0aG9yX2lkIjoiNm5UeEFGTTVjazRIb2I3N2hHUW9MIiwiY3JlYXRlZF9hdCI6IjIwMjMtMDUtMjJUMTc6MTc6NDEuMzI2WiIsInVwZGF0ZWRfYXQiOiIyMDIzLTA1LTIyVDE3OjE3OjQxLjMyNloifSx7ImlkIjoidlpzWVZtemR4dGloeFFOcUNzLTNmIiwibmFtZSI6IlRoZSBHcmVhdCBHYXRzYnkiLCJhdXRob3JfaWQiOiJOanBUd2dtRU5qMTFyR2RVZ3BDUTkiLCJjcmVhdGVkX2F0IjoiMjAyMy0wMy0yMlQxMDoxMTo1MS40MjFaIiwidXBkYXRlZF9hdCI6IjIwMjMtMDMtMjJUMTA6MTE6NTEuNDIxWiJ9LHsiaWQiOiJscXFYQ1dudWVGUWJpaGdadEs5YS0iLCJuYW1lIjoiVG8gS2lsbCBhIE1vY2tpbmdiaXJkIiwiYXV0aG9yX2lkIjoiQWNTd2lRcnlXQmVRcWNOQnFCZzQzIiwiY3JlYXRlZF9hdCI6IjIwMjMtMDUtMDFUMDc6MTE6MDEuNzAxWiIsInVwZGF0ZWRfYXQiOiIyMDIzLTA1LTEyVDA3OjE4OjE5LjEyN1oifSx7ImlkIjoidF82aS1uUk9yNjY5QU9QTkUzUlRxIiwibmFtZSI6Ik5pbmV0ZWVuIEVpZ2h0eS1Gb3VyIiwiYXV0aG9yX2lkIjoidE5wT3BRWmJ4eXR4VHhEVDE1R1F5IiwiY3JlYXRlZF9hdCI6IjIwMjMtMDMtMTFUMjE6MTk6MDguNjAwWiIsInVwZGF0ZWRfYXQiOiIyMDIzLTAzLTExVDIxOjE5OjA4LjYwMFoifV0sIm5leHQiOm51bGwsImhhc19tb3JlX2RhdGEiOmZhbHNlfQ==",
+            "encoding": "base64"
+          }
+        },
+        "cache": {},
+        "timings": { "send": 100, "wait": 100, "receive": 100 },
+        "startedDateTime": "1970-01-01T00:00:33.232Z",
+        "time": 300
+      },
+      {
+        "request": {
+          "method": "GET",
+          "url": "http://localhost:3030/books/WjE9O1d8ELCb8POiOw4pn",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "bodySize": 0,
+          "cookies": [],
+          "queryString": []
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "cookies": [],
+          "redirectURL": "",
+          "bodySize": 175,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 236,
+            "text": "eyJpZCI6IldqRTlPMWQ4RUxDYjhQT2lPdzRwbiIsIm5hbWUiOiJQcmlkZSBhbmQgUHJlanVkaWNlIiwiYXV0aG9yX2lkIjoiNm5UeEFGTTVjazRIb2I3N2hHUW9MIiwiY3JlYXRlZF9hdCI6IjIwMjMtMDUtMjJUMTc6MTc6NDEuMzI2WiIsInVwZGF0ZWRfYXQiOiIyMDIzLTA1LTIyVDE3OjE3OjQxLjMyNloifQ==",
+            "encoding": "base64"
+          }
+        },
+        "cache": {},
+        "timings": { "send": 100, "wait": 100, "receive": 100 },
+        "startedDateTime": "1970-01-01T00:00:42.055Z",
+        "time": 300
+      },
+      {
+        "request": {
+          "method": "GET",
+          "url": "http://localhost:3030/authors/6nTxAFM5ck4Hob77hGQoL",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "bodySize": 0,
+          "cookies": [],
+          "queryString": []
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "cookies": [],
+          "redirectURL": "",
+          "bodySize": 131,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 176,
+            "text": "eyJpZCI6IjZuVHhBRk01Y2s0SG9iNzdoR1FvTCIsIm5hbWUiOiJKYW5lIEF1c3RlbiIsImNyZWF0ZWRfYXQiOiIyMDIzLTA1LTIyVDE3OjE3OjQxLjMyNloiLCJ1cGRhdGVkX2F0IjoiMjAyMy0wNS0yMlQxNzoxNzo0MS4zMjZaIn0=",
+            "encoding": "base64"
+          }
+        },
+        "cache": {},
+        "timings": { "send": 100, "wait": 100, "receive": 100 },
+        "startedDateTime": "1970-01-01T00:00:55.736Z",
+        "time": 300
+      },
+      {
+        "request": {
+          "method": "POST",
+          "url": "http://localhost:3030/authors",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" },
+            { "name": "Content-Type", "value": "application/json" },
+            { "name": "Content-Length", "value": "18" }
+          ],
+          "headersSize": -1,
+          "bodySize": 18,
+          "cookies": [],
+          "queryString": [],
+          "postData": {
+            "mimeType": "application/json",
+            "text": "eyJuYW1lIjogIm1yLW1hbiJ9",
+            "encoding": "base64",
+            "params": []
+          }
+        },
+        "response": {
+          "status": 201,
+          "statusText": "Created",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" },
+            { "name": "Content-Type", "value": "application/json" },
+            { "name": "Content-Length", "value": "18" }
+          ],
+          "headersSize": -1,
+          "cookies": [],
+          "redirectURL": "",
+          "bodySize": 46,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "eyJpZCI6InNnb2xHRkNSOXRhMi1sQjlRUVdfUSIsIm5hbWUiOiJtci1tYW4ifQ==",
+            "encoding": "base64"
+          }
+        },
+        "cache": {},
+        "timings": { "send": 100, "wait": 100, "receive": 100 },
+        "startedDateTime": "1970-01-01T00:01:48.997Z",
+        "time": 300
+      }
+    ]
+  }
+}

--- a/projects/optic/src/__tests__/integration/workspaces/update/empty-spec/openapi.yml
+++ b/projects/optic/src/__tests__/integration/workspaces/update/empty-spec/openapi.yml
@@ -1,0 +1,6 @@
+openapi: 3.1.0
+info:
+  title: a spec
+  description: The API
+  version: 0.1.0
+paths: {}

--- a/projects/optic/src/__tests__/integration/workspaces/update/existing-spec/har.har
+++ b/projects/optic/src/__tests__/integration/workspaces/update/existing-spec/har.har
@@ -1,0 +1,349 @@
+{
+  "log": {
+    "version": "1.3",
+    "creator": "Optic capture command",
+    "entries": [
+      {
+        "request": {
+          "method": "GET",
+          "url": "http://localhost:3030/books/NjpTwgmENj11rGdUgpCQ9",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "bodySize": 0,
+          "cookies": [],
+          "queryString": []
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "cookies": [],
+          "redirectURL": "",
+          "bodySize": 175,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 236,
+            "text": "eyJpZCI6Ik5qcFR3Z21FTmoxMXJHZFVncENROSIsIm5hbWUiOiJQcmlkZSBhbmQgUHJlanVkaWNlIiwiYXV0aG9yX2lkIjoiNm5UeEFGTTVjazRIb2I3N2hHUW9MIiwiY3JlYXRlZF9hdCI6IjIwMjMtMDUtMjJUMTc6MTc6NDEuMzI2WiIsInVwZGF0ZWRfYXQiOiIyMDIzLTA1LTIyVDE3OjE3OjQxLjMyNloifQ==",
+            "encoding": "base64"
+          }
+        },
+        "cache": {},
+        "timings": { "send": 100, "wait": 100, "receive": 100 },
+        "startedDateTime": "1970-01-01T00:00:18.682Z",
+        "time": 300
+      },
+      {
+        "request": {
+          "method": "GET",
+          "url": "http://localhost:3030/authors/NjpTwgmENj11rGdUgpCQ9",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "bodySize": 0,
+          "cookies": [],
+          "queryString": []
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "cookies": [],
+          "redirectURL": "",
+          "bodySize": 139,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 188,
+            "text": "eyJpZCI6Ik5qcFR3Z21FTmoxMXJHZFVncENROSIsIm5hbWUiOiJGLiBTY290dCBGaXR6Z2VyYWxkIiwiY3JlYXRlZF9hdCI6IjIwMjMtMDMtMjJUMTA6MTE6NTEuNDIxWiIsInVwZGF0ZWRfYXQiOiIyMDIzLTAzLTIyVDEwOjExOjUxLjQyMVoifQ==",
+            "encoding": "base64"
+          }
+        },
+        "cache": {},
+        "timings": { "send": 100, "wait": 100, "receive": 100 },
+        "startedDateTime": "1970-01-01T00:00:24.052Z",
+        "time": 300
+      },
+
+      {
+        "request": {
+          "method": "GET",
+          "url": "http://localhost:3030/some/example",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "bodySize": 0,
+          "cookies": [],
+          "queryString": []
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "cookies": [],
+          "redirectURL": "",
+          "bodySize": 240,
+          "content": {
+            "mimeType": "application/json",
+            "size": 240,
+            "text": "eyJzb21ldGhpbmciOlt7Im5hbWUiOiJhYWRzYXNkIiwiYW5vdGhlciI6W3sicGF0aCI6IjEyMzQiLCJtYXgiOjAsIm1pbiI6MX1dfSx7Im5hbWUiOiJxd2VyZ2giLCJhbm90aGVyIjpudWxsfSx7Im5hbWUiOiJhYWRzYXNkIiwiYW5vdGhlciI6W3sicGF0aCI6IjEyMTIzNDUzNCIsIm1heCI6MCwibWluIjoxfV19XX0=",
+            "encoding": "base64"
+          }
+        },
+        "cache": {},
+        "timings": { "send": 100, "wait": 100, "receive": 100 },
+        "startedDateTime": "1970-01-01T00:00:07.607Z",
+        "time": 300
+      },
+      {
+        "request": {
+          "method": "POST",
+          "url": "http://localhost:3030/books",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" },
+            { "name": "Content-Type", "value": "application/json" },
+            { "name": "Content-Length", "value": "61" }
+          ],
+          "headersSize": -1,
+          "bodySize": 61,
+          "cookies": [],
+          "queryString": [],
+          "postData": {
+            "mimeType": "application/json",
+            "text": "eyJuYW1lIjogIkFuaW1hbCBGYXJtIiwgImF1dGhvcl9pZCI6ICI2blR4QUZNNWNrNEhvYjc3aEdRb0wifQ==",
+            "encoding": "base64",
+            "params": []
+          }
+        },
+        "response": {
+          "status": 201,
+          "statusText": "Created",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" },
+            { "name": "Content-Type", "value": "application/json" },
+            { "name": "Content-Length", "value": "61" }
+          ],
+          "headersSize": -1,
+          "cookies": [],
+          "redirectURL": "",
+          "bodySize": 87,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 116,
+            "text": "eyJpZCI6Il8talZNQXBHeFVOWmo5akVtcGNqSSIsIm5hbWUiOiJBbmltYWwgRmFybSIsImF1dGhvcl9pZCI6IjZuVHhBRk01Y2s0SG9iNzdoR1FvTCJ9",
+            "encoding": "base64"
+          }
+        },
+        "cache": {},
+        "timings": { "send": 100, "wait": 100, "receive": 100 },
+        "startedDateTime": "1970-01-01T00:00:28.497Z",
+        "time": 300
+      },
+      {
+        "request": {
+          "method": "GET",
+          "url": "http://localhost:3030/books",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "bodySize": 0,
+          "cookies": [],
+          "queryString": []
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "cookies": [],
+          "redirectURL": "",
+          "bodySize": 748,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1000,
+            "text": "eyJkYXRhIjpbeyJpZCI6IldqRTlPMWQ4RUxDYjhQT2lPdzRwbiIsIm5hbWUiOiJQcmlkZSBhbmQgUHJlanVkaWNlIiwiYXV0aG9yX2lkIjoiNm5UeEFGTTVjazRIb2I3N2hHUW9MIiwiY3JlYXRlZF9hdCI6IjIwMjMtMDUtMjJUMTc6MTc6NDEuMzI2WiIsInVwZGF0ZWRfYXQiOiIyMDIzLTA1LTIyVDE3OjE3OjQxLjMyNloifSx7ImlkIjoidlpzWVZtemR4dGloeFFOcUNzLTNmIiwibmFtZSI6IlRoZSBHcmVhdCBHYXRzYnkiLCJhdXRob3JfaWQiOiJOanBUd2dtRU5qMTFyR2RVZ3BDUTkiLCJjcmVhdGVkX2F0IjoiMjAyMy0wMy0yMlQxMDoxMTo1MS40MjFaIiwidXBkYXRlZF9hdCI6IjIwMjMtMDMtMjJUMTA6MTE6NTEuNDIxWiJ9LHsiaWQiOiJscXFYQ1dudWVGUWJpaGdadEs5YS0iLCJuYW1lIjoiVG8gS2lsbCBhIE1vY2tpbmdiaXJkIiwiYXV0aG9yX2lkIjoiQWNTd2lRcnlXQmVRcWNOQnFCZzQzIiwiY3JlYXRlZF9hdCI6IjIwMjMtMDUtMDFUMDc6MTE6MDEuNzAxWiIsInVwZGF0ZWRfYXQiOiIyMDIzLTA1LTEyVDA3OjE4OjE5LjEyN1oifSx7ImlkIjoidF82aS1uUk9yNjY5QU9QTkUzUlRxIiwibmFtZSI6Ik5pbmV0ZWVuIEVpZ2h0eS1Gb3VyIiwiYXV0aG9yX2lkIjoidE5wT3BRWmJ4eXR4VHhEVDE1R1F5IiwiY3JlYXRlZF9hdCI6IjIwMjMtMDMtMTFUMjE6MTk6MDguNjAwWiIsInVwZGF0ZWRfYXQiOiIyMDIzLTAzLTExVDIxOjE5OjA4LjYwMFoifV0sIm5leHQiOm51bGwsImhhc19tb3JlX2RhdGEiOmZhbHNlfQ==",
+            "encoding": "base64"
+          }
+        },
+        "cache": {},
+        "timings": { "send": 100, "wait": 100, "receive": 100 },
+        "startedDateTime": "1970-01-01T00:00:33.232Z",
+        "time": 300
+      },
+      {
+        "request": {
+          "method": "GET",
+          "url": "http://localhost:3030/books/WjE9O1d8ELCb8POiOw4pn",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "bodySize": 0,
+          "cookies": [],
+          "queryString": []
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "cookies": [],
+          "redirectURL": "",
+          "bodySize": 175,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 236,
+            "text": "eyJpZCI6IldqRTlPMWQ4RUxDYjhQT2lPdzRwbiIsIm5hbWUiOiJQcmlkZSBhbmQgUHJlanVkaWNlIiwiYXV0aG9yX2lkIjoiNm5UeEFGTTVjazRIb2I3N2hHUW9MIiwiY3JlYXRlZF9hdCI6IjIwMjMtMDUtMjJUMTc6MTc6NDEuMzI2WiIsInVwZGF0ZWRfYXQiOiIyMDIzLTA1LTIyVDE3OjE3OjQxLjMyNloifQ==",
+            "encoding": "base64"
+          }
+        },
+        "cache": {},
+        "timings": { "send": 100, "wait": 100, "receive": 100 },
+        "startedDateTime": "1970-01-01T00:00:42.055Z",
+        "time": 300
+      },
+      {
+        "request": {
+          "method": "GET",
+          "url": "http://localhost:3030/authors/6nTxAFM5ck4Hob77hGQoL",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "bodySize": 0,
+          "cookies": [],
+          "queryString": []
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "cookies": [],
+          "redirectURL": "",
+          "bodySize": 131,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 176,
+            "text": "eyJpZCI6IjZuVHhBRk01Y2s0SG9iNzdoR1FvTCIsIm5hbWUiOiJKYW5lIEF1c3RlbiIsImNyZWF0ZWRfYXQiOiIyMDIzLTA1LTIyVDE3OjE3OjQxLjMyNloiLCJ1cGRhdGVkX2F0IjoiMjAyMy0wNS0yMlQxNzoxNzo0MS4zMjZaIn0=",
+            "encoding": "base64"
+          }
+        },
+        "cache": {},
+        "timings": { "send": 100, "wait": 100, "receive": 100 },
+        "startedDateTime": "1970-01-01T00:00:55.736Z",
+        "time": 300
+      },
+      {
+        "request": {
+          "method": "POST",
+          "url": "http://localhost:3030/authors",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" },
+            { "name": "Content-Type", "value": "application/json" },
+            { "name": "Content-Length", "value": "18" }
+          ],
+          "headersSize": -1,
+          "bodySize": 18,
+          "cookies": [],
+          "queryString": [],
+          "postData": {
+            "mimeType": "application/json",
+            "text": "eyJuYW1lIjogIm1yLW1hbiJ9",
+            "encoding": "base64",
+            "params": []
+          }
+        },
+        "response": {
+          "status": 201,
+          "statusText": "Created",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" },
+            { "name": "Content-Type", "value": "application/json" },
+            { "name": "Content-Length", "value": "18" }
+          ],
+          "headersSize": -1,
+          "cookies": [],
+          "redirectURL": "",
+          "bodySize": 46,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "eyJpZCI6InNnb2xHRkNSOXRhMi1sQjlRUVdfUSIsIm5hbWUiOiJtci1tYW4ifQ==",
+            "encoding": "base64"
+          }
+        },
+        "cache": {},
+        "timings": { "send": 100, "wait": 100, "receive": 100 },
+        "startedDateTime": "1970-01-01T00:01:48.997Z",
+        "time": 300
+      }
+    ]
+  }
+}

--- a/projects/optic/src/__tests__/integration/workspaces/update/existing-spec/openapi.yml
+++ b/projects/optic/src/__tests__/integration/workspaces/update/existing-spec/openapi.yml
@@ -1,0 +1,6 @@
+openapi: 3.1.0
+info:
+  title: a spec
+  description: The API
+  version: 0.1.0
+paths: {}

--- a/projects/optic/src/__tests__/integration/workspaces/update/prefix-server-spec/har.har
+++ b/projects/optic/src/__tests__/integration/workspaces/update/prefix-server-spec/har.har
@@ -6,7 +6,7 @@
       {
         "request": {
           "method": "GET",
-          "url": "http://localhost:3030/books/NjpTwgmENj11rGdUgpCQ9",
+          "url": "http://localhost:3030/api/books/NjpTwgmENj11rGdUgpCQ9",
           "httpVersion": "1.1",
           "headers": [
             { "name": "Host", "value": "localhost:3030" },
@@ -46,7 +46,7 @@
       {
         "request": {
           "method": "GET",
-          "url": "http://localhost:3030/authors/NjpTwgmENj11rGdUgpCQ9",
+          "url": "http://localhost:3030/api/authors/NjpTwgmENj11rGdUgpCQ9",
           "httpVersion": "1.1",
           "headers": [
             { "name": "Host", "value": "localhost:3030" },
@@ -87,7 +87,7 @@
       {
         "request": {
           "method": "GET",
-          "url": "http://localhost:3030/some/example",
+          "url": "http://localhost:3030/api/some/example",
           "httpVersion": "1.1",
           "headers": [
             { "name": "Host", "value": "localhost:3030" },
@@ -127,7 +127,7 @@
       {
         "request": {
           "method": "POST",
-          "url": "http://localhost:3030/books",
+          "url": "http://localhost:3030/api/books",
           "httpVersion": "1.1",
           "headers": [
             { "name": "Host", "value": "localhost:3030" },
@@ -177,7 +177,7 @@
       {
         "request": {
           "method": "GET",
-          "url": "http://localhost:3030/books",
+          "url": "http://localhost:3030/api/books",
           "httpVersion": "1.1",
           "headers": [
             { "name": "Host", "value": "localhost:3030" },
@@ -217,7 +217,7 @@
       {
         "request": {
           "method": "GET",
-          "url": "http://localhost:3030/books/WjE9O1d8ELCb8POiOw4pn",
+          "url": "http://localhost:3030/api/books/WjE9O1d8ELCb8POiOw4pn",
           "httpVersion": "1.1",
           "headers": [
             { "name": "Host", "value": "localhost:3030" },
@@ -257,7 +257,7 @@
       {
         "request": {
           "method": "GET",
-          "url": "http://localhost:3030/authors/6nTxAFM5ck4Hob77hGQoL",
+          "url": "http://localhost:3030/api/authors/6nTxAFM5ck4Hob77hGQoL",
           "httpVersion": "1.1",
           "headers": [
             { "name": "Host", "value": "localhost:3030" },
@@ -297,7 +297,7 @@
       {
         "request": {
           "method": "POST",
-          "url": "http://localhost:3030/authors",
+          "url": "http://localhost:3030/api/authors",
           "httpVersion": "1.1",
           "headers": [
             { "name": "Host", "value": "localhost:3030" },

--- a/projects/optic/src/__tests__/integration/workspaces/update/prefix-server-spec/har.har
+++ b/projects/optic/src/__tests__/integration/workspaces/update/prefix-server-spec/har.har
@@ -1,0 +1,349 @@
+{
+  "log": {
+    "version": "1.3",
+    "creator": "Optic capture command",
+    "entries": [
+      {
+        "request": {
+          "method": "GET",
+          "url": "http://localhost:3030/books/NjpTwgmENj11rGdUgpCQ9",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "bodySize": 0,
+          "cookies": [],
+          "queryString": []
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "cookies": [],
+          "redirectURL": "",
+          "bodySize": 175,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 236,
+            "text": "eyJpZCI6Ik5qcFR3Z21FTmoxMXJHZFVncENROSIsIm5hbWUiOiJQcmlkZSBhbmQgUHJlanVkaWNlIiwiYXV0aG9yX2lkIjoiNm5UeEFGTTVjazRIb2I3N2hHUW9MIiwiY3JlYXRlZF9hdCI6IjIwMjMtMDUtMjJUMTc6MTc6NDEuMzI2WiIsInVwZGF0ZWRfYXQiOiIyMDIzLTA1LTIyVDE3OjE3OjQxLjMyNloifQ==",
+            "encoding": "base64"
+          }
+        },
+        "cache": {},
+        "timings": { "send": 100, "wait": 100, "receive": 100 },
+        "startedDateTime": "1970-01-01T00:00:18.682Z",
+        "time": 300
+      },
+      {
+        "request": {
+          "method": "GET",
+          "url": "http://localhost:3030/authors/NjpTwgmENj11rGdUgpCQ9",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "bodySize": 0,
+          "cookies": [],
+          "queryString": []
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "cookies": [],
+          "redirectURL": "",
+          "bodySize": 139,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 188,
+            "text": "eyJpZCI6Ik5qcFR3Z21FTmoxMXJHZFVncENROSIsIm5hbWUiOiJGLiBTY290dCBGaXR6Z2VyYWxkIiwiY3JlYXRlZF9hdCI6IjIwMjMtMDMtMjJUMTA6MTE6NTEuNDIxWiIsInVwZGF0ZWRfYXQiOiIyMDIzLTAzLTIyVDEwOjExOjUxLjQyMVoifQ==",
+            "encoding": "base64"
+          }
+        },
+        "cache": {},
+        "timings": { "send": 100, "wait": 100, "receive": 100 },
+        "startedDateTime": "1970-01-01T00:00:24.052Z",
+        "time": 300
+      },
+
+      {
+        "request": {
+          "method": "GET",
+          "url": "http://localhost:3030/some/example",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "bodySize": 0,
+          "cookies": [],
+          "queryString": []
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "cookies": [],
+          "redirectURL": "",
+          "bodySize": 240,
+          "content": {
+            "mimeType": "application/json",
+            "size": 240,
+            "text": "eyJzb21ldGhpbmciOlt7Im5hbWUiOiJhYWRzYXNkIiwiYW5vdGhlciI6W3sicGF0aCI6IjEyMzQiLCJtYXgiOjAsIm1pbiI6MX1dfSx7Im5hbWUiOiJxd2VyZ2giLCJhbm90aGVyIjpudWxsfSx7Im5hbWUiOiJhYWRzYXNkIiwiYW5vdGhlciI6W3sicGF0aCI6IjEyMTIzNDUzNCIsIm1heCI6MCwibWluIjoxfV19XX0=",
+            "encoding": "base64"
+          }
+        },
+        "cache": {},
+        "timings": { "send": 100, "wait": 100, "receive": 100 },
+        "startedDateTime": "1970-01-01T00:00:07.607Z",
+        "time": 300
+      },
+      {
+        "request": {
+          "method": "POST",
+          "url": "http://localhost:3030/books",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" },
+            { "name": "Content-Type", "value": "application/json" },
+            { "name": "Content-Length", "value": "61" }
+          ],
+          "headersSize": -1,
+          "bodySize": 61,
+          "cookies": [],
+          "queryString": [],
+          "postData": {
+            "mimeType": "application/json",
+            "text": "eyJuYW1lIjogIkFuaW1hbCBGYXJtIiwgImF1dGhvcl9pZCI6ICI2blR4QUZNNWNrNEhvYjc3aEdRb0wifQ==",
+            "encoding": "base64",
+            "params": []
+          }
+        },
+        "response": {
+          "status": 201,
+          "statusText": "Created",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" },
+            { "name": "Content-Type", "value": "application/json" },
+            { "name": "Content-Length", "value": "61" }
+          ],
+          "headersSize": -1,
+          "cookies": [],
+          "redirectURL": "",
+          "bodySize": 87,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 116,
+            "text": "eyJpZCI6Il8talZNQXBHeFVOWmo5akVtcGNqSSIsIm5hbWUiOiJBbmltYWwgRmFybSIsImF1dGhvcl9pZCI6IjZuVHhBRk01Y2s0SG9iNzdoR1FvTCJ9",
+            "encoding": "base64"
+          }
+        },
+        "cache": {},
+        "timings": { "send": 100, "wait": 100, "receive": 100 },
+        "startedDateTime": "1970-01-01T00:00:28.497Z",
+        "time": 300
+      },
+      {
+        "request": {
+          "method": "GET",
+          "url": "http://localhost:3030/books",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "bodySize": 0,
+          "cookies": [],
+          "queryString": []
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "cookies": [],
+          "redirectURL": "",
+          "bodySize": 748,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1000,
+            "text": "eyJkYXRhIjpbeyJpZCI6IldqRTlPMWQ4RUxDYjhQT2lPdzRwbiIsIm5hbWUiOiJQcmlkZSBhbmQgUHJlanVkaWNlIiwiYXV0aG9yX2lkIjoiNm5UeEFGTTVjazRIb2I3N2hHUW9MIiwiY3JlYXRlZF9hdCI6IjIwMjMtMDUtMjJUMTc6MTc6NDEuMzI2WiIsInVwZGF0ZWRfYXQiOiIyMDIzLTA1LTIyVDE3OjE3OjQxLjMyNloifSx7ImlkIjoidlpzWVZtemR4dGloeFFOcUNzLTNmIiwibmFtZSI6IlRoZSBHcmVhdCBHYXRzYnkiLCJhdXRob3JfaWQiOiJOanBUd2dtRU5qMTFyR2RVZ3BDUTkiLCJjcmVhdGVkX2F0IjoiMjAyMy0wMy0yMlQxMDoxMTo1MS40MjFaIiwidXBkYXRlZF9hdCI6IjIwMjMtMDMtMjJUMTA6MTE6NTEuNDIxWiJ9LHsiaWQiOiJscXFYQ1dudWVGUWJpaGdadEs5YS0iLCJuYW1lIjoiVG8gS2lsbCBhIE1vY2tpbmdiaXJkIiwiYXV0aG9yX2lkIjoiQWNTd2lRcnlXQmVRcWNOQnFCZzQzIiwiY3JlYXRlZF9hdCI6IjIwMjMtMDUtMDFUMDc6MTE6MDEuNzAxWiIsInVwZGF0ZWRfYXQiOiIyMDIzLTA1LTEyVDA3OjE4OjE5LjEyN1oifSx7ImlkIjoidF82aS1uUk9yNjY5QU9QTkUzUlRxIiwibmFtZSI6Ik5pbmV0ZWVuIEVpZ2h0eS1Gb3VyIiwiYXV0aG9yX2lkIjoidE5wT3BRWmJ4eXR4VHhEVDE1R1F5IiwiY3JlYXRlZF9hdCI6IjIwMjMtMDMtMTFUMjE6MTk6MDguNjAwWiIsInVwZGF0ZWRfYXQiOiIyMDIzLTAzLTExVDIxOjE5OjA4LjYwMFoifV0sIm5leHQiOm51bGwsImhhc19tb3JlX2RhdGEiOmZhbHNlfQ==",
+            "encoding": "base64"
+          }
+        },
+        "cache": {},
+        "timings": { "send": 100, "wait": 100, "receive": 100 },
+        "startedDateTime": "1970-01-01T00:00:33.232Z",
+        "time": 300
+      },
+      {
+        "request": {
+          "method": "GET",
+          "url": "http://localhost:3030/books/WjE9O1d8ELCb8POiOw4pn",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "bodySize": 0,
+          "cookies": [],
+          "queryString": []
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "cookies": [],
+          "redirectURL": "",
+          "bodySize": 175,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 236,
+            "text": "eyJpZCI6IldqRTlPMWQ4RUxDYjhQT2lPdzRwbiIsIm5hbWUiOiJQcmlkZSBhbmQgUHJlanVkaWNlIiwiYXV0aG9yX2lkIjoiNm5UeEFGTTVjazRIb2I3N2hHUW9MIiwiY3JlYXRlZF9hdCI6IjIwMjMtMDUtMjJUMTc6MTc6NDEuMzI2WiIsInVwZGF0ZWRfYXQiOiIyMDIzLTA1LTIyVDE3OjE3OjQxLjMyNloifQ==",
+            "encoding": "base64"
+          }
+        },
+        "cache": {},
+        "timings": { "send": 100, "wait": 100, "receive": 100 },
+        "startedDateTime": "1970-01-01T00:00:42.055Z",
+        "time": 300
+      },
+      {
+        "request": {
+          "method": "GET",
+          "url": "http://localhost:3030/authors/6nTxAFM5ck4Hob77hGQoL",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "bodySize": 0,
+          "cookies": [],
+          "queryString": []
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" }
+          ],
+          "headersSize": -1,
+          "cookies": [],
+          "redirectURL": "",
+          "bodySize": 131,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 176,
+            "text": "eyJpZCI6IjZuVHhBRk01Y2s0SG9iNzdoR1FvTCIsIm5hbWUiOiJKYW5lIEF1c3RlbiIsImNyZWF0ZWRfYXQiOiIyMDIzLTA1LTIyVDE3OjE3OjQxLjMyNloiLCJ1cGRhdGVkX2F0IjoiMjAyMy0wNS0yMlQxNzoxNzo0MS4zMjZaIn0=",
+            "encoding": "base64"
+          }
+        },
+        "cache": {},
+        "timings": { "send": 100, "wait": 100, "receive": 100 },
+        "startedDateTime": "1970-01-01T00:00:55.736Z",
+        "time": 300
+      },
+      {
+        "request": {
+          "method": "POST",
+          "url": "http://localhost:3030/authors",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" },
+            { "name": "Content-Type", "value": "application/json" },
+            { "name": "Content-Length", "value": "18" }
+          ],
+          "headersSize": -1,
+          "bodySize": 18,
+          "cookies": [],
+          "queryString": [],
+          "postData": {
+            "mimeType": "application/json",
+            "text": "eyJuYW1lIjogIm1yLW1hbiJ9",
+            "encoding": "base64",
+            "params": []
+          }
+        },
+        "response": {
+          "status": 201,
+          "statusText": "Created",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" },
+            { "name": "Content-Type", "value": "application/json" },
+            { "name": "Content-Length", "value": "18" }
+          ],
+          "headersSize": -1,
+          "cookies": [],
+          "redirectURL": "",
+          "bodySize": 46,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 64,
+            "text": "eyJpZCI6InNnb2xHRkNSOXRhMi1sQjlRUVdfUSIsIm5hbWUiOiJtci1tYW4ifQ==",
+            "encoding": "base64"
+          }
+        },
+        "cache": {},
+        "timings": { "send": 100, "wait": 100, "receive": 100 },
+        "startedDateTime": "1970-01-01T00:01:48.997Z",
+        "time": 300
+      }
+    ]
+  }
+}

--- a/projects/optic/src/__tests__/integration/workspaces/update/prefix-server-spec/openapi.yml
+++ b/projects/optic/src/__tests__/integration/workspaces/update/prefix-server-spec/openapi.yml
@@ -1,0 +1,9 @@
+openapi: 3.1.0
+info:
+  title: a spec
+  description: The API
+  version: 0.1.0
+servers:
+  - name: book server
+    url: http://localhost:3030/books
+paths: {}

--- a/projects/optic/src/__tests__/integration/workspaces/update/prefix-server-spec/openapi.yml
+++ b/projects/optic/src/__tests__/integration/workspaces/update/prefix-server-spec/openapi.yml
@@ -5,5 +5,5 @@ info:
   version: 0.1.0
 servers:
   - name: book server
-    url: http://localhost:3030/books
+    url: http://localhost:3030/api
 paths: {}

--- a/projects/optic/src/commands/oas/captures/interaction.ts
+++ b/projects/optic/src/commands/oas/captures/interaction.ts
@@ -82,7 +82,7 @@ export class CapturedInteraction {
 
     return {
       request: {
-        host: url.hostname,
+        host: url.host,
         method,
         path: url.pathname,
         body: requestBody,
@@ -223,12 +223,10 @@ export class CapturedInteraction {
       response: response
         ? {
             statusCode: response.code.toString(),
-            headers: response.headers
-              .all()
-              .map(({ key, value }) => ({
-                name: resolve(key),
-                value: resolve(value),
-              })),
+            headers: response.headers.all().map(({ key, value }) => ({
+              name: resolve(key),
+              value: resolve(value),
+            })),
             body: response.body
               ? CapturedBody.from(
                   responseBodySource,

--- a/projects/optic/src/commands/oas/diffing/document.ts
+++ b/projects/optic/src/commands/oas/diffing/document.ts
@@ -420,9 +420,7 @@ export function addOperations(
     // phase one: documented all undocumented operations
     let updatingSpec: AT.Subject<OpenAPIV3.Document> = new AT.Subject();
     const undocumentedOperations = UndocumentedOperations.fromPairs(
-      AT.from(
-        requiredOperations.map((add) => ({ ...add, onApiBasePath: true }))
-      ),
+      AT.from(requiredOperations),
       spec,
       updatingSpec.iterator
     );

--- a/projects/optic/src/commands/oas/operations/__snapshots__/queries.test.ts.snap
+++ b/projects/optic/src/commands/oas/operations/__snapshots__/queries.test.ts.snap
@@ -24,30 +24,6 @@ exports[`OperationsQueries findSpecPath ambigious paths will match parameterized
 }
 `;
 
-exports[`OperationsQueries findSpecPath base urls will match operations prefixed by the path of a base url with multiple components 1`] = `
-{
-  "method": "get",
-  "pathPattern": "/app/hook/config",
-  "specPath": "debug-path-1-get",
-}
-`;
-
-exports[`OperationsQueries findSpecPath base urls will match operations prefixed by the path of a relative base url 1`] = `
-{
-  "method": "get",
-  "pathPattern": "/app/hook/config",
-  "specPath": "debug-path-1-get",
-}
-`;
-
-exports[`OperationsQueries findSpecPath base urls will match operations prefixed by the path of an absolute base url 1`] = `
-{
-  "method": "get",
-  "pathPattern": "/app/hook/config",
-  "specPath": "debug-path-1-get",
-}
-`;
-
 exports[`OperationsQueries findSpecPath can match / 1`] = `
 {
   "method": "get",

--- a/projects/optic/src/commands/oas/operations/index.ts
+++ b/projects/optic/src/commands/oas/operations/index.ts
@@ -110,7 +110,7 @@ export class PathComponents {
     under https://github.com/stoplightio/prism/blob/master/LICENSE
    */
     if (path.length === 0 || !path.startsWith('/')) {
-      throw new Error(`Malformed path '${path}'`);
+      return [];
     }
     return path
       .split('/')

--- a/projects/optic/src/commands/oas/operations/index.ts
+++ b/projects/optic/src/commands/oas/operations/index.ts
@@ -109,8 +109,8 @@ export class PathComponents {
     Copied from https://github.com/stoplightio/prism/blob/0ad49235879ad4f7fcafa7b5badcb763b0c37a6a/packages/http/src/router/matchPath.ts
     under https://github.com/stoplightio/prism/blob/master/LICENSE
    */
-    if (path.length === 0 || !path.startsWith('/')) {
-      return [];
+    if (!path.startsWith('/')) {
+      path = `/${path};`;
     }
     return path
       .split('/')

--- a/projects/optic/src/commands/oas/operations/infer-path-structure.ts
+++ b/projects/optic/src/commands/oas/operations/infer-path-structure.ts
@@ -395,7 +395,7 @@ function reducePathPattern(component: PathComponentCandidate): string {
 
 function fragmentize(path: string): string[] {
   if (path.length === 0 || !path.startsWith('/')) {
-    throw new Error(`Malformed path '${path}'`);
+    return [];
   }
   return path.split('/').slice(1).map(decodePathFragment);
 }

--- a/projects/optic/src/commands/oas/operations/infer-path-structure.ts
+++ b/projects/optic/src/commands/oas/operations/infer-path-structure.ts
@@ -394,8 +394,8 @@ function reducePathPattern(component: PathComponentCandidate): string {
 }
 
 function fragmentize(path: string): string[] {
-  if (path.length === 0 || !path.startsWith('/')) {
-    return [];
+  if (!path.startsWith('/')) {
+    path = `/${path};`;
   }
   return path.split('/').slice(1).map(decodePathFragment);
 }

--- a/projects/optic/src/commands/oas/operations/queries.test.ts
+++ b/projects/optic/src/commands/oas/operations/queries.test.ts
@@ -124,62 +124,6 @@ describe('OperationsQueries', () => {
         expect(result.unwrap()).toMatchSnapshot();
       });
     });
-
-    describe('base urls', () => {
-      let queries: OperationQueries;
-      beforeEach(() => {
-        queries = new OperationQueries(
-          testPaths.flatMap((pathPattern, i) => [
-            {
-              pathPattern,
-              method: HttpMethods.GET,
-              specPath: `debug-path-${i}-get`, // spec paths don't have to be actual OpenAPI paths, just be unique
-            },
-            {
-              pathPattern,
-              method: HttpMethods.POST,
-              specPath: `debug-path-${i}-post`,
-            },
-          ]),
-          ['https://useoptic.com/v1', '/v2', '/versions/v3']
-        );
-      });
-
-      it('will match operations prefixed by the path of an absolute base url', () => {
-        const result = queries
-          .findOperation('/v1/app/hook/config', HttpMethods.GET)
-          .expect('unambigious paths to be ok');
-
-        expect(result.some).toBe(true);
-        expect(result.unwrap()).toMatchSnapshot();
-      });
-
-      it('will not match non-prefixed operations when base urls given', () => {
-        const result = queries
-          .findOperation('/app/hook/config', HttpMethods.GET)
-          .expect('unambigious paths to be ok');
-
-        expect(result.none).toBe(true);
-      });
-
-      it('will match operations prefixed by the path of a relative base url', () => {
-        const result = queries
-          .findOperation('/v2/app/hook/config', HttpMethods.GET)
-          .expect('unambigious paths to be ok');
-
-        expect(result.some).toBe(true);
-        expect(result.unwrap()).toMatchSnapshot();
-      });
-
-      it('will match operations prefixed by the path of a base url with multiple components', () => {
-        const result = queries
-          .findOperation('/versions/v3/app/hook/config', HttpMethods.GET)
-          .expect('unambigious paths to be ok');
-
-        expect(result.some).toBe(true);
-        expect(result.unwrap()).toMatchSnapshot();
-      });
-    });
   });
 
   describe('findPathPattern', () => {
@@ -199,8 +143,7 @@ describe('OperationsQueries', () => {
           method: HttpMethods.GET,
           specPath: `debug-path-${i}-get`, // spec paths don't have to be actual OpenAPI paths, just be unique
         },
-      ]),
-      ['https://useoptic.com/v1', '/v2', '/versions/v3']
+      ])
     );
 
     it('will not match paths outside of set', () => {

--- a/projects/optic/src/commands/oas/operations/streams/documented-interactions.ts
+++ b/projects/optic/src/commands/oas/operations/streams/documented-interactions.ts
@@ -26,11 +26,13 @@ export class DocumentedInteractions {
       specUpdates && specUpdates[Symbol.asyncIterator]();
 
     for await (let interaction of interactions) {
+      console.log(interaction);
       // find matching interaction operation by matching path and method
       const matchedOperationResult = queries.findOperation(
         interaction.request.path,
         interaction.request.method
       );
+      console.log(matchedOperationResult.val);
 
       if (matchedOperationResult.err) {
         console.warn(

--- a/projects/optic/src/commands/oas/operations/streams/documented-interactions.ts
+++ b/projects/optic/src/commands/oas/operations/streams/documented-interactions.ts
@@ -26,13 +26,11 @@ export class DocumentedInteractions {
       specUpdates && specUpdates[Symbol.asyncIterator]();
 
     for await (let interaction of interactions) {
-      console.log(interaction);
       // find matching interaction operation by matching path and method
       const matchedOperationResult = queries.findOperation(
         interaction.request.path,
         interaction.request.method
       );
-      console.log(matchedOperationResult.val);
 
       if (matchedOperationResult.err) {
         console.warn(

--- a/projects/optic/src/commands/oas/shapes/schema.ts
+++ b/projects/optic/src/commands/oas/shapes/schema.ts
@@ -114,12 +114,7 @@ export class Schema {
   }
 
   static isPolymorphic(schema: SchemaObject) {
-    for (let key of Object.keys(schema)) {
-      if (!allowedKeysForOneOf.includes(key) && !isExtension(key)) {
-        return false;
-      }
-    }
-    return true;
+    return !!(schema.allOf || schema.anyOf || schema.oneOf);
   }
 }
 

--- a/projects/optic/src/commands/oas/update.ts
+++ b/projects/optic/src/commands/oas/update.ts
@@ -87,14 +87,14 @@ export function updateCommand(): Command {
 
       let { observations } = matchInteractions(
         spec,
-        await getInteractions(options, specPath, feedback)
+        await getInteractions(options, spec, specPath, feedback)
       );
 
       const documentResult = await addIfUndocumented(
         operationsToAdd.val,
         isAddAll,
         observations,
-        await getInteractions(options, specPath, feedback),
+        await getInteractions(options, spec, specPath, feedback),
         spec,
         sourcemap
       );
@@ -123,6 +123,7 @@ export function updateCommand(): Command {
 
       const patchInteractions = await getInteractions(
         options,
+        spec,
         specPath,
         feedback
       );

--- a/projects/optic/src/commands/oas/verify.ts
+++ b/projects/optic/src/commands/oas/verify.ts
@@ -98,7 +98,7 @@ export async function runVerify(
 
   const opticUrlDetails = getApiFromOpticUrl(spec[OPTIC_URL_KEY]);
 
-  const interactions = await getInteractions(options, specPath, feedback);
+  const interactions = await getInteractions(options, spec, specPath, feedback);
 
   feedback.notable(
     `Verifying API behavior with traffic ${
@@ -117,7 +117,7 @@ export async function runVerify(
 
   let { observations, coverage } = matchInteractions(
     spec,
-    await getInteractions(options, specPath, feedback)
+    await getInteractions(options, spec, specPath, feedback)
   );
 
   const renderingStatus = await renderOperationStatus(

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.47.3",
+  "version": "0.47.4-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -40,5 +40,6 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
-  }
+  },
+  "stableVersion": "0.47.3"
 }

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.6.0",
-  "version": "0.47.3",
+  "version": "0.47.4-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -39,5 +39,6 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
-  }
+  },
+  "stableVersion": "0.47.3"
 }


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Writes integration tests for `optic update` - Some bugs from the snapshots I need to investigate
- [x] Request bodies aren't documented from the snapshots (they're set in the har)
- [x] When passing a server prefix, we're getting unexpected behaviors (all documented paths but with empty bodies)

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
