### PR TITLE
Update transpilation target to be node16

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.47.14",
+  "version": "0.47.15-1",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",
@@ -28,5 +28,6 @@
     "**/*.+(js|jsx|ts|tsx|json|css)": [
       "yarn prettier --write"
     ]
-  }
+  },
+  "stableVersion": "0.47.14"
 }

--- a/projects/fastify-capture/babel.config.js
+++ b/projects/fastify-capture/babel.config.js
@@ -6,4 +6,7 @@ module.exports = {
       ignore: ['**/*.test.ts', '**/*.test.tsx'],
     },
   },
+  targets: {
+    node: 16,
+  },
 };

--- a/projects/fastify-capture/package.json
+++ b/projects/fastify-capture/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/fastify-capture",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.47.14",
+  "version": "0.47.15-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -37,5 +37,6 @@
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
     "typescript": "^5.0.4"
-  }
+  },
+  "stableVersion": "0.47.14"
 }

--- a/projects/fastify-capture/tsconfig.json
+++ b/projects/fastify-capture/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2021",
     "rootDir": "src",
     "declaration": true,
     "declarationMap": true,

--- a/projects/fastify-capture/tsconfig.json
+++ b/projects/fastify-capture/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2020",
     "rootDir": "src",
     "declaration": true,
     "declarationMap": true,
@@ -14,7 +14,8 @@
     "allowJs": false,
     "allowSyntheticDefaultImports": true,
     "noFallthroughCasesInSwitch": true,
-    "moduleResolution": "node",
+    "module": "node16",
+    "moduleResolution": "node16",
     "resolveJsonModule": true,
     "noImplicitAny": false,
     "downlevelIteration": true,
