### PR TITLE
Fix running capture without a local server

### DIFF
--- a/projects/optic/src/commands/capture/actions/captureRequests.ts
+++ b/projects/optic/src/commands/capture/actions/captureRequests.ts
@@ -252,7 +252,8 @@ export async function captureRequestsFromProxy(
   try {
     let bailout: Bailout = {
       didBailout: false,
-      promise: Promise.resolve(),
+      // If no server is started, we never need to bailout so we need a noop promise that never resolves
+      promise: new Promise(() => {}),
     };
     if (!options.serverOverride && captureConfig.server.command) {
       [app, bailout] = startApp(captureConfig.server.command, serverDir);

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -265,13 +265,20 @@ const getCaptureAction =
     }
     const endpointCounts = captures.counts();
     if (endpointCounts.total > 0 && endpointCounts.unmatched > 0) {
-      logger.info(
-        chalk.gray(
-          `...and ${endpointCounts.unmatched} other endpoint${
-            endpointCounts.unmatched === 1 ? '' : 's'
-          }`
-        )
-      );
+      const unmatchedEndpointsText = `${endpointCounts.unmatched} endpoint${
+        endpointCounts.unmatched === 1 ? '' : 's'
+      }`;
+      if (endpointCounts.matched > 0) {
+        logger.info(
+          chalk.gray(
+            `...and ${unmatchedEndpointsText} that did not receive traffic`
+          )
+        );
+      } else {
+        logger.info(
+          chalk.gray(`${unmatchedEndpointsText} did not receive traffic`)
+        );
+      }
     }
 
     // document new endpoints

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -316,7 +316,7 @@ const getCaptureAction =
     }
 
     if (options.upload) {
-      if (options.upload && options.update) {
+      if (options.update) {
         logger.error(
           'optic capture --upload cannot be run with the --update flag'
         );


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Running without a local server was bailing out early (due toi the Promise.resolve) - changed the default case of bailout to be a promsie that never resolves since we never want to bailout if we never start a server

Also updated some small text changes to be a little more clear

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
