### PR TITLE
Prepare capture release

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.47.16",
+  "version": "0.47.17-0",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",
@@ -27,5 +27,6 @@
     "**/*.+(js|jsx|ts|tsx|json|css)": [
       "yarn prettier --write"
     ]
-  }
+  },
+  "stableVersion": "0.47.16"
 }

--- a/projects/fastify-capture/package.json
+++ b/projects/fastify-capture/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/fastify-capture",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.47.16",
+  "version": "0.47.17-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -37,5 +37,6 @@
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
     "typescript": "^5.0.4"
-  }
+  },
+  "stableVersion": "0.47.16"
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.47.16",
+  "version": "0.47.17-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -32,5 +32,6 @@
   "dependencies": {
     "jsonpointer": "^5.0.1",
     "minimatch": "9.0.3"
-  }
+  },
+  "stableVersion": "0.47.16"
 }

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.47.16",
+  "version": "0.47.17-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -57,5 +57,6 @@
     "upath": "^2.0.1",
     "yaml": "^2.2.2",
     "yaml-ast-parser": "^0.0.43"
-  }
+  },
+  "stableVersion": "0.47.16"
 }

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.47.16",
+  "version": "0.47.17-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -52,5 +52,6 @@
     "openapi-types": "^12.0.2",
     "ts-invariant": "^0.9.3",
     "yaml-ast-parser": "^0.0.43"
-  }
+  },
+  "stableVersion": "0.47.16"
 }

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.47.16",
+  "version": "0.47.17-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -137,5 +137,6 @@
       "node18-win-x64"
     ],
     "outputPath": "../../dist"
-  }
+  },
+  "stableVersion": "0.47.16"
 }

--- a/projects/optic/src/__tests__/integration/__snapshots__/update.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/update.test.ts.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`update update an existing spec with prefixed server 1`] = `
-"[94m» [39mDocumenting new operations...
+"[33m[1moptic update is deprecated. Start using the new capture flow by running optic capture openapi.yml --update (read the docs <TODO>)[22m[39m
+[94m» [39mDocumenting new operations...
   [32madded[39m  post /books
   [32madded[39m  get /books
   [32madded[39m  post /authors
@@ -351,7 +352,8 @@ exports[`update update an existing spec with prefixed server 2`] = `
 `;
 
 exports[`update updates an empty spec 1`] = `
