### PR TITLE
chore(capture): shorten server ready timeout from 3m to 10s

### DIFF
--- a/projects/optic/src/commands/capture/actions/captureRequests.ts
+++ b/projects/optic/src/commands/capture/actions/captureRequests.ts
@@ -16,6 +16,8 @@ import {
 import { ProxyInteractions } from '../sources/proxy';
 import { HarEntries } from '../sources/har';
 
+const defaultServerReadyTimeout = 10_000; // 10s
+
 const wait = (time: number) =>
   new Promise((r) => setTimeout(() => r(null), time));
 
@@ -91,7 +93,7 @@ async function waitForServer(
   //
 
   const url = urljoin(targetUrl, readyEndpoint);
-  const timeout = readyTimeout || 3 * 60 * 1_000; // 3 minutes
+  const timeout = readyTimeout || defaultServerReadyTimeout;
   const now = Date.now();
 
   const checkServer = (): Promise<boolean> =>
@@ -243,7 +245,8 @@ export async function captureRequestsFromProxy(
     captureConfig.server.dir === undefined
       ? config.root
       : captureConfig.server.dir;
-  const timeout = captureConfig.server.ready_timeout || 3 * 60 * 1_000; // 3 minutes
+  const timeout =
+    captureConfig.server.ready_timeout || defaultServerReadyTimeout;
   const readyInterval = captureConfig.server.ready_interval || 1000;
   // start app
   let app: ChildProcessWithoutNullStreams | undefined;

--- a/projects/optic/src/commands/capture/init.ts
+++ b/projects/optic/src/commands/capture/init.ts
@@ -42,7 +42,7 @@ export function captureConfigExample(oasFile: string) {
           ready_endpoint: /
           # The interval to check 'ready_endpoint', in ms.
           # Optional: default: 1000
-          ready_interval: 100
+          ready_interval: 1000
           # The length of time in ms to wait for a successful ready check to occur.
           # Optional: default: 10_000, 10 seconds
           ready_timeout: 10_000

--- a/projects/optic/src/commands/capture/init.ts
+++ b/projects/optic/src/commands/capture/init.ts
@@ -44,8 +44,8 @@ export function captureConfigExample(oasFile: string) {
           # Optional: default: 1000
           ready_interval: 100
           # The length of time in ms to wait for a successful ready check to occur.
-          # Optional: default: 60_000, 1 minute
-          ready_timeout: 60_000
+          # Optional: default: 10_000, 10 seconds
+          ready_timeout: 10_000
         # At least one of 'requests.run' or 'requests.send' is required below.
         requests:
           # Run a command to generate traffic. Requests should be sent to the Optic proxy, the address of which is injected


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

hilariously, this was even longer than we had documented and we thought 1m was excessive. drops the default server ready timeout to 10s.

todo:
- [x] update capture init docs
- [x] update website docs (https://github.com/opticdev/useoptic.com/pull/86)

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._
- closes https://github.com/opticdev/monorail/issues/4723

## 👹 QA
_How can other humans verify that this PR is correct?_
