### PR TITLE
Handle interactions for documented endpoints

### DIFF
--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -259,7 +259,7 @@ const getCaptureAction =
       const spinner = ora(endpointText);
       spinner.start();
       spinner.color = 'blue';
-      const { patchSummaries } = await consumeDocumentedInteractions(
+      const { patchSummaries, hasDiffs } = await consumeDocumentedInteractions(
         interactions,
         spec,
         coverage,
@@ -283,10 +283,6 @@ const getCaptureAction =
         }
         spinner.succeed(endpointText);
       } else {
-        const hasDiffs = countOperationCoverage(
-          endpointCoverage,
-          (x) => x.diffs
-        );
         !hasDiffs ? spinner.succeed(endpointText) : spinner.fail(endpointText);
       }
       const summaryText = getSummaryText(endpointCoverage);

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -199,7 +199,6 @@ const getCaptureAction =
         fetch(readyUrl)
           .then((res) => String(res.status).startsWith('2'))
           .catch((e) => {
-            logger.debug(chalk.yellow(`\nDEBUG:`));
             logger.debug(e);
             return false;
           });
@@ -290,8 +289,8 @@ const getCaptureAction =
         );
         !hasDiffs ? spinner.succeed(endpointText) : spinner.fail(endpointText);
       }
-
-      logger.info(indent(1) + getSummaryText(endpointCoverage));
+      const summaryText = getSummaryText(endpointCoverage);
+      summaryText && logger.info(indent(1) + summaryText);
       for (const patchSummary of patchSummaries) {
         logger.info(indent(1) + patchSummary);
       }

--- a/projects/optic/src/commands/capture/interactions/consume-documented.ts
+++ b/projects/optic/src/commands/capture/interactions/consume-documented.ts
@@ -195,6 +195,9 @@ export async function consumeDocumentedInteractions(
     for await (const { path, contents } of updatedSpecFiles) {
       await fs.writeFile(path, contents);
     }
+  } else {
+    for await (const _ of specPatches) {
+    }
   }
 
   return { patchSummaries };

--- a/projects/optic/src/commands/capture/interactions/consume-documented.ts
+++ b/projects/optic/src/commands/capture/interactions/consume-documented.ts
@@ -185,6 +185,7 @@ export async function consumeDocumentedInteractions(
   })(
     generateSpecPatches(interactions, parseResult.jsonLike, endpoint, coverage)
   );
+  let hasDiffs = false;
 
   if (options.update) {
     let { results: updatedSpecFiles } = updateSpecFiles(
@@ -197,8 +198,9 @@ export async function consumeDocumentedInteractions(
     }
   } else {
     for await (const _ of specPatches) {
+      hasDiffs = true;
     }
   }
 
-  return { patchSummaries };
+  return { patchSummaries, hasDiffs };
 }

--- a/projects/optic/src/commands/capture/interactions/consume-documented.ts
+++ b/projects/optic/src/commands/capture/interactions/consume-documented.ts
@@ -1,0 +1,111 @@
+import fs from 'node:fs/promises';
+import { ParseResult } from '../../../utils/spec-loaders';
+import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
+import { checkOpenAPIVersion } from '@useoptic/openapi-io';
+
+import { updateSpecFiles } from '../../oas/diffing/document';
+import { SpecPatch, SpecPatches } from '../../oas/specs';
+import { CapturedInteractions } from '../../oas/captures';
+import { DocumentedInteraction, Operation } from '../../oas/operations';
+import { DocumentedBodies } from '../../oas/shapes';
+import { ApiCoverageCounter } from '../../oas/coverage/api-coverage';
+import * as AT from '../../oas/lib/async-tools';
+
+async function* generateSpecPatches(
+  interactions: CapturedInteractions,
+  spec: ParseResult['jsonLike'],
+  endpoint: { method: string; path: string },
+  coverage: ApiCoverageCounter
+) {
+  const openAPIVersion = checkOpenAPIVersion(spec);
+  let patchedSpec = spec;
+  const jsonPath = jsonPointerHelpers.compile([
+    'paths',
+    endpoint.path,
+    endpoint.method,
+  ]);
+  const operation = Operation.fromOperationObject(
+    endpoint.path,
+    endpoint.method,
+    jsonPointerHelpers.get(spec, jsonPath) as any
+  );
+  for await (const interaction of interactions) {
+    let documentedInteraction: DocumentedInteraction = {
+      interaction,
+      operation,
+      specJsonPath: jsonPath,
+    };
+
+    coverage.operationInteraction(
+      documentedInteraction.operation.pathPattern,
+      documentedInteraction.operation.method,
+      !!documentedInteraction.interaction.request.body,
+      documentedInteraction.interaction.response?.statusCode
+    );
+
+    // phase one: operation patches, making sure all requests / responses are documented
+    let opPatches = SpecPatches.operationAdditions(documentedInteraction);
+
+    for await (let patch of opPatches) {
+      patchedSpec = SpecPatch.applyPatch(patch, patchedSpec);
+      yield patch;
+    }
+
+    // phase two: shape patches, describing request / response bodies in detail
+    documentedInteraction = DocumentedInteraction.updateOperation(
+      documentedInteraction,
+      patchedSpec
+    );
+    let documentedBodies = DocumentedBodies.fromDocumentedInteraction(
+      documentedInteraction
+    );
+
+    let shapePatches = SpecPatches.shapeAdditions(
+      documentedBodies,
+      openAPIVersion
+    );
+
+    for await (let patch of shapePatches) {
+      patchedSpec = SpecPatch.applyPatch(patch, patchedSpec);
+      yield patch;
+    }
+  }
+}
+
+export async function consumeDocumentedInteractions(
+  interactions: CapturedInteractions,
+  parseResult: ParseResult,
+  coverage: ApiCoverageCounter,
+  endpoint: {
+    path: string;
+    method: string;
+  },
+  options: {
+    update: boolean;
+  }
+) {
+  const patchSummaries: string[] = [];
+
+  // TODO handle spec patch summarization
+  const specPatches = AT.tap((patch: SpecPatch) => {
+    coverage.shapeDiff(patch);
+    if (options.update) {
+    } else {
+    }
+  })(
+    generateSpecPatches(interactions, parseResult.jsonLike, endpoint, coverage)
+  );
+
+  if (options.update) {
+    let { results: updatedSpecFiles } = updateSpecFiles(
+      specPatches,
+      parseResult.sourcemap
+    );
+
+    for await (const { path, contents } of updatedSpecFiles) {
+      await fs.writeFile(path, contents);
+    }
+  }
+
+  return { patchSummaries };
+}

