### PR TITLE
handle components rules rendering

### DIFF
--- a/projects/openapi-utilities/inputs/openapi3/smallpetstore1.json
+++ b/projects/openapi-utilities/inputs/openapi3/smallpetstore1.json
@@ -1,9 +1,9 @@
 {
   "openapi": "3.0.1",
   "info": {
-    "title": "Swagger Petstore",
-    "description": "This is a sample server Petstore server.  You can find out more about     Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).      For this sample, you can use the api key `special-key` to test the authorization     filters.",
-    "version": "1.0.0"
+    "title": "Swagger Petstore 1",
+    "description": "This is a sample server Petstore server.  You can find out more about     Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).      For thiasds sample, you can use the api key `special-key` to test the authorization     filters.",
+    "version": "1.0.1"
   },
   "paths": {
     "/user": {

--- a/projects/openapi-utilities/src/compare-specs/compare-specs.ts
+++ b/projects/openapi-utilities/src/compare-specs/compare-specs.ts
@@ -36,7 +36,9 @@ export const compareSpecs = async (
   ruleRunner: RuleRunner,
   context: any
 ): Promise<CompareSpecResults> => {
-  const diffs = diff(from.jsonLike, to.jsonLike);
+  const adjustedFromSpec = from.isEmptySpec ? { paths: {} } : from.jsonLike;
+  const adjustedToSpec = to.isEmptySpec ? { paths: {} } : to.jsonLike;
+  const diffs = diff(adjustedFromSpec, adjustedToSpec);
 
   const results = await ruleRunner.runRules({
     context,

--- a/projects/openapi-utilities/src/openapi3/__tests__/__snapshots__/group-diffs.test.ts.snap
+++ b/projects/openapi-utilities/src/openapi3/__tests__/__snapshots__/group-diffs.test.ts.snap
@@ -315,6 +315,29 @@ GroupedDiffs {
     },
   },
   "specification": {
+    "diffs": [
+      {
+        "after": "/info/title",
+        "before": "/info/title",
+        "change": "changed",
+        "trail": "/info/title",
+      },
+      {
+        "after": "/info/description",
+        "before": "/info/description",
+        "change": "changed",
+        "trail": "/info/description",
+      },
+      {
+        "after": "/info/version",
+        "before": "/info/version",
+        "change": "changed",
+        "trail": "/info/version",
+      },
+    ],
+    "rules": [],
+  },
+  "unmatched": {
     "diffs": [],
     "rules": [],
   },

--- a/projects/openapi-utilities/src/openapi3/__tests__/__snapshots__/traverser.test.ts.snap
+++ b/projects/openapi-utilities/src/openapi3/__tests__/__snapshots__/traverser.test.ts.snap
@@ -259,9 +259,9 @@ exports[`interpreters for response-header get locations from json paths 1`] = `
 exports[`interpreters for specification can get raw fact details 1`] = `
 {
   "info": {
-    "description": "This is a sample server Petstore server.  You can find out more about     Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).      For this sample, you can use the api key \`special-key\` to test the authorization     filters.",
-    "title": "Swagger Petstore",
-    "version": "1.0.0",
+    "description": "This is a sample server Petstore server.  You can find out more about     Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).      For thiasds sample, you can use the api key \`special-key\` to test the authorization     filters.",
+    "title": "Swagger Petstore 1",
+    "version": "1.0.1",
   },
   "openapi": "3.0.1",
   "paths": {

--- a/projects/optic/src/__tests__/integration/__snapshots__/diff-all.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/diff-all.test.ts.snap
@@ -142,7 +142,7 @@ exports[`diff-all diff all not in the root of a repo 1`] = `
 [31mx [39m [1mChecks:[22m 0/6 passed 
 
 specification details:
-- /x-optic-url, /info/description [31mremoved[39m
+- /openapi, /info, /x-optic-url [31mremoved[39m
 
 [31mx [1mPOST[22m /filler_route[39m: [31mremoved[39m
   
@@ -219,8 +219,7 @@ specification details:
 [31mx [39m [1mChecks:[22m 0/2 passed 
 
 specification details:
-- /x-optic-url, /info/description [32madded[39m
-- /openapi, /info/version, /info/title [33mchanged[39m
+- /openapi, /info, /x-optic-url [32madded[39m
 
 [31mx [1mPOST[22m /filler_route[39m: [32madded[39m
   
@@ -256,7 +255,7 @@ exports[`diff-all diff all with glob and ignores 1`] = `
 [31mx [39m [1mChecks:[22m 0/3 passed 
 
 specification details:
-- /x-optic-url, /info/description [31mremoved[39m
+- /openapi, /info, /x-optic-url [31mremoved[39m
 
 [31mx [1mPOST[22m /filler_route[39m: [31mremoved[39m
   
@@ -283,8 +282,7 @@ specification details:
 [1mOperations: [22m1 operation added
 
 specification details:
-- /x-optic-url, /info/description [32madded[39m
-- /openapi, /info/version, /info/title [33mchanged[39m
+- /openapi, /info, /x-optic-url [32madded[39m
 
 [32m✔ [1mPOST[22m /filler_route[39m: [32madded[39m
   
@@ -324,7 +322,7 @@ exports[`diff-all diffs all files in a workspace with x-optic-url keys with --up
 [31mx [39m [1mChecks:[22m 0/6 passed 
 
 specification details:
-- /x-optic-url, /info/description [31mremoved[39m
+- /openapi, /info, /x-optic-url [31mremoved[39m
 
 [31mx [1mPOST[22m /filler_route[39m: [31mremoved[39m
   
@@ -401,8 +399,7 @@ specification details:
 [31mx [39m [1mChecks:[22m 0/2 passed 
 
 specification details:
-- /x-optic-url, /info/description [32madded[39m
-- /openapi, /info/version, /info/title [33mchanged[39m
+- /openapi, /info, /x-optic-url [32madded[39m
 
 [31mx [1mPOST[22m /filler_route[39m: [32madded[39m
   
@@ -500,6 +497,10 @@ exports[`diff-all diffs all files in a workspace with x-optic-url keys with --up
             },
           },
           "specification": {
+            "diffs": [],
+            "rules": [],
+          },
+          "unmatched": {
             "diffs": [],
             "rules": [],
           },
@@ -720,18 +721,28 @@ exports[`diff-all diffs all files in a workspace with x-optic-url keys with --up
           "specification": {
             "diffs": [
               {
+                "before": "/openapi",
+                "change": "removed",
+                "pathReconciliation": [],
+                "trail": "/openapi",
+              },
+              {
+                "before": "/info",
+                "change": "removed",
+                "pathReconciliation": [],
+                "trail": "/info",
+              },
+              {
                 "before": "/x-optic-url",
                 "change": "removed",
                 "pathReconciliation": [],
                 "trail": "/x-optic-url",
               },
-              {
-                "before": "/info/description",
-                "change": "removed",
-                "pathReconciliation": [],
-                "trail": "/info/description",
-              },
             ],
+            "rules": [],
+          },
+          "unmatched": {
+            "diffs": [],
             "rules": [],
           },
         },
@@ -950,6 +961,10 @@ exports[`diff-all diffs all files in a workspace with x-optic-url keys with --up
             "diffs": [],
             "rules": [],
           },
+          "unmatched": {
+            "diffs": [],
+            "rules": [],
+          },
         },
         "results": [
           {
@@ -1044,6 +1059,10 @@ exports[`diff-all diffs all files in a workspace with x-optic-url keys with --up
             },
           },
           "specification": {
+            "diffs": [],
+            "rules": [],
+          },
+          "unmatched": {
             "diffs": [],
             "rules": [],
           },
@@ -1152,33 +1171,24 @@ exports[`diff-all diffs all files in a workspace with x-optic-url keys with --up
             "diffs": [
               {
                 "after": "/openapi",
-                "before": "/openapi",
-                "change": "changed",
+                "change": "added",
                 "trail": "/openapi",
+              },
+              {
+                "after": "/info",
+                "change": "added",
+                "trail": "/info",
               },
               {
                 "after": "/x-optic-url",
                 "change": "added",
                 "trail": "/x-optic-url",
               },
-              {
-                "after": "/info/version",
-                "before": "/info/version",
-                "change": "changed",
-                "trail": "/info/version",
-              },
-              {
-                "after": "/info/title",
-                "before": "/info/title",
-                "change": "changed",
-                "trail": "/info/title",
-              },
-              {
-                "after": "/info/description",
-                "change": "added",
-                "trail": "/info/description",
-              },
             ],
+            "rules": [],
+          },
+          "unmatched": {
+            "diffs": [],
             "rules": [],
           },
         },
@@ -1231,7 +1241,7 @@ exports[`diff-all diffs all files in a workspace without --upload 1`] = `
 [31mx [39m [1mChecks:[22m 0/6 passed 
 
 specification details:
-- /info/description [31mremoved[39m
+- /openapi, /info [31mremoved[39m
 
 [31mx [1mPOST[22m /filler_route[39m: [31mremoved[39m
   
@@ -1273,8 +1283,7 @@ specification details:
 [1mOperations: [22m2 operations added
 
 specification details:
-- /info/description [32madded[39m
-- /openapi, /info/version, /info/title [33mchanged[39m
+- /openapi, /info [32madded[39m
 
 [32m✔ [1mPOST[22m /filler_route[39m: [32madded[39m
   

--- a/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
@@ -698,6 +698,9 @@ exports[`diff with mock server with cloud tag ref 1`] = `
 [32m✔ [39m[1mEmpty[22m [90mnull:[39m
 [1mOperations: [22m1 operation added
 
+specification details:
+- /openapi, /info [32madded[39m
+
 [32m✔ [1mGET[22m /api/users[39m: [32madded[39m
   
 
@@ -713,8 +716,7 @@ exports[`diff with mock server with web url 1`] = `
 [1mOperations: [22mNo operations changed
 
 specification details:
-- /info/description [32madded[39m
-- /openapi, /info/version, /info/title [33mchanged[39m
+- /openapi, /info [32madded[39m
 
 
 "

--- a/projects/optic/src/commands/diff/changelog-renderers/terminal-changelog.ts
+++ b/projects/optic/src/commands/diff/changelog-renderers/terminal-changelog.ts
@@ -354,11 +354,13 @@ export function* terminalChangelog(
 
   yield '';
 
-  const { endpoints, specification } = groupedDiffs;
+  const { endpoints, specification, unmatched } = groupedDiffs;
   yield* getDetailLogs(specification.diffs, {
     label: 'specification details:',
   });
   yield* getRuleLogs(specification.rules, sourcemapReaders, options);
+
+  yield* getRuleLogs(unmatched.rules, sourcemapReaders, options);
 
   for (const [, endpoint] of Object.entries(endpoints))
     yield* getEndpointLogs(


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

component rules (or other unmatched rules) could be considered a rule failure, but not show up in our terminal. This should fix cases where we fail a certain endpoint because of rules but it doesn't show up (since we don't render component diffs)

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