-"[94m» [39mDocumenting new operations...
+"[33m[1moptic update is deprecated. Start using the new capture flow by running optic capture openapi.yml --update (read the docs <TODO>)[22m[39m
+[94m» [39mDocumenting new operations...
   [32madded[39m  post /books
   [32madded[39m  get /books
   [32madded[39m  post /authors
@@ -695,7 +697,8 @@ exports[`update updates an empty spec 2`] = `
 `;
 
 exports[`update updates an existing spec 1`] = `
-"[94m» [39mDocumenting new operations...
+"[33m[1moptic update is deprecated. Start using the new capture flow by running optic capture openapi.yml --update (read the docs <TODO>)[22m[39m
+[94m» [39mDocumenting new operations...
   [32madded[39m  post /books
   [32madded[39m  get /books
   [32madded[39m  post /authors

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -127,6 +127,11 @@ const getCaptureAction =
   ) => {
     // capture v1
     if (targetUrl !== undefined) {
+      logger.warn(
+        chalk.yellow.bold(
+          `optic capture <filepath> <url> is deprecated. Start using the new capture flow by running optic capture ${filePath} (read the docs <TODO>)`
+        )
+      );
       await captureV1(filePath, targetUrl, config, command);
       return;
     }

--- a/projects/optic/src/commands/oas/capture.ts
+++ b/projects/optic/src/commands/oas/capture.ts
@@ -289,6 +289,11 @@ export async function captureCommand(config: OpticCliConfig): Promise<Command> {
     )
     .option('-o, --output <output>', 'file name for output')
     .action(async (filePath: string, targetUrl: string) => {
+      logger.warn(
+        chalk.yellow.bold(
+          'optic oas capture is deprecated. Use optic capture instead'
+        )
+      );
       await captureV1(filePath, targetUrl, config, command);
     });
 

--- a/projects/optic/src/commands/oas/new.ts
+++ b/projects/optic/src/commands/oas/new.ts
@@ -6,6 +6,7 @@ import { trackEvent, flushEvents } from '../../segment';
 import { createCommandFeedback, InputErrors } from './reporters/feedback';
 import { logger } from '../../logger';
 import { createNewSpecFile } from '../../utils/specs';
+import chalk from 'chalk';
 
 const defaultOpenAPIVersion = '3.1.0';
 
@@ -26,6 +27,11 @@ export async function newCommand(): Promise<Command> {
       defaultOpenAPIVersion
     )
     .action(async (filePath: string) => {
+      logger.warn(
+        chalk.yellow.bold(
+          'optic new is deprecated. You can now run `optic capture <file_name>.yml` which will create a new file for you if it doesnt exist'
+        )
+      );
       if (await fs.pathExists(filePath)) {
         return await feedback.inputError(
           `File  already exists at ${filePath}`,

--- a/projects/optic/src/commands/oas/update.ts
+++ b/projects/optic/src/commands/oas/update.ts
@@ -15,6 +15,7 @@ import { getInteractions } from './captures';
 import { getApiFromOpticUrl } from '../../utils/cloud-urls';
 import { OPTIC_URL_KEY } from '../../constants';
 import { patchOperationsAsNeeded } from './diffing/patch';
+import { logger } from '../../logger';
 
 type UpdateOptions = {
   all?: string;
@@ -38,6 +39,11 @@ export function updateCommand(): Command {
       []
     )
     .action(async (specPath, operations) => {
+      logger.warn(
+        chalk.yellow.bold(
+          `optic update is deprecated. Start using the new capture flow by running optic capture ${specPath} --update (read the docs <TODO>)`
+        )
+      );
       const analytics: { event: string; properties: any }[] = [];
       const options: UpdateOptions = command.opts();
 

--- a/projects/optic/src/commands/oas/verify.ts
+++ b/projects/optic/src/commands/oas/verify.ts
@@ -23,6 +23,7 @@ import * as Git from '../../utils/git-utils';
 import { sanitizeGitTag } from '@useoptic/openapi-utilities';
 import { nextCommand } from './reporters/next-command';
 import { getInteractions } from './captures';
+import { logger } from '../../logger';
 
 type VerifyOptions = {
   exit0?: boolean;
@@ -56,6 +57,11 @@ export function verifyCommand(config: OpticCliConfig): Command {
     )
     .action(async (specPath) => {
       const options = command.opts();
+      logger.warn(
+        chalk.yellow.bold(
+          `optic update is deprecated. Start using the new capture flow by running optic capture ${specPath} (read the docs <TODO>)`
+        )
+      );
 
       return await runVerify(
         specPath,

--- a/projects/optic/src/init.ts
+++ b/projects/optic/src/init.ts
@@ -120,7 +120,7 @@ export const initCli = async (
   registerDiff(cli, cliConfig);
 
   const betaSubcommands = cli.command('beta', { hidden: true });
-  registerCaptureCommand(betaSubcommands, cliConfig);
+  registerCaptureCommand(cli, cliConfig);
 
   //@todo by 2023/5/10
   const oas = new Command('oas').description(
@@ -135,7 +135,6 @@ export const initCli = async (
   cli.addCommand(oas);
 
   // commands for tracking changes with openapi
-  cli.addCommand(await captureV1Command(cliConfig));
   cli.addCommand(await newCommand());
   cli.addCommand(await setupTlsCommand());
   cli.addCommand(verifyCommand(cliConfig));

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.47.16",
+  "version": "0.47.17-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -39,5 +39,6 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
-  }
+  },
+  "stableVersion": "0.47.16"
 }

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.47.16",
+  "version": "0.47.17-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -38,5 +38,6 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
-  }
+  },
+  "stableVersion": "0.47.16"
 }


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Moves capture command out of `optic beta capture` -> `optic capture` and deprecates the old commands

Any old capture command called with `optic capture <file> <url>` will call the old capture methods

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
