### PR TITLE
use project root is server.dir not set

### DIFF
--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -129,9 +129,7 @@ const getCaptureAction =
         return;
       }
     }
-    if (captureConfig.server.dir === undefined) {
-      chdir(path.dirname(filePath));
-    } else {
+    if (captureConfig.server.dir) {
       chdir(captureConfig.server.dir);
     }
     const serverUrl = options.serverOverride || captureConfig.server.url;

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -129,7 +129,9 @@ const getCaptureAction =
         return;
       }
     }
-    if (captureConfig.server.dir) {
+    if (captureConfig.server.dir === undefined) {
+      chdir(config.root);
+    } else {
       chdir(captureConfig.server.dir);
     }
     const serverUrl = options.serverOverride || captureConfig.server.url;


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Uses the project root if the server.dir not set insetad of the OAS file path

This will:
- be the git root if in a git repo
- the cwd if not in a git repo


## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