--- a/projects/optic/src/commands/capture/interactions/consume-documented.ts
+++ b/projects/optic/src/commands/capture/interactions/consume-documented.ts
@@ -10,6 +10,7 @@ import { DocumentedInteraction, Operation } from '../../oas/operations';
 import { DocumentedBodies } from '../../oas/shapes';
 import { ApiCoverageCounter } from '../../oas/coverage/api-coverage';
 import * as AT from '../../oas/lib/async-tools';
+import chalk from 'chalk';
 
 async function* generateSpecPatches(
   interactions: CapturedInteractions,
@@ -72,6 +73,93 @@ async function* generateSpecPatches(
   }
 }
 
+function summarizePatch(
+  patch: SpecPatch,
+  spec: ParseResult['jsonLike'],
+  mode: 'update' | 'verify'
+): string | null {
+  const { diff, path, groupedOperations } = patch;
+  const parts = jsonPointerHelpers.decode(path);
+  if (!diff || groupedOperations.length === 0) return null;
+  if (
+    diff.kind === 'UnmatchdResponseBody' ||
+    diff.kind === 'UnmatchedRequestBody' ||
+    diff.kind === 'UnmatchedResponseStatusCode'
+  ) {
+    const location =
+      diff.kind === 'UnmatchedRequestBody'
+        ? '[request body]'
+        : `[${diff.statusCode} response body]`;
+    const action = mode === 'update' ? 'has been added' : 'is not documented';
+    const color = mode === 'update' ? chalk.green : chalk.red;
+    return color(`${location} body ${action}`);
+  } else {
+    // expected patterns:
+    // /paths/:path/:method/requestBody
+    // /paths/:path/:method/responses/:statusCode
+    const location =
+      parts[3] === 'requestBody'
+        ? '[request body]'
+        : parts[3] === 'responses' && parts[4]
+        ? `[${parts[4]} response body]`
+        : '';
+
+    if (diff.kind === 'AdditionalProperty') {
+      // filter out dependent diffs
+      if (
+        !jsonPointerHelpers.tryGet(
+          spec,
+          jsonPointerHelpers.join(path, diff.parentObjectPath)
+        ).match
+      )
+        return null;
+
+      const action = mode === 'update' ? 'has been added' : 'is not documented';
+      const color = mode === 'update' ? chalk.green : chalk.red;
+      return color(`${location} '${diff.key}' ${action}`);
+    } else if (diff.kind === 'UnmatchedType') {
+      // filter out dependent diffs
+      if (
+        !jsonPointerHelpers.tryGet(
+          spec,
+          jsonPointerHelpers.join(path, diff.propertyPath)
+        ).match
+      )
+        return null;
+      let action: string;
+      if (diff.keyword === 'oneOf') {
+        action =
+          mode === 'update' ? 'now matches schema' : `does not match schema`;
+      } else {
+        action =
+          mode === 'update'
+            ? `is now type ${diff.expectedType}`
+            : `does not match type ${diff.expectedType}}. Received ${diff.example}`;
+      }
+      const color = mode === 'update' ? chalk.yellow : chalk.red;
+
+      return color(`${location} '${diff.key}' ${action}`);
+    } else if (diff.kind === 'MissingRequiredProperty') {
+      // filter out dependent diffs
+      if (
+        !jsonPointerHelpers.tryGet(
+          spec,
+          jsonPointerHelpers.join(path, diff.propertyPath)
+        ).match
+      )
+        return null;
+
+      const action =
+        mode === 'update' ? `is now optional` : `is required and missing`;
+      const color = mode === 'update' ? chalk.yellow : chalk.red;
+
+      return color(`${location} '${diff.key}' ${action}`);
+    }
+  }
+
+  return null;
+}
+
 export async function consumeDocumentedInteractions(
   interactions: CapturedInteractions,
   parseResult: ParseResult,
@@ -86,12 +174,14 @@ export async function consumeDocumentedInteractions(
 ) {
   const patchSummaries: string[] = [];
 
-  // TODO handle spec patch summarization
   const specPatches = AT.tap((patch: SpecPatch) => {
     coverage.shapeDiff(patch);
-    if (options.update) {
-    } else {
-    }
+    const summarized = summarizePatch(
+      patch,
+      parseResult.jsonLike,
+      options.update ? 'update' : 'verify'
+    );
+    if (summarized) patchSummaries.push(summarized);
   })(
     generateSpecPatches(interactions, parseResult.jsonLike, endpoint, coverage)
   );

--- a/projects/optic/src/commands/capture/storage.ts
+++ b/projects/optic/src/commands/capture/storage.ts
@@ -103,7 +103,8 @@ export class GroupedCaptures {
   }
 
   async writeHarFiles(): Promise<void> {
-    for (const [, file] of this.paths) {
+    for (const file of [...this.paths.values(), this.unmatched]) {
+      if (!file.hars.length) continue;
       const har = {
         log: {
           version: '1.3',

--- a/projects/optic/src/commands/capture/storage.ts
+++ b/projects/optic/src/commands/capture/storage.ts
@@ -2,14 +2,13 @@ import crypto from 'crypto';
 import fs from 'node:fs/promises';
 import os from 'os';
 import path from 'path';
-import { HttpArchive } from '../oas/captures';
+import { CapturedInteraction, HttpArchive } from '../oas/captures';
 import { OperationQueries } from '../oas/operations/queries';
 import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
 import { getEndpointId } from '../../utils/id';
+import { logger } from '../../logger';
 
 const tmpDirectory = os.tmpdir();
-
-export const UNMATCHED_PATH = 'unmatched';
 
 export async function getCaptureStorage(filePath: string): Promise<string> {
   const resolvedFilepath = path.resolve(filePath);
@@ -34,7 +33,15 @@ export async function getCaptureStorage(filePath: string): Promise<string> {
 }
 
 export class GroupedCaptures {
-  private paths: Map<string, { path: string; hars: HttpArchive.Entry[] }>;
+  private paths: Map<
+    string,
+    {
+      path: string;
+      hars: HttpArchive.Entry[];
+      endpoint: { method: string; path: string };
+    }
+  >;
+  private unmatched: { path: string; hars: HttpArchive.Entry[] };
   private queries: OperationQueries;
   constructor(
     trafficDir: string,
@@ -57,21 +64,28 @@ export class GroupedCaptures {
       this.paths.set(id, {
         path: fPath,
         hars: [],
+        endpoint,
       });
     }
 
     const unmatched = path.join(trafficDir, `unmatched.har`);
-    this.paths.set(UNMATCHED_PATH, {
+    this.unmatched = {
       path: unmatched,
       hars: [],
-    });
+    };
   }
 
   addHar(har: HttpArchive.Entry) {
-    const opRes = this.queries.findOperation(
-      har.request.url,
-      har.request.method
-    );
+    let pathname: string;
+    try {
+      pathname = new URL(har.request.url).pathname;
+    } catch (e) {
+      logger.debug(`Skipping har entry - invalid URL`);
+      logger.debug(har);
+      logger.debug(e);
+      return;
+    }
+    const opRes = this.queries.findOperation(pathname, har.request.method);
     const operation = opRes.ok && opRes.val.some ? opRes.val.val : null;
     const pathNode = operation
       ? this.paths.get(
@@ -81,9 +95,8 @@ export class GroupedCaptures {
           })
         )
       : null;
-
     if (!pathNode) {
-      this.paths.get(UNMATCHED_PATH)!.hars.push(har);
+      this.unmatched.hars.push(har);
     } else {
       pathNode.hars.push(har);
     }
@@ -99,6 +112,49 @@ export class GroupedCaptures {
         },
       };
       await fs.writeFile(file.path, JSON.stringify(har));
+    }
+  }
+
+  counts() {
+    let total = 0;
+    let unmatched = 0;
+    let matched = 0;
+    for (const [, node] of this.paths) {
+      total++;
+      if (node.hars.length === 0) unmatched++;
+      if (node.hars.length !== 0) matched++;
+    }
+
+    return {
+      total,
+      unmatched,
+      matched,
+    };
+  }
+
+  *getDocumentedEndpointInteractions(): Iterable<{
+    endpoint: { path: string; method: string };
+    interactions: AsyncIterable<CapturedInteraction>;
+  }> {
+    for (const [, node] of this.paths) {
+      if (node.hars.length) {
+        yield {
+          endpoint: node.endpoint,
+          interactions: this.getInteractionsIterator(node.hars),
+        };
+      }
+    }
+  }
+
+  getUndocumentedInteractions(): AsyncIterable<CapturedInteraction> {
+    return this.getInteractionsIterator(this.unmatched.hars);
+  }
+
+  private async *getInteractionsIterator(
+    hars: HttpArchive.Entry[]
+  ): AsyncIterable<CapturedInteraction> {
+    for (const har of hars) {
+      yield CapturedInteraction.fromHarEntry(har);
     }
   }
 }

--- a/projects/optic/src/commands/oas/coverage/api-coverage.ts
+++ b/projects/optic/src/commands/oas/coverage/api-coverage.ts
@@ -27,33 +27,39 @@ export class ApiCoverageCounter {
         ];
 
         if (Object.values(OpenAPIV3.HttpMethods).includes(method)) {
-          const responses: {
-            [statusCode: string]: CoverageNode;
-          } = {};
-
-          Object.keys(operation.responses || {}).forEach((res) => {
-            responses[res] = { seen: false, diffs: false };
-          });
-
-          const endpointChecksum = computeEndpointChecksum(
-            path,
-            method,
-            operation
-          );
-
-          this.coverage.paths[path][method] = {
-            checksum: endpointChecksum,
-            interactions: 0,
-            responses,
-            requestBody: operation.requestBody
-              ? { seen: false, diffs: false }
-              : undefined,
-            seen: false,
-            diffs: false,
-          };
+          this.addEndpoint(operation, path, method, { newlyDocumented: false });
         }
       });
     });
+  }
+
+  addEndpoint(
+    operation: OpenAPIV3.OperationObject,
+    path: string,
+    method: string,
+    options: { newlyDocumented: boolean }
+  ) {
+    const responses: {
+      [statusCode: string]: CoverageNode;
+    } = {};
+    const initialSeen = options.newlyDocumented;
+
+    Object.keys(operation.responses || {}).forEach((res) => {
+      responses[res] = { seen: initialSeen, diffs: false };
+    });
+
+    const endpointChecksum = computeEndpointChecksum(path, method, operation);
+
+    this.coverage.paths[path][method] = {
+      checksum: endpointChecksum,
+      interactions: 0,
+      responses,
+      requestBody: operation.requestBody
+        ? { seen: initialSeen, diffs: false }
+        : undefined,
+      seen: initialSeen,
+      diffs: false,
+    };
   }
 
   operationInteraction = (

--- a/projects/optic/src/commands/oas/operations/index.ts
+++ b/projects/optic/src/commands/oas/operations/index.ts
@@ -110,7 +110,7 @@ export class PathComponents {
     under https://github.com/stoplightio/prism/blob/master/LICENSE
    */
     if (!path.startsWith('/')) {
-      path = `/${path};`;
+      path = `/${path}`;
     }
     return path
       .split('/')

--- a/projects/optic/src/commands/oas/operations/infer-path-structure.ts
+++ b/projects/optic/src/commands/oas/operations/infer-path-structure.ts
@@ -330,7 +330,7 @@ function reducePathPattern(component: PathComponentCandidate): string {
 
 function fragmentize(path: string): string[] {
   if (!path.startsWith('/')) {
-    path = `/${path};`;
+    path = `/${path}`;
   }
   return path.split('/').slice(1).map(decodePathFragment);
 }

--- a/projects/optic/src/commands/oas/operations/queries.ts
+++ b/projects/optic/src/commands/oas/operations/queries.ts
@@ -62,13 +62,14 @@ export class OperationQueries {
   > {
     const matchedPatternResult = this.matchPathPattern(path);
     if (matchedPatternResult.err) return matchedPatternResult;
-
     let maybeMatchedPattern = matchedPatternResult.unwrap();
     if (maybeMatchedPattern.none) return Ok(None);
     let matchedPattern = maybeMatchedPattern.unwrap();
 
     const operation = this.operations.find(
-      (op) => matchedPattern === op.pathPattern && op.method == method
+      (op) =>
+        matchedPattern.toLowerCase() === op.pathPattern.toLowerCase() &&
+        op.method.toLowerCase() == method.toLowerCase()
     );
 
     if (!operation) return Ok(None);

--- a/projects/optic/src/commands/oas/shapes/diffs/index.test.ts
+++ b/projects/optic/src/commands/oas/shapes/diffs/index.test.ts
@@ -1,14 +1,14 @@
 import { it, describe, expect } from '@jest/globals';
-import { diffValueBySchema, SchemaCompilationError } from '.';
+import { diffBodyBySchema, SchemaCompilationError } from '.';
 
-describe('diffValueBySchema', () => {
+describe('diffBodyBySchema', () => {
   it('will return an Err Result when schema isnt valid and cant be compiled', () => {
     let schema = {
       // oneOf: [{ type: 'number' }, { type: 'string' }],
       nullable: true,
     };
 
-    let result = diffValueBySchema(null, schema);
+    let result = diffBodyBySchema({ value: null }, schema);
     expect(result.err).toBe(true);
     expect(result.val).toBeInstanceOf(SchemaCompilationError);
   });

--- a/projects/optic/src/commands/oas/shapes/diffs/index.ts
+++ b/projects/optic/src/commands/oas/shapes/diffs/index.ts
@@ -6,7 +6,7 @@ import {
 import { ShapeDiffResult, ShapeDiffResultKind } from './result';
 import { Body } from '../body';
 import { SchemaObject } from '../schema';
-import { Result, Ok, Err } from 'ts-results';
+import { Result } from 'ts-results';
 
 export type { ShapeDiffResult };
 export { ShapeDiffResultKind };
@@ -16,14 +16,7 @@ export { SchemaCompilationError };
 export function diffBodyBySchema(
   body: Body,
   schema: SchemaObject
-): ReturnType<typeof diffValueBySchema> {
-  return diffValueBySchema(body.value, schema);
-}
-
-export function diffValueBySchema(
-  value: any,
-  schema: SchemaObject
 ): Result<IterableIterator<ShapeDiffResult>, SchemaCompilationError> {
   let traverser = new ShapeDiffTraverser();
-  return traverser.traverse(value, schema).map(() => traverser.results());
+  return traverser.traverse(body.value, schema).map(() => traverser.results());
 }

--- a/projects/optic/src/commands/oas/shapes/diffs/result.ts
+++ b/projects/optic/src/commands/oas/shapes/diffs/result.ts
@@ -10,10 +10,6 @@ export enum ShapeDiffResultKind {
 // The result of matching a body against it's (JSON) schema
 export type ShapeDiffResult = {
   keyword: JsonSchemaKnownKeyword;
-
-  // TODO: figure out if location belongs here, or whether one level up (its just passed
-  // in and attached, not needed for logic)
-  // location: FieldLocation;
   key: string;
   example: any;
   instancePath: JsonPath;
@@ -37,6 +33,7 @@ export type ShapeDiffResult = {
   | {
       kind: ShapeDiffResultKind.UnmatchedType;
       keyword: JsonSchemaKnownKeyword.type | JsonSchemaKnownKeyword.oneOf;
+      expectedType: string;
 
       propertyPath: JsonPath;
     }

--- a/projects/optic/src/commands/oas/shapes/diffs/visitors/__snapshots__/oneOf.test.ts.snap
+++ b/projects/optic/src/commands/oas/shapes/diffs/visitors/__snapshots__/oneOf.test.ts.snap
@@ -9,6 +9,7 @@ exports[`one of json schema diff visitor can add an additional branch to a compl
       2,
       3,
     ],
+    "expectedType": "oneOf schema",
     "instancePath": "/location/principality/coordinates",
     "key": "oneOf",
     "keyword": "oneOf",
@@ -39,6 +40,7 @@ exports[`one of json schema diff visitor when new primitive types provided to ex
   {
     "description": "'oneOf' did not match schema",
     "example": true,
+    "expectedType": "oneOf schema",
     "instancePath": "/polyProp",
     "key": "oneOf",
     "keyword": "oneOf",
@@ -57,6 +59,7 @@ exports[`one of json schema diff visitor when one of variant is an array with mi
       "user2",
       "user3",
     ],
+    "expectedType": "oneOf schema",
     "instancePath": "",
     "key": "oneOf",
     "keyword": "oneOf",
@@ -71,6 +74,7 @@ exports[`one of json schema diff visitor when root schema is obejct and is shown
   {
     "description": "'' did not match schema",
     "example": [],
+    "expectedType": "object",
     "instancePath": "",
     "key": "",
     "keyword": "type",

--- a/projects/optic/src/commands/oas/shapes/diffs/visitors/__snapshots__/type.test.ts.snap
+++ b/projects/optic/src/commands/oas/shapes/diffs/visitors/__snapshots__/type.test.ts.snap
@@ -10,6 +10,7 @@ exports[`type json schema diff visitor when provided with an array 1`] = `
       "3",
       true,
     ],
+    "expectedType": "string",
     "instancePath": "/stringField",
     "key": "stringField",
     "keyword": "type",
@@ -26,6 +27,7 @@ exports[`type json schema diff visitor when provided with an object 1`] = `
     "example": {
       "field": "string",
     },
+    "expectedType": "string",
     "instancePath": "/stringField",
     "key": "stringField",
     "keyword": "type",
@@ -40,6 +42,7 @@ exports[`type json schema diff visitor when provided with another primitive 1`] 
   {
     "description": "'stringField' did not match schema",
     "example": 123,
+    "expectedType": "string",
     "instancePath": "/stringField",
     "key": "stringField",
     "keyword": "type",
@@ -54,6 +57,7 @@ exports[`type json schema diff visitor when provided with null value 1`] = `
   {
     "description": "'stringField' did not match schema",
     "example": null,
+    "expectedType": "string",
     "instancePath": "/stringField",
     "key": "stringField",
     "keyword": "type",

--- a/projects/optic/src/commands/oas/shapes/diffs/visitors/oneOf.test.ts
+++ b/projects/optic/src/commands/oas/shapes/diffs/visitors/oneOf.test.ts
@@ -1,5 +1,5 @@
 import { it, describe, expect } from '@jest/globals';
-import { diffValueBySchema } from '..';
+import { diffBodyBySchema } from '..';
 import {
   objectOrStringOneOf,
   rootObjectOrArray,
@@ -20,14 +20,14 @@ describe('one of json schema diff visitor', () => {
     const input = {
       polyProp: 'hello-string',
     };
-    const diffs = diffValueBySchema(input, jsonSchema);
+    const diffs = diffBodyBySchema({ value: input }, jsonSchema);
     expect([...diffs]).toHaveLength(0);
   });
   it('when valid case 2, no diff', () => {
     const input = {
       polyProp: 123,
     };
-    const diffs = diffValueBySchema(input, jsonSchema);
+    const diffs = diffBodyBySchema({ value: input }, jsonSchema);
     expect([...diffs]).toHaveLength(0);
   });
 
@@ -46,7 +46,7 @@ describe('one of json schema diff visitor', () => {
     };
     const input = { id: 'an-identifier' };
 
-    const diffs = diffValueBySchema(input, jsonSchema);
+    const diffs = diffBodyBySchema({ value: input }, jsonSchema);
     expect([...diffs]).toHaveLength(0);
   });
 
@@ -55,7 +55,7 @@ describe('one of json schema diff visitor', () => {
       polyProp: true,
     };
 
-    const diffs = diffValueBySchema(input, jsonSchema);
+    const diffs = diffBodyBySchema({ value: input }, jsonSchema);
 
     // expect(result.totalDiffsAfterPatches).toBe(0);
     expect([...diffs]).toMatchSnapshot();
@@ -75,7 +75,7 @@ describe('one of json schema diff visitor', () => {
       polyProp: { hello: 'world' },
     };
 
-    const diffs = diffValueBySchema(input, jsonSchema);
+    const diffs = diffBodyBySchema({ value: input }, jsonSchema);
     expect([...diffs]).toMatchSnapshot();
   });
 
@@ -98,7 +98,7 @@ describe('one of json schema diff visitor', () => {
 
     const input = ['user1', 'user2', 'user3'];
 
-    const diffs = [...diffValueBySchema(input, jsonSchema)];
+    const diffs = [...diffBodyBySchema({ value: input }, jsonSchema)];
     expect(diffs).toHaveLength(1);
     expect(diffs).toMatchSnapshot();
   });
@@ -113,7 +113,7 @@ describe('one of json schema diff visitor', () => {
 
     const input: any = [];
 
-    const diffs = diffValueBySchema(input, jsonSchema);
+    const diffs = diffBodyBySchema({ value: input }, jsonSchema);
     expect([...diffs]).toMatchSnapshot();
   });
 
@@ -130,7 +130,7 @@ describe('one of json schema diff visitor', () => {
       },
     };
 
-    const diffs = diffValueBySchema(input, jsonSchema);
+    const diffs = diffBodyBySchema({ value: input }, jsonSchema);
     expect([...diffs]).toMatchSnapshot();
   });
 });

--- a/projects/optic/src/commands/oas/shapes/diffs/visitors/oneOf.ts
+++ b/projects/optic/src/commands/oas/shapes/diffs/visitors/oneOf.ts
@@ -30,6 +30,7 @@ export function* oneOfKeyword(
 
   yield {
     description: `'${keyName}' did not match schema`,
+    expectedType: 'oneOf schema',
     kind: ShapeDiffResultKind.UnmatchedType,
     keyword: JsonSchemaKnownKeyword.oneOf,
     instancePath: validationError.instancePath,

--- a/projects/optic/src/commands/oas/shapes/diffs/visitors/required.test.ts
+++ b/projects/optic/src/commands/oas/shapes/diffs/visitors/required.test.ts
@@ -1,5 +1,5 @@
 import { it, describe, expect } from '@jest/globals';
-import { diffValueBySchema } from '..';
+import { diffBodyBySchema } from '..';
 import { SchemaObject } from '../../schema';
 
 describe('required json schema diff visitor', () => {
@@ -23,7 +23,7 @@ describe('required json schema diff visitor', () => {
       hello: { f1: 'value', f2: 122 },
     };
 
-    const diffs = diffValueBySchema(input, jsonSchema);
+    const diffs = diffBodyBySchema({ value: input }, jsonSchema);
 
     expect([...diffs]).toMatchSnapshot();
   });

--- a/projects/optic/src/commands/oas/shapes/diffs/visitors/type.test.ts
+++ b/projects/optic/src/commands/oas/shapes/diffs/visitors/type.test.ts
@@ -1,5 +1,5 @@
 import { it, describe, expect } from '@jest/globals';
-import { diffValueBySchema } from '..';
+import { diffBodyBySchema } from '..';
 import { SchemaObject } from '../../schema';
 
 describe('type json schema diff visitor', () => {
@@ -14,7 +14,7 @@ describe('type json schema diff visitor', () => {
     const input = {
       stringField: 'hello-string',
     };
-    const diffs = diffValueBySchema(input, jsonSchema);
+    const diffs = diffBodyBySchema({ value: input }, jsonSchema);
     expect([...diffs]).toHaveLength(0);
   });
 
@@ -22,7 +22,7 @@ describe('type json schema diff visitor', () => {
     const input = {
       // stringField: "hello-string", // commented to show ommitted
     };
-    const diffs = diffValueBySchema(input, jsonSchema);
+    const diffs = diffBodyBySchema({ value: input }, jsonSchema);
     expect([...diffs]).toHaveLength(0);
   });
 
@@ -31,7 +31,7 @@ describe('type json schema diff visitor', () => {
       stringField: 123,
     };
 
-    const diffs = diffValueBySchema(input, jsonSchema);
+    const diffs = diffBodyBySchema({ value: input }, jsonSchema);
     expect([...diffs]).toMatchSnapshot();
   });
 
@@ -40,7 +40,7 @@ describe('type json schema diff visitor', () => {
       stringField: ['1', '2', '3', true],
     };
 
-    const diffs = diffValueBySchema(input, jsonSchema);
+    const diffs = diffBodyBySchema({ value: input }, jsonSchema);
     expect([...diffs]).toMatchSnapshot();
   });
 
@@ -49,7 +49,7 @@ describe('type json schema diff visitor', () => {
       stringField: { field: 'string' },
     };
 
-    const diffs = diffValueBySchema(input, jsonSchema);
+    const diffs = diffBodyBySchema({ value: input }, jsonSchema);
     expect([...diffs]).toMatchSnapshot();
   });
 
@@ -58,7 +58,7 @@ describe('type json schema diff visitor', () => {
       stringField: null,
     };
 
-    const diffs = diffValueBySchema(input, jsonSchema);
+    const diffs = diffBodyBySchema({ value: input }, jsonSchema);
     expect([...diffs]).toMatchSnapshot();
   });
 });

--- a/projects/optic/src/commands/oas/shapes/diffs/visitors/type.ts
+++ b/projects/optic/src/commands/oas/shapes/diffs/visitors/type.ts
@@ -25,6 +25,7 @@ export function* typeKeyword(
 
   yield {
     description: `'${keyName}' did not match schema`,
+    expectedType: `${validationError.params.type}`,
     kind: ShapeDiffResultKind.UnmatchedType,
     keyword: JsonSchemaKnownKeyword.type,
     instancePath: validationError.instancePath,

--- a/projects/optic/src/commands/oas/shapes/patches/generators/__snapshots__/oneOf.test.ts.snap
+++ b/projects/optic/src/commands/oas/shapes/patches/generators/__snapshots__/oneOf.test.ts.snap
@@ -11,6 +11,7 @@ exports[`one of shape patch generator can add an additional branch to a complex 
         2,
         3,
       ],
+      "expectedType": "oneOf schema",
       "instancePath": "/location/principality/coordinates",
       "key": "oneOf",
       "keyword": "oneOf",
@@ -101,6 +102,7 @@ exports[`one of shape patch generator when new primitive types provided to exist
     "diff": {
       "description": "'oneOf' did not match schema",
       "example": true,
+      "expectedType": "oneOf schema",
       "instancePath": "/polyProp",
       "key": "oneOf",
       "keyword": "oneOf",
@@ -137,6 +139,7 @@ exports[`one of shape patch generator when root schema is obejct and is shown an
     "diff": {
       "description": "'' did not match schema",
       "example": [],
+      "expectedType": "object",
       "instancePath": "",
       "key": "",
       "keyword": "type",
@@ -187,6 +190,7 @@ exports[`one of shape patch generator when root schema is obejct and is shown an
     "diff": {
       "description": "'' did not match schema",
       "example": [],
+      "expectedType": "object",
       "instancePath": "",
       "key": "",
       "keyword": "type",

--- a/projects/optic/src/commands/oas/shapes/patches/generators/__snapshots__/type.test.ts.snap
+++ b/projects/optic/src/commands/oas/shapes/patches/generators/__snapshots__/type.test.ts.snap
@@ -12,6 +12,7 @@ exports[`type shape patch generator when provided with an array, it can apply pa
         "3",
         true,
       ],
+      "expectedType": "string",
       "instancePath": "/stringField",
       "key": "stringField",
       "keyword": "type",
@@ -60,6 +61,7 @@ exports[`type shape patch generator when provided with an array, it can apply pa
         "3",
         true,
       ],
+      "expectedType": "string",
       "instancePath": "/stringField",
       "key": "stringField",
       "keyword": "type",
@@ -100,6 +102,7 @@ exports[`type shape patch generator when provided with an object, it can apply p
       "example": {
         "field": "string",
       },
+      "expectedType": "string",
       "instancePath": "/stringField",
       "key": "stringField",
       "keyword": "type",
@@ -142,6 +145,7 @@ exports[`type shape patch generator when provided with an object, it can apply p
       "example": {
         "field": "string",
       },
+      "expectedType": "string",
       "instancePath": "/stringField",
       "key": "stringField",
       "keyword": "type",
@@ -177,6 +181,7 @@ exports[`type shape patch generator when provided with another primitive, it can
     "diff": {
       "description": "'stringField' did not match schema",
       "example": 123,
+      "expectedType": "string",
       "instancePath": "/stringField",
       "key": "stringField",
       "keyword": "type",
@@ -217,6 +222,7 @@ exports[`type shape patch generator when provided with another primitive, it can
     "diff": {
       "description": "'stringField' did not match schema",
       "example": 123,
+      "expectedType": "string",
       "instancePath": "/stringField",
       "key": "stringField",
       "keyword": "type",
@@ -252,6 +258,7 @@ exports[`type shape patch generator when provided with null value, it can apply 
     "diff": {
       "description": "'stringField' did not match schema",
       "example": null,
+      "expectedType": "string",
       "instancePath": "/stringField",
       "key": "stringField",
       "keyword": "type",

--- a/projects/optic/src/commands/oas/shapes/patches/generators/oneOf.test.ts
+++ b/projects/optic/src/commands/oas/shapes/patches/generators/oneOf.test.ts
@@ -1,6 +1,6 @@
 import { it, describe, expect } from '@jest/globals';
 import { SchemaObject } from '../..';
-import { diffValueBySchema } from '../../diffs';
+import { diffBodyBySchema } from '../../diffs';
 import { generateShapePatchesByDiff } from '..';
 import { objectOrStringOneOf } from '../../../tests/fixtures/oneof-schemas';
 
@@ -19,7 +19,7 @@ describe('one of shape patch generator', () => {
       polyProp: true,
     };
 
-    const diffs = [...diffValueBySchema(input, jsonSchema)];
+    const diffs = [...diffBodyBySchema({ value: input }, jsonSchema)];
 
     const patches = diffs.flatMap((diff) => [
       ...generateShapePatchesByDiff(diff, jsonSchema, {}, '3.1.x'),
@@ -42,7 +42,7 @@ describe('one of shape patch generator', () => {
       polyProp: { hello: 'world' },
     };
 
-    const diffs = [...diffValueBySchema(input, jsonSchema)];
+    const diffs = [...diffBodyBySchema({ value: input }, jsonSchema)];
 
     const patches = diffs.flatMap((diff) => [
       ...generateShapePatchesByDiff(diff, jsonSchema, {}, '3.1.x'),
@@ -61,7 +61,7 @@ describe('one of shape patch generator', () => {
 
     const input: any = [];
 
-    const diffs = [...diffValueBySchema(input, jsonSchema)];
+    const diffs = [...diffBodyBySchema({ value: input }, jsonSchema)];
 
     const patches = diffs.flatMap((diff) => [
       ...generateShapePatchesByDiff(diff, jsonSchema, {}, '3.1.x'),
@@ -83,7 +83,7 @@ describe('one of shape patch generator', () => {
       },
     };
 
-    const diffs = [...diffValueBySchema(input, jsonSchema)];
+    const diffs = [...diffBodyBySchema({ value: input }, jsonSchema)];
 
     const patches = diffs.flatMap((diff) => [
       ...generateShapePatchesByDiff(diff, jsonSchema, {}, '3.1.x'),

--- a/projects/optic/src/commands/oas/shapes/patches/generators/required.test.ts
+++ b/projects/optic/src/commands/oas/shapes/patches/generators/required.test.ts
@@ -1,6 +1,6 @@
 import { it, describe, expect } from '@jest/globals';
 import { SchemaObject } from '../..';
-import { diffValueBySchema } from '../../diffs';
+import { diffBodyBySchema } from '../../diffs';
 import { generateShapePatchesByDiff } from '..';
 
 describe('required shape patch generator', () => {
@@ -23,7 +23,7 @@ describe('required shape patch generator', () => {
     const input = {
       hello: { f1: 'value', f2: 122 },
     };
-    const diffs = [...diffValueBySchema(input, jsonSchema)];
+    const diffs = [...diffBodyBySchema({ value: input }, jsonSchema)];
 
     const patches = diffs.flatMap((diff) => [
       ...generateShapePatchesByDiff(diff, jsonSchema, {}, '3.1.x'),

--- a/projects/optic/src/commands/oas/shapes/patches/generators/type.test.ts
+++ b/projects/optic/src/commands/oas/shapes/patches/generators/type.test.ts
@@ -1,6 +1,6 @@
 import { it, describe, expect } from '@jest/globals';
 import { SchemaObject } from '../..';
-import { diffValueBySchema } from '../../diffs';
+import { diffBodyBySchema } from '../../diffs';
 import { generateShapePatchesByDiff } from '..';
 
 describe('type shape patch generator', () => {
@@ -16,7 +16,7 @@ describe('type shape patch generator', () => {
       stringField: 123,
     };
 
-    const diffs = [...diffValueBySchema(input, jsonSchema)];
+    const diffs = [...diffBodyBySchema({ value: input }, jsonSchema)];
 
     const patches = diffs.flatMap((diff) => [
       ...generateShapePatchesByDiff(diff, jsonSchema, {}, '3.1.x'),
@@ -30,7 +30,7 @@ describe('type shape patch generator', () => {
       stringField: ['1', '2', '3', true],
     };
 
-    const diffs = [...diffValueBySchema(input, jsonSchema)];
+    const diffs = [...diffBodyBySchema({ value: input }, jsonSchema)];
 
     const patches = diffs.flatMap((diff) => [
       ...generateShapePatchesByDiff(diff, jsonSchema, {}, '3.1.x'),
@@ -44,7 +44,7 @@ describe('type shape patch generator', () => {
       stringField: { field: 'string' },
     };
 
-    const diffs = [...diffValueBySchema(input, jsonSchema)];
+    const diffs = [...diffBodyBySchema({ value: input }, jsonSchema)];
 
     const patches = diffs.flatMap((diff) => [
       ...generateShapePatchesByDiff(diff, jsonSchema, {}, '3.1.x'),
@@ -58,7 +58,7 @@ describe('type shape patch generator', () => {
       stringField: null,
     };
 
-    const diffs = [...diffValueBySchema(input, jsonSchema)];
+    const diffs = [...diffBodyBySchema({ value: input }, jsonSchema)];
 
     const patches = diffs.flatMap((diff) => [
       ...generateShapePatchesByDiff(diff, jsonSchema, {}, '3.1.x'),

--- a/projects/optic/src/commands/oas/tests/shapes/extend.test.ts
+++ b/projects/optic/src/commands/oas/tests/shapes/extend.test.ts
@@ -1,6 +1,6 @@
 import { it, describe, expect } from '@jest/globals';
 import { SchemaObject, ShapePatches, Schema } from '../../shapes';
-import { diffValueBySchema } from '../../shapes/diffs';
+import { diffBodyBySchema } from '../../shapes/diffs';
 
 import * as DocumentedBodyFixtures from '../fixtures/documented-body';
 
@@ -24,7 +24,7 @@ function patchSchema(
 function* diffs(schema: SchemaObject | null, ...inputs: any[]) {
   if (!schema) return;
   for (let input of inputs) {
-    yield* diffValueBySchema(input, schema);
+    yield* diffBodyBySchema({ value: input }, schema);
   }
 }
 

--- a/projects/optic/src/commands/oas/tests/shapes/generate.test.ts
+++ b/projects/optic/src/commands/oas/tests/shapes/generate.test.ts
@@ -1,6 +1,6 @@
 import { it, describe, expect } from '@jest/globals';
 import { SchemaObject, ShapePatches, Schema } from '../../shapes';
-import { diffValueBySchema, ShapeDiffResult } from '../../shapes/diffs';
+import { diffBodyBySchema, ShapeDiffResult } from '../../shapes/diffs';
 import * as DocumentedBodyFixtures from '../fixtures/documented-body';
 import { rootObjectOrArray } from '../fixtures/oneof-schemas';
 import { SupportedOpenAPIVersions } from '@useoptic/openapi-io';
@@ -33,7 +33,7 @@ function patchSchema(
 function* diffs(schema: SchemaObject | null, ...inputs: any[]) {
   if (!schema) return;
   for (let input of inputs) {
-    yield* diffValueBySchema(input, schema);
+    yield* diffBodyBySchema({ value: input }, schema);
   }
 }
 


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

This PR makes endpoints that are documented (i.e. are in the spec) work with interactions. With the flag `-u` we update the spec, without it we run a verify. This also runs endpoints one at a time -> flushes them to disk -> renders UI results so we can provide incremental progress as we update (especially for large specs / updates)

I'm pulling a lot of the relevant code from different parts of the oas codebase

Up next will be the undocumented interactions flow

```
➜  my-openapi-specs git:(main) ✗ npx ts-node ../optic/projects/optic/src/index.ts beta capture abe.yml
✔ Server check passed
✖ GET /books
  [200 response body] body is not documented
➜  my-openapi-specs git:(main) ✗ npx ts-node ../optic/projects/optic/src/index.ts beta capture abe.yml -u
✔ Server check passed
✔ GET /books
  ✓ 200 response
  [200 response body] body has been added
➜  my-openapi-specs git:(main) npx ts-node ../optic/projects/optic/src/index.ts beta capture abe.yml 
✔ Server check passed
✔ GET /books
  ✓ 200 response
```

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
