### PR TITLE
Fix property rules not validing example property correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.48.1",
+  "version": "0.48.2",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/fastify-capture/package.json
+++ b/projects/fastify-capture/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/fastify-capture",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.48.1",
+  "version": "0.48.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.48.1",
+  "version": "0.48.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.48.1",
+  "version": "0.48.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.48.1",
+  "version": "0.48.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.48.1",
+  "version": "0.48.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.48.1",
+  "version": "0.48.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.48.1",
+  "version": "0.48.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/src/examples/__tests__/__snapshots__/examples-are-valid-rules.test.ts.snap
+++ b/projects/standard-rulesets/src/examples/__tests__/__snapshots__/examples-are-valid-rules.test.ts.snap
@@ -904,6 +904,206 @@ exports[`examples ruleset invalid response top level example errors 1`] = `
 ]
 `;
 
+exports[`examples ruleset passing property example 1`] = `
+[
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "correctObj",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "correctObj",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200/content/application~1json/schema/properties/correctObj",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "example": {
+            "name": "hello",
+          },
+          "type": "object",
+        },
+        "key": "correctObj",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require property examples match schemas",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /api/users response 200 response body: application/json property correctObj",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "correctObj",
+            "name",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "correctObj",
+          "name",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200/content/application~1json/schema/properties/correctObj/properties/name",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "string",
+        },
+        "key": "name",
+        "required": true,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require property examples match schemas",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /api/users response 200 response body: application/json property correctObj/name",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "correctStr",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "correctStr",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200/content/application~1json/schema/properties/correctStr",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "example": "abcdefg",
+          "type": "string",
+        },
+        "key": "correctStr",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require property examples match schemas",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /api/users response 200 response body: application/json property correctStr",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "statusCode": "200",
+          },
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200",
+        "kind": "response",
+      },
+      "value": {
+        "description": "ok",
+        "statusCode": "200",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response body examples must match schemas",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /api/users response 200",
+  },
+]
+`;
+
 exports[`examples should default to additional properties false ajv config will be strict on additional properties 1`] = `
 {
   "error": "  - example  must NOT have additional property 'c'",

--- a/projects/standard-rulesets/src/examples/__tests__/examples-are-required.test.ts
+++ b/projects/standard-rulesets/src/examples/__tests__/examples-are-required.test.ts
@@ -3,17 +3,6 @@ import { OpenAPIV3 } from '@useoptic/openapi-utilities';
 import { TestHelpers } from '@useoptic/rulesets-base';
 import { ExamplesRuleset } from '../index';
 
-describe('fromOpticConfig', () => {
-  test('invalid configuration', async () => {
-    const out = await ExamplesRuleset.fromOpticConfig({
-      require_parameter_examples: 123,
-    });
-    expect(out).toEqual(
-      '- ruleset/examples/require_parameter_examples must be boolean'
-    );
-  });
-});
-
 const requireAll = new ExamplesRuleset({
   require_parameter_examples: true,
   require_request_examples: true,

--- a/projects/standard-rulesets/src/examples/__tests__/examples-are-valid-rules.test.ts
+++ b/projects/standard-rulesets/src/examples/__tests__/examples-are-valid-rules.test.ts
@@ -5,27 +5,57 @@ import { ExamplesRuleset } from '../index';
 import { defaultAjv, validateSchema } from '../requireValidExamples';
 
 const ajvInstance = defaultAjv();
-describe('fromOpticConfig', () => {
-  test('invalid configuration', async () => {
-    const out = await ExamplesRuleset.fromOpticConfig({
-      require_parameter_examples: 123,
-    });
-    expect(out).toEqual(
-      '- ruleset/examples/require_parameter_examples must be boolean'
-    );
-  });
-
-  test('valid config', async () => {
-    const ruleset = await ExamplesRuleset.fromOpticConfig({
-      require_parameter_examples: true,
-      exclude_operations_with_extension: 'x-legacy',
-      docs_link: 'asdasd.com',
-    });
-    expect(ruleset).toBeInstanceOf(ExamplesRuleset);
-  });
-});
 
 describe('examples ruleset', () => {
+  test('passing property example', async () => {
+    const input: OpenAPIV3.Document = {
+      ...TestHelpers.createEmptySpec(),
+      paths: {
+        '/api/users': {
+          get: {
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        correctObj: {
+                          type: 'object',
+                          properties: {
+                            name: { type: 'string' },
+                          },
+                          required: ['name'],
+                          example: {
+                            name: 'hello',
+                          },
+                        },
+                        correctStr: {
+                          type: 'string',
+                          example: 'abcdefg',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const results = await TestHelpers.runRulesWithInputs(
+      [new ExamplesRuleset({})],
+      input,
+      input
+    );
+    expect(results.length > 0).toBe(true);
+
+    expect(results).toMatchSnapshot();
+    expect(results.every((result) => result.passed)).toBe(true);
+  });
+
   test('invalid property example errors', async () => {
     const input: OpenAPIV3.Document = {
       ...TestHelpers.createEmptySpec(),

--- a/projects/standard-rulesets/src/examples/example-ruleset.test.ts
+++ b/projects/standard-rulesets/src/examples/example-ruleset.test.ts
@@ -1,0 +1,22 @@
+import { test, expect, describe } from '@jest/globals';
+import { ExamplesRuleset } from '../index';
+
+describe('fromOpticConfig', () => {
+  test('invalid configuration', async () => {
+    const out = await ExamplesRuleset.fromOpticConfig({
+      require_parameter_examples: 123,
+    });
+    expect(out).toEqual(
+      '- ruleset/examples/require_parameter_examples must be boolean'
+    );
+  });
+
+  test('valid config', async () => {
+    const ruleset = await ExamplesRuleset.fromOpticConfig({
+      require_parameter_examples: true,
+      exclude_operations_with_extension: 'x-legacy',
+      docs_link: 'asdasd.com',
+    });
+    expect(ruleset).toBeInstanceOf(ExamplesRuleset);
+  });
+});

--- a/projects/standard-rulesets/src/examples/requireValidExamples.ts
+++ b/projects/standard-rulesets/src/examples/requireValidExamples.ts
@@ -304,10 +304,9 @@ export const requirePropertyExamplesMatchSchema = (ajv: Ajv) =>
     name: 'require property examples match schemas',
     rule: (property) => {
       property.requirement((property) => {
-        const flatSchema = property.value.flatSchema;
         if (property.raw.example) {
           const result = validateSchema(
-            flatSchema as SchemaObject,
+            property.raw,
             property.raw.example,
             ajv
           );


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

https://github.com/opticdev/optic/issues/2160 - fixes one part of this issue

This false positive rule is triggered because it runs on a property example and does not pass in the correct schema. Take this example:

```yml
schema:
  type: object
  example:
    name: hello
  properties:
    name:
      type: object
  required:
    - name
```

By passing in `flatSchema` we pass in the schema without `properties` (https://github.com/opticdev/optic/pull/2163/files#diff-5c3b77acb2fedce62da220a46539859a0bbc24c836b4c127db750af2349d4141R309)  since that's how our facts are laid out - we instead need to pass in the entire raw object. This PR fixes that



## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
