### PR TITLE
Support `postman` and `har` inputs for capture 2.0

### DIFF
--- a/projects/optic/src/commands/capture/actions/captureRequests.ts
+++ b/projects/optic/src/commands/capture/actions/captureRequests.ts
@@ -1,0 +1,305 @@
+import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
+import fetch from 'node-fetch';
+import Bottleneck from 'bottleneck';
+
+import ora from 'ora';
+import urljoin from 'url-join';
+import { UserError } from '@useoptic/openapi-utilities';
+
+import { logger } from '../../../logger';
+import { commandSplitter } from '../../../utils/capture';
+import {
+  CaptureConfigData,
+  OpticCliConfig,
+  RequestSend,
+} from '../../../config';
+import { ProxyInteractions } from '../sources/proxy';
+import { HarEntries } from '../sources/har';
+
+const wait = (time: number) =>
+  new Promise((r) => setTimeout(() => r(null), time));
+
+class ProxyInstance {
+  interactions!: ProxyInteractions;
+  url!: string;
+  targetUrl: string;
+  private abortController: AbortController;
+
+  constructor(target: string) {
+    this.abortController = new AbortController();
+    this.targetUrl = target;
+  }
+
+  public async start(port: number | undefined) {
+    [this.interactions, this.url] = await ProxyInteractions.create(
+      this.targetUrl,
+      this.abortController.signal,
+      {
+        mode: 'reverse-proxy',
+        proxyPort: port,
+      }
+    );
+  }
+
+  stop() {
+    this.abortController.abort();
+  }
+}
+
+type Bailout = { didBailout: boolean; promise: Promise<any> };
+function startApp(
+  command: string,
+  dir: string
+): [ChildProcessWithoutNullStreams, Bailout] {
+  const cmd = commandSplitter(command);
+  const app = spawn(cmd.cmd, cmd.args, { detached: true, cwd: dir });
+
+  app.stderr.on('data', (data) => {
+    logger.error(data.toString());
+  });
+
+  const bailout: Bailout = {
+    didBailout: false,
+    promise: new Promise((resolve, reject) => {
+      app!.on('exit', (code) => {
+        bailout.didBailout = true;
+        reject(`Server unexpectedly exited with error code ${code}`);
+      });
+    }),
+  };
+  return [app, bailout];
+}
+
+async function waitForServer(
+  bailout: Bailout,
+  readyEndpoint: string,
+  readyInterval: number,
+  readyTimeout: number,
+  targetUrl: string
+) {
+  // since ready_endpoint is not required always wait one interval. without ready_endpoint,
+  // ready_interval must be at least the time it takes to start the server.
+  await wait(readyInterval);
+
+  //
+  // wait for the app to be ready
+  //
+
+  const url = urljoin(targetUrl, readyEndpoint);
+  const timeout = readyTimeout || 3 * 60 * 1_000; // 3 minutes
+  const now = Date.now();
+  const spinner = ora('Waiting for server to come online...');
+  spinner.start();
+  spinner.color = 'blue';
+
+  const checkServer = (): Promise<boolean> =>
+    fetch(url)
+      .then((res) => String(res.status).startsWith('2'))
+      .catch((e) => {
+        logger.debug(e);
+        return false;
+      });
+
+  const serverReadyPromise = new Promise(async (resolve) => {
+    let done = false;
+    // We need to bail out if the server shut down, otherwise we never conclude this promise chain
+    while (!done && !bailout.didBailout) {
+      const isReady = await checkServer();
+
+      if (isReady) {
+        done = true;
+      } else if (Date.now() > now + timeout) {
+        spinner.fail('Server check timed out');
+        throw new UserError({ message: 'Server check timed out.' });
+      }
+      await wait(readyInterval);
+    }
+    if (bailout.didBailout) spinner.fail('Server unexpectedly exited');
+    else spinner.succeed('Server check passed');
+    resolve(null);
+  });
+
+  await Promise.race([serverReadyPromise, bailout.promise]);
+}
+
+function sendRequests(
+  reqs: RequestSend[],
+  proxyUrl: string,
+  concurrency: number
+): Promise<void>[] {
+  const limiter = new Bottleneck({
+    maxConcurrent: concurrency,
+    minTime: 0,
+  });
+
+  return reqs.map(async (r) => {
+    let verb = r.method || 'GET';
+    let opts = { method: verb };
+
+    if (verb === 'POST') {
+      opts['headers'] = {
+        'content-type': 'application/json;charset=UTF-8',
+      };
+      opts['body'] = JSON.stringify(r.data || '{}');
+    }
+
+    return limiter.schedule(() =>
+      fetch(`${proxyUrl}${r.path}`, opts)
+        .then((response) => response.json())
+        .catch((error) => {
+          logger.error(error);
+        })
+    );
+  });
+}
+
+async function runRequestsCommand(
+  command: string,
+  proxyVar: string,
+  proxyUrl: string
+): Promise<void> {
+  const cmd = commandSplitter(command);
+  const reqCmd = spawn(cmd.cmd, cmd.args, {
+    env: {
+      ...process.env,
+      [proxyVar]: proxyUrl,
+    },
+    detached: true,
+    shell: true,
+  });
+
+  let reqCmdPromise: Promise<void>;
+  reqCmdPromise = new Promise((resolve, reject) => {
+    reqCmd.on('exit', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject();
+      }
+    });
+  });
+  reqCmd.stderr.on('data', (data) => {
+    logger.error(data.toString());
+  });
+  return reqCmdPromise;
+}
+
+function makeAllRequests(
+  captureConfig: CaptureConfigData,
+  proxy: ProxyInstance
+) {
+  // send requests
+  let sendRequestsPromise: Promise<any> = Promise.resolve();
+  if (captureConfig.requests && captureConfig.requests.send) {
+    const requests = sendRequests(
+      captureConfig.requests.send,
+      proxy.url,
+      captureConfig.config?.request_concurrency || 5
+    );
+    sendRequestsPromise = Promise.allSettled(requests).then((results) => {
+      let hasError = false;
+      results.forEach((result, idx) => {
+        if (result.status === 'rejected') {
+          const req = captureConfig.requests![idx];
+          logger.error(
+            `Request ${req.method ?? 'GET'} ${req.path} failed with ${
+              result.reason
+            }`
+          );
+          hasError = true;
+        }
+      });
+      if (hasError) throw new Error('Some requests failed');
+    });
+  }
+
+  // run requests command
+  let runRequestsPromise: Promise<void> = Promise.resolve();
+  if (captureConfig.requests && captureConfig.requests.run) {
+    const proxyVar = captureConfig.requests.run.proxy_variable || 'OPTIC_PROXY';
+
+    runRequestsPromise = runRequestsCommand(
+      captureConfig.requests.run.command,
+      proxyVar,
+      proxy.url
+    );
+  }
+
+  return [sendRequestsPromise, runRequestsPromise];
+}
+
+export async function captureRequestsFromProxy(
+  config: OpticCliConfig,
+  captureConfig: CaptureConfigData,
+  options: { proxyPort?: string; serverOverride?: string }
+) {
+  // start proxy
+  const proxy = new ProxyInstance(
+    options.serverOverride || captureConfig.server.url
+  );
+  await proxy.start(options.proxyPort ? Number(options.proxyPort) : undefined);
+
+  const serverDir =
+    captureConfig.server.dir === undefined
+      ? config.root
+      : captureConfig.server.dir;
+  const timeout = captureConfig.server.ready_timeout || 3 * 60 * 1_000; // 3 minutes
+  const readyInterval = captureConfig.server.ready_interval || 1000;
+  // start app
+  let app: ChildProcessWithoutNullStreams | undefined;
+
+  let errors: any[] = [];
+  try {
+    let bailout: Bailout = {
+      didBailout: false,
+      promise: Promise.resolve(),
+    };
+    if (!options.serverOverride && captureConfig.server.command) {
+      [app, bailout] = startApp(captureConfig.server.command, serverDir);
+      // If we don't bail out (i.e. the server is still running), we need the promise to be passed down to the next request
+      if (captureConfig.server.ready_endpoint) {
+        await waitForServer(
+          bailout,
+          captureConfig.server.ready_endpoint,
+          readyInterval,
+          timeout,
+          proxy.targetUrl
+        );
+      }
+    }
+
+    let [sendRequestsPromise, runRequestsPromise] = makeAllRequests(
+      captureConfig,
+      proxy
+    );
+    // Here we continue even if some of the requests failed - we log out the requests errors but use the rest to query
+    const requestsPromises = Promise.allSettled([
+      sendRequestsPromise,
+      runRequestsPromise,
+    ]);
+    // Wait for either all the requests to complete (or reject), or for the app to shutdown prematurely
+    await Promise.race([bailout.promise, requestsPromises]);
+    // catch the bailout promise rejection when we shutdown the app
+    bailout.promise.catch((e) => {});
+  } catch (e) {
+    // Meaning either the requests threw an uncaught exception or the app server randomly quit
+    process.exitCode = 1;
+    // The finally block will run before we return from the fn call
+    return;
+  } finally {
+    proxy.stop();
+    if (app && app.pid && app.exitCode === null) {
+      process.kill(-app.pid);
+    }
+
+    if (errors.length > 0) {
+      logger.error('finished with errors:');
+      errors.forEach((error, index) => {
+        logger.error(`${index}:\n${error}`);
+      });
+    }
+  }
+
+  // process proxy interactions into hars
+  return HarEntries.fromProxyInteractions(proxy.interactions);
+}

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -120,38 +120,9 @@ const getCaptureAction =
     targetUrl: string | undefined,
     options: CaptureActionOptions
   ) => {
-    const pathFromRoot = path.relative(config.root, path.resolve(filePath));
-    const captureConfig = config.capture?.[pathFromRoot];
-
     // capture v1
     if (targetUrl !== undefined) {
       await captureV1(filePath, targetUrl, config, command);
-      return;
-    }
-
-    // verify capture v2 config is present
-    if (targetUrl !== undefined || captureConfig === undefined) {
-      logger.error(`no capture config for ${filePath} was found`);
-      // TODO log error and run capture init or something - tbd what the first use is
-      process.exitCode = 1;
-      return;
-    }
-
-    // verify that capture.requests or capture.requests_command is set
-    if (!captureConfig.requests?.run && !captureConfig.requests?.send) {
-      logger.error(
-        `"requests.send" or "requests.run" must be specified in optic.yml`
-      );
-      process.exitCode = 1;
-      return;
-    }
-
-    // verify port number is valid
-    if (options.proxyPort && isNaN(Number(options.proxyPort))) {
-      logger.error(
-        `--proxy-port must be a number - received ${options.proxyPort}`
-      );
-      process.exitCode = 1;
       return;
     }
 
@@ -197,6 +168,35 @@ const getCaptureAction =
         captures.addInteraction(interaction);
       }
     } else {
+      const pathFromRoot = path.relative(config.root, path.resolve(filePath));
+      const captureConfig = config.capture?.[pathFromRoot];
+
+      // verify capture v2 config is present
+      if (targetUrl !== undefined || captureConfig === undefined) {
+        logger.error(`no capture config for ${filePath} was found`);
+        // TODO log error and run capture init or something - tbd what the first use is
+        process.exitCode = 1;
+        return;
+      }
+
+      // verify that capture.requests or capture.requests_command is set
+      if (!captureConfig.requests?.run && !captureConfig.requests?.send) {
+        logger.error(
+          `"requests.send" or "requests.run" must be specified in optic.yml`
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      // verify port number is valid
+      if (options.proxyPort && isNaN(Number(options.proxyPort))) {
+        logger.error(
+          `--proxy-port must be a number - received ${options.proxyPort}`
+        );
+        process.exitCode = 1;
+        return;
+      }
+
       const harEntries = await captureRequestsFromProxy(
         config,
         captureConfig,

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -36,10 +36,9 @@ import {
   promptUserForPathPattern,
   diffExistingEndpoint,
 } from './actions';
+import { captureRequestsFromProxy } from './actions/captureRequests';
 
 const indent = (n: number) => '  '.repeat(n);
-const wait = (time: number) =>
-  new Promise((r) => setTimeout(() => r(null), time));
 
 export function registerCaptureCommand(cli: Command, config: OpticCliConfig) {
   const command = new Command('capture');
@@ -122,33 +121,6 @@ type CaptureActionOptions = {
   har?: string;
 };
 
-class ProxyInstance {
-  interactions!: ProxyInteractions;
-  url!: string;
-  targetUrl: string;
-  private abortController: AbortController;
-
-  constructor(target: string) {
-    this.abortController = new AbortController();
-    this.targetUrl = target;
-  }
-
-  public async start(port: number | undefined) {
-    [this.interactions, this.url] = await ProxyInteractions.create(
-      this.targetUrl,
-      this.abortController.signal,
-      {
-        mode: 'reverse-proxy',
-        proxyPort: port,
-      }
-    );
-  }
-
-  stop() {
-    this.abortController.abort();
-  }
-}
-
 const getCaptureAction =
   (config: OpticCliConfig, command: Command) =>
   async (
@@ -222,85 +194,25 @@ const getCaptureAction =
         return;
       }
     } else if (options.postman) {
+      // TODO
     } else {
-    }
-
-    // start proxy
-    const proxy = new ProxyInstance(
-      options.serverOverride || captureConfig.server.url
-    );
-    await proxy.start(
-      options.proxyPort ? Number(options.proxyPort) : undefined
-    );
-
-    const serverDir =
-      captureConfig.server.dir === undefined
-        ? config.root
-        : captureConfig.server.dir;
-    const timeout = captureConfig.server.ready_timeout || 3 * 60 * 1_000; // 3 minutes
-    const readyInterval = captureConfig.server.ready_interval || 1000;
-
-    let app: ChildProcessWithoutNullStreams | undefined;
-    let errors: any[] = [];
-
-    // start app
-    try {
-      let bailout: Bailout = { didBailout: false, promise: Promise.resolve() };
-      if (!options.serverOverride && captureConfig.server.command) {
-        [app, bailout] = startApp(captureConfig.server.command, serverDir);
-        // If we don't bail out (i.e. the server is still running), we need the promise to be passed down to the next request
-        if (captureConfig.server.ready_endpoint) {
-          await waitForServer(
-            bailout,
-            captureConfig.server.ready_endpoint,
-            readyInterval,
-            timeout,
-            proxy.targetUrl
-          );
-        }
-      }
-      // TODO handle error handling properly
-      let [sendRequestsPromise, runRequestsPromise] = makeAllRequests(
+      const harEntries = await captureRequestsFromProxy(
+        config,
         captureConfig,
-        proxy
+        options
       );
-      // Here we continue even if some of the requests failed - we log out the requests errors but use the rest to query
-      const requestsPromises = Promise.allSettled([
-        sendRequestsPromise,
-        runRequestsPromise,
-      ]);
-      // Wait for either all the requests to complete (or reject), or for the app to shutdown prematurely
-      await Promise.race([bailout.promise, requestsPromises]);
-      // catch the bailout promise rejection when we shutdown the app
-      bailout.promise.catch((e) => {});
-    } catch (e) {
-      // Meaning either the requests threw an uncaught exception or the app server randomly quit
-      process.exitCode = 1;
-      // The finally block will run before we return from the fn call
-      return;
-    } finally {
-      proxy.stop();
-      if (app && app.pid && app.exitCode === null) {
-        process.kill(-app.pid);
+      if (!harEntries) {
+        // Error thrown where we don't have requests
+        return;
       }
-
-      if (errors.length > 0) {
-        logger.error('finished with errors:');
-        errors.forEach((error, index) => {
-          logger.error(`${index}:\n${error}`);
-        });
+      for await (const har of harEntries) {
+        captures.addHar(har);
+        logger.debug(
+          `Captured ${har.request.method.toUpperCase()} ${har.request.url}`
+        );
       }
+      await captures.writeHarFiles();
     }
-
-    // process proxy interactions into hars
-    const harEntries = HarEntries.fromProxyInteractions(proxy.interactions);
-    for await (const har of harEntries) {
-      captures.addHar(har);
-      logger.debug(
-        `Captured ${har.request.method.toUpperCase()} ${har.request.url}`
-      );
-    }
-    await captures.writeHarFiles();
 
     // update existing endpoints
     let hasAnyEndpointDiffs = false;
@@ -454,112 +366,6 @@ function getSummaryText(endpointCoverage: OperationCoverage) {
   return items.join(', ');
 }
 
-function sendRequests(
-  reqs: RequestSend[],
-  proxyUrl: string,
-  concurrency: number
-): Promise<void>[] {
-  const limiter = new Bottleneck({
-    maxConcurrent: concurrency,
-    minTime: 0,
-  });
-
-  return reqs.map(async (r) => {
-    let verb = r.method || 'GET';
-    let opts = { method: verb };
-
-    if (verb === 'POST') {
-      opts['headers'] = {
-        'content-type': 'application/json;charset=UTF-8',
-      };
-      opts['body'] = JSON.stringify(r.data || '{}');
-    }
-
-    return limiter.schedule(() =>
-      fetch(`${proxyUrl}${r.path}`, opts)
-        .then((response) => response.json())
-        .catch((error) => {
-          logger.error(error);
-        })
-    );
-  });
-}
-
-async function runRequestsCommand(
-  command: string,
-  proxyVar: string,
-  proxyUrl: string
-): Promise<void> {
-  const cmd = commandSplitter(command);
-  const reqCmd = spawn(cmd.cmd, cmd.args, {
-    env: {
-      ...process.env,
-      [proxyVar]: proxyUrl,
-    },
-    detached: true,
-    shell: true,
-  });
-
-  let reqCmdPromise: Promise<void>;
-  reqCmdPromise = new Promise((resolve, reject) => {
-    reqCmd.on('exit', (code) => {
-      if (code === 0) {
-        resolve();
-      } else {
-        reject();
-      }
-    });
-  });
-  reqCmd.stderr.on('data', (data) => {
-    logger.error(data.toString());
-  });
-  return reqCmdPromise;
-}
-
-function makeAllRequests(
-  captureConfig: CaptureConfigData,
-  proxy: ProxyInstance
-) {
-  // send requests
-  let sendRequestsPromise: Promise<any> = Promise.resolve();
-  if (captureConfig.requests && captureConfig.requests.send) {
-    const requests = sendRequests(
-      captureConfig.requests.send,
-      proxy.url,
-      captureConfig.config?.request_concurrency || 5
-    );
-    sendRequestsPromise = Promise.allSettled(requests).then((results) => {
-      let hasError = false;
-      results.forEach((result, idx) => {
-        if (result.status === 'rejected') {
-          const req = captureConfig.requests![idx];
-          logger.error(
-            `Request ${req.method ?? 'GET'} ${req.path} failed with ${
-              result.reason
-            }`
-          );
-          hasError = true;
-        }
-      });
-      if (hasError) throw new Error('Some requests failed');
-    });
-  }
-
-  // run requests command
-  let runRequestsPromise: Promise<void> = Promise.resolve();
-  if (captureConfig.requests && captureConfig.requests.run) {
-    const proxyVar = captureConfig.requests.run.proxy_variable || 'OPTIC_PROXY';
-
-    runRequestsPromise = runRequestsCommand(
-      captureConfig.requests.run.command,
-      proxyVar,
-      proxy.url
-    );
-  }
-
-  return [sendRequestsPromise, runRequestsPromise];
-}
-
 async function setup(filePath: string): Promise<string> {
   const resolvedPath = path.resolve(filePath);
   let openApiExists = false;
@@ -577,80 +383,4 @@ async function setup(filePath: string): Promise<string> {
     }
   }
   return await getCaptureStorage(resolvedPath);
-}
-
-type Bailout = { didBailout: boolean; promise: Promise<any> };
-function startApp(
-  command: string,
-  dir: string
-): [ChildProcessWithoutNullStreams, Bailout] {
-  const cmd = commandSplitter(command);
-  const app = spawn(cmd.cmd, cmd.args, { detached: true, cwd: dir });
-
-  app.stderr.on('data', (data) => {
-    logger.error(data.toString());
-  });
-
-  const bailout: Bailout = {
-    didBailout: false,
-    promise: new Promise((resolve, reject) => {
-      app!.on('exit', (code) => {
-        bailout.didBailout = true;
-        reject(`Server unexpectedly exited with error code ${code}`);
-      });
-    }),
-  };
-  return [app, bailout];
-}
-
-async function waitForServer(
-  bailout: Bailout,
-  readyEndpoint: string,
-  readyInterval: number,
-  readyTimeout: number,
-  targetUrl: string
-) {
-  // since ready_endpoint is not required always wait one interval. without ready_endpoint,
-  // ready_interval must be at least the time it takes to start the server.
-  await wait(readyInterval);
-
-  //
-  // wait for the app to be ready
-  //
-
-  const url = urljoin(targetUrl, readyEndpoint);
-  const timeout = readyTimeout || 3 * 60 * 1_000; // 3 minutes
-  const now = Date.now();
-  const spinner = ora('Waiting for server to come online...');
-  spinner.start();
-  spinner.color = 'blue';
-
-  const checkServer = (): Promise<boolean> =>
-    fetch(url)
-      .then((res) => String(res.status).startsWith('2'))
-      .catch((e) => {
-        logger.debug(e);
-        return false;
-      });
-
-  const serverReadyPromise = new Promise(async (resolve) => {
-    let done = false;
-    // We need to bail out if the server shut down, otherwise we never conclude this promise chain
-    while (!done && !bailout.didBailout) {
-      const isReady = await checkServer();
-
-      if (isReady) {
-        done = true;
-      } else if (Date.now() > now + timeout) {
-        spinner.fail('Server check timed out');
-        throw new UserError({ message: 'Server check timed out.' });
-      }
-      await wait(readyInterval);
-    }
-    if (bailout.didBailout) spinner.fail('Server unexpectedly exited');
-    else spinner.succeed('Server check passed');
-    resolve(null);
-  });
-
-  await Promise.race([serverReadyPromise, bailout.promise]);
 }


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Updates to support `postman` and `har` inputs. I moved out the capture / server / request generation into a separate file since it's pretty big and self contained (i.e. you make requests and run a server to get interactions out)



## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
