### PR TITLE
feat(capture): add headers to requests.send

### DIFF
--- a/projects/optic/src/commands/capture/actions/captureRequests.ts
+++ b/projects/optic/src/commands/capture/actions/captureRequests.ts
@@ -143,7 +143,24 @@ function sendRequests(
 
     r.data ? (opts['body'] = JSON.stringify(r.data)) : '{}';
 
-    if (r.headers) opts['headers'] = r.headers;
+    // add headers to the request
+    if (r.headers) {
+      // convert all map keys to lowercase for ease of use
+      const headers = Object.keys(r.headers).reduce(
+        (acc, key) => {
+          acc[key.toLowerCase()] = r.headers![key];
+          return acc;
+        },
+        {} as { [key: string]: string }
+      );
+
+      opts['headers'] = headers;
+    }
+
+    // if a content-type header is not set, add it
+    if (opts['headers'] && !opts['headers'].hasOwnProperty('content-type')) {
+      opts['headers']['content-type'] = 'application/json;charset=utf-8';
+    }
 
     return limiter.schedule(() =>
       fetch(`${proxyUrl}${r.path}`, opts)

--- a/projects/optic/src/commands/capture/actions/captureRequests.ts
+++ b/projects/optic/src/commands/capture/actions/captureRequests.ts
@@ -158,7 +158,7 @@ function sendRequests(
     }
 
     // if a content-type header is not set, add it
-    if (opts['headers'] && !opts['headers'].hasOwnProperty('content-type')) {
+    if (!opts['headers'].hasOwnProperty('content-type')) {
       opts['headers']['content-type'] = 'application/json;charset=UTF-8';
     }
 

--- a/projects/optic/src/commands/capture/actions/captureRequests.ts
+++ b/projects/optic/src/commands/capture/actions/captureRequests.ts
@@ -159,7 +159,7 @@ function sendRequests(
 
     // if a content-type header is not set, add it
     if (opts['headers'] && !opts['headers'].hasOwnProperty('content-type')) {
-      opts['headers']['content-type'] = 'application/json;charset=utf-8';
+      opts['headers']['content-type'] = 'application/json;charset=UTF-8';
     }
 
     return limiter.schedule(() =>

--- a/projects/optic/src/commands/capture/actions/captureRequests.ts
+++ b/projects/optic/src/commands/capture/actions/captureRequests.ts
@@ -139,11 +139,16 @@ function sendRequests(
     let verb = r.method || 'GET';
     let opts = { method: verb };
 
-    if (verb === 'POST') {
-      opts['headers'] = {
-        'content-type': 'application/json;charset=UTF-8',
-      };
-      opts['body'] = JSON.stringify(r.data || '{}');
+    r.data ? (opts['body'] = JSON.stringify(r.data)) : '{}';
+
+    if (r.headers && r.headers.length > 0) {
+      let headers = {};
+      r.headers.forEach((header) => {
+        for (const key in header) {
+          headers[key] = header[key];
+        }
+      });
+      opts['headers'] = headers;
     }
 
     return limiter.schedule(() =>

--- a/projects/optic/src/commands/capture/actions/captureRequests.ts
+++ b/projects/optic/src/commands/capture/actions/captureRequests.ts
@@ -146,26 +146,22 @@ function sendRequests(
 
     if (r.data) opts['body'] = JSON.stringify(r.data);
 
-    try {
-      if (r.headers) {
-        // convert all header keys to lowercase for easier content-type checking below
-        const headers = Object.keys(r.headers).reduce(
-          (acc, key) => {
-            acc[key.toLowerCase()] = r.headers![key];
-            return acc;
-          },
-          {} as { [key: string]: string }
-        );
+    if (r.headers) {
+      // convert all header keys to lowercase for easier content-type checking below
+      const headers = Object.keys(r.headers).reduce(
+        (acc, key) => {
+          acc[key.toLowerCase()] = r.headers![key];
+          return acc;
+        },
+        {} as { [key: string]: string }
+      );
 
-        opts['headers'] = headers;
-      }
+      opts['headers'] = headers;
+    }
 
-      // if a content-type header is not set, add it
-      if (!opts['headers'].hasOwnProperty('content-type')) {
-        opts['headers']['content-type'] = 'application/json;charset=UTF-8';
-      }
-    } catch (error) {
-      logger.error(error);
+    // if a content-type header is not set, add it
+    if (!opts['headers'].hasOwnProperty('content-type')) {
+      opts['headers']['content-type'] = 'application/json;charset=UTF-8';
     }
 
     return limiter.schedule(() =>
@@ -312,7 +308,7 @@ export async function captureRequestsFromProxy(
       proxy
     );
     // Here we continue even if some of the requests failed - we log out the requests errors but use the rest to query
-    const requestsPromises = Promise.allSettled([
+    const requestsPromises = Promise.all([
       sendRequestsPromise,
       runRequestsPromise,
     ]);
@@ -321,6 +317,9 @@ export async function captureRequestsFromProxy(
     // catch the bailout promise rejection when we shutdown the app
     bailout.promise.catch((e) => {});
   } catch (e) {
+    spinner.fail('Some requests failed to send');
+    logger.error(e);
+
     // Meaning either the requests threw an uncaught exception or the app server randomly quit
     process.exitCode = 1;
     // The finally block will run before we return from the fn call

--- a/projects/optic/src/commands/capture/actions/captureRequests.ts
+++ b/projects/optic/src/commands/capture/actions/captureRequests.ts
@@ -139,27 +139,34 @@ function sendRequests(
   });
   return reqs.map(async (r) => {
     let verb = r.method || 'GET';
-    let opts = { method: verb };
+    let opts = {
+      method: verb,
+      headers: {},
+    };
 
-    r.data ? (opts['body'] = JSON.stringify(r.data)) : '{}';
+    if (r.data) opts['body'] = JSON.stringify(r.data);
 
-    // add headers to the request
-    if (r.headers) {
-      // convert all map keys to lowercase for ease of use
-      const headers = Object.keys(r.headers).reduce(
-        (acc, key) => {
-          acc[key.toLowerCase()] = r.headers![key];
-          return acc;
-        },
-        {} as { [key: string]: string }
-      );
+    try {
+      // add headers to the request
+      if (r.headers) {
+        // convert all map keys to lowercase for ease of use
+        const headers = Object.keys(r.headers).reduce(
+          (acc, key) => {
+            acc[key.toLowerCase()] = r.headers![key];
+            return acc;
+          },
+          {} as { [key: string]: string }
+        );
 
-      opts['headers'] = headers;
-    }
+        opts['headers'] = headers;
+      }
 
-    // if a content-type header is not set, add it
-    if (!opts['headers'].hasOwnProperty('content-type')) {
-      opts['headers']['content-type'] = 'application/json;charset=UTF-8';
+      // if a content-type header is not set, add it
+      if (!opts['headers'].hasOwnProperty('content-type')) {
+        opts['headers']['content-type'] = 'application/json;charset=UTF-8';
+      }
+    } catch (error) {
+      logger.error(error);
     }
 
     return limiter.schedule(() =>

--- a/projects/optic/src/commands/capture/actions/captureRequests.ts
+++ b/projects/optic/src/commands/capture/actions/captureRequests.ts
@@ -141,15 +141,7 @@ function sendRequests(
 
     r.data ? (opts['body'] = JSON.stringify(r.data)) : '{}';
 
-    if (r.headers && r.headers.length > 0) {
-      let headers = {};
-      r.headers.forEach((header) => {
-        for (const key in header) {
-          headers[key] = header[key];
-        }
-      });
-      opts['headers'] = headers;
-    }
+    if (r.headers) opts['headers'] = r.headers;
 
     return limiter.schedule(() =>
       fetch(`${proxyUrl}${r.path}`, opts)

--- a/projects/optic/src/commands/capture/actions/captureRequests.ts
+++ b/projects/optic/src/commands/capture/actions/captureRequests.ts
@@ -147,9 +147,8 @@ function sendRequests(
     if (r.data) opts['body'] = JSON.stringify(r.data);
 
     try {
-      // add headers to the request
       if (r.headers) {
-        // convert all map keys to lowercase for ease of use
+        // convert all header keys to lowercase for easier content-type checking below
         const headers = Object.keys(r.headers).reduce(
           (acc, key) => {
             acc[key.toLowerCase()] = r.headers![key];

--- a/projects/optic/src/commands/capture/init.ts
+++ b/projects/optic/src/commands/capture/init.ts
@@ -63,10 +63,13 @@ export function captureConfigExample(oasFile: string) {
             # path: Required
             # method: Optional: default: GET
             # data: Optional: If omitted on a POST request, default: {}
+            # headers: Optional: If 'content-type' is omitted, it is set to 'application/json;charset=UTF-8'.
             - path: /
               method: GET
             - path: /users/create
               method: POST
+              headers:
+                content-type: application/json;charset=UTF-8
               data:
                 name: Hank
         config:

--- a/projects/optic/src/config.ts
+++ b/projects/optic/src/config.ts
@@ -43,6 +43,7 @@ const RequestSend = Type.Object({
     })
   ),
   data: Type.Optional(Type.Object({})),
+  headers: Type.Optional(Type.Array(Type.Record(Type.String(), Type.String()))),
 });
 
 const RequestRun = Type.Optional(

--- a/projects/optic/src/config.ts
+++ b/projects/optic/src/config.ts
@@ -43,7 +43,7 @@ const RequestSend = Type.Object({
     })
   ),
   data: Type.Optional(Type.Object({})),
-  headers: Type.Optional(Type.Array(Type.Record(Type.String(), Type.String()))),
+  headers: Type.Optional(Type.Record(Type.String(), Type.String())),
 });
 
 const RequestRun = Type.Optional(


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

allows setting headers on `requests.send`... requests. to keep the verbosity and repetition down you can use anchors and aliases.

```yaml
send:
  - path: /
    headers: &headers
      x-some-header: awesome
      content-type: application/json;charset=utf-8
  - path: /users/create
    method: POST
    data:
      name: Hank
    headers:
      <<: *headers
      x-additional-header: also-awesome
```

```
===BEGIN HEADERS===
Content-Type: [application/json;charset=utf-8]
Accept: [*/*]
User-Agent: [node-fetch/1.0 (+https://github.com/bitinn/node-fetch)]
Accept-Encoding: [gzip,deflate]
Connection: [close]
X-Some-Header: [awesome]
===END HEADERS===
[GIN] 2023/07/27 - 13:02:37 | 200 |      54.375µs |       127.0.0.1 | GET      "/"

===BEGIN HEADERS===
X-Some-Header: [awesome]
Content-Length: [15]
Accept-Encoding: [gzip,deflate]
Connection: [close]
Content-Type: [application/json;charset=utf-8]
X-Additional-Header: [also-awesome]
Accept: [*/*]
User-Agent: [node-fetch/1.0 (+https://github.com/bitinn/node-fetch)]
===END HEADERS===
[GIN] 2023/07/27 - 13:02:37 | 201 |     241.833µs |       127.0.0.1 | POST     "/users/create"
```

todo: 
- [x] add a special case for content-type: if its supplied in the yaml, use that value, otherwise set it to `application/json;charset=utf-8`
- [x] update website docs
- [x] update CLI docs

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
