### PR TITLE
chore(capture): mild refactor

### DIFF
--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -247,8 +247,18 @@ const getCaptureAction =
       if (app) {
         process.kill(-app.pid!);
       }
+
+      if (errors.length > 0) {
+        logger.error('finished with errors:');
+        errors.forEach((error, index) => {
+          logger.error(`${index}:\n${error}`);
+        });
+      }
     }
 
+    //
+    // process proxy interactions into hars
+    //
     const harEntries = HarEntries.fromProxyInteractions(proxy.interactions);
     const captures = new GroupedCaptures(
       trafficDirectory,
@@ -262,13 +272,6 @@ const getCaptureAction =
         `Captured ${har.request.method.toUpperCase()} ${har.request.url}`
       );
     }
-    if (errors.length > 0) {
-      logger.error('finished with errors:');
-      errors.forEach((error, index) => {
-        logger.error(`${index}:\n${error}`);
-      });
-    }
-
     await captures.writeHarFiles();
     let hasAnyEndpointDiffs = false;
 
@@ -324,6 +327,7 @@ const getCaptureAction =
       );
     }
 
+    // learn path patterns
     if (options.update && options.interactive) {
       logger.info('');
       logger.info(

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -198,7 +198,7 @@ const getCaptureAction =
       options.proxyPort ? Number(options.proxyPort) : undefined
     );
 
-    // parse optic.yml
+    // parse spec
     let spec = await loadSpec(filePath, config, {
       strict: false,
       denormalize: false,

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -190,9 +190,7 @@ const getCaptureAction =
     const trafficDirectory = await setup(filePath);
     logger.debug(`Writing captured traffic to ${trafficDirectory}`);
 
-    //
     // start proxy
-    //
     const proxy = new ProxyInstance(
       options.serverOverride || captureConfig.server.url
     );
@@ -200,17 +198,13 @@ const getCaptureAction =
       options.proxyPort ? Number(options.proxyPort) : undefined
     );
 
-    //
     // parse optic.yml
-    //
     let spec = await loadSpec(filePath, config, {
       strict: false,
       denormalize: false,
     });
 
-    //
     // start app
-    //
     let app: ChildProcessWithoutNullStreams | undefined;
     if (!options.serverOverride && captureConfig.server.command) {
       const serverDir =
@@ -230,9 +224,7 @@ const getCaptureAction =
       );
     }
 
-    //
     // make requests
-    //
     let errors: any[] = [];
     try {
       let [sendRequestsPromise, runRequestsPromise] = makeAllRequests(
@@ -256,9 +248,7 @@ const getCaptureAction =
       }
     }
 
-    //
     // process proxy interactions into hars
-    //
     const harEntries = HarEntries.fromProxyInteractions(proxy.interactions);
     const captures = new GroupedCaptures(
       trafficDirectory,
@@ -273,8 +263,9 @@ const getCaptureAction =
       );
     }
     await captures.writeHarFiles();
-    let hasAnyEndpointDiffs = false;
 
+    // update existing endpoints
+    let hasAnyEndpointDiffs = false;
     const coverage = new ApiCoverageCounter(spec.jsonLike);
     // Handle interactions for documented endpoints first
     for (const {
@@ -327,7 +318,7 @@ const getCaptureAction =
       );
     }
 
