### PR TITLE
fix(capture): exit early if we cant start the app

### DIFF
--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -182,6 +182,13 @@ const getCaptureAction =
       app.stderr.on('data', (data) => {
         logger.error(data.toString());
       });
+
+      app.on('error', (err) => {
+        logger.error(
+          `"server.command" exited unexpectedly with status ${app?.exitCode}.`
+        );
+        process.exit(1);
+      });
     }
 
     // wait until the server is ready


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_

testing with these scenarios:
- `server.command: exit 1`
- `server.command` is already running outside of capture (`server.command` needs to exit non-zero)
