### PR TITLE
Misc capture fixes

### DIFF
--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -468,8 +468,11 @@ async function runRequestsCommand(
   proxyUrl: string
 ): Promise<void> {
   const cmd = commandSplitter(command);
-  process.env[proxyVar] = proxyUrl;
   const reqCmd = spawn(cmd.cmd, cmd.args, {
+    env: {
+      ...process.env,
+      [proxyVar]: proxyUrl,
+    },
     detached: true,
     shell: true,
   });

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -148,8 +148,8 @@ const getCaptureAction =
     targetUrl: string | undefined,
     options: CaptureActionOptions
   ) => {
-    // TODO capturev2 - handle relative path from root (tbd - what do we do when we handle this outside of a git repo)
-    const captureConfig = config.capture?.[filePath];
+    const pathFromRoot = path.relative(config.root, path.resolve(filePath));
+    const captureConfig = config.capture?.[pathFromRoot];
 
     // capture v1
     if (targetUrl !== undefined) {

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -427,7 +427,7 @@ function getSummaryText(endpointCoverage: OperationCoverage) {
     const icon = getIcon(node);
     items.push(`${icon}${statusCode} response`);
   }
-  return items.join();
+  return items.join(', ');
 }
 
 function sendRequests(

--- a/projects/optic/src/commands/capture/interactions/undocumented.ts
+++ b/projects/optic/src/commands/capture/interactions/undocumented.ts
@@ -157,7 +157,13 @@ export async function documentNewEndpoint(
 ) {
   const interactionsAsAsyncIterator = (async function* () {
     for (const interaction of interactions) {
-      yield interaction;
+      const { path, method } = interaction.request;
+      if (
+        matchPathPattern(endpoint.path, path).match &&
+        endpoint.method === method
+      ) {
+        yield interaction;
+      }
     }
   })();
 

--- a/projects/optic/src/commands/capture/interactions/undocumented.ts
+++ b/projects/optic/src/commands/capture/interactions/undocumented.ts
@@ -19,6 +19,7 @@ import {
   generatePathAndMethodSpecPatches,
 } from '../patches/patches';
 import { SpecPatches } from '../../oas/specs';
+import chalk from 'chalk';
 
 type MethodMap = Map<string, { add: Set<string>; ignore: Set<string> }>;
 
@@ -79,12 +80,15 @@ export async function promptUserForPathPattern(
     } else {
       const guessedPattern =
         inferredPathStructure.includeObservedUrlPath(method, path) ?? path;
+      logger.info(`> ` + chalk.bold.blue(guessedPattern));
       const results = await prompts(
         [
           {
             type: 'select',
             name: 'action',
-            message: `Is ${guessedPattern} the right pattern for ${method.toUpperCase()} ${path}`,
+            message: `Is this the right pattern for ${chalk.green(
+              `${method.toUpperCase()} ${path}`
+            )}`,
             choices: [
               {
                 title: 'yes',
@@ -107,7 +111,9 @@ export async function promptUserForPathPattern(
           {
             type: (pre) => (pre === 'no' ? 'text' : null),
             name: 'newPath',
-            message: 'Provide the correct path (e.g. /api/users/{userId)',
+            message: `Provide the correct path (e.g. ${chalk.gray(
+              '/api/users/{userId}'
+            )})`,
             validate: (pattern) =>
               matchPathPattern(pattern, interaction.request.path).match
                 ? true

--- a/projects/optic/src/commands/capture/operations/infer-path-structure.ts
+++ b/projects/optic/src/commands/capture/operations/infer-path-structure.ts
@@ -89,7 +89,7 @@ export class InferPathStructure {
     };
 
     const fragments = fragmentize(urlPath);
-    let first: PathComponentCandidate | null = null;
+    let last: PathComponentCandidate | null = null;
     let parent: PathComponentCandidate | null = null;
     fragments.forEach((fragment, index) => {
       const isLast = fragments.length - 1 === index;
@@ -107,7 +107,7 @@ export class InferPathStructure {
           match.examplePath = urlPath;
         }
         parent = match;
-        if (isFirst) first = match;
+        if (isLast) last = match;
       } else if (!match) {
         const isConfidentVariable = !isFirst && looksLikeAVariable(fragment);
         const name = isConfidentVariable
@@ -125,11 +125,11 @@ export class InferPathStructure {
         };
         this.paths.push(insert);
         parent = insert;
-        if (isFirst) first = insert;
+        if (isLast) last = insert;
       }
     });
 
-    return first && reducePathPattern(first);
+    return last && reducePathPattern(last);
   };
 
   replaceConstantsWithVariables = () => {


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Couple of misc capture fixes to fix a number of bugs
- Generates the correct guessed URL path a639d15a92a026e98060017cee6625b624e40b6e
- Fixes bodies from being consumed twice (i.e. `Could not decode body of captured interaction: Could not parse captured body as json`) 3a9b42e2170da561da88c326c9d97a7de031932d
- Handle errors being thrown in `requests` and `request_command` 95fc48e8fe6dd23f3563d2371c9455e27cc0eb6c
- Updates the proxy var to only be injected into spawned instance (rather than current node process) fc22275b70c0b9299e591e085898b8e9777f618d
- Use the relative path from project root for file config [29a2487](https://github.com/opticdev/optic/pull/2103/commits/29a24879ddf08a18db1fe3ec6fcbee43d7b96bea)

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
