### PR TITLE
feat(capture): run custom commands to generate capture traffic

### DIFF
--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -162,7 +162,6 @@ const getCaptureAction =
       const args = captureConfig.server.command.split(' ').slice(1);
       app = spawn(cmd, args, { detached: true });
 
-      // log error output from the app
       app.stderr.on('data', (data) => {
         logger.error(data.toString());
       });
@@ -234,7 +233,6 @@ const getCaptureAction =
             }
           });
         });
-        // log error output from the app
         reqCmd.stderr.on('data', (data) => {
           logger.error(data.toString());
         });

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -104,6 +104,12 @@ const getCaptureAction =
       // TODO log error and run capture init or something - tbd what the first use is
       process.exitCode = 1;
       return;
+    } else if (!captureConfig.requests && !captureConfig.requests_command) {
+      logger.error(
+        `"requests" or "requests_command" must be specified in optic.yml`
+      );
+      process.exitCode = 1;
+      return;
     } else if (options.proxyPort && isNaN(Number(options.proxyPort))) {
       logger.error(
         `--proxy-port must be a number - received ${options.proxyPort}`

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -207,6 +207,7 @@ const getCaptureAction =
       getEndpointsFromSpec(spec.jsonLike)
     );
 
+    let errors: any[] = [];
     try {
       let requestsPromise: Promise<any> = Promise.resolve();
       if (captureConfig.requests) {
@@ -244,7 +245,7 @@ const getCaptureAction =
       }
       await Promise.all([requestsPromise, reqCmdPromise]);
     } catch (error) {
-      logger.error(error);
+      errors.push(error);
     } finally {
       sourcesController.abort();
       if (app) {
@@ -262,6 +263,12 @@ const getCaptureAction =
     await captures.writeHarFiles();
 
     logger.info(`${count} requests captured`);
+    if (errors.length > 0) {
+      logger.error('finished with errors:');
+      errors.forEach((error, index) => {
+        logger.error(`${index}:\n${error}`);
+      });
+    }
 
     // TODO start running endpoint by endpoint of captures
     // run update or verify

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -226,6 +226,8 @@ const getCaptureAction =
 
       for await (const har of harEntries) {
         captures.addHar(har);
+        // TODO: switch this to debug logging
+        console.log(`Captured ${har.request.url}`);
       }
       await captures.writeHarFiles();
     }

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -21,6 +21,7 @@ import { clearCommand } from '../oas/capture-clear';
 import { captureV1 } from '../oas/capture';
 import { getCaptureStorage, GroupedCaptures } from './storage';
 import { loadSpec } from '../../utils/spec-loaders';
+import { commandSplitter } from '../../utils/capture';
 
 const wait = (time: number) =>
   new Promise((r) => setTimeout(() => r(null), time));
@@ -158,9 +159,8 @@ const getCaptureAction =
     // start the app
     let app: ChildProcessWithoutNullStreams | undefined = undefined;
     if (!options.serverOverride && captureConfig.server.command) {
-      const cmd = captureConfig.server.command.split(' ')[0];
-      const args = captureConfig.server.command.split(' ').slice(1);
-      app = spawn(cmd, args, { detached: true });
+      const cmd = commandSplitter(captureConfig.server.command);
+      app = spawn(cmd.cmd, cmd.args, { detached: true });
 
       app.stderr.on('data', (data) => {
         logger.error(data.toString());
@@ -220,9 +220,11 @@ const getCaptureAction =
       }
 
       if (captureConfig.requests_command) {
-        const cmd = captureConfig.requests_command.split(' ')[0];
-        const args = captureConfig.requests_command.split(' ').slice(1);
-        const reqCmd = spawn(cmd, args, { detached: true, shell: true });
+        const cmd = commandSplitter(captureConfig.requests_command);
+        const reqCmd = spawn(cmd.cmd, cmd.args, {
+          detached: true,
+          shell: true,
+        });
 
         reqCmdPromise = new Promise((resolve, reject) => {
           reqCmd.on('exit', (code) => {

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -207,9 +207,8 @@ const getCaptureAction =
       getEndpointsFromSpec(spec.jsonLike)
     );
 
-    let requestsPromise: Promise<any> = Promise.resolve();
-    let reqCmdPromise: Promise<void> = Promise.resolve();
     try {
+      let requestsPromise: Promise<any> = Promise.resolve();
       if (captureConfig.requests) {
         const requests = makeRequests(
           captureConfig.requests,
@@ -219,6 +218,7 @@ const getCaptureAction =
         requestsPromise = Promise.allSettled(requests);
       }
 
+      let reqCmdPromise: Promise<void> = Promise.resolve();
       if (captureConfig.requests_command) {
         const cmd = commandSplitter(captureConfig.requests_command.command);
         const proxyVar =
@@ -242,10 +242,10 @@ const getCaptureAction =
           logger.error(data.toString());
         });
       }
+      await Promise.all([requestsPromise, reqCmdPromise]);
     } catch (error) {
       logger.error(error);
     } finally {
-      await Promise.all([requestsPromise, reqCmdPromise]);
       sourcesController.abort();
       if (app) {
         process.kill(-app.pid!);
@@ -261,9 +261,7 @@ const getCaptureAction =
     }
     await captures.writeHarFiles();
 
-    logger.info(
-      `${count} requests captured`
-    );
+    logger.info(`${count} requests captured`);
 
     // TODO start running endpoint by endpoint of captures
     // run update or verify

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -220,7 +220,10 @@ const getCaptureAction =
       }
 
       if (captureConfig.requests_command) {
-        const cmd = commandSplitter(captureConfig.requests_command);
+        const cmd = commandSplitter(captureConfig.requests_command.command);
+        const proxyVar =
+          captureConfig.requests_command.proxy_variable || 'OPTIC_PROXY';
+        process.env[proxyVar] = proxyUrl;
         const reqCmd = spawn(cmd.cmd, cmd.args, {
           detached: true,
           shell: true,

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -216,7 +216,7 @@ const getCaptureAction =
           proxyUrl,
           captureConfig.config?.request_concurrency || 5
         );
-        requestsPromise = Promise.all(requests);
+        requestsPromise = Promise.allSettled(requests);
       }
 
       if (captureConfig.requests_command) {

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -262,7 +262,7 @@ const getCaptureAction =
     await captures.writeHarFiles();
 
     logger.info(
-      `${count} requests captured. Run \`optic update --all\` to document updates.`
+      `${count} requests captured`
     );
 
     // TODO start running endpoint by endpoint of captures

--- a/projects/optic/src/config.ts
+++ b/projects/optic/src/config.ts
@@ -59,7 +59,12 @@ const CaptureConfigData = Type.Object({
     ready_timeout: Type.Optional(Type.Number()),
   }),
   requests: Type.Optional(Type.Array(Request)),
-  requests_command: Type.Optional(Type.String()),
+  requests_command: Type.Optional(
+    Type.Object({
+      command: Type.String(),
+      proxy_variable: Type.Optional(Type.String()),
+    })
+  ),
 });
 
 export type CaptureConfigData = Static<typeof CaptureConfigData>;

--- a/projects/optic/src/config.ts
+++ b/projects/optic/src/config.ts
@@ -34,6 +34,16 @@ const DefaultOpticCliConfig: OpticCliConfig = {
   isInCi: process.env.CI === 'true',
 };
 
+const Request = Type.Object({
+  path: Type.String(),
+  verb: Type.Optional(
+    Type.String({
+      enum: ['GET', 'POST', 'PATCH', 'DELETE'],
+    })
+  ),
+  data: Type.Optional(Type.Object({})),
+});
+
 const CaptureConfigData = Type.Object({
   config: Type.Optional(
     Type.Object({
@@ -48,21 +58,14 @@ const CaptureConfigData = Type.Object({
     ready_interval: Type.Optional(Type.Number()),
     ready_timeout: Type.Optional(Type.Number()),
   }),
-  requests: Type.Array(
-    Type.Object({
-      path: Type.String(),
-      verb: Type.Optional(
-        Type.String({
-          enum: ['GET', 'POST', 'PATCH', 'DELETE'],
-        })
-      ),
-      data: Type.Optional(Type.Object({})),
-    })
-  ),
+  requests: Type.Optional(Type.Array(Request)),
+  requests_command: Type.Optional(Type.String()),
 });
+
 export type CaptureConfigData = Static<typeof CaptureConfigData>;
 export type ServerConfig = CaptureConfigData['server'];
-export type Request = CaptureConfigData['requests'][number];
+export type Request = Static<typeof Request>;
+export type CaptureConfigConfig = CaptureConfigData['config'];
 
 export const ProjectYmlConfig = Type.Object({
   extends: Type.Optional(Type.String()),

--- a/projects/optic/src/utils/capture.ts
+++ b/projects/optic/src/utils/capture.ts
@@ -1,0 +1,11 @@
+export type SpawnCommand = {
+  cmd: string;
+  args: string[];
+};
+
+export function commandSplitter(command: string): SpawnCommand {
+  return {
+    cmd: command.split(' ')[0],
+    args: command.split(' ').slice(1),
+  };
+}


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

- adds a `capture.requests_command.(command|proxy_variable)` fields to optic.yaml allowing arbitrary commands to be run and send traffic to the proxy. can be used in conjunction with `capture.requests`.

- `capture.requests_command.proxy_variable` is the name of the environment variable that will be injected into process.env when running `capture.requests_command.command`. the value will be the URL for the running reverse proxy. the default values are `OPTIC_PROXY`, `http://localhost:8000`. 

an example using [hurl](https://hurl.dev),

```
➜ cat optic.yml
capture:
  openapi.yml:
    server:
      command: go run main.go
      url: http://localhost:8080
    requests_command:
      command: hurl hurl/*.hurl
      # variables must be prefixed with HURL_ to be available in hurl
      proxy_variable: HURL_OPTIC_PROXY

➜ cat hurl/requests.hurl
GET {{OPTIC_PROXY}}/
GET {{OPTIC_PROXY}}/users
POST {{OPTIC_PROXY}}/users/create
{
    "name": "Hank"
}

➜ optic beta capture -r openapi.yml                                                                               ⠋✔ Server check passed
3 requests captured. Run `optic update --all` to document updates.
```



## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._
- closes https://github.com/opticdev/monorail/issues/4628

## 👹 QA
_How can other humans verify that this PR is correct?_
