### PR TITLE
Prompt user to input path patterns for unmatched requests

### DIFF
--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import fs from 'node:fs/promises';
 import fetch from 'node-fetch';
 import Bottleneck from 'bottleneck';
+import jsonpatch from 'fast-json-patch';
 
 import { isJson, isYaml, writeYaml } from '@useoptic/openapi-io';
 import ora from 'ora';
@@ -27,13 +28,17 @@ import { clearCommand } from '../oas/capture-clear';
 import { captureV1 } from '../oas/capture';
 import { getCaptureStorage, GroupedCaptures } from './storage';
 import { loadSpec } from '../../utils/spec-loaders';
-import { consumeDocumentedInteractions } from './interactions/consume-documented';
+import { updateExistingEndpoint } from './interactions/documented';
 import { ApiCoverageCounter } from '../oas/coverage/api-coverage';
 import { commandSplitter } from '../../utils/capture';
 import {
-  consumeUndocumentedInteractions,
+  documentNewEndpoint,
   promptUserForPathPattern,
-} from './interactions/consume-undocumented';
+} from './interactions/undocumented';
+import { OPTIC_PATH_IGNORE_KEY } from '../../constants';
+import { specToOperations } from '../oas/operations/queries';
+import { SpecFiles } from '../oas/specs';
+import { updateSpecFiles } from '../oas/diffing/document';
 
 const indent = (n: number) => '  '.repeat(n);
 const wait = (time: number) =>
@@ -233,7 +238,9 @@ const getCaptureAction =
     // make requests
     const captures = new GroupedCaptures(
       trafficDirectory,
-      getEndpointsFromSpec(spec.jsonLike)
+      specToOperations(spec.jsonLike).flatMap((o) =>
+        o.methods.map((m) => ({ method: m, path: o.pathPattern }))
+      )
     );
 
     let errors: any[] = [];
