### PR TITLE
Fix/non root server urls

### DIFF
--- a/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
@@ -1003,6 +1003,166 @@ components:
 "
 `;
 
+exports[`capture with requests update behavior handle servers not at root of host 1`] = `
+"Generating traffic to send to server
+GET /books
+  [32m✓ [39m200 response
+  [32m[200 response body] 'name' has been added[39m
+  [32m[200 response body] 'author_id' has been added[39m
+  [32m[200 response body] 'price' has been added[39m
+  [32m[200 response body] 'created_at' has been added[39m
+  [32m[200 response body] 'updated_at' has been added[39m
+
+[1m[90mLearning path patterns for unmatched requests...[39m[22m
+[1m[90mDocumenting new operations:[39m[22m
+GET /books/{book}
+GET /authors
+POST /books/{book}
+"
+`;
+
+exports[`capture with requests update behavior handle servers not at root of host 2`] = `
+"openapi: 3.0.3
+info:
+  title: a spec
+  description: The API
+  version: 0.1.0
+paths:
+  /books:
+    get:
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GetBooks200ResponseBody"
+  "/books/{book}":
+    parameters:
+      - in: path
+        name: book
+        required: true
+        schema:
+          type: string
+    get:
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GetBooksBook200ResponseBody"
+    post:
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GetBooksBook200ResponseBody"
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: "#/components/schemas/PostBooksBookRequestBody"
+  /authors:
+    get:
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GetAuthors200ResponseBody"
+components:
+  schemas:
+    GetBooks200ResponseBody:
+      type: object
+      properties:
+        books:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              name:
+                type: string
+              author_id:
+                type: string
+              price:
+                type: number
+              created_at:
+                type: string
+              updated_at:
+                type: string
+            required:
+              - name
+              - author_id
+              - price
+              - created_at
+              - updated_at
+    GetBooksBook200ResponseBody:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        author_id:
+          type: string
+        price:
+          type: number
+        created_at:
+          type: string
+        updated_at:
+          type: string
+      required:
+        - id
+        - name
+        - author_id
+        - price
+        - created_at
+        - updated_at
+    GetAuthors200ResponseBody:
+      type: object
+      properties:
+        authors:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              name:
+                type: string
+              created_at:
+                type: string
+              updated_at:
+                type: string
+            required:
+              - id
+              - name
+              - created_at
+              - updated_at
+      required:
+        - authors
+    PostBooksBookRequestBody:
+      type: object
+      properties:
+        name:
+          type: string
+        price:
+          type: number
+        author_id:
+          type: string
+      required:
+        - name
+        - price
+        - author_id
+"
+`;
+
 exports[`capture with requests update behavior handles update in other file 1`] = `
 "Generating traffic to send to server
 GET /books

--- a/projects/optic/src/__tests__/integration/capture.test.ts
+++ b/projects/optic/src/__tests__/integration/capture.test.ts
@@ -113,6 +113,25 @@ describe('capture with requests', () => {
       ).toMatchSnapshot();
     });
 
+    test('handle servers not at root of host', async () => {
+      process.env.SERVER_PREFIX = '/api';
+      const workspace = await setupWorkspace('capture/with-server');
+      await setPortInFile(workspace, 'optic.yml');
+
+      const { combined, code } = await runOptic(
+        workspace,
+        `capture openapi-prefixed-url.yml --update automatic`
+      );
+      expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
+      expect(code).toBe(0);
+      expect(
+        await fs.readFile(
+          path.join(workspace, 'openapi-prefixed-url.yml'),
+          'utf-8'
+        )
+      ).toMatchSnapshot();
+    });
+
     test('handle server path prefixes in spec', async () => {
       process.env.SERVER_PREFIX = '/api';
       const workspace = await setupWorkspace('capture/with-server');

--- a/projects/optic/src/__tests__/integration/workspaces/capture/with-server/openapi-prefixed-url.yml
+++ b/projects/optic/src/__tests__/integration/workspaces/capture/with-server/openapi-prefixed-url.yml
@@ -1,0 +1,27 @@
+openapi: 3.0.3
+info:
+  title: a spec
+  description: The API
+  version: 0.1.0
+paths:
+  /books:
+    get:
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GetBooks200ResponseBody"
+components:
+  schemas:
+    GetBooks200ResponseBody:
+      type: object
+      properties:
+        books:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string

--- a/projects/optic/src/__tests__/integration/workspaces/capture/with-server/optic.yml
+++ b/projects/optic/src/__tests__/integration/workspaces/capture/with-server/optic.yml
@@ -43,6 +43,27 @@ capture:
             author_id: 6nTxAFM5ck4Hob77hGQoL
         - path: /authors
           method: GET
+  openapi-prefixed-url.yml:
+    server:
+      command: node server.js
+      url: http://localhost:%PORT/api
+      ready_endpoint: /healthcheck
+    requests:
+      send:
+        - path: /books
+          method: GET
+        - path: /books/asd
+          method: GET
+        - path: /books/def
+          method: GET
+        - path: /books/asd
+          method: POST
+          data:
+            name: asd
+            price: 1
+            author_id: 6nTxAFM5ck4Hob77hGQoL
+        - path: /authors
+          method: GET
   openapi-with-external-ref.yml:
     server:
       command: node server.js

--- a/projects/optic/src/__tests__/integration/workspaces/capture/with-server/server.js
+++ b/projects/optic/src/__tests__/integration/workspaces/capture/with-server/server.js
@@ -56,7 +56,7 @@ const requestListener = function (req, res) {
   }else if (normalizedUrl === '/authors' && req.method === 'GET') {
     res.writeHead(200);
     res.end(JSON.stringify({authors}));
-  } else if (req.url === '/healthcheck' && req.method === 'GET') {
+  } else if (normalizedUrl === '/healthcheck' && req.method === 'GET') {
     res.writeHead(200);
     res.end(JSON.stringify({authors}));
   } else {

--- a/projects/optic/src/commands/capture/actions/captureRequests.ts
+++ b/projects/optic/src/commands/capture/actions/captureRequests.ts
@@ -196,7 +196,7 @@ function sendRequests(
     }
 
     return limiter.schedule(() =>
-      fetch(`${proxyUrl}${r.path}`, opts)
+      fetch(urljoin(proxyUrl, r.path), opts)
         .then((response) => response.json())
         .catch((error) => {
           loggerWhileSpinning.error(spinner, error);

--- a/projects/optic/src/commands/capture/sources/proxy.ts
+++ b/projects/optic/src/commands/capture/sources/proxy.ts
@@ -44,11 +44,13 @@ export class ProxyInteractions {
       proxyPort?: number;
     }
   ): Promise<[ProxyInteractions, string, string]> {
+    let host: string;
     let protocol: string;
     let origin: string;
     let serverPathnamePrefix: string;
     try {
       ({
+        host,
         protocol,
         origin,
         pathname: serverPathnamePrefix,
@@ -61,6 +63,7 @@ export class ProxyInteractions {
       );
       throw new UserError();
     }
+    targetHost = host;
 
     const forwardHost = options.mode === 'reverse-proxy' ? origin : targetHost;
 


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Fixes the case where the server is not at the host root - e.g. `http://example.com/prefix`

Sending requests via the requests.send, requests.cmd and the ready check should all be adjusted. e.g.
a request to `/books` should be routed to `/prefix/books` if server. This request should be modeled in the OpenAPI file as `/books` (not `/prefix/books`).

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
