### PR TITLE
fix case where root schema is added twice

### DIFF
--- a/projects/optic/src/commands/oas/specs/patches/index.ts
+++ b/projects/optic/src/commands/oas/specs/patches/index.ts
@@ -139,7 +139,9 @@ export class SpecPatch {
 
   static *operations(patch: ShapePatch): IterableIterator<PatchOperation> {
     for (let group of patch.groupedOperations) {
-      yield* PatchOperationGroup.operations(group);
+      for (const op of group.operations) {
+        yield op;
+      }
     }
   }
 }


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

In the case where a spec has no schema, but multiple request or response bodies, optic fails to add all of them

This is because the patches will all overwrite the old value since at the time of generating the patches, the spec will look like it will have no `components.schema` key and every ref refactor will include `add: components.schema`

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
