### PR TITLE
fix capture not forwarding the correct headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.49.0",
+  "version": "0.49.1-1",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",
@@ -27,5 +27,6 @@
     "**/*.+(js|jsx|ts|tsx|json|css)": [
       "yarn prettier --write"
     ]
-  }
+  },
+  "stableVersion": "0.49.0"
 }

--- a/projects/fastify-capture/package.json
+++ b/projects/fastify-capture/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/fastify-capture",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.49.0",
+  "version": "0.49.1-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -37,5 +37,6 @@
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
     "typescript": "^5.0.4"
-  }
+  },
+  "stableVersion": "0.49.0"
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.49.0",
+  "version": "0.49.1-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -32,5 +32,6 @@
   "dependencies": {
     "jsonpointer": "^5.0.1",
     "minimatch": "9.0.3"
-  }
+  },
+  "stableVersion": "0.49.0"
 }

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.49.0",
+  "version": "0.49.1-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -57,5 +57,6 @@
     "upath": "^2.0.1",
     "yaml": "^2.2.2",
     "yaml-ast-parser": "^0.0.43"
-  }
+  },
+  "stableVersion": "0.49.0"
 }

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.49.0",
+  "version": "0.49.1-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -52,5 +52,6 @@
     "openapi-types": "^12.0.2",
     "ts-invariant": "^0.9.3",
     "yaml-ast-parser": "^0.0.43"
-  }
+  },
+  "stableVersion": "0.49.0"
 }

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.49.0",
+  "version": "0.49.1-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -138,5 +138,6 @@
       "node18-win-x64"
     ],
     "outputPath": "../../dist"
-  }
+  },
+  "stableVersion": "0.49.0"
 }

--- a/projects/optic/src/sentry.ts
+++ b/projects/optic/src/sentry.ts
@@ -11,7 +11,13 @@ export const initSentry = (sentryUrl: string | undefined, version: string) => {
   if (sentryUrl && !isSentryDisabled) {
     Sentry.init({
       dsn: sentryUrl,
-      tracesSampleRate: 1.0,
+      integrations: (integrations) => {
+        // Disable the Sentry Http integration, we don't use traces across http bounds and this breaks certain cases with capture
+        // as it adds custom sentry http headers
+        return integrations.filter(
+          (integration) => integration.name !== 'Http'
+        );
+      },
       release: version,
     });
   }

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.49.0",
+  "version": "0.49.1-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -39,5 +39,6 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
-  }
+  },
+  "stableVersion": "0.49.0"
 }

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.49.0",
+  "version": "0.49.1-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -38,5 +38,6 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
-  }
+  },
+  "stableVersion": "0.49.0"
 }


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Sometimes, when forwarding requests sentry would add additional headers for tracing (it may also be messing up the existing headers as well). This would be attached whenever we forwarded requests using `capture`. Certain gateways and servers don't like it when you add in extra headers. Disabling this will no longer add sentry headers to http requests

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
