### PR TITLE
Sentry errors for capture interactions and patching

### DIFF
--- a/projects/optic/src/commands/oas/shapes/streams/documented-bodies.ts
+++ b/projects/optic/src/commands/oas/shapes/streams/documented-bodies.ts
@@ -17,6 +17,7 @@ import {
 } from '../../operations';
 import { CapturedBody } from '../../../capture/sources/body';
 import { logger } from '../../../../logger';
+import { SentryClient } from '@useoptic/openapi-utilities/build/utilities/sentry';
 
 export type { DocumentedBody };
 
@@ -263,6 +264,7 @@ async function decodeCapturedBody(
     try {
       value = await CapturedBody.json(capturedBody);
     } catch (err) {
+      SentryClient.captureException(err);
       return Err('Could not parse captured body as json');
     }
 


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Adding sentry captures when:
- interactions fail to be decoded (i think it's because we're double decoding somehow / reusing interactions - interactions use streams and can only be decoded / used once)
- applying spec patches in memory fails

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
