### PR TITLE
Add capture verbose mode

### DIFF
--- a/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
@@ -1474,7 +1474,9 @@ operation: [1mget /books[22m
 [90m$workspace$/openapi.yml[39m
 
 
-4 unmatched interactions
+100.0% coverage of your documented operations. 4 requests did not match a documented path (5 total requests).
+7 diffs detected in documented operations
+
 [33mNew endpoints are only added in interactive mode.[39m
 [34mRun with \`--update interactive\` to add new endpoints[39m
 [33mHint: optic capture openapi.yml --update interactive[39m

--- a/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
@@ -1188,10 +1188,10 @@ exports[`capture with requests update behavior updates all endpoints with --upda
 GET /books
   [32m✓ [39m200 response
   [32m[200 response body] 'name' has been added[39m
-  [32m[200 response body] 'author_id' has been added[39m
-  [32m[200 response body] 'price' has been added[39m
   [32m[200 response body] 'created_at' has been added[39m
   [32m[200 response body] 'updated_at' has been added[39m
+  [33m[200 response body] 'author_id' is now type number[39m
+  [33m[200 response body] 'price' is now type string[39m
 
 [1m[90mLearning path patterns for unmatched requests...[39m[22m
 [1m[90mDocumenting new operations:[39m[22m
@@ -1266,20 +1266,24 @@ components:
             properties:
               id:
                 type: string
+              author_id:
+                oneOf:
+                  - type: number
+                  - type: string
+              price:
+                oneOf:
+                  - type: string
+                  - type: number
               name:
                 type: string
-              author_id:
-                type: string
-              price:
-                type: number
               created_at:
                 type: string
               updated_at:
                 type: string
             required:
-              - name
+              - id
               - author_id
-              - price
+              - name
               - created_at
               - updated_at
     GetBooksBook200ResponseBody:
@@ -1348,10 +1352,10 @@ exports[`capture with requests update behavior updates only existing endpoints b
 GET /books
   [32m✓ [39m200 response
   [32m[200 response body] 'name' has been added[39m
-  [32m[200 response body] 'author_id' has been added[39m
-  [32m[200 response body] 'price' has been added[39m
   [32m[200 response body] 'created_at' has been added[39m
   [32m[200 response body] 'updated_at' has been added[39m
+  [33m[200 response body] 'author_id' is now type number[39m
+  [33m[200 response body] 'price' is now type string[39m
 
 4 unmatched interactions
 [33mNew endpoints are only added in interactive mode.[39m
@@ -1388,20 +1392,24 @@ components:
             properties:
               id:
                 type: string
+              author_id:
+                oneOf:
+                  - type: number
+                  - type: string
+              price:
+                oneOf:
+                  - type: string
+                  - type: number
               name:
                 type: string
-              author_id:
-                type: string
-              price:
-                type: number
               created_at:
                 type: string
               updated_at:
                 type: string
             required:
-              - name
+              - id
               - author_id
-              - price
+              - name
               - created_at
               - updated_at
 "
@@ -1429,15 +1437,54 @@ GET /books/{bookId}
 "
 `;
 
+exports[`capture with requests verify behavior verifies the specification in verbose mode 1`] = `
+"Generating traffic to send to server
+GET /books
+  [31m× [39m200 response
+  [31m[200 response body] 'name' is not documented[39m
+  [31m[200 response body] 'created_at' is not documented[39m
+  [31m[200 response body] 'updated_at' is not documented[39m
+  [31m[200 response body] 'author_id' does not match type number. Received 6nTxAFM5ck4Hob77hGQoL[39m
+  [41m  Diff  [49m 'author_id' did not match schema
+operation: [1mget /books[22m  
+[90m25 |[39m properties:
+[90m26 |[39m   id:
+[90m27 |[39m     type: string
+[90m28 |[39m [1m[33m  author_id:  [41m[Actual] "6nTxAFM5ck4Hob77hGQoL"[49m[39m[22m
+[90m29 |[39m     type: number
+[90m30 |[39m   price:
+[90m31 |[39m     type: string
+[90m$workspace$/openapi.yml[39m
+
+  [31m[200 response body] 'price' does not match type string. Received 10[39m
+  [41m  Diff  [49m 'price' did not match schema
+operation: [1mget /books[22m  
+[90m27 |[39m     type: string
+[90m28 |[39m   author_id:
+[90m29 |[39m     type: number
+[90m30 |[39m [1m[33m  price:  [41m[Actual] 10[49m[39m[22m
+[90m31 |[39m     type: string
+[90m32 |[39m required:
+[90m33 |[39m   - id
+[90m$workspace$/openapi.yml[39m
+
+
+4 unmatched interactions
+[33mNew endpoints are only added in interactive mode.[39m
+[34mRun with \`--update interactive\` to add new endpoints[39m
+[33mHint: optic capture openapi.yml --update interactive[39m
+"
+`;
+
 exports[`capture with requests verify behavior verifies the specification with coverage 1`] = `
 "Generating traffic to send to server
 GET /books
   [31m× [39m200 response
   [31m[200 response body] 'name' is not documented[39m
-  [31m[200 response body] 'author_id' is not documented[39m
-  [31m[200 response body] 'price' is not documented[39m
   [31m[200 response body] 'created_at' is not documented[39m
   [31m[200 response body] 'updated_at' is not documented[39m
+  [31m[200 response body] 'author_id' does not match type number. Received 6nTxAFM5ck4Hob77hGQoL[39m
+  [31m[200 response body] 'price' does not match type string. Received 10[39m
 
 4 unmatched interactions
 [33mNew endpoints are only added in interactive mode.[39m

--- a/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
@@ -3,9 +3,9 @@
 exports[`capture with inputs --har updating an OpenAPI spec 1`] = `
 "GET /books
   [32m✓ [39m200 response
-  [32m[200 response body] 'data' has been added[39m
-  [32m[200 response body] 'next' has been added[39m
-  [32m[200 response body] 'has_more_data' has been added[39m
+  [32m[200 response body] 'data' (/properties/data) has been added[39m
+  [32m[200 response body] 'next' (/properties/next) has been added[39m
+  [32m[200 response body] 'has_more_data' (/properties/has_more_data) has been added[39m
 
 [1m[90mLearning path patterns for unmatched requests...[39m[22m
 [1m[90mDocumenting new operations:[39m[22m
@@ -236,9 +236,9 @@ components:
 exports[`capture with inputs --har verifying OpenAPI spec 1`] = `
 "GET /books
   [31m× [39m200 response
-  [31m[200 response body] 'data' is not documented[39m
-  [31m[200 response body] 'next' is not documented[39m
-  [31m[200 response body] 'has_more_data' is not documented[39m
+  [31m[200 response body] 'data' (/properties/data) is not documented[39m
+  [31m[200 response body] 'next' (/properties/next) is not documented[39m
+  [31m[200 response body] 'has_more_data' (/properties/has_more_data) is not documented[39m
 
 7 unmatched interactions
 [33mNew endpoints are only added in interactive mode.[39m
@@ -1004,11 +1004,11 @@ exports[`capture with requests update behavior handles update in other file 1`] 
 "Generating traffic to send to server
 GET /books
   [32m✓ [39m200 response
-  [32m[200 response body] 'name' has been added[39m
-  [32m[200 response body] 'author_id' has been added[39m
-  [32m[200 response body] 'price' has been added[39m
-  [32m[200 response body] 'created_at' has been added[39m
-  [32m[200 response body] 'updated_at' has been added[39m
+  [32m[200 response body] 'name' (/properties/books/items/properties/name) has been added[39m
+  [32m[200 response body] 'author_id' (/properties/books/items/properties/author_id) has been added[39m
+  [32m[200 response body] 'price' (/properties/books/items/properties/price) has been added[39m
+  [32m[200 response body] 'created_at' (/properties/books/items/properties/created_at) has been added[39m
+  [32m[200 response body] 'updated_at' (/properties/books/items/properties/updated_at) has been added[39m
 "
 `;
 
@@ -1065,11 +1065,11 @@ exports[`capture with requests update behavior respects x-optic-path-ignore 1`] 
 "Generating traffic to send to server
 GET /books
   [32m✓ [39m200 response
-  [32m[200 response body] 'name' has been added[39m
-  [32m[200 response body] 'author_id' has been added[39m
-  [32m[200 response body] 'price' has been added[39m
-  [32m[200 response body] 'created_at' has been added[39m
-  [32m[200 response body] 'updated_at' has been added[39m
+  [32m[200 response body] 'name' (/properties/books/items/properties/name) has been added[39m
+  [32m[200 response body] 'author_id' (/properties/books/items/properties/author_id) has been added[39m
+  [32m[200 response body] 'price' (/properties/books/items/properties/price) has been added[39m
+  [32m[200 response body] 'created_at' (/properties/books/items/properties/created_at) has been added[39m
+  [32m[200 response body] 'updated_at' (/properties/books/items/properties/updated_at) has been added[39m
 
 [1m[90mLearning path patterns for unmatched requests...[39m[22m
 [1m[90mDocumenting new operations:[39m[22m
@@ -1187,11 +1187,11 @@ exports[`capture with requests update behavior updates all endpoints with --upda
 "Generating traffic to send to server
 GET /books
   [32m✓ [39m200 response
-  [32m[200 response body] 'name' has been added[39m
-  [32m[200 response body] 'created_at' has been added[39m
-  [32m[200 response body] 'updated_at' has been added[39m
-  [33m[200 response body] 'author_id' is now type number[39m
-  [33m[200 response body] 'price' is now type string[39m
+  [32m[200 response body] 'name' (/properties/books/items/properties/name) has been added[39m
+  [32m[200 response body] 'created_at' (/properties/books/items/properties/created_at) has been added[39m
+  [32m[200 response body] 'updated_at' (/properties/books/items/properties/updated_at) has been added[39m
+  [33m[200 response body] 'author_id' (/properties/books/items/properties/author_id) is now type number[39m
+  [33m[200 response body] 'price' (/properties/books/items/properties/price) is now type string[39m
 
 [1m[90mLearning path patterns for unmatched requests...[39m[22m
 [1m[90mDocumenting new operations:[39m[22m
@@ -1351,11 +1351,11 @@ exports[`capture with requests update behavior updates only existing endpoints b
 "Generating traffic to send to server
 GET /books
   [32m✓ [39m200 response
-  [32m[200 response body] 'name' has been added[39m
-  [32m[200 response body] 'created_at' has been added[39m
-  [32m[200 response body] 'updated_at' has been added[39m
-  [33m[200 response body] 'author_id' is now type number[39m
-  [33m[200 response body] 'price' is now type string[39m
+  [32m[200 response body] 'name' (/properties/books/items/properties/name) has been added[39m
+  [32m[200 response body] 'created_at' (/properties/books/items/properties/created_at) has been added[39m
+  [32m[200 response body] 'updated_at' (/properties/books/items/properties/updated_at) has been added[39m
+  [33m[200 response body] 'author_id' (/properties/books/items/properties/author_id) is now type number[39m
+  [33m[200 response body] 'price' (/properties/books/items/properties/price) is now type string[39m
 
 4 unmatched interactions
 [33mNew endpoints are only added in interactive mode.[39m
@@ -1419,16 +1419,16 @@ exports[`capture with requests verify behavior verifies spec with endpoint speci
 "Generating traffic to send to server
 GET /books
   [31m× [39m200 response
-  [31m[200 response body] 'name' is not documented[39m
-  [31m[200 response body] 'author_id' is not documented[39m
-  [31m[200 response body] 'price' is not documented[39m
-  [31m[200 response body] 'created_at' is not documented[39m
-  [31m[200 response body] 'updated_at' is not documented[39m
+  [31m[200 response body] 'name' (/properties/books/items/properties/name) is not documented[39m
+  [31m[200 response body] 'author_id' (/properties/books/items/properties/author_id) is not documented[39m
+  [31m[200 response body] 'price' (/properties/books/items/properties/price) is not documented[39m
+  [31m[200 response body] 'created_at' (/properties/books/items/properties/created_at) is not documented[39m
+  [31m[200 response body] 'updated_at' (/properties/books/items/properties/updated_at) is not documented[39m
 GET /books/status
   [32m✓ [39m200 response
 GET /books/{bookId}
   [31m× [39m200 response
-  [31m[200 response body] 'price' is not documented[39m
+  [31m[200 response body] 'price' (/properties/price) is not documented[39m
 
 2 unmatched interactions
 [33mNew endpoints are only added in interactive mode.[39m
@@ -1441,10 +1441,10 @@ exports[`capture with requests verify behavior verifies the specification in ver
 "Generating traffic to send to server
 GET /books
   [31m× [39m200 response
-  [31m[200 response body] 'name' is not documented[39m
-  [31m[200 response body] 'created_at' is not documented[39m
-  [31m[200 response body] 'updated_at' is not documented[39m
-  [31m[200 response body] 'author_id' does not match type number. Received 6nTxAFM5ck4Hob77hGQoL[39m
+  [31m[200 response body] 'name' (/properties/books/items/properties/name) is not documented[39m
+  [31m[200 response body] 'created_at' (/properties/books/items/properties/created_at) is not documented[39m
+  [31m[200 response body] 'updated_at' (/properties/books/items/properties/updated_at) is not documented[39m
+  [31m[200 response body] 'author_id' (/properties/books/items/properties/author_id) does not match type number. Received 6nTxAFM5ck4Hob77hGQoL[39m
   [41m  Diff  [49m 'author_id' did not match schema
 operation: [1mget /books[22m  
 [90m25 |[39m properties:
@@ -1456,7 +1456,7 @@ operation: [1mget /books[22m
 [90m31 |[39m     type: string
 [90m$workspace$/openapi.yml[39m
 
-  [31m[200 response body] 'price' does not match type string. Received 10[39m
+  [31m[200 response body] 'price' (/properties/books/items/properties/price) does not match type string. Received 10[39m
   [41m  Diff  [49m 'price' did not match schema
 operation: [1mget /books[22m  
 [90m27 |[39m     type: string
@@ -1480,11 +1480,11 @@ exports[`capture with requests verify behavior verifies the specification with c
 "Generating traffic to send to server
 GET /books
   [31m× [39m200 response
-  [31m[200 response body] 'name' is not documented[39m
-  [31m[200 response body] 'created_at' is not documented[39m
-  [31m[200 response body] 'updated_at' is not documented[39m
-  [31m[200 response body] 'author_id' does not match type number. Received 6nTxAFM5ck4Hob77hGQoL[39m
-  [31m[200 response body] 'price' does not match type string. Received 10[39m
+  [31m[200 response body] 'name' (/properties/books/items/properties/name) is not documented[39m
+  [31m[200 response body] 'created_at' (/properties/books/items/properties/created_at) is not documented[39m
+  [31m[200 response body] 'updated_at' (/properties/books/items/properties/updated_at) is not documented[39m
+  [31m[200 response body] 'author_id' (/properties/books/items/properties/author_id) does not match type number. Received 6nTxAFM5ck4Hob77hGQoL[39m
+  [31m[200 response body] 'price' (/properties/books/items/properties/price) does not match type string. Received 10[39m
 
 4 unmatched interactions
 [33mNew endpoints are only added in interactive mode.[39m

--- a/projects/optic/src/__tests__/integration/capture.test.ts
+++ b/projects/optic/src/__tests__/integration/capture.test.ts
@@ -50,6 +50,18 @@ describe('capture with requests', () => {
       expect(code).toBe(1);
     });
 
+    test('verifies the specification in verbose mode', async () => {
+      const workspace = await setupWorkspace('capture/with-server');
+      await setPortInFile(workspace, 'optic.yml');
+
+      const { combined, code } = await runOptic(
+        workspace,
+        'capture openapi.yml --verbose'
+      );
+      expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
+      expect(code).toBe(1);
+    });
+
     test('verifies spec with endpoint specificity', async () => {
       const workspace = await setupWorkspace('capture/with-server');
       await setPortInFile(workspace, 'optic.yml');

--- a/projects/optic/src/__tests__/integration/workspaces/capture/with-server/openapi.yml
+++ b/projects/optic/src/__tests__/integration/workspaces/capture/with-server/openapi.yml
@@ -25,3 +25,10 @@ components:
             properties:
               id:
                 type: string
+              author_id:
+                type: number
+              price:
+                type: string
+            required:
+              - id
+              - author_id

--- a/projects/optic/src/commands/capture/actions/documented.ts
+++ b/projects/optic/src/commands/capture/actions/documented.ts
@@ -84,7 +84,9 @@ function summarizePatch(
       const action =
         options.mode === 'update' ? 'has been added' : 'is not documented';
       const color = options.mode === 'update' ? chalk.green : chalk.red;
-      return [color(`${location} '${diff.key}' ${action}`)];
+      return [
+        color(`${location} '${diff.key}' (${diff.propertyPath}) ${action}`),
+      ];
     } else if (diff.kind === 'UnmatchedType') {
       // filter out dependent diffs
       if (
@@ -108,7 +110,9 @@ function summarizePatch(
       }
       const color = options.mode === 'update' ? chalk.yellow : chalk.red;
 
-      const lines = [color(`${location} '${diff.key}' ${action}`)];
+      const lines = [
+        color(`${location} '${diff.key}' (${diff.propertyPath}) ${action}`),
+      ];
       if (verbose) {
         lines.push(
           getShapeDiffDetails(
@@ -138,7 +142,9 @@ function summarizePatch(
           : `is required and missing`;
       const color = options.mode === 'update' ? chalk.yellow : chalk.red;
 
-      const lines = [color(`${location} '${diff.key}' ${action}`)];
+      const lines = [
+        color(`${location} '${diff.key}' (${diff.propertyPath}) ${action}`),
+      ];
       if (verbose) {
         lines.push(
           getShapeDiffDetails(

--- a/projects/optic/src/commands/capture/actions/documented.ts
+++ b/projects/optic/src/commands/capture/actions/documented.ts
@@ -6,21 +6,47 @@ import {
   jsonOpsFromSpecPatches,
 } from '../patches/patches';
 
-import { SpecPatch } from '../../oas/specs';
 import { CapturedInteractions } from '../sources/captured-interactions';
 import { ApiCoverageCounter } from '../coverage/api-coverage';
 import * as AT from '../../oas/lib/async-tools';
 import { writePatchesToFiles } from '../write/file';
 import { logger } from '../../../logger';
+import { SpecPatch } from '../../oas/specs';
+import { ShapeDiffResult } from '../../oas/shapes/diffs';
+import { jsonPointerLogger } from '@useoptic/openapi-io';
+
+function getShapeDiffDetails(
+  diff: ShapeDiffResult,
+  pathToHighlight: string,
+  error: string,
+  pointerLogger: ReturnType<typeof jsonPointerLogger>,
+  method: string,
+  pathPattern: string
+): string {
+  const lines = `${chalk.bgRed('  Diff  ')} ${diff.description}
+operation: ${chalk.bold(`${method} ${pathPattern}`)}  
+${pointerLogger.log(pathToHighlight, {
+  highlightColor: 'yellow',
+  observation: error,
+})}\n`;
+  return lines;
+}
 
 function summarizePatch(
   patch: SpecPatch,
-  spec: ParseResult['jsonLike'],
-  mode: 'update' | 'verify'
-): string | null {
+  parseResult: ParseResult,
+  options: {
+    mode: 'update' | 'verify';
+    verbose: boolean;
+  }
+): string[] {
+  const verbose = options.verbose && options.mode === 'verify';
+  const { jsonLike: spec, sourcemap } = parseResult;
+  const pointerLogger = jsonPointerLogger(sourcemap);
   const { diff, path, groupedOperations } = patch;
   const parts = jsonPointerHelpers.decode(path);
-  if (!diff || groupedOperations.length === 0) return null;
+  const [_, pathPattern, method] = parts;
+  if (!diff || groupedOperations.length === 0) return [];
   if (
     diff.kind === 'UnmatchdResponseBody' ||
     diff.kind === 'UnmatchedRequestBody' ||
@@ -30,9 +56,10 @@ function summarizePatch(
       diff.kind === 'UnmatchedRequestBody'
         ? '[request body]'
         : `[${diff.statusCode} response body]`;
-    const action = mode === 'update' ? 'has been added' : 'is not documented';
-    const color = mode === 'update' ? chalk.green : chalk.red;
-    return color(`${location} body ${action}`);
+    const action =
+      options.mode === 'update' ? 'has been added' : 'is not documented';
+    const color = options.mode === 'update' ? chalk.green : chalk.red;
+    return [color(`${location} body ${action}`)];
   } else {
     // expected patterns:
     // /paths/:path/:method/requestBody
@@ -52,11 +79,12 @@ function summarizePatch(
           jsonPointerHelpers.join(path, diff.parentObjectPath)
         ).match
       )
-        return null;
+        return [];
 
-      const action = mode === 'update' ? 'has been added' : 'is not documented';
-      const color = mode === 'update' ? chalk.green : chalk.red;
-      return color(`${location} '${diff.key}' ${action}`);
+      const action =
+        options.mode === 'update' ? 'has been added' : 'is not documented';
+      const color = options.mode === 'update' ? chalk.green : chalk.red;
+      return [color(`${location} '${diff.key}' ${action}`)];
     } else if (diff.kind === 'UnmatchedType') {
       // filter out dependent diffs
       if (
@@ -65,20 +93,35 @@ function summarizePatch(
           jsonPointerHelpers.join(path, diff.propertyPath)
         ).match
       )
-        return null;
+        return [];
       let action: string;
       if (diff.keyword === 'oneOf') {
         action =
-          mode === 'update' ? 'now matches schema' : `does not match schema`;
+          options.mode === 'update'
+            ? 'now matches schema'
+            : `does not match schema`;
       } else {
         action =
-          mode === 'update'
+          options.mode === 'update'
             ? `is now type ${diff.expectedType}`
             : `does not match type ${diff.expectedType}. Received ${diff.example}`;
       }
-      const color = mode === 'update' ? chalk.yellow : chalk.red;
+      const color = options.mode === 'update' ? chalk.yellow : chalk.red;
 
-      return color(`${location} '${diff.key}' ${action}`);
+      const lines = [color(`${location} '${diff.key}' ${action}`)];
+      if (verbose) {
+        lines.push(
+          getShapeDiffDetails(
+            diff,
+            jsonPointerHelpers.join(path, diff.propertyPath),
+            `[Actual] ${JSON.stringify(diff.example)}`,
+            pointerLogger,
+            method,
+            pathPattern
+          )
+        );
+      }
+      return lines;
     } else if (diff.kind === 'MissingRequiredProperty') {
       // filter out dependent diffs
       if (
@@ -87,17 +130,32 @@ function summarizePatch(
           jsonPointerHelpers.join(path, diff.propertyPath)
         ).match
       )
-        return null;
+        return [];
 
       const action =
-        mode === 'update' ? `is now optional` : `is required and missing`;
-      const color = mode === 'update' ? chalk.yellow : chalk.red;
+        options.mode === 'update'
+          ? `is now optional`
+          : `is required and missing`;
+      const color = options.mode === 'update' ? chalk.yellow : chalk.red;
 
-      return color(`${location} '${diff.key}' ${action}`);
+      const lines = [color(`${location} '${diff.key}' ${action}`)];
+      if (verbose) {
+        lines.push(
+          getShapeDiffDetails(
+            diff,
+            jsonPointerHelpers.join(path, diff.propertyPath),
+            `missing`,
+            pointerLogger,
+            method,
+            pathPattern
+          )
+        );
+      }
+      return lines;
     }
   }
 
-  return null;
+  return [];
 }
 
 export async function diffExistingEndpoint(
@@ -110,19 +168,19 @@ export async function diffExistingEndpoint(
   },
   options: {
     update?: 'documented' | 'interactive' | 'automatic';
+    verbose: boolean;
   }
 ) {
   const patchSummaries: string[] = [];
 
   const specPatches = AT.tap((patch: SpecPatch) => {
     coverage.shapeDiff(patch);
-    const summarized = summarizePatch(
-      patch,
-      parseResult.jsonLike,
-      options.update ? 'update' : 'verify'
-    );
-    if (summarized) {
-      patchSummaries.push(summarized);
+    const summarized = summarizePatch(patch, parseResult, {
+      mode: options.update ? 'update' : 'verify',
+      verbose: options.verbose,
+    });
+    if (summarized.length) {
+      patchSummaries.push(...summarized);
     } else {
       logger.debug(`skipping patch:`);
       logger.debug(patch);

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -70,6 +70,8 @@ export function registerCaptureCommand(cli: Command, config: OpticCliConfig) {
       'path to postman collection'
     )
     .option('--har <har-file>', 'path to har file (v1.2, v1.3)')
+    .option('--verbose', 'display verbose diff output', false)
+
     .addOption(
       new Option(
         '-s, --server-override <url>',
@@ -118,6 +120,7 @@ type CaptureActionOptions = {
   har?: string;
   update?: 'documented' | 'interactive' | 'automatic';
   upload: boolean;
+  verbose: boolean;
 };
 
 const getCaptureAction =


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

- Adds a `capture --verbose` mode which adds details to the diff where there's shape diffs
- Adds the property paths to the diff details (e.g. in nested objects we need to render the diffs)

```
➜  my-openapi-specs git:(main) ✗ npx ts-node ../optic/projects/optic/src/index.ts capture test.yml --verbose
✔ Successfully captured requests
✖ GET /users
  × 200 response
  [200 response body] 'avatar_url' (/items/properties/avatar_url) is not documented
  [200 response body] 'events_url' (/items/properties/events_url) does not match type number. Received https://api.github.com/users/mojombo/events{/privacy}
    Diff   'events_url' did not match schema
operation: get /users  
80 |   type: string
81 | repos_url:
82 |   type: string
83 | events_url:  [Actual] "https://api.git...
84 |   type: number
85 | received_events_url:
86 |   type: string
/Users/nicholaslim/Desktop/repos/my-openapi-specs/test.yml

  [200 response body] 'site_admin' (/items/properties/site_admin) does not match type string. Received false
    Diff   'site_admin' did not match schema
operation: get /users  
86 |     type: string
87 |   type:
88 |     type: string
89 |   site_admin:  [Actual] false
90 |     type: string
91 | required:
92 |   - login
/Users/nicholaslim/Desktop/repos/my-openapi-specs/test.yml

...and 1 endpoint that did not receive traffic
```

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
