### PR TITLE
handle lint and diff file doesn't exist

### DIFF
--- a/projects/optic/src/commands/lint/lint.ts
+++ b/projects/optic/src/commands/lint/lint.ts
@@ -14,6 +14,7 @@ import {
   trackEvent,
 } from '@useoptic/openapi-utilities/build/utilities/segment';
 import { openUrl } from '../../utils/open-url';
+import { fileExists } from '../../utils/file';
 
 const description = `lints and validates an OpenAPI file`;
 
@@ -50,6 +51,12 @@ const getLintAction =
   (config: OpticCliConfig) =>
   async (path: string, options: LintActionOptions) => {
     logger.info(`Linting spec ${path}...`);
+    if (!(await fileExists(path))) {
+      logger.error(chalk.red.bold(`Error: Could not open ${path}`));
+      process.exitCode = 1;
+      return;
+    }
+
     let file: ParseResult;
     try {
       file = await loadSpec(path, config, {

--- a/projects/optic/src/utils/file.ts
+++ b/projects/optic/src/utils/file.ts
@@ -1,0 +1,10 @@
+import fs from 'node:fs/promises';
+
+export async function fileExists(path: string): Promise<boolean> {
+  try {
+    await fs.access(path);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

With how we've changed spec loading, we don't throw errors on empty specs (because it's valid to compare against a gitref empty) - this means we have to throw on empty spec at some other point

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
