### PR TITLE
use 127.0.0.1 over localhost

### DIFF
--- a/projects/optic/src/client/optic-backend.ts
+++ b/projects/optic/src/client/optic-backend.ts
@@ -240,7 +240,7 @@ export const createOpticClient = (opticToken: string) => {
     : process.env.OPTIC_ENV === 'staging'
     ? 'https://api.o3c.info'
     : process.env.OPTIC_ENV === 'local'
-    ? 'http://localhost:3030'
+    ? 'http://127.0.0.1:3030'
     : 'https://api.useoptic.com';
 
   const opticClient = new OpticBackendClient(backendWebBase, () =>


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

For some reason my node version + node fetch returns `ECONNREFUSED` when trying to hit a local server - this looks like it's because we're using localhost over 127.0.0.1 which node fetch appears to have some issue with?

Changing to use 127.0.0.1 

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

https://github.com/node-fetch/node-fetch/issues/1624

## 👹 QA
_How can other humans verify that this PR is correct?_