-    // learn path patterns
+    // document new endpoints
     if (options.update && options.interactive) {
       logger.info('');
       logger.info(

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -17,7 +17,7 @@ import {
   OperationCoverage,
   UserError,
 } from '@useoptic/openapi-utilities';
-import { Request } from '../../config';
+import { CaptureConfigData, Request } from '../../config';
 import { HarEntries, ProxyInteractions } from '../oas/captures';
 import { errorHandler } from '../../error-handler';
 

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -129,7 +129,7 @@ class ProxyInstance {
     this.targetUrl = target;
   }
 
-  public async init(port: number | undefined) {
+  public async start(port: number | undefined) {
     [this.interactions, this.url] = await ProxyInteractions.create(
       this.targetUrl,
       this.abortController.signal,
@@ -196,7 +196,9 @@ const getCaptureAction =
     const proxy = new ProxyInstance(
       options.serverOverride || captureConfig.server.url
     );
-    await proxy.init(options.proxyPort ? Number(options.proxyPort) : undefined);
+    await proxy.start(
+      options.proxyPort ? Number(options.proxyPort) : undefined
+    );
 
     //
     // parse optic.yml

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -581,6 +581,13 @@ async function startApp(
   app.stderr.on('data', (data) => {
     logger.error(data.toString());
   });
+
+  app.on('exit', (code) => {
+    if (code! > 0) {
+      throw `Unexpected exit from the server with exit code: ${code}`;
+    }
+  });
+
   // since ready_endpoint is not required always wait one interval. without ready_endpoint,
   // ready_interval must be at least the time it takes to start the server.
   await wait(readyInterval);

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -214,14 +214,21 @@ const getCaptureAction =
       const timeout = captureConfig.server.ready_timeout || 3 * 60 * 1_000; // 3 minutes
       const readyInterval = captureConfig.server.ready_interval || 1000;
 
-      app = await startApp(
-        captureConfig.server.command,
-        serverDir,
-        captureConfig.server.ready_endpoint,
-        readyInterval,
-        timeout,
-        proxy.targetUrl
-      );
+      try {
+        app = await startApp(
+          captureConfig.server.command,
+          serverDir,
+          captureConfig.server.ready_endpoint,
+          readyInterval,
+          timeout,
+          proxy.targetUrl
+        );
+      } catch (err) {
+        proxy.stop();
+        logger.error(err);
+        process.exitCode = 1;
+        return;
+      }
     }
 
     // make requests

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -541,19 +541,16 @@ async function serverReady(
   }
 }
 
-async function specExists(filePath: string): Promise<boolean> {
-  try {
-    await fs.stat(filePath);
-  } catch {
-    return false;
-  }
-  return true;
-}
-
 async function setup(filePath: string): Promise<string> {
   const resolvedPath = path.resolve(filePath);
-  const oasSpecExists = await specExists(resolvedPath);
-  if (!oasSpecExists) {
+  let openApiExists = false;
+
+  try {
+    await fs.stat(resolvedPath);
+    openApiExists = true;
+  } catch (e) {}
+
+  if (!openApiExists) {
     const fileCreated = await createOpenAPIFile(filePath);
     if (!fileCreated) {
       logger.error('Could not create OpenAPI file');

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -586,7 +586,7 @@ async function startApp(
   // lets find a better way.
   app.on('exit', (code) => {
     if (code! > 0) {
-      throw `Unexpected exit from the server with exit code: ${code}`;
+      throw Error(`Unexpected exit from the server with exit code: ${code}`);
     }
   });
 

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -582,6 +582,8 @@ async function startApp(
     logger.error(data.toString());
   });
 
+  // TODO: this doesn't get caught by the calller but doesn't seem to leave the proxy hanging.
+  // lets find a better way.
   app.on('exit', (code) => {
     if (code! > 0) {
       throw `Unexpected exit from the server with exit code: ${code}`;

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -177,21 +177,31 @@ const getCaptureAction =
     // TODO capturev2 - handle relative path from root (tbd - what do we do when we handle this outside of a git repo)
     const captureConfig = config.capture?.[filePath];
 
+    // capture v1
     if (targetUrl !== undefined) {
       await captureV1(filePath, targetUrl, config, command);
       return;
-    } else if (targetUrl !== undefined || captureConfig === undefined) {
+    }
+
+    // verify capture v2 config is present
+    if (targetUrl !== undefined || captureConfig === undefined) {
       logger.error(`no capture config for ${filePath} was found`);
       // TODO log error and run capture init or something - tbd what the first use is
       process.exitCode = 1;
       return;
-    } else if (!captureConfig.requests && !captureConfig.requests_command) {
+    }
+
+    // verify that capture.requests or capture.requests_command is set
+    if (!captureConfig.requests && !captureConfig.requests_command) {
       logger.error(
         `"requests" or "requests_command" must be specified in optic.yml`
       );
       process.exitCode = 1;
       return;
-    } else if (options.proxyPort && isNaN(Number(options.proxyPort))) {
+    }
+
+    // verify port number is valid
+    if (options.proxyPort && isNaN(Number(options.proxyPort))) {
       logger.error(
         `--proxy-port must be a number - received ${options.proxyPort}`
       );

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -570,7 +570,7 @@ async function startApp(
   readyInterval: number,
   readyTimeout: number,
   targetUrl: string
-): Promise<ChildProcessWithoutNullStreams | undefined> {
+): Promise<ChildProcessWithoutNullStreams> {
   const cmd = commandSplitter(command);
   const app = spawn(cmd.cmd, cmd.args, { detached: true, cwd: dir });
 

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -477,6 +477,34 @@ function sendRequests(
   });
 }
 
+async function runRequestsCommand(
+  command: string,
+  proxyVar: string,
+  proxyUrl: string
+): Promise<void> {
+  const cmd = commandSplitter(command);
+  process.env[proxyVar] = proxyUrl;
+  const reqCmd = spawn(cmd.cmd, cmd.args, {
+    detached: true,
+    shell: true,
+  });
+
+  let reqCmdPromise: Promise<void>;
+  reqCmdPromise = new Promise((resolve, reject) => {
+    reqCmd.on('exit', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject();
+      }
+    });
+  });
+  reqCmd.stderr.on('data', (data) => {
+    logger.error(data.toString());
+  });
+  return reqCmdPromise;
+}
+
 async function serverReady(
   checkUrl: string,
   interval: number,
@@ -560,30 +588,4 @@ async function startApp(
   return app;
 }
 
-async function runRequestsCommand(
-  command: string,
-  proxyVar: string,
-  proxyUrl: string
-): Promise<void> {
-  const cmd = commandSplitter(command);
-  process.env[proxyVar] = proxyUrl;
-  const reqCmd = spawn(cmd.cmd, cmd.args, {
-    detached: true,
-    shell: true,
-  });
-
-  let reqCmdPromise: Promise<void>;
-  reqCmdPromise = new Promise((resolve, reject) => {
-    reqCmd.on('exit', (code) => {
-      if (code === 0) {
-        resolve();
-      } else {
-        reject();
-      }
-    });
-  });
-  reqCmd.stderr.on('data', (data) => {
-    logger.error(data.toString());
-  });
-  return reqCmdPromise;
-}
+function makeAllRequests() {}


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

moves bits of logic from getCaptureAction() into smaller function. the intention was to avoid changing the logic much and just split it out into smaller units. whenever we deprecate and remove the original capture bits, there's an opportunity to move some of these changes into the lower-level abstractions. very allergic to breaking or otherwise trying to modifying the v1 capture flow.

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
