### PR TITLE
render coverage on capture

### DIFF
--- a/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
@@ -240,7 +240,9 @@ exports[`capture with inputs --har verifying OpenAPI spec 1`] = `
   [31m[200 response body] 'next' is not documented[39m
   [31m[200 response body] 'has_more_data' is not documented[39m
 
-7 unmatched interactions
+100.0% coverage of your documented operations. 7 requests did not match a documented path (8 total requests).
+3 diffs detected in documented operations
+
 [33mNew endpoints are only added in interactive mode.[39m
 [34mRun with \`--update interactive\` to add new endpoints[39m
 [33mHint: optic capture openapi.yml --update interactive[39m
@@ -833,7 +835,8 @@ components:
 exports[`capture with inputs --postman verifying OpenAPI spec 1`] = `
 "[90m1 endpoint did not receive traffic[39m
 
-58 unmatched interactions
+0.0% coverage of your documented operations. 58 requests did not match a documented path (58 total requests).
+
 [33mNew endpoints are only added in interactive mode.[39m
 [34mRun with \`--update interactive\` to add new endpoints[39m
 [33mHint: optic capture openapi.yml --update interactive[39m
@@ -1353,7 +1356,7 @@ GET /books
   [32m[200 response body] 'created_at' has been added[39m
   [32m[200 response body] 'updated_at' has been added[39m
 
-4 unmatched interactions
+4 unmatched requests
 [33mNew endpoints are only added in interactive mode.[39m
 [34mRun with \`--update interactive\` to add new endpoints[39m
 [33mHint: optic capture openapi.yml --update interactive[39m
@@ -1422,7 +1425,9 @@ GET /books/{bookId}
   [31m× [39m200 response
   [31m[200 response body] 'price' is not documented[39m
 
-2 unmatched interactions
+100.0% coverage of your documented operations. 2 requests did not match a documented path (6 total requests).
+6 diffs detected in documented operations
+
 [33mNew endpoints are only added in interactive mode.[39m
 [34mRun with \`--update interactive\` to add new endpoints[39m
 [33mHint: optic capture openapi-with-overlapping-paths.yml --update interactive[39m
@@ -1439,7 +1444,9 @@ GET /books
   [31m[200 response body] 'created_at' is not documented[39m
   [31m[200 response body] 'updated_at' is not documented[39m
 
-4 unmatched interactions
+100.0% coverage of your documented operations. 4 requests did not match a documented path (5 total requests).
+5 diffs detected in documented operations
+
 [33mNew endpoints are only added in interactive mode.[39m
 [34mRun with \`--update interactive\` to add new endpoints[39m
 [33mHint: optic capture openapi.yml --update interactive[39m

--- a/projects/optic/src/commands/capture/interactions/grouped-interactions.ts
+++ b/projects/optic/src/commands/capture/interactions/grouped-interactions.ts
@@ -199,8 +199,19 @@ export class GroupedCaptures {
     };
   }
 
-  unmatchedInteractionsCount(): number {
-    return this.unmatched.hars.length + this.unmatched.interactions.length;
+  interactionCount() {
+    const unmatched =
+      this.unmatched.hars.length + this.unmatched.interactions.length;
+    let matched = 0;
+    for (const [, node] of this.paths) {
+      matched += node.hars.length + node.interactions.length;
+    }
+    const total = matched + unmatched;
+    return {
+      total,
+      unmatched,
+      matched,
+    };
   }
 
   *getDocumentedEndpointInteractions(): Iterable<{


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Renders the coverage output on capture

```
➜  my-openapi-specs git:(main) ✗ npx ts-node ../optic/projects/optic/src/index.ts capture abe.yml 
✔ Successfully captured requests
✔ GET /books
  ✓ 200 response

100.0% coverage of your documented operations. 3 requests did not match a documented path (4 total requests).

➜  my-openapi-specs git:(main) ✗ npx ts-node ../optic/projects/optic/src/index.ts capture abe.yml 
✔ Successfully captured requests
✖ GET /books
  × 200 response
  [200 response body] 'id' does not match type number. Received t_6i-nROr669AOPNE3RTq

100.0% coverage of your documented operations. 3 requests did not match a documented path (4 total requests).
1 diffs detected in documented operations
```

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
