### PR TITLE
fix: install xdg-utils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:latest
 
 ARG OPTIC_CLI_VERSION=latest
 
-RUN apk --no-cache add git curl
+RUN apk --no-cache add git curl xdg-utils
 RUN echo "optic-docker" > /etc/machine-id
 RUN set -e; sh -c "$(curl -s --location https://install.useoptic.com/install.sh)" -- $OPTIC_CLI_VERSION /usr/local/bin
 


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

- vercel/pkg can't bundle xdg-open with the binary it produces. the CLI uses this to try and open web browsers. the absence of xdg-open entirely leads to errors when doing something that uses it,

```
➜ docker run --rm docker.io/useoptic/optic:local login
Generate a token below
Create an account and generate a personal access token at https://app.useoptic.com/user-settings/personal-access-token/new
? Enter your token here: › Error: spawn xdg-open ENOENT
    at ChildProcess._handle.onexit (node:internal/child_process:283:19)
    at onErrorNT (node:internal/child_process:476:16)
    at process.processTicksAndRejections (node:intern
```

installing xdg-utils will at least smooth out the experience somewhat,

```
➜ docker run --rm docker.io/useoptic/optic:local login
Generate a token below
Create an account and generate a personal access token at https://app.useoptic.com/user-settings/personal-access-token/new
? Enter your token here: › dfdsfd
```

this won't be useful for `diff --web`, but for a certain size of URL, it wouldn't matter anyway. `xdg-open` exits non-0 when there is no browser to open a link in, so optic would be able to look at that to determine when we couldn't launch a browser.

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
