### PR TITLE
Set spectral rule result spec to after

### DIFF
--- a/projects/rulesets-base/src/__tests__/__snapshots__/spectral-rule.test.ts.snap
+++ b/projects/rulesets-base/src/__tests__/__snapshots__/spectral-rule.test.ts.snap
@@ -8,7 +8,7 @@ exports[`spectral rule test runs spectral rules on added 1`] = `
     "exempted": false,
     "location": {
       "jsonPath": "/paths/~1api/get",
-      "spec": "before",
+      "spec": "after",
     },
     "name": "Spectral added rule",
     "passed": false,
@@ -22,7 +22,7 @@ exports[`spectral rule test runs spectral rules on added 1`] = `
     "exempted": false,
     "location": {
       "jsonPath": "/paths/~1api/get",
-      "spec": "before",
+      "spec": "after",
     },
     "name": "Spectral added rule",
     "passed": false,
@@ -36,7 +36,7 @@ exports[`spectral rule test runs spectral rules on added 1`] = `
     "exempted": false,
     "location": {
       "jsonPath": "/paths/~1api/get",
-      "spec": "before",
+      "spec": "after",
     },
     "name": "Spectral added rule",
     "passed": false,
@@ -50,7 +50,7 @@ exports[`spectral rule test runs spectral rules on added 1`] = `
     "exempted": false,
     "location": {
       "jsonPath": "/paths/~1api/get",
-      "spec": "before",
+      "spec": "after",
     },
     "name": "Spectral added rule",
     "passed": false,

--- a/projects/rulesets-base/src/extended-rules/spectral-rule.ts
+++ b/projects/rulesets-base/src/extended-rules/spectral-rule.ts
@@ -93,7 +93,7 @@ function toOpticRuleResult(
     where: `${lifecycle} `,
     location: {
       jsonPath,
-      spec: 'before',
+      spec: 'after',
     },
     name: `Spectral ${lifecycle} rule`,
     type: lifecycle === 'always' ? 'requirement' : lifecycle,


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

I think this will actually fix https://github.com/opticdev/optic/issues/2135

What's happening is that:
- we run spectral rules and we specify that the rule failure is from the before spec - which is incorrect as it should be from the after spec
- when we try to group this rule into the relevant node, it cannot be associated with the right tree and fails to find where it should go
- because of this, it doesn't render

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