@@ -24,4 +25,3 @@
   "include": ["src"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx", "./build/**/*", "examples/**"]
 }
-

--- a/projects/json-pointer-helpers/babel.config.js
+++ b/projects/json-pointer-helpers/babel.config.js
@@ -1,9 +1,5 @@
 module.exports = {
-  presets: [
-    '@babel/preset-env',
-    '@babel/preset-react',
-    '@babel/preset-typescript',
-  ],
+  presets: ['@babel/preset-env', '@babel/preset-typescript'],
   plugins: ['@babel/plugin-transform-runtime'],
   env: {
     production: {

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.47.14",
+  "version": "0.47.15-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -32,5 +32,6 @@
   "dependencies": {
     "jsonpointer": "^5.0.1",
     "minimatch": "9.0.3"
-  }
+  },
+  "stableVersion": "0.47.14"
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -18,7 +18,6 @@
     "@babel/core": "^7.17.0",
     "@babel/plugin-transform-runtime": "^7.17.0",
     "@babel/preset-env": "^7.17.0",
-    "@babel/preset-react": "^7.17.0",
     "@babel/preset-typescript": "^7.17.0",
     "@types/babel__core": "^7",
     "@types/babel__preset-env": "^7",

--- a/projects/json-pointer-helpers/tsconfig.json
+++ b/projects/json-pointer-helpers/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es5" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "target": "ES2021" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
@@ -26,7 +26,7 @@
     /* Modules */
     "module": "commonjs" /* Specify what module code is generated. */,
     "rootDir": "src" /* Specify the root folder within your source files. */,
-    // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "moduleResolution": "node16",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */

--- a/projects/openapi-io/babel.config.js
+++ b/projects/openapi-io/babel.config.js
@@ -1,9 +1,5 @@
 module.exports = {
-  presets: [
-    '@babel/preset-env',
-    '@babel/preset-react',
-    '@babel/preset-typescript',
-  ],
+  presets: ['@babel/preset-env', '@babel/preset-typescript'],
   plugins: ['@babel/plugin-transform-runtime'],
   env: {
     production: {

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.47.14",
+  "version": "0.47.15-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -57,5 +57,6 @@
     "upath": "^2.0.1",
     "yaml": "^2.2.2",
     "yaml-ast-parser": "^0.0.43"
-  }
+  },
+  "stableVersion": "0.47.14"
 }

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -18,7 +18,6 @@
     "@babel/core": "^7.17.0",
     "@babel/plugin-transform-runtime": "^7.17.0",
     "@babel/preset-env": "^7.17.0",
-    "@babel/preset-react": "^7.17.0",
     "@babel/preset-typescript": "^7.17.0",
     "@types/babel__core": "^7",
     "@types/babel__preset-env": "^7",

--- a/projects/openapi-io/tsconfig.json
+++ b/projects/openapi-io/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es5" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "target": "ES2021" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
@@ -26,7 +26,7 @@
     /* Modules */
     "module": "commonjs" /* Specify what module code is generated. */,
     "rootDir": "src" /* Specify the root folder within your source files. */,
-    // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "moduleResolution": "node16",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */

--- a/projects/openapi-utilities/babel.config.js
+++ b/projects/openapi-utilities/babel.config.js
@@ -1,9 +1,5 @@
 module.exports = {
-  presets: [
-    '@babel/preset-env',
-    '@babel/preset-react',
-    '@babel/preset-typescript',
-  ],
+  presets: ['@babel/preset-env', '@babel/preset-typescript'],
   plugins: ['@babel/plugin-transform-runtime'],
   env: {
     production: {

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -18,7 +18,6 @@
     "@babel/core": "^7.17.0",
     "@babel/plugin-transform-runtime": "^7.17.0",
     "@babel/preset-env": "^7.17.0",
-    "@babel/preset-react": "^7.17.0",
     "@babel/preset-typescript": "^7.17.0",
     "@types/analytics-node": "^3.1.10",
     "@types/babel__core": "^7",

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.47.14",
+  "version": "0.47.15-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -56,5 +56,6 @@
     "openapi-types": "^12.0.2",
     "ts-invariant": "^0.9.3",
     "yaml-ast-parser": "^0.0.43"
-  }
+  },
+  "stableVersion": "0.47.14"
 }

--- a/projects/openapi-utilities/tsconfig.json
+++ b/projects/openapi-utilities/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es5" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "target": "ES2021" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
@@ -26,7 +26,7 @@
     /* Modules */
     "module": "commonjs" /* Specify what module code is generated. */,
     "rootDir": "src" /* Specify the root folder within your source files. */,
-    // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "moduleResolution": "node16",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */

--- a/projects/optic-ci/babel.config.js
+++ b/projects/optic-ci/babel.config.js
@@ -1,9 +1,5 @@
 module.exports = {
-  presets: [
-    '@babel/preset-env',
-    '@babel/preset-react',
-    '@babel/preset-typescript',
-  ],
+  presets: ['@babel/preset-env', '@babel/preset-typescript'],
   plugins: [
     '@babel/plugin-transform-runtime',
     [

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic-ci",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.47.14",
+  "version": "0.47.15-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -63,5 +63,6 @@
     "picomatch": "^2.3.1",
     "url-join": "^4.0.1",
     "uuid": "^9.0.0"
-  }
+  },
+  "stableVersion": "0.47.14"
 }

--- a/projects/optic-ci/package.json
+++ b/projects/optic-ci/package.json
@@ -21,7 +21,6 @@
     "@babel/core": "^7.17.0",
     "@babel/plugin-transform-runtime": "^7.17.0",
     "@babel/preset-env": "^7.17.0",
-    "@babel/preset-react": "^7.17.0",
     "@babel/preset-typescript": "^7.17.0",
     "@types/babel__core": "^7",
     "@types/babel__preset-env": "^7",

--- a/projects/optic-ci/tsconfig.json
+++ b/projects/optic-ci/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2021",
     "rootDir": "src",
     "declaration": true,
     "declarationMap": true,

--- a/projects/optic-ci/tsconfig.json
+++ b/projects/optic-ci/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2020",
     "rootDir": "src",
     "declaration": true,
     "declarationMap": true,
@@ -15,7 +15,8 @@
     "allowJs": false,
     "allowSyntheticDefaultImports": true,
     "noFallthroughCasesInSwitch": true,
-    "moduleResolution": "node",
+    "module": "node16",
+    "moduleResolution": "node16",
     "resolveJsonModule": true,
     "noImplicitAny": false,
     "downlevelIteration": true,

--- a/projects/optic/babel.config.js
+++ b/projects/optic/babel.config.js
@@ -1,9 +1,5 @@
 module.exports = {
-  presets: [
-    '@babel/preset-env',
-    '@babel/preset-react',
-    '@babel/preset-typescript',
-  ],
+  presets: ['@babel/preset-env', '@babel/preset-typescript'],
   plugins: [
     '@babel/plugin-transform-runtime',
     [
@@ -17,5 +13,8 @@ module.exports = {
     production: {
       ignore: ['**/*.test.ts', '**/*.test.tsx'],
     },
+  },
+  targets: {
+    node: 16,
   },
 };

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -22,7 +22,6 @@
     "@babel/core": "^7.17.0",
     "@babel/plugin-transform-runtime": "^7.17.0",
     "@babel/preset-env": "^7.17.0",
-    "@babel/preset-react": "^7.17.0",
     "@babel/preset-typescript": "^7.17.0",
     "@types/babel__core": "^7",
     "@types/babel__preset-env": "^7",

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.47.14",
+  "version": "0.47.15-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -135,5 +135,6 @@
       "node18-win-x64"
     ],
     "outputPath": "../../dist"
-  }
+  },
+  "stableVersion": "0.47.14"
 }