@@ -310,10 +317,8 @@ const getCaptureAction =
     } of captures.getDocumentedEndpointInteractions()) {
       const { path, method } = endpoint;
       const endpointText = `${method.toUpperCase()} ${path}`;
-      const spinner = ora(endpointText);
-      spinner.start();
-      spinner.color = 'blue';
-      const { patchSummaries, hasDiffs } = await consumeDocumentedInteractions(
+      const spinner = ora({ text: endpointText, color: 'blue' }).start();
+      const { patchSummaries, hasDiffs } = await updateExistingEndpoint(
         interactions,
         spec,
         coverage,
@@ -363,7 +368,7 @@ const getCaptureAction =
       );
       const {
         interactions: filteredInteractions,
-        ignorePaths,
+        ignorePaths: newIgnorePaths,
         endpointsToAdd,
       } = await promptUserForPathPattern(
         captures.getUndocumentedInteractions(),
@@ -371,6 +376,30 @@ const getCaptureAction =
       );
 
       logger.info(chalk.bold.gray('Documenting new operations:'));
+
+      for (const endpoint of endpointsToAdd) {
+        const { path, method } = endpoint;
+        const endpointText = `${method.toUpperCase()} ${path}`;
+        const spinner = ora({ text: endpointText, color: 'blue' }).start();
+
+        await documentNewEndpoint(filteredInteractions, spec, endpoint);
+
+        // Since we flush each endpoint updates to disk, we should reload the spec to get the latest spec and sourcemap which we both use to generate the next set of patches
+        spec = await loadSpec(filePath, config, {
+          strict: false,
+          denormalize: false,
+        });
+        spinner.succeed();
+      }
+
+      const existingIgnorePaths = Array.isArray(
+        spec.jsonLike[OPTIC_PATH_IGNORE_KEY]
+      )
+        ? spec.jsonLike[OPTIC_PATH_IGNORE_KEY]
+        : [];
+      const ignorePaths = existingIgnorePaths.push(...newIgnorePaths);
+
+      // TODO Write the ignore paths to the spec
     } else if (captures.unmatched.hars.length) {
       logger.info('');
       logger.info(`${captures.unmatched.hars.length} unmatched interactions`);
@@ -418,20 +447,6 @@ async function createOpenAPIFile(filePath: string): Promise<boolean> {
   }
 }
 
-function getEndpointsFromSpec(
-  spec: OpenAPIV3.Document
-): { method: string; path: string }[] {
-  const endpoints: { method: string; path: string }[] = [];
-  for (const [path, pathObj] of Object.entries(spec.paths)) {
-    for (const method of Object.values(OpenAPIV3.HttpMethods)) {
-      const methodObj = pathObj && pathObj[method as string];
-      if (methodObj) {
-        endpoints.push({ method, path });
-      }
-    }
-  }
-  return endpoints;
-}
 function getSummaryText(endpointCoverage: OperationCoverage) {
   const getIcon = (node: CoverageNode) =>
     node.seen ? (node.diffs ? chalk.red('× ') : chalk.green('✓ ')) : '';

--- a/projects/optic/src/commands/capture/interactions/consume-undocumented.ts
+++ b/projects/optic/src/commands/capture/interactions/consume-undocumented.ts
@@ -1,0 +1,147 @@
+import prompts from 'prompts';
+import { OpenAPIV3 } from '@useoptic/openapi-utilities';
+import { matchPathPattern } from '../../../utils/pathPatterns';
+import { minimatch } from 'minimatch';
+import { logger } from '../../../logger';
+import { ParseResult } from '../../../utils/spec-loaders';
+import { getIgnorePaths } from '../../../utils/specs';
+
+import { CapturedInteraction, CapturedInteractions } from '../../oas/captures';
+import { InferPathStructure } from '../../oas/operations/infer-path-structure';
+import { specToOperations } from '../../oas/operations/queries';
+
+type MethodMap = Map<string, { add: Set<string>; ignore: Set<string> }>;
+
+export async function promptUserForPathPattern(
+  interactions: CapturedInteractions,
+  spec: OpenAPIV3.Document
+) {
+  const filteredInteractions: CapturedInteraction[] = [];
+  const methodMap: MethodMap = new Map(
+    Object.values(OpenAPIV3.HttpMethods)
+      .filter((method) => method !== 'options' && method !== 'head')
+      .map((method) => [
+        method,
+        {
+          add: new Set(),
+          ignore: new Set(),
+        },
+      ])
+  );
+
+  const ignorePaths = getIgnorePaths(spec);
+  const newIgnorePaths: { method: string; pattern: string }[] = [];
+
+  for (const ignore of ignorePaths) {
+    if (!ignore.method) {
+      for (const [, methodNode] of methodMap) {
+        methodNode.ignore.add(ignore.path);
+      }
+    } else if (ignore.method) {
+      const maybeNode = methodMap.get(ignore.method);
+      maybeNode?.ignore.add(ignore.path);
+    }
+  }
+  const inferredPathStructure = new InferPathStructure(specToOperations(spec));
+
+  for await (const interaction of interactions) {
+    const { path, method } = interaction.request;
+    const pathsNode = methodMap.get(method);
+    if (!pathsNode) {
+      logger.debug(
+        `Skipping ${method} ${path} because ${method} is not a supported method`
+      );
+      continue;
+    }
+    const { add, ignore } = pathsNode;
+    const pathInAdd = [...add.values()].some(
+      (p) => matchPathPattern(p, path).match
+    );
+    const pathInIgnore = [...ignore.values()].some((ignore) =>
+      minimatch(path, ignore)
+    );
+
+    if (pathInAdd) {
+      filteredInteractions.push(interaction);
+    } else if (pathInIgnore) {
+      logger.debug(`Skipping ${method} ${path} because is in ignored specs`);
+      continue;
+    } else {
+      const guessedPattern =
+        inferredPathStructure.includeObservedUrlPath(method, path) ?? path;
+      const results = await prompts(
+        [
+          {
+            type: 'select',
+            name: 'action',
+            message: `Is ${guessedPattern} the right pattern for ${method.toUpperCase()} ${path}`,
+            choices: [
+              {
+                title: 'yes',
+                value: 'yes',
+              },
+              {
+                title: 'no',
+                value: 'no',
+              },
+              {
+                title: 'ignore',
+                value: 'ignore',
+              },
+              {
+                title: 'skip',
+                value: 'skip',
+              },
+            ],
+          },
+          {
+            type: (pre) => (pre === 'no' ? 'text' : null),
+            name: 'newPath',
+            message: 'Provide the correct path (e.g. /api/users/{userId)',
+            validate: (pattern) =>
+              matchPathPattern(pattern, interaction.request.path).match
+                ? true
+                : `Must be a valid path pattern and match the path ${path}`,
+          },
+        ],
+        { onCancel: () => process.exit(1) }
+      );
+
+      if (results.action === 'yes') {
+        add.add(guessedPattern);
+        filteredInteractions.push(interaction);
+      } else if (results.action === 'no') {
+        add.add(results.newPath);
+        filteredInteractions.push(interaction);
+      } else if (results.action === 'skip') {
+        continue;
+      } else {
+        ignore.add(path);
+        newIgnorePaths.push({ method, pattern: path });
+      }
+    }
+  }
+  const endpointsToAdd: { method: string; path: string }[] = [];
+  for (const [method, methodNode] of methodMap) {
+    for (const path of methodNode.add) {
+      endpointsToAdd.push({ method, path });
+    }
+  }
+  return {
+    interactions: filteredInteractions,
+    endpointsToAdd,
+    ignorePaths: newIgnorePaths,
+  };
+}
+
+export async function consumeUndocumentedInteractions(
+  interactions: CapturedInteractions,
+  totalInteractions: number,
+  parseResult: ParseResult
+) {
+  for await (const a of interactions) {
+  }
+
+  // TODO write ignore paths back to spec
+  // TODO use add paths to add by paths
+}

--- a/projects/optic/src/commands/capture/interactions/patches.ts
+++ b/projects/optic/src/commands/capture/interactions/patches.ts
@@ -1,0 +1,115 @@
+import { ParseResult } from '../../../utils/spec-loaders';
+import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
+import { checkOpenAPIVersion } from '@useoptic/openapi-io';
+
+import { ApiCoverageCounter } from '../../oas/coverage/api-coverage';
+import { OpenAPIV3, SpecPatch, SpecPatches } from '../../oas/specs';
+import { CapturedInteractions } from '../../oas/captures';
+import { DocumentedInteraction, Operation } from '../../oas/operations';
+import { DocumentedBodies } from '../../oas/shapes';
+import { createMissingMethodPatch } from '../../oas/specs/patches/generators/missing-method';
+import { createMissingPathPatches } from '../../oas/specs/patches/generators/missing-path';
+import { UndocumentedOperationType } from '../../oas/operations';
+
+export async function* generatePathAndMethodSpecPatches(
+  specHolder: {
+    spec: ParseResult['jsonLike'];
+  },
+  endpoint: { method: string; path: string }
+) {
+  const hasPath = !!specHolder.spec.paths[endpoint.path];
+  const hasMethod = !!specHolder.spec.paths[endpoint.path]?.[endpoint.method];
+  if (!hasPath) {
+    const pathParameters = endpoint.path
+      .split('/')
+      .filter((p) => p.startsWith('{') && p.endsWith('}'))
+      .map((p) => p.slice(1, -1));
+    const patch = createMissingPathPatches({
+      type: UndocumentedOperationType.MissingPath,
+      pathPattern: endpoint.path,
+      specPath: jsonPointerHelpers.compile(['paths', endpoint.path]),
+      methods: [endpoint.method as OpenAPIV3.HttpMethods],
+      pathParameters,
+    });
+    specHolder.spec = SpecPatch.applyPatch(patch, specHolder.spec);
+    yield patch;
+  } else if (!hasMethod) {
+    const patch = createMissingMethodPatch({
+      type: UndocumentedOperationType.MissingMethod,
+      pathPattern: endpoint.path,
+      specPath: jsonPointerHelpers.compile([
+        'paths',
+        endpoint.path,
+        endpoint.method,
+      ]),
+      method: endpoint.method as OpenAPIV3.HttpMethods,
+    });
+    specHolder.spec = SpecPatch.applyPatch(patch, specHolder.spec);
+    yield patch;
+  }
+}
+
+// Generate spec patches for an endpoint in the spec
+export async function* generateEndpointSpecPatches(
+  interactions: CapturedInteractions,
+  specHolder: {
+    spec: ParseResult['jsonLike'];
+  },
+  endpoint: { method: string; path: string },
+  opts: {
+    coverage?: ApiCoverageCounter;
+  } = {}
+) {
+  const openAPIVersion = checkOpenAPIVersion(specHolder.spec);
+  const jsonPath = jsonPointerHelpers.compile([
+    'paths',
+    endpoint.path,
+    endpoint.method,
+  ]);
+  const operation = Operation.fromOperationObject(
+    endpoint.path,
+    endpoint.method,
+    jsonPointerHelpers.get(specHolder.spec, jsonPath) as any
+  );
+  for await (const interaction of interactions) {
+    let documentedInteraction: DocumentedInteraction = {
+      interaction,
+      operation,
+      specJsonPath: jsonPath,
+    };
+
+    opts.coverage?.operationInteraction(
+      documentedInteraction.operation.pathPattern,
+      documentedInteraction.operation.method,
+      !!documentedInteraction.interaction.request.body,
+      documentedInteraction.interaction.response?.statusCode
+    );
+
+    // phase one: operation patches, making sure all requests / responses are documented
+    let opPatches = SpecPatches.operationAdditions(documentedInteraction);
+
+    for await (let patch of opPatches) {
+      specHolder.spec = SpecPatch.applyPatch(patch, specHolder.spec);
+      yield patch;
+    }
+
+    // phase two: shape patches, describing request / response bodies in detail
+    documentedInteraction = DocumentedInteraction.updateOperation(
+      documentedInteraction,
+      specHolder.spec
+    );
+    let documentedBodies = DocumentedBodies.fromDocumentedInteraction(
+      documentedInteraction
+    );
+
+    let shapePatches = SpecPatches.shapeAdditions(
+      documentedBodies,
+      openAPIVersion
+    );
+
+    for await (let patch of shapePatches) {
+      specHolder.spec = SpecPatch.applyPatch(patch, specHolder.spec);
+      yield patch;
+    }
+  }
+}

--- a/projects/optic/src/commands/capture/storage.ts
+++ b/projects/optic/src/commands/capture/storage.ts
@@ -41,7 +41,7 @@ export class GroupedCaptures {
       endpoint: { method: string; path: string };
     }
   >;
-  private unmatched: { path: string; hars: HttpArchive.Entry[] };
+  public unmatched: { path: string; hars: HttpArchive.Entry[] };
   private queries: OperationQueries;
   constructor(
     trafficDir: string,

--- a/projects/optic/src/commands/oas/operations/infer-path-structure.ts
+++ b/projects/optic/src/commands/oas/operations/infer-path-structure.ts
@@ -74,7 +74,7 @@ export class InferPathStructure {
       - did not match other urls
    */
 
-  includeObservedUrlPath = (method: string, urlPath: string) => {
+  includeObservedUrlPath = (method: string, urlPath: string): string | null => {
     const findMatch = (
       parent: PathComponentCandidate | null,
       inferred: PathComponentCandidate['inferred'],
@@ -89,6 +89,7 @@ export class InferPathStructure {
     };
 
     const fragments = fragmentize(urlPath);
+    let first: PathComponentCandidate | null = null;
     let parent: PathComponentCandidate | null = null;
     fragments.forEach((fragment, index) => {
       const isLast = fragments.length - 1 === index;
@@ -106,6 +107,7 @@ export class InferPathStructure {
           match.examplePath = urlPath;
         }
         parent = match;
+        if (isFirst) first = match;
       } else if (!match) {
         const isConfidentVariable = !isFirst && looksLikeAVariable(fragment);
         const name = isConfidentVariable
@@ -123,8 +125,11 @@ export class InferPathStructure {
         };
         this.paths.push(insert);
         parent = insert;
+        if (isFirst) first = insert;
       }
     });
+
+    return first && reducePathPattern(first);
   };
 
   replaceConstantsWithVariables = () => {

--- a/projects/optic/src/commands/oas/specs/patches/generators/missing-method.ts
+++ b/projects/optic/src/commands/oas/specs/patches/generators/missing-method.ts
@@ -2,7 +2,7 @@ import {
   UndocumentedOperation,
   UndocumentedOperationType,
 } from '../../../operations';
-import { SpecPatch, OpenAPIV3 } from '../..';
+import { SpecPatch } from '../..';
 import { PatchOperationGroup, PatchImpact } from '../../../patches';
 import { OperationDiffResultKind } from '../../../operations/diffs';
 import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
@@ -13,6 +13,15 @@ export function* missingMethodPatches(
   if (undocumentedOperation.type !== UndocumentedOperationType.MissingMethod)
     return;
 
+  yield createMissingMethodPatch(undocumentedOperation);
+}
+
+export function createMissingMethodPatch(
+  undocumentedOperation: Extract<
+    UndocumentedOperation,
+    { type: UndocumentedOperationType.MissingMethod }
+  >
+): SpecPatch {
   const { specPath, method, pathPattern } = undocumentedOperation;
 
   let groupedOperations: PatchOperationGroup[] = [];
@@ -27,7 +36,7 @@ export function* missingMethodPatches(
     })
   );
 
-  yield {
+  return {
     diff: {
       kind: OperationDiffResultKind.UnmatchedMethod,
       subject: method,

--- a/projects/optic/src/commands/oas/specs/patches/generators/missing-path.ts
+++ b/projects/optic/src/commands/oas/specs/patches/generators/missing-path.ts
@@ -17,6 +17,15 @@ export function* missingPathPatches(
   if (undocumentedOperation.type !== UndocumentedOperationType.MissingPath)
     return;
 
+  yield createMissingPathPatches(undocumentedOperation);
+}
+
+export function createMissingPathPatches(
+  undocumentedOperation: Extract<
+    UndocumentedOperation,
+    { type: UndocumentedOperationType.MissingPath }
+  >
+): SpecPatch {
   const { specPath, methods, pathPattern, pathParameters } =
     undocumentedOperation;
 
@@ -63,7 +72,7 @@ export function* missingPathPatches(
     PatchOperationGroup.create('add methods', ...methodOperations)
   );
 
-  yield {
+  return {
     diff: {
       kind: OperationDiffResultKind.UnmatchedPath,
       subject: pathPattern,

--- a/projects/optic/src/constants.ts
+++ b/projects/optic/src/constants.ts
@@ -1,3 +1,4 @@
 export const OPTIC_STANDARD_KEY = 'x-optic-standard';
 export const OPTIC_URL_KEY = 'x-optic-url';
 export const OPTIC_EMPTY_SPEC_KEY = 'x-optic-ci-empty-spec';
+export const OPTIC_PATH_IGNORE = 'x-optic-path-ignore';

--- a/projects/optic/src/constants.ts
+++ b/projects/optic/src/constants.ts
@@ -1,4 +1,4 @@
 export const OPTIC_STANDARD_KEY = 'x-optic-standard';
 export const OPTIC_URL_KEY = 'x-optic-url';
 export const OPTIC_EMPTY_SPEC_KEY = 'x-optic-ci-empty-spec';
-export const OPTIC_PATH_IGNORE = 'x-optic-path-ignore';
+export const OPTIC_PATH_IGNORE_KEY = 'x-optic-path-ignore';

--- a/projects/optic/src/utils/__tests__/pathPattern.test.ts
+++ b/projects/optic/src/utils/__tests__/pathPattern.test.ts
@@ -1,0 +1,35 @@
+import { test, expect, describe } from '@jest/globals';
+import { matchPathPattern } from '../pathPatterns';
+
+describe('matchPathPattern', () => {
+  test('returns true when pattern matches path', () => {
+    expect(
+      matchPathPattern('/orgs/{orgId}/users/{userId}', '/orgs/123/users/123')
+    ).toEqual({ match: true, exact: false });
+  });
+
+  test('returns true when pattern matches path with pattern', () => {
+    expect(matchPathPattern('/orgs/settings', '/orgs/settings')).toEqual({
+      match: true,
+      exact: true,
+    });
+  });
+
+  test('returns false when pattern is a different length', () => {
+    expect(
+      matchPathPattern('/orgs/{orgId}/users/{userId}', '/orgs/users/123')
+    ).toEqual({ match: false });
+  });
+
+  test('returns false when pattern is not an exact match', () => {
+    expect(matchPathPattern('/orgs/settings', '/orgs/others')).toEqual({
+      match: false,
+    });
+  });
+
+  test('returns false when pattern is not a pattern match', () => {
+    expect(
+      matchPathPattern('/orgs/{orgId}/users/{userId}', '/orgs/123/projects/123')
+    ).toEqual({ match: false });
+  });
+});

--- a/projects/optic/src/utils/pathPatterns.ts
+++ b/projects/optic/src/utils/pathPatterns.ts
@@ -1,0 +1,27 @@
+function isPattern(part: string) {
+  return part.startsWith('{') && part.endsWith('}');
+}
+
+export function matchPathPattern(
+  pathPattern: string,
+  path: string
+): { match: true; exact: boolean } | { match: false } {
+  const patternParts = pathPattern.split('/');
+  const pathParts = path.split('/');
+  if (patternParts.length !== pathParts.length) {
+    return { match: false };
+  }
+
+  for (let i = 0; i < patternParts.length; i++) {
+    const pathPart = pathParts[i];
+    const patternPart = patternParts[i];
+    if (!isPattern(patternPart) && pathPart !== patternPart) {
+      return { match: false };
+    }
+  }
+
+  return {
+    match: true,
+    exact: patternParts.every((part) => !isPattern(part)),
+  };
+}

--- a/projects/optic/src/utils/specs.ts
+++ b/projects/optic/src/utils/specs.ts
@@ -1,5 +1,5 @@
 import { OpenAPIV3, defaultEmptySpec } from '@useoptic/openapi-utilities';
-import { OPTIC_EMPTY_SPEC_KEY, OPTIC_PATH_IGNORE } from '../constants';
+import { OPTIC_EMPTY_SPEC_KEY, OPTIC_PATH_IGNORE_KEY } from '../constants';
 import { JsonSchemaSourcemap } from '@useoptic/openapi-io';
 import { logger } from '../logger';
 
@@ -12,7 +12,7 @@ export function getIgnorePaths(
         method?: string;
         path?: string;
       }
-  )[] = spec[OPTIC_PATH_IGNORE];
+  )[] = spec[OPTIC_PATH_IGNORE_KEY];
   const paths: { path: string; method?: string }[] = [];
   if (!Array.isArray(ignorePaths)) {
     return [];

--- a/projects/optic/src/utils/specs.ts
+++ b/projects/optic/src/utils/specs.ts
@@ -1,6 +1,38 @@
 import { OpenAPIV3, defaultEmptySpec } from '@useoptic/openapi-utilities';
-import { OPTIC_EMPTY_SPEC_KEY } from '../constants';
+import { OPTIC_EMPTY_SPEC_KEY, OPTIC_PATH_IGNORE } from '../constants';
 import { JsonSchemaSourcemap } from '@useoptic/openapi-io';
+import { logger } from '../logger';
+
+export function getIgnorePaths(
+  spec: OpenAPIV3.Document
+): { path: string; method?: string }[] {
+  const ignorePaths: (
+    | string
+    | {
+        method?: string;
+        path?: string;
+      }
+  )[] = spec[OPTIC_PATH_IGNORE];
+  const paths: { path: string; method?: string }[] = [];
+  if (!Array.isArray(ignorePaths)) {
+    return [];
+  } else {
+    for (const ignore of ignorePaths) {
+      if (typeof ignore === 'string') {
+        paths.push({ path: ignore });
+      } else if (ignore.method && ignore.path) {
+        paths.push({ method: ignore.method, path: ignore.path });
+      } else {
+        logger.debug(
+          `Skipping x-optic-path-ignore ${JSON.stringify(
+            ignore
+          )} - must be type string or {method: string, path: string}`
+        );
+      }
+    }
+  }
+  return paths;
+}
 
 export function createNewSpecFile(version: string): OpenAPIV3.Document {
   return {


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

This PR:
- adds the `--interactive` flag + handles cases where you have unmatched requests and the different variants (`--update` `--interactive`
- Prompts the user to tell us which path patterns we need

Follow up PR will be to actually use this data to document unmatched interactions

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
