### PR TITLE
Allow user to specify update mode for capture 2.0

### DIFF
--- a/projects/optic/src/commands/capture/actions/documented.ts
+++ b/projects/optic/src/commands/capture/actions/documented.ts
@@ -108,7 +108,7 @@ export async function diffExistingEndpoint(
     method: string;
   },
   options: {
-    update: boolean;
+    update?: 'documented' | 'interactive' | 'automatic';
   }
 ) {
   const patchSummaries: string[] = [];

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -56,15 +56,14 @@ export function registerCaptureCommand(cli: Command, config: OpticCliConfig) {
       '--proxy-port <proxy-port>',
       'specify the port the proxy should be running on'
     )
-    .option(
-      '-u, --update',
-      'update the OpenAPI spec to match the traffic',
-      false
-    )
-    .option(
-      '-i, --interactive',
-      'add new endpoints in interactive mode. must be run with --update',
-      false
+    .addOption(
+      new Option(
+        '-u, --update [mode]',
+        'update the OpenAPI spec to match the traffic. specify the mode to change the update behavior on how to handle undocumented endpoints (endpoints not in your spec). \
+ documented will only update documented endpoints. interactive will prompt you for new endpoint paths. automatic will guess the correct path'
+      )
+        .preset('documented')
+        .choices(['interactive', 'automatic', 'documented'])
     )
 
     // TODO deprecate hidden options below
@@ -110,8 +109,7 @@ export function registerCaptureCommand(cli: Command, config: OpticCliConfig) {
 type CaptureActionOptions = {
   proxyPort?: string;
   serverOverride?: string;
-  update: boolean;
-  interactive: boolean;
+  update?: 'documented' | 'interactive' | 'automatic';
 };
 
 class ProxyInstance {
@@ -330,7 +328,7 @@ const getCaptureAction =
     }
 
     // document new endpoints
-    if (options.update && options.interactive) {
+    if (options.update === 'interactive' || options.update === 'automatic') {
       logger.info('');
       logger.info(
         chalk.bold.gray('Learning path patterns for unmatched requests...')
@@ -341,7 +339,8 @@ const getCaptureAction =
         endpointsToAdd,
       } = await promptUserForPathPattern(
         captures.getUndocumentedInteractions(),
-        spec.jsonLike
+        spec.jsonLike,
+        { update: options.update }
       );
 
       logger.info(chalk.bold.gray('Documenting new operations:'));
@@ -372,16 +371,16 @@ const getCaptureAction =
 
     if (
       captures.unmatched.hars.length &&
-      !(options.update && options.interactive)
+      !(options.update && options.update === 'documented')
     ) {
       logger.info(
         chalk.yellow('New endpoints are only added in interactive mode.')
       );
       logger.info(
-        chalk.blue('Run with `--update --interactive` to add new endpoints')
+        chalk.blue('Run with `--update interactive` to add new endpoints')
       );
       logger.info(
-        chalk.yellow(`Hint: optic capture ${filePath} --update --interactive`)
+        chalk.yellow(`Hint: optic capture ${filePath} --update interactive`)
       );
     } else if (
       !options.update &&


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Updates update modes to support interactive, documented only and automatically guessing paths `--update [mode]`

If there's suggestions for better update mode names

```
➜   optic beta capture abe.yml --update 
documented
➜  optic capture abe.yml --update documented
documented
➜  optic --update automatic 
automatic
➜   optic beta capture abe.yml --update  interactive
interactive
```

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
