### PR TITLE
chore(capture): improve the error messages when optic has no capture config

### DIFF
--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -185,11 +185,13 @@ const getCaptureAction =
     } else {
       // verify capture v2 config is present
       if (targetUrl !== undefined || captureConfig === undefined) {
-        logger.error(`no capture config for ${filePath} was found`);
+        const initSuggestion = `'optic capture init ${filePath}'`;
         config.isDefaultConfig
-          ? logger.error('no optic.yml file was detected')
+          ? logger.error(
+              `An optic.yml file wasn't found. To create an optic.yml file with a default capture block, run ${initSuggestion}.`
+            )
           : logger.error(
-              `expected an capture config entry for ${pathFromRoot}`
+              `Expected a capture config entry for ${pathFromRoot}. To add a capture config entry to your optic.yml, run ${initSuggestion}.`
             );
         // TODO log error and run capture init or something - tbd what the first use is
         process.exitCode = 1;


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

### when optic.yml doesn't exist
```
➜ npx ts-node ../optic/projects/optic/src/index.ts capture openapi.yml
An optic.yml file wasn't found. To create an optic.yml file with a default capture block, run 'optic capture init openapi.yml'.
```

### when optic.yml exists, but doesn't contain a config block for the openapi spec
```
➜ echo "rulesets: {}" > optic.yml
➜ npx ts-node ../optic/projects/optic/src/index.ts capture openapi.yml
Expected a capture config entry for openapi.yml. To add a capture config entry to your optic.yml, run 'optic capture init openapi.yml'
```

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._
closes https://github.com/opticdev/optic/issues/2189

## 👹 QA
_How can other humans verify that this PR is correct?_
