### PR TITLE
Flip the order of inputs to the diff command

### DIFF
--- a/projects/optic/src/commands/diff/diff.ts
+++ b/projects/optic/src/commands/diff/diff.ts
@@ -53,14 +53,14 @@ type DiffActionOptions = {
 const description = `run a diff between two API specs`;
 
 const usage = () => `
-  optic diff --base <base> <file_path>
+  optic diff <file_path> --base <base>
   optic diff <file_to_compare_against> <file_path>
   optic diff <file_to_compare_against> <file_path> --check`;
 
 const helpText = `
 Example usage:
   Diff \`specs/openapi-spec.yml\` against master
-  $ optic diff --base master openapi-spec.yml
+  $ optic diff openapi-spec.yml --base master
 
   Diff \`openapi-spec-v0.yml\` against \`openapi-spec-v1.yml\`
   $ optic diff openapi-spec-v0.yml openapi-spec-v1.yml

--- a/projects/optic/src/commands/diff/diff.ts
+++ b/projects/optic/src/commands/diff/diff.ts
@@ -53,14 +53,14 @@ type DiffActionOptions = {
 const description = `run a diff between two API specs`;
 
 const usage = () => `
-  optic diff <file_path> --base <base>
-  optic diff <file_path> <file_to_compare_against>
-  optic diff <file_path> <file_to_compare_against> --check`;
+  optic diff --base <base> <file_path>
+  optic diff <file_to_compare_against> <file_path>
+  optic diff <file_to_compare_against> <file_path> --check`;
 
 const helpText = `
 Example usage:
   Diff \`specs/openapi-spec.yml\` against master
-  $ optic diff openapi-spec.yml --base master
+  $ optic diff --base master openapi-spec.yml
 
   Diff \`openapi-spec-v0.yml\` against \`openapi-spec-v1.yml\`
   $ optic diff openapi-spec-v0.yml openapi-spec-v1.yml
@@ -80,8 +80,8 @@ export const registerDiff = (cli: Command, config: OpticCliConfig) => {
     })
     .addHelpText('after', helpText)
     .description(description)
-    .argument('[file_path]', 'path to file to compare')
     .argument('[file_to_compare_against]', 'path to file to compare with')
+    .argument('[file_path]', 'path to file to compare')
     .option(
       '--base <base>',
       'the base ref to compare against. Defaults to HEAD. Also supports optic cloud tags (cloud:tag_name)',


### PR DESCRIPTION
When running the diff command, the actual order of inputs is `optic diff old_file new_file` or
`optic diff --base branch new_file`

## 🍗 Description
_What does this PR do? Anything folks should know?_
This makes an improvement the manual for `optic diff` to make it more clear.

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
I was confused by the current help manual. I don't know if others feel the same. It was not clear which one is the old version spec and the new version spec. I did not change variable names, but it may help to indicate what is the old one and what is the new one.