### PR TITLE
Allow excluding multiple extensions from breaking changes

### DIFF
--- a/projects/standard-rulesets/src/breaking-changes/__tests__/breaking-changes.test.ts
+++ b/projects/standard-rulesets/src/breaking-changes/__tests__/breaking-changes.test.ts
@@ -8,14 +8,25 @@ describe('fromOpticConfig', () => {
     const out = await BreakingChangesRuleset.fromOpticConfig({
       exclude_operations_with_extension: 12,
     });
-    expect(out).toEqual(
-      '- ruleset/breaking-changes/exclude_operations_with_extension must be string'
-    );
+    expect(out)
+      .toEqual(`- ruleset/breaking-changes/exclude_operations_with_extension must be string
+- ruleset/breaking-changes/exclude_operations_with_extension must be array
+- ruleset/breaking-changes/exclude_operations_with_extension must match exactly one schema in oneOf`);
   });
 
   test('valid config', async () => {
     const out = await BreakingChangesRuleset.fromOpticConfig({
       exclude_operations_with_extension: 'x-legacy',
+      docs_link: 'asdasd.com',
+      severity: 'warn',
+    });
+
+    expect(out).toBeInstanceOf(BreakingChangesRuleset);
+  });
+
+  test('valid config with array', async () => {
+    const out = await BreakingChangesRuleset.fromOpticConfig({
+      exclude_operations_with_extension: ['x-legacy', 'x-meta'],
       docs_link: 'asdasd.com',
       severity: 'warn',
     });

--- a/projects/standard-rulesets/src/breaking-changes/index.ts
+++ b/projects/standard-rulesets/src/breaking-changes/index.ts
@@ -48,7 +48,7 @@ const configSchema = {
   type: 'object',
   properties: {
     exclude_operations_with_extension: {
-      type: 'string',
+      oneOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
     },
     skip_when_major_version_changes: {
       type: 'boolean',
@@ -102,8 +102,16 @@ export class BreakingChangesRuleset extends Ruleset<Rule[]> {
         return false;
 
       if (validatedConfig.exclude_operations_with_extension) {
-        const extension = validatedConfig.exclude_operations_with_extension;
-        return (context.operation.raw as any)[extension] !== true;
+        if (Array.isArray(validatedConfig.exclude_operations_with_extension)) {
+          return validatedConfig.exclude_operations_with_extension.some(
+            (extension) => {
+              return (context.operation.raw as any)[extension] !== true;
+            }
+          );
+        } else {
+          const extension = validatedConfig.exclude_operations_with_extension;
+          return (context.operation.raw as any)[extension] !== true;
+        }
       }
 
       return true;


### PR DESCRIPTION
## 🍗 Description

Before only strings were supported 
```
exclude_operations_with_extension: x-legacy
```

```
exclude_operations_with_extension: 
  - x-legacy
  - x-meta-endpoint
```


## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
