### PR TITLE
handle windows kill app

### DIFF
--- a/projects/optic/src/commands/capture/actions/captureRequests.ts
+++ b/projects/optic/src/commands/capture/actions/captureRequests.ts
@@ -2,7 +2,7 @@ import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
 import fetch from 'node-fetch';
 import Bottleneck from 'bottleneck';
 import exitHook from 'exit-hook';
-
+import { exec } from 'child_process';
 import ora from 'ora';
 import urljoin from 'url-join';
 import { UserError } from '@useoptic/openapi-utilities';
@@ -312,7 +312,12 @@ export async function captureRequestsFromProxy(
   function cleanup() {
     proxy?.stop();
     if (app && app.pid && app.exitCode === null) {
-      process.kill(-app.pid);
+      if (process.platform === 'win32') {
+        // https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/taskkill
+        exec(`taskkill /pid ${app.pid} /t /f`);
+      } else {
+        process.kill(-app.pid);
+      }
     }
   }
   const unsubscribeHook = exitHook(() => {


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

killing a spawned app apparently doesn't work with windows (sending a `-pid`) - we can work around this using taskkill 

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._
https://github.com/nodejs/node/issues/3617

## 👹 QA
_How can other humans verify that this PR is correct?_
