### PR TITLE
feat(capture): configurable timeout

### DIFF
--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -161,9 +161,9 @@ const getCaptureAction =
     // wait until server is ready
     const readyEndpoint = captureConfig.server.ready_endpoint || '/';
     const readyInterval = captureConfig.server.ready_interval || 1000;
+    const readyTimeout = captureConfig.server.ready_timeout || 3 * 60 * 1_000; // 3 minutes
     const readyUrl = urljoin(serverUrl, readyEndpoint);
 
-    const timeout = 10 * 60 * 1_000; // 10 minutes
     const now = Date.now();
     const spinner = ora('Waiting for server to come online...');
     spinner.start();
@@ -180,8 +180,8 @@ const getCaptureAction =
       if (isReady) {
         spinner.succeed('Server check passed');
         done = true;
-      } else if (Date.now() > now + timeout) {
-        throw new UserError('Server check timed out (waited for 10 minutes)');
+      } else if (Date.now() > now + readyTimeout) {
+        throw new UserError('Server check timed out.');
       }
       await wait(readyInterval);
     }

--- a/projects/optic/src/config.ts
+++ b/projects/optic/src/config.ts
@@ -46,6 +46,7 @@ const CaptureConfigData = Type.Object({
     url: Type.String(),
     ready_endpoint: Type.Optional(Type.String()),
     ready_interval: Type.Optional(Type.Number()),
+    ready_timeout: Type.Optional(Type.Number()),
   }),
   requests: Type.Array(
     Type.Object({


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

- makes the server ready timeout configurable
- lowers the default timeout to 3 minutes, which still seems very generous to me

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