--- a/projects/optic/src/commands/ruleset/upload.ts
+++ b/projects/optic/src/commands/ruleset/upload.ts
@@ -11,6 +11,7 @@ import { uploadFileToS3 } from '../../utils/s3';
 import { errorHandler } from '../../error-handler';
 import { getOrganizationFromToken } from '../../utils/organization';
 import { logger } from '../../logger';
+import { loadRuleset } from '@useoptic/rulesets-base';
 
 const expectedFileShape = `Expected ruleset file to have a default export with the shape
 {
@@ -77,10 +78,13 @@ const getUploadAction =
     }
 
     const absolutePath = path.join(process.cwd(), filePath);
-    const userRuleFile = await import(absolutePath).catch((e) => {
+    let userRuleFile: any;
+    try {
+      userRuleFile = loadRuleset(absolutePath);
+    } catch (e) {
       console.error(e);
       throw new UserError();
-    });
+    }
 
     if (!fileIsValid(userRuleFile)) {
       throw new UserError({

--- a/projects/optic/tsconfig.json
+++ b/projects/optic/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2021",
     "rootDir": "src",
     "declaration": true,
     "declarationMap": true,

--- a/projects/optic/tsconfig.json
+++ b/projects/optic/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2020",
     "rootDir": "src",
     "declaration": true,
     "declarationMap": true,
@@ -15,7 +15,8 @@
     "allowJs": false,
     "allowSyntheticDefaultImports": true,
     "noFallthroughCasesInSwitch": true,
-    "moduleResolution": "node",
+    "module": "node16",
+    "moduleResolution": "node16",
     "resolveJsonModule": true,
     "noImplicitAny": false,
     "downlevelIteration": true,

--- a/projects/rulesets-base/babel.config.js
+++ b/projects/rulesets-base/babel.config.js
@@ -1,9 +1,5 @@
 module.exports = {
-  presets: [
-    '@babel/preset-env',
-    '@babel/preset-react',
-    '@babel/preset-typescript',
-  ],
+  presets: ['@babel/preset-env', '@babel/preset-typescript'],
   plugins: ['@babel/plugin-transform-runtime'],
   env: {
     production: {

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -28,7 +28,6 @@
     "@babel/core": "^7.17.0",
     "@babel/plugin-transform-runtime": "^7.17.0",
     "@babel/preset-env": "^7.17.0",
-    "@babel/preset-react": "^7.17.0",
     "@babel/preset-typescript": "^7.17.0",
     "@types/babel__core": "^7",
     "@types/babel__preset-env": "^7",

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.47.14",
+  "version": "0.47.15-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -39,5 +39,6 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
-  }
+  },
+  "stableVersion": "0.47.14"
 }

--- a/projects/rulesets-base/src/custom-rulesets/load-ruleset.ts
+++ b/projects/rulesets-base/src/custom-rulesets/load-ruleset.ts
@@ -1,0 +1,5 @@
+// Handle ESM and CJS modules
+export function loadRuleset(path: string) {
+  const mod = require(path);
+  return mod && mod.__esModule ? mod : { default: mod };
+}

--- a/projects/rulesets-base/src/custom-rulesets/resolve-ruleset.ts
+++ b/projects/rulesets-base/src/custom-rulesets/resolve-ruleset.ts
@@ -1,6 +1,7 @@
 import Ajv, { AnySchema } from 'ajv';
 
 import { Ruleset } from '../rules/ruleset';
+import { loadRuleset } from './load-ruleset';
 
 type RulesetModule = {
   default: {
@@ -22,7 +23,7 @@ export async function resolveRuleset(
   ruleset: RulesetDef,
   rulesetPath: string
 ): Promise<Ruleset | string> {
-  const rulesetMod = (await import(rulesetPath)).default as RulesetModule;
+  const rulesetMod = loadRuleset(rulesetPath) as RulesetModule;
 
   const validate = ajv.compile(rulesetMod.default.configSchema);
   const valid = validate(ruleset.config);

--- a/projects/rulesets-base/src/custom-rulesets/resolve-ruleset.ts
+++ b/projects/rulesets-base/src/custom-rulesets/resolve-ruleset.ts
@@ -22,7 +22,7 @@ export async function resolveRuleset(
   ruleset: RulesetDef,
   rulesetPath: string
 ): Promise<Ruleset | string> {
-  const rulesetMod = (await import(rulesetPath)) as RulesetModule;
+  const rulesetMod = (await import(rulesetPath)).default as RulesetModule;
 
   const validate = ajv.compile(rulesetMod.default.configSchema);
   const valid = validate(ruleset.config);

--- a/projects/rulesets-base/src/index.ts
+++ b/projects/rulesets-base/src/index.ts
@@ -1,5 +1,6 @@
 import * as TestHelpers from './test-helpers';
 export { prepareRulesets } from './custom-rulesets/prepare-rulesets';
+export { loadRuleset } from './custom-rulesets/load-ruleset';
 
 export * from './errors';
 export * from './rules';

--- a/projects/rulesets-base/tsconfig.json
+++ b/projects/rulesets-base/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2021",
     "rootDir": "src",
     "declaration": true,
     "declarationMap": true,

--- a/projects/rulesets-base/tsconfig.json
+++ b/projects/rulesets-base/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2020",
     "rootDir": "src",
     "declaration": true,
     "declarationMap": true,
@@ -15,7 +15,8 @@
     "allowJs": false,
     "allowSyntheticDefaultImports": true,
     "noFallthroughCasesInSwitch": true,
-    "moduleResolution": "node",
+    "module": "node16",
+    "moduleResolution": "node16",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noImplicitAny": false

--- a/projects/standard-rulesets/babel.config.js
+++ b/projects/standard-rulesets/babel.config.js
@@ -1,9 +1,5 @@
 module.exports = {
-  presets: [
-    '@babel/preset-env',
-    '@babel/preset-react',
-    '@babel/preset-typescript',
-  ],
+  presets: ['@babel/preset-env', '@babel/preset-typescript'],
   plugins: ['@babel/plugin-transform-runtime'],
   env: {
     production: {

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.47.14",
+  "version": "0.47.15-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -38,5 +38,6 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
-  }
+  },
+  "stableVersion": "0.47.14"
 }

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -26,7 +26,6 @@
     "@babel/core": "^7.17.0",
     "@babel/plugin-transform-runtime": "^7.17.0",
     "@babel/preset-env": "^7.17.0",
-    "@babel/preset-react": "^7.17.0",
     "@babel/preset-typescript": "^7.17.0",
     "@types/babel__core": "^7",
     "@types/babel__preset-env": "^7",

--- a/projects/standard-rulesets/tsconfig.json
+++ b/projects/standard-rulesets/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2021",
     "rootDir": "src",
     "declaration": true,
     "declarationMap": true,

--- a/projects/standard-rulesets/tsconfig.json
+++ b/projects/standard-rulesets/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2020",
     "rootDir": "src",
     "declaration": true,
     "declarationMap": true,
@@ -15,7 +15,8 @@
     "allowJs": false,
     "allowSyntheticDefaultImports": true,
     "noFallthroughCasesInSwitch": true,
-    "moduleResolution": "node",
+    "module": "node16",
+    "moduleResolution": "node16",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noImplicitAny": false

--- a/yarn.lock
+++ b/yarn.lock
@@ -1403,55 +1403,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-react-display-name@npm:^7.22.5":
-  version: 7.22.5
-  resolution: "@babel/plugin-transform-react-display-name@npm:7.22.5"
-  dependencies:
-    "@babel/helper-plugin-utils": ^7.22.5
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: a12bfd1e4e93055efca3ace3c34722571bda59d9740dca364d225d9c6e3ca874f134694d21715c42cc63d79efd46db9665bd4a022998767f9245f1e29d5d204d
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-react-jsx-development@npm:^7.22.5":
-  version: 7.22.5
-  resolution: "@babel/plugin-transform-react-jsx-development@npm:7.22.5"
-  dependencies:
-    "@babel/plugin-transform-react-jsx": ^7.22.5
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 36bc3ff0b96bb0ef4723070a50cfdf2e72cfd903a59eba448f9fe92fea47574d6f22efd99364413719e1f3fb3c51b6c9b2990b87af088f8486a84b2a5f9e4560
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-react-jsx@npm:^7.22.5":
-  version: 7.22.5
-  resolution: "@babel/plugin-transform-react-jsx@npm:7.22.5"
-  dependencies:
-    "@babel/helper-annotate-as-pure": ^7.22.5
-    "@babel/helper-module-imports": ^7.22.5
-    "@babel/helper-plugin-utils": ^7.22.5
-    "@babel/plugin-syntax-jsx": ^7.22.5
-    "@babel/types": ^7.22.5
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: c8f93f29f32cf79683ca2b8958fd62f38155674846ef27a7d4b6fbeb8713c37257418391731b58ff8024ec37b888bed5960e615a3f552e28245d2082e7f2a2df
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-transform-react-pure-annotations@npm:^7.22.5":
-  version: 7.22.5
-  resolution: "@babel/plugin-transform-react-pure-annotations@npm:7.22.5"
-  dependencies:
-    "@babel/helper-annotate-as-pure": ^7.22.5
-    "@babel/helper-plugin-utils": ^7.22.5
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 092021c4f404e267002099ec20b3f12dd730cb90b0d83c5feed3dc00dbe43b9c42c795a18e7c6c7d7bddea20c7dd56221b146aec81b37f2e7eb5137331c61120
-  languageName: node
-  linkType: hard
-
 "@babel/plugin-transform-regenerator@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-regenerator@npm:7.22.5"
@@ -1710,22 +1661,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 8430e0e9e9d520b53e22e8c4c6a5a080a12b63af6eabe559c2310b187bd62ae113f3da82ba33e9d1d0f3230930ca702843aae9dd226dec51f7d7114dc1f51c10
-  languageName: node
-  linkType: hard
-
-"@babel/preset-react@npm:^7.17.0":
-  version: 7.22.5
-  resolution: "@babel/preset-react@npm:7.22.5"
-  dependencies:
-    "@babel/helper-plugin-utils": ^7.22.5
-    "@babel/helper-validator-option": ^7.22.5
-    "@babel/plugin-transform-react-display-name": ^7.22.5
-    "@babel/plugin-transform-react-jsx": ^7.22.5
-    "@babel/plugin-transform-react-jsx-development": ^7.22.5
-    "@babel/plugin-transform-react-pure-annotations": ^7.22.5
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: b977c7ee83e93f62d77e61929ca3d97e5291e026e2f025a1b8b7ac9186486ed56c7d5bc36f0becabe0c24e8c42a4e4f2243a3cf841384cfafc3204c5d3e6c619
   languageName: node
   linkType: hard
 
@@ -3629,7 +3564,6 @@ __metadata:
     "@babel/core": ^7.17.0
     "@babel/plugin-transform-runtime": ^7.17.0
     "@babel/preset-env": ^7.17.0
-    "@babel/preset-react": ^7.17.0
     "@babel/preset-typescript": ^7.17.0
     "@types/babel__core": ^7
     "@types/babel__preset-env": ^7
@@ -3653,7 +3587,6 @@ __metadata:
     "@babel/core": ^7.17.0
     "@babel/plugin-transform-runtime": ^7.17.0
     "@babel/preset-env": ^7.17.0
-    "@babel/preset-react": ^7.17.0
     "@babel/preset-typescript": ^7.17.0
     "@jsdevtools/ono": ^7.1.3
     "@types/babel__core": ^7
@@ -3700,7 +3633,6 @@ __metadata:
     "@babel/core": ^7.17.0
     "@babel/plugin-transform-runtime": ^7.17.0
     "@babel/preset-env": ^7.17.0
-    "@babel/preset-react": ^7.17.0
     "@babel/preset-typescript": ^7.17.0
     "@octokit/rest": ^19.0.0
     "@sentry/node": ^7.10.0
@@ -3748,7 +3680,6 @@ __metadata:
     "@babel/core": ^7.17.0
     "@babel/plugin-transform-runtime": ^7.17.0
     "@babel/preset-env": ^7.17.0
-    "@babel/preset-react": ^7.17.0
     "@babel/preset-typescript": ^7.17.0
     "@babel/runtime": ^7.20.6
     "@octokit/rest": ^19.0.0
@@ -3801,7 +3732,6 @@ __metadata:
     "@babel/core": ^7.17.0
     "@babel/plugin-transform-runtime": ^7.17.0
     "@babel/preset-env": ^7.17.0
-    "@babel/preset-react": ^7.17.0
     "@babel/preset-typescript": ^7.17.0
     "@babel/runtime": ^7.20.6
     "@httptoolkit/httpolyglot": ^2.0.1
@@ -3906,7 +3836,6 @@ __metadata:
     "@babel/core": ^7.17.0
     "@babel/plugin-transform-runtime": ^7.17.0
     "@babel/preset-env": ^7.17.0
-    "@babel/preset-react": ^7.17.0
     "@babel/preset-typescript": ^7.17.0
     "@stoplight/spectral-core": ^1.8.1
     "@stoplight/spectral-rulesets": ^1.14.1
@@ -3937,7 +3866,6 @@ __metadata:
     "@babel/core": ^7.17.0
     "@babel/plugin-transform-runtime": ^7.17.0
     "@babel/preset-env": ^7.17.0
-    "@babel/preset-react": ^7.17.0
     "@babel/preset-typescript": ^7.17.0
     "@types/babel__core": ^7
     "@types/babel__preset-env": ^7


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Updates our transpilation target to be node16+ - before this was generating ES5 which the sourcemaps that were generated are harder to debug. node16+ looks like it's ES2021+ compatible from this table https://node.green/

TODO
- [x] create prerelease and test
- [x] test ruleset imports

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
prerelease with version v0.47.15-1