### PR TITLE
Update ignore paths to ignore already documented

### DIFF
--- a/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
@@ -1202,6 +1202,8 @@ exports[`capture with requests update behavior handles update in other file 3`] 
 
 exports[`capture with requests update behavior respects x-optic-path-ignore 1`] = `
 "Generating traffic to send to server
+GET /authors
+  [32m✓ [39m200 response
 GET /books
   [32m✓ [39m200 response
   [32m[200 response body] 'name' (/properties/books/items/properties/name) has been added[39m
@@ -1236,6 +1238,15 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetBooks200ResponseBody"
+  /authors:
+    get:
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: object
   "/books/{book}":
     parameters:
       - in: path

--- a/projects/optic/src/__tests__/integration/workspaces/capture/with-server/openapi-with-ignore.yml
+++ b/projects/optic/src/__tests__/integration/workspaces/capture/with-server/openapi-with-ignore.yml
@@ -17,6 +17,15 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetBooks200ResponseBody"
+  /authors:
+    get:
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: object
 components:
   schemas:
     GetBooks200ResponseBody:

--- a/projects/optic/src/__tests__/integration/workspaces/capture/with-server/optic.yml
+++ b/projects/optic/src/__tests__/integration/workspaces/capture/with-server/optic.yml
@@ -111,6 +111,12 @@ capture:
           method: GET
         - path: /books/def
           method: GET
+        - path: /books/lqs
+          method: POST
+          data:
+            name: asd
+            price: 1
+            author_id: 6nTxAFM5ck4Hob77hGQoL
         - path: /books/asd
           method: POST
           data:

--- a/projects/optic/src/commands/capture/actions/undocumented.ts
+++ b/projects/optic/src/commands/capture/actions/undocumented.ts
@@ -4,14 +4,12 @@ import { matchPathPattern } from '../../../utils/pathPatterns';
 import { minimatch } from 'minimatch';
 import { logger } from '../../../logger';
 import { ParseResult } from '../../../utils/spec-loaders';
-import { getIgnorePaths } from '../../../utils/specs';
 
 import {
   CapturedInteraction,
   CapturedInteractions,
 } from '../sources/captured-interactions';
 import { InferPathStructure } from '../operations/infer-path-structure';
-import { specToPaths } from '../operations/queries';
 import {
   generateEndpointSpecPatches,
   generatePathAndMethodSpecPatches,
@@ -26,7 +24,6 @@ type MethodMap = Map<string, { add: Set<string>; ignore: Set<string> }>;
 
 export async function promptUserForPathPattern(
   interactions: CapturedInteractions,
-  spec: OpenAPIV3.Document,
   inferredPathStructure: InferPathStructure,
   options: { update: 'interactive' | 'automatic' }
 ) {
@@ -43,19 +40,7 @@ export async function promptUserForPathPattern(
       ])
   );
 
-  const ignorePaths = getIgnorePaths(spec);
   const newIgnorePaths: { method: string; path: string }[] = [];
-
-  for (const ignore of ignorePaths) {
-    if (!ignore.method) {
-      for (const [, methodNode] of methodMap) {
-        methodNode.ignore.add(ignore.path);
-      }
-    } else if (ignore.method) {
-      const maybeNode = methodMap.get(ignore.method);
-      maybeNode?.ignore.add(ignore.path);
-    }
-  }
 
   for await (const interaction of interactions) {
     const { path, method } = interaction.request;

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -350,7 +350,6 @@ const getCaptureAction =
           endpointsToAdd,
         } = await promptUserForPathPattern(
           captures.getUndocumentedInteractions(),
-          spec.jsonLike,
           inferredPathStructure,
           { update: options.update }
         );

--- a/projects/optic/src/commands/oas/captures/getInteractions.ts
+++ b/projects/optic/src/commands/oas/captures/getInteractions.ts
@@ -8,7 +8,10 @@ import { OpenAPIV3 } from '@useoptic/openapi-utilities';
 import { CapturedInteractions } from '../../capture/sources/captured-interactions';
 import { PostmanCollectionEntries } from '../../capture/sources/postman';
 import { HarEntries } from '../../capture/sources/har';
-import { handleServerPathPrefix } from '../../capture/interactions/grouped-interactions';
+import {
+  filterIgnoredInteractions,
+  handleServerPathPrefix,
+} from '../../capture/interactions/grouped-interactions';
 
 export async function getInteractions(
   options: { har?: string; postman?: string },
@@ -85,5 +88,8 @@ export async function getInteractions(
     );
   }
 
-  return handleServerPathPrefix(AT.merge(...sources), spec);
+  return handleServerPathPrefix(
+    filterIgnoredInteractions(AT.merge(...sources), spec),
+    spec
+  );
 }


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Previously, ignore paths were only applied to undocumented endpoints (i.e. if you already had an endpoint documented, we would still use ignored interactions)

This updates it to apply to both undocumneted and documented endpoints. This is useful for cases where:
- optic update has trouble running interactions
- you want to manually document certain endpoints but capture every piece of traffic

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
