### PR TITLE
Fix config loading when not in git repo

### DIFF
--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -179,6 +179,11 @@ const getCaptureAction =
       // verify capture v2 config is present
       if (targetUrl !== undefined || captureConfig === undefined) {
         logger.error(`no capture config for ${filePath} was found`);
+        config.isDefaultConfig
+          ? logger.error('no optic.yml file was detected')
+          : logger.error(
+              `expected an capture config entry for ${pathFromRoot}`
+            );
         // TODO log error and run capture init or something - tbd what the first use is
         process.exitCode = 1;
         return;

--- a/projects/optic/src/config.ts
+++ b/projects/optic/src/config.ts
@@ -26,6 +26,7 @@ export const USER_CONFIG_PATH =
     : path.join(USER_CONFIG_DIR, 'config.json');
 
 const DefaultOpticCliConfig: OpticCliConfig = {
+  isDefaultConfig: true,
   root: process.cwd(),
   configPath: undefined,
   ruleset: undefined,
@@ -100,6 +101,8 @@ export type ProjectYmlConfig = Static<typeof ProjectYmlConfig>;
 export type ConfigRuleset = { name: string; config: unknown };
 
 export type OpticCliConfig = Omit<ProjectYmlConfig, 'ruleset'> & {
+  isDefaultConfig: boolean;
+
   ruleset?: ConfigRuleset[];
 
   // path to the loaded config, or undefined if it was the default config
@@ -290,6 +293,7 @@ export async function initializeConfig(): Promise<OpticCliConfig> {
       cliConfig = {
         ...cliConfig,
         ...(await loadCliConfig(opticYmlPath, cliConfig.client)),
+        isDefaultConfig: false,
       };
     } else {
       cliConfig.root = gitRoot;

--- a/projects/optic/src/config.ts
+++ b/projects/optic/src/config.ts
@@ -308,6 +308,17 @@ export async function initializeConfig(): Promise<OpticCliConfig> {
     } catch (e) {
       // Git command can fail in a repo with no commits, we should treat this as having no commits
     }
+  } else {
+    const opticYmlPath = await detectCliConfig(process.cwd());
+
+    if (opticYmlPath) {
+      logger.debug(`Using config found at ${opticYmlPath}`);
+      cliConfig = {
+        ...cliConfig,
+        ...(await loadCliConfig(opticYmlPath, cliConfig.client)),
+        isDefaultConfig: false,
+      };
+    }
   }
 
   logger.debug(cliConfig);


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

- Adds better debugging when we don't detect a optic yml config
- Fixes loading config when not in a git repo (we look in the cwd instead of the git root)

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
