### PR TITLE
Rerun interactions when refactoring a ref in patches

### DIFF
--- a/projects/optic/src/commands/capture/patches/__tests__/patches.test.ts
+++ b/projects/optic/src/commands/capture/patches/__tests__/patches.test.ts
@@ -393,11 +393,15 @@ describe('generateRefRefactorPatches', () => {
         },
       },
     };
-
+    const meta = {
+      schemaAdditionsSet: addedSchemaPaths,
+      usedExistingRef: false,
+    };
     const patches = await AT.collect(
-      generateRefRefactorPatches(specHolder, addedSchemaPaths)
+      generateRefRefactorPatches(specHolder, meta)
     );
 
+    expect(meta.usedExistingRef).toBe(false);
     expect(patches).toMatchSnapshot();
     expect(specHolder.spec).toMatchSnapshot();
   });
@@ -418,11 +422,15 @@ describe('generateRefRefactorPatches', () => {
         },
       },
     };
-
+    const meta = {
+      schemaAdditionsSet: addedSchemaPaths,
+      usedExistingRef: false,
+    };
     const patches = await AT.collect(
-      generateRefRefactorPatches(specHolder, addedSchemaPaths)
+      generateRefRefactorPatches(specHolder, meta)
     );
 
+    expect(meta.usedExistingRef).toBe(true);
     expect(patches).toMatchSnapshot();
     expect(specHolder.spec).toMatchSnapshot();
   });

--- a/projects/optic/src/commands/capture/patches/patchers/closeness/schema-inventory.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/closeness/schema-inventory.ts
@@ -51,7 +51,10 @@ export class SchemaInventory {
 
   async *refsForAdditions(
     addedPaths: Set<string>,
-    spec: OpenAPIV3.Document
+    spec: OpenAPIV3.Document,
+    meta: {
+      usedExistingRef?: boolean;
+    } = {}
   ): SpecPatches {
     if (addedPaths.size === 0) return [];
     const sorted = Array.from(addedPaths).sort();
@@ -88,6 +91,7 @@ export class SchemaInventory {
         const match = this.findClosest(addedSchema);
         // use ref
         if (match) {
+          meta.usedExistingRef = true;
           matchedRoot = true;
           const patch: SpecPatch = {
             description: `use $ref ${match.ref}`,
@@ -117,6 +121,7 @@ export class SchemaInventory {
         for await (let items of arrayItems) {
           const match = this.findClosest(jsonPointerHelpers.get(spec, items));
           if (match && match.percent > this.closeness) {
+            meta.usedExistingRef = true;
             matchedSub = true;
             const patch: SpecPatch = {
               description: `use $ref ${match.ref}`,

--- a/projects/optic/src/commands/capture/patches/patches.ts
+++ b/projects/optic/src/commands/capture/patches/patches.ts
@@ -124,7 +124,10 @@ export async function* generateRefRefactorPatches(
   specHolder: {
     spec: ParseResult['jsonLike'];
   },
-  schemaAdditionsSet: Set<string>
+  meta: {
+    schemaAdditionsSet: Set<string>;
+    usedExistingRef: boolean;
+  }
 ) {
   const schemaInventory = new SchemaInventory();
   schemaInventory.addSchemas(
@@ -133,8 +136,9 @@ export async function* generateRefRefactorPatches(
   );
 
   const refRefactors = schemaInventory.refsForAdditions(
-    schemaAdditionsSet,
-    specHolder.spec
+    meta.schemaAdditionsSet,
+    specHolder.spec,
+    meta
   );
 
   for await (let patch of refRefactors) {


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

When we patch and use an existing ref, we need to rerun the interactions since we the ref refactor code just uses the ref, and doesn't merge the schemas. This is how it is currently implemented in capture 1.0 (i.e. runs the patch -> checks for refactors -> reruns the patch again)

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
