### PR TITLE
Support uploading coverage details

### DIFF
--- a/projects/optic/src/commands/capture/actions/upload-coverage.ts
+++ b/projects/optic/src/commands/capture/actions/upload-coverage.ts
@@ -1,0 +1,38 @@
+import { sanitizeGitTag } from '@useoptic/openapi-utilities';
+import { OpticCliConfig, VCS } from '../../../config';
+import { uploadSpec, uploadSpecVerification } from '../../../utils/cloud-specs';
+import * as Git from '../../../utils/git-utils';
+import { ParseResult } from '../../../utils/spec-loaders';
+import { ApiCoverageCounter } from '../coverage/api-coverage';
+import { getSpecUrl } from '../../../utils/cloud-urls';
+
+export async function uploadCoverage(
+  spec: ParseResult,
+  coverage: ApiCoverageCounter,
+  { orgId, apiId }: { orgId: string; apiId: string },
+  config: OpticCliConfig
+) {
+  const tags: string[] = [];
+  let branchTag: string | undefined = undefined;
+  if (config.vcs?.type === VCS.Git) {
+    tags.push(`git:${config.vcs.sha}`);
+    const currentBranch = await Git.getCurrentBranchName();
+    branchTag = sanitizeGitTag(`gitbranch:${currentBranch}`);
+    tags.push(branchTag);
+  }
+  const specId = await uploadSpec(apiId, {
+    spec: spec,
+    client: config.client,
+    tags,
+    orgId,
+  });
+
+  await uploadSpecVerification(specId, {
+    client: config.client,
+    verificationData: coverage.coverage,
+  });
+
+  const specUrl = getSpecUrl(config.client.getWebBase(), orgId, apiId, specId);
+
+  return { specUrl, branchTag };
+}


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Supports the `--upload` flag which will upload coverage data to optic cloud - can only be run when no `--update` flag is set

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
