### PR TITLE
feat(capture): combine requests* into requests.send and requests.run

### DIFF
--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -14,7 +14,7 @@ import {
   OperationCoverage,
   UserError,
 } from '@useoptic/openapi-utilities';
-import { CaptureConfigData, Request } from '../../config';
+import { CaptureConfigData, RequestSend } from '../../config';
 import { errorHandler } from '../../error-handler';
 
 import { createNewSpecFile } from '../../utils/specs';
@@ -166,9 +166,9 @@ const getCaptureAction =
     }
 
     // verify that capture.requests or capture.requests_command is set
-    if (!captureConfig.requests && !captureConfig.requests_command) {
+    if (!captureConfig.requests?.run && !captureConfig.requests?.send) {
       logger.error(
-        `"requests" or "requests_command" must be specified in optic.yml`
+        `"requests.send" or "requests.run" must be specified in optic.yml`
       );
       process.exitCode = 1;
       return;
@@ -206,10 +206,11 @@ const getCaptureAction =
         : captureConfig.server.dir;
     const timeout = captureConfig.server.ready_timeout || 3 * 60 * 1_000; // 3 minutes
     const readyInterval = captureConfig.server.ready_interval || 1000;
-    // start app
-    let app: ChildProcessWithoutNullStreams | undefined;
 
+    let app: ChildProcessWithoutNullStreams | undefined;
     let errors: any[] = [];
+
+    // start app
     try {
       let bailout: Bailout = { didBailout: false, promise: Promise.resolve() };
       if (!options.serverOverride && captureConfig.server.command) {
@@ -428,7 +429,7 @@ function getSummaryText(endpointCoverage: OperationCoverage) {
 }
 
 function sendRequests(
-  reqs: Request[],
+  reqs: RequestSend[],
   proxyUrl: string,
   concurrency: number
 ): Promise<void>[] {
@@ -495,9 +496,9 @@ function makeAllRequests(
 ) {
   // send requests
   let sendRequestsPromise: Promise<any> = Promise.resolve();
-  if (captureConfig.requests) {
+  if (captureConfig.requests && captureConfig.requests.send) {
     const requests = sendRequests(
-      captureConfig.requests,
+      captureConfig.requests.send,
       proxy.url,
       captureConfig.config?.request_concurrency || 5
     );
@@ -520,12 +521,11 @@ function makeAllRequests(
 
   // run requests command
   let runRequestsPromise: Promise<void> = Promise.resolve();
-  if (captureConfig.requests_command) {
-    const proxyVar =
-      captureConfig.requests_command.proxy_variable || 'OPTIC_PROXY';
+  if (captureConfig.requests && captureConfig.requests.run) {
+    const proxyVar = captureConfig.requests.run.proxy_variable || 'OPTIC_PROXY';
 
     runRequestsPromise = runRequestsCommand(
-      captureConfig.requests_command.command,
+      captureConfig.requests.run.command,
       proxyVar,
       proxy.url
     );

--- a/projects/optic/src/config.ts
+++ b/projects/optic/src/config.ts
@@ -34,7 +34,7 @@ const DefaultOpticCliConfig: OpticCliConfig = {
   isInCi: process.env.CI === 'true',
 };
 
-const Request = Type.Object({
+const RequestSend = Type.Object({
   path: Type.String(),
   method: Type.Optional(
     Type.String({
@@ -43,6 +43,13 @@ const Request = Type.Object({
   ),
   data: Type.Optional(Type.Object({})),
 });
+
+const RequestRun = Type.Optional(
+  Type.Object({
+    command: Type.String(),
+    proxy_variable: Type.Optional(Type.String()),
+  })
+);
 
 const CaptureConfigData = Type.Object({
   config: Type.Optional(
@@ -58,18 +65,19 @@ const CaptureConfigData = Type.Object({
     ready_interval: Type.Optional(Type.Number()),
     ready_timeout: Type.Optional(Type.Number()),
   }),
-  requests: Type.Optional(Type.Array(Request)),
-  requests_command: Type.Optional(
+  requests: Type.Optional(
     Type.Object({
-      command: Type.String(),
-      proxy_variable: Type.Optional(Type.String()),
+      // one of these is technically required, but that's enforced at runtime
+      run: Type.Optional(RequestRun),
+      send: Type.Optional(Type.Array(RequestSend)),
     })
   ),
 });
 
 export type CaptureConfigData = Static<typeof CaptureConfigData>;
 export type ServerConfig = CaptureConfigData['server'];
-export type Request = Static<typeof Request>;
+export type RequestSend = Static<typeof RequestSend>;
+export type RequestRun = Static<typeof RequestRun>;
 export type CaptureConfigConfig = CaptureConfigData['config'];
 
 export const ProjectYmlConfig = Type.Object({

--- a/projects/optic/src/config.ts
+++ b/projects/optic/src/config.ts
@@ -65,13 +65,11 @@ const CaptureConfigData = Type.Object({
     ready_interval: Type.Optional(Type.Number()),
     ready_timeout: Type.Optional(Type.Number()),
   }),
-  requests: Type.Optional(
-    Type.Object({
-      // one of these is technically required, but that's enforced at runtime
-      run: Type.Optional(RequestRun),
-      send: Type.Optional(Type.Array(RequestSend)),
-    })
-  ),
+  requests: Type.Object({
+    // one of these is technically required, but that's enforced at runtime
+    run: Type.Optional(RequestRun),
+    send: Type.Optional(Type.Array(RequestSend)),
+  }),
 });
 
 export type CaptureConfigData = Static<typeof CaptureConfigData>;


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

combines `requests` and `requests_command` configuration into `requests.(send|run)`. like before, you can use either or both. the config will wind up looking like this,

```
capture:
  openapi.yml:
    server:
      command: go run main.go
      url: http://localhost:8080
    requests:
      run:
        command: hurl hurl/*.hurl
        proxy_variable: HURL_OPTIC_PROXY
      send:
        - path: /
        - path: /users
        - path: /users/create
          method: POST
          data:
            name: Hank⏎  
```

if `requests` is missing entirely or an empty object,
```
➜ optic beta capture openapi.yml
"requests.send" or "requests.run" must be specified in optic.yml
```

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._
- closes https://github.com/opticdev/monorail/issues/4640

## 👹 QA
_How can other humans verify that this PR is correct?_
