### PR TITLE
Fix adding a host header to a capture request rerouting to different place

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.49.1-1",
+  "version": "0.49.1-2",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.49.1-2",
+  "version": "0.49.1-3",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/fastify-capture/package.json
+++ b/projects/fastify-capture/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/fastify-capture",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.49.1-2",
+  "version": "0.49.1-3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/fastify-capture/package.json
+++ b/projects/fastify-capture/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/fastify-capture",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.49.1-1",
+  "version": "0.49.1-2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.49.1-2",
+  "version": "0.49.1-3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.49.1-1",
+  "version": "0.49.1-2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.49.1-1",
+  "version": "0.49.1-2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.49.1-2",
+  "version": "0.49.1-3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.49.1-1",
+  "version": "0.49.1-2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.49.1-2",
+  "version": "0.49.1-3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.49.1-1",
+  "version": "0.49.1-2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.49.1-2",
+  "version": "0.49.1-3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/src/commands/capture/actions/captureRequests.ts
+++ b/projects/optic/src/commands/capture/actions/captureRequests.ts
@@ -14,9 +14,9 @@ import {
   OpticCliConfig,
   RequestSend,
 } from '../../../config';
-import { ProxyInteractions } from '../../oas/captures/proxy';
 import { HarEntries } from '../sources/har';
 import { getSpinner } from '../../../utils/spinner';
+import { ProxyInteractions, ProxyServer } from '../sources/proxy';
 
 const defaultServerReadyTimeout = 10_000; // 10s
 
@@ -41,33 +41,6 @@ const loggerWhileSpinning = {
 
 const wait = (time: number) =>
   new Promise((r) => setTimeout(() => r(null), time));
-
-class ProxyInstance {
-  interactions!: ProxyInteractions;
-  url!: string;
-  targetUrl: string;
-  private abortController: AbortController;
-
-  constructor(target: string) {
-    this.abortController = new AbortController();
-    this.targetUrl = target;
-  }
-
-  public async start(port: number | undefined) {
-    [this.interactions, this.url] = await ProxyInteractions.create(
-      this.targetUrl,
-      this.abortController.signal,
-      {
-        mode: 'reverse-proxy',
-        proxyPort: port,
-      }
-    );
-  }
-
-  stop() {
-    this.abortController.abort();
-  }
-}
 
 type Bailout = { didBailout: boolean; promise: Promise<any> };
 function startApp(
@@ -266,7 +239,7 @@ async function runRequestsCommand(
 
 function makeAllRequests(
   captureConfig: CaptureConfigData,
-  proxy: ProxyInstance,
+  proxyUrl: string,
   spinner?: ora.Ora
 ) {
   // send requests
@@ -274,7 +247,7 @@ function makeAllRequests(
   if (captureConfig.requests && captureConfig.requests.send) {
     const requests = sendRequests(
       captureConfig.requests.send,
-      proxy.url,
+      proxyUrl,
       captureConfig.config?.request_concurrency || 5,
       spinner
     );
@@ -304,7 +277,7 @@ function makeAllRequests(
     runRequestsPromise = runRequestsCommand(
       captureConfig.requests.run.command,
       proxyVar,
-      proxy.url,
+      proxyUrl,
       spinner
     );
   }
@@ -318,7 +291,7 @@ export async function captureRequestsFromProxy(
   options: { proxyPort?: string; serverOverride?: string; serverUrl: string }
 ) {
   let app: ChildProcessWithoutNullStreams | undefined = undefined;
-  let proxy: ProxyInstance | undefined = undefined;
+  let proxy: ProxyServer | undefined = undefined;
   function cleanup() {
     proxy?.stop();
     if (app && app.pid && app.exitCode === null) {
@@ -337,6 +310,7 @@ export async function captureRequestsFromProxy(
     text: 'Generating traffic to send to server',
     color: 'blue',
   })?.start();
+  let interactions: ProxyInteractions | null = null;
 
   const serverUrl = options.serverUrl;
   const serverDir =
@@ -383,15 +357,16 @@ export async function captureRequestsFromProxy(
       }
     }
     // start proxy
-    proxy = new ProxyInstance(serverUrl);
-    await proxy.start(
+    proxy = new ProxyServer(serverUrl);
+    const [proxyInteractions, proxyUrl] = await proxy.start(
       options.proxyPort ? Number(options.proxyPort) : undefined
     );
+    interactions = proxyInteractions;
 
     if (spinner) spinner.text = 'Sending requests to server';
     let [sendRequestsPromise, runRequestsPromise] = makeAllRequests(
       captureConfig,
-      proxy,
+      proxyUrl,
       spinner
     );
     // Here we continue even if some of the requests failed - we log out the requests errors but use the rest to query
@@ -430,5 +405,5 @@ export async function captureRequestsFromProxy(
   spinner?.succeed('Finished running requests');
 
   // process proxy interactions into hars
-  return HarEntries.fromProxyInteractions(proxy.interactions);
+  return HarEntries.fromProxyInteractions(interactions);
 }

--- a/projects/optic/src/commands/capture/actions/captureRequests.ts
+++ b/projects/optic/src/commands/capture/actions/captureRequests.ts
@@ -14,7 +14,7 @@ import {
   OpticCliConfig,
   RequestSend,
 } from '../../../config';
-import { ProxyInteractions } from '../sources/proxy';
+import { ProxyInteractions } from '../../oas/captures/proxy';
 import { HarEntries } from '../sources/har';
 import { getSpinner } from '../../../utils/spinner';
 

--- a/projects/optic/src/commands/capture/sources/captured-interactions.ts
+++ b/projects/optic/src/commands/capture/sources/captured-interactions.ts
@@ -2,7 +2,7 @@ import { OpenAPIV3 } from '@useoptic/openapi-utilities';
 
 import { HttpArchive, HarEntries } from './har';
 import { PostmanEntry, PostmanCollectionEntries } from './postman';
-import { ProxySource, ProxyInteractions } from './proxy';
+import { ProxySource, ProxyInteractions } from '../../oas/captures/proxy';
 
 import { URL } from 'url';
 import { Buffer } from 'buffer';

--- a/projects/optic/src/commands/capture/sources/captured-interactions.ts
+++ b/projects/optic/src/commands/capture/sources/captured-interactions.ts
@@ -2,7 +2,7 @@ import { OpenAPIV3 } from '@useoptic/openapi-utilities';
 
 import { HttpArchive, HarEntries } from './har';
 import { PostmanEntry, PostmanCollectionEntries } from './postman';
-import { ProxySource, ProxyInteractions } from '../../oas/captures/proxy';
+import { ProxySource, ProxyInteractions } from '../sources/proxy';
 
 import { URL } from 'url';
 import { Buffer } from 'buffer';

--- a/projects/optic/src/commands/capture/sources/har.ts
+++ b/projects/optic/src/commands/capture/sources/har.ts
@@ -11,7 +11,7 @@ import { chain } from 'stream-chain'; // replace with  stream.compose once it st
 import HarSchemas from 'har-schema';
 import Ajv, { SchemaObject, ErrorObject } from 'ajv';
 import ajvFormats from 'ajv-formats';
-import { ProxyInteractions } from './proxy';
+import { ProxyInteractions } from '../../oas/captures/proxy';
 import isUrl from 'is-url';
 import { Result, Ok, Err } from 'ts-results';
 import zlib from 'node:zlib';

--- a/projects/optic/src/commands/capture/sources/proxy.ts
+++ b/projects/optic/src/commands/capture/sources/proxy.ts
@@ -1,0 +1,165 @@
+import * as mockttp from 'mockttp';
+import { CompletedRequest, CompletedResponse, TimingEvents } from 'mockttp';
+import { URL } from 'url';
+import portfinder from 'portfinder';
+import chalk from 'chalk';
+import { UserError } from '@useoptic/openapi-utilities';
+import urljoin from 'url-join';
+import { Subject } from 'axax/esnext';
+
+import { logger } from '../../../logger';
+
+export interface ProxyInteractions
+  extends AsyncIterable<ProxySource.Interaction> {}
+
+export declare namespace ProxySource {
+  interface Interaction {
+    request: Request;
+    response: Response;
+  }
+
+  interface Request
+    extends Omit<
+      CompletedRequest,
+      'matchedRuleId' | 'remoteIpAddress' | 'remotePort' | 'tags' | 'body'
+    > {
+    timingEvents: TimingEvents;
+    body: Body;
+  }
+  interface Response extends Omit<CompletedResponse, 'tags' | 'body'> {
+    timingEvents: TimingEvents;
+    body: Body;
+  }
+
+  type Body = Pick<mockttp.CompletedBody, 'buffer'>;
+}
+
+export class ProxyServer {
+  private interactionSubject?: Subject<ProxySource.Interaction>;
+  private url: URL;
+  private capturingProxy?: mockttp.Mockttp = undefined;
+
+  constructor(target: string) {
+    try {
+      this.url = new URL(target);
+    } catch (e) {
+      logger.error(
+        `${chalk.red(
+          'Error:'
+        )} Invalid URL. Valid URLs must include the protocol and host, e.g. http://localhost:3030 or https://api.example.com, received: ${target}`
+      );
+      throw new UserError();
+    }
+  }
+
+  public async start(
+    port: number | undefined
+  ): Promise<[ProxyInteractions, string]> {
+    const { origin, pathname: serverPathnamePrefix } = this.url;
+
+    const capturingProxy = mockttp.getLocal({
+      cors: false,
+      debug: false,
+      recordTraffic: false,
+    });
+    const interactionSubject = new Subject<ProxySource.Interaction>();
+    this.interactionSubject = interactionSubject;
+    const requestsById = new Map<string, ProxySource.Request>();
+    if (!port) {
+      port = await portfinder.getPortPromise({
+        port: 8000,
+        stopPort: 8999,
+      });
+    }
+
+    await capturingProxy
+      .forAnyRequest()
+      .always()
+      .thenPassThrough({
+        beforeRequest: (capturedRequest: CompletedRequest) => {
+          const {
+            matchedRuleId,
+            remoteIpAddress,
+            remotePort,
+            tags,
+            body,
+            timingEvents,
+            ...rest
+          } = capturedRequest;
+          // Sometimes we need to adjust the request url if the server url is not at the hostname root
+          // e.g. `http://example.com/server-lives-here - requests going to the proxy root should be forwarded to `/server-lives-here`
+          const urlObj = new URL(rest.url);
+          urlObj.pathname = urljoin(serverPathnamePrefix, urlObj.pathname);
+          const prefixedUrl = urlObj.toString();
+          logger.debug(
+            `Forwarding request ${
+              rest.path
+            } ${prefixedUrl} with headers: ${JSON.stringify(
+              rest.headers
+            )}. id: ${capturedRequest.id}`
+          );
+
+          const request = {
+            ...rest,
+            body: { buffer: body.buffer },
+            timingEvents: timingEvents as TimingEvents,
+          };
+          requestsById.set(request.id, request);
+          return {
+            url: prefixedUrl,
+          };
+        },
+        forwarding: {
+          targetHost: origin,
+          updateHostHeader: true,
+        },
+      });
+
+    await capturingProxy.on(
+      'response',
+      (capturedResponse: CompletedResponse) => {
+        const { id } = capturedResponse;
+        const request = requestsById.get(id);
+        if (!request) return;
+
+        const { tags, body, timingEvents, ...rest } = capturedResponse;
+        logger.debug(
+          `Received response for request id ${id} status code: ${
+            rest.statusCode
+          } message: ${rest.statusMessage} headers: ${JSON.stringify(
+            rest.rawHeaders
+          )}`
+        );
+
+        const response = {
+          ...rest,
+          body: { buffer: body.buffer },
+          timingEvents: timingEvents as TimingEvents,
+        };
+        interactionSubject.onNext({
+          request,
+          response,
+        });
+
+        requestsById.delete(id);
+      }
+    );
+
+    await capturingProxy.start({
+      startPort: port,
+      endPort: port + 999,
+    });
+
+    const stream = (async function* () {
+      yield* interactionSubject.iterator;
+    })();
+
+    return [stream, capturingProxy.url];
+  }
+
+  stop() {
+    this.capturingProxy?.reset();
+    this.capturingProxy?.stop();
+    this.interactionSubject?.onCompleted();
+  }
+}

--- a/projects/optic/src/commands/capture/sources/proxy.ts
+++ b/projects/optic/src/commands/capture/sources/proxy.ts
@@ -64,6 +64,7 @@ export class ProxyServer {
     });
     const interactionSubject = new Subject<ProxySource.Interaction>();
     this.interactionSubject = interactionSubject;
+    this.capturingProxy = capturingProxy;
     const requestsById = new Map<string, ProxySource.Request>();
     if (!port) {
       port = await portfinder.getPortPromise({

--- a/projects/optic/src/commands/oas/capture.ts
+++ b/projects/optic/src/commands/oas/capture.ts
@@ -23,10 +23,7 @@ import { clearCommand } from './capture-clear';
 import { createNewSpecFile } from '../../utils/specs';
 import { logger } from '../../logger';
 import { HarEntries, HttpArchive } from '../capture/sources/har';
-import {
-  ProxyCertAuthority,
-  ProxyInteractions,
-} from '../capture/sources/proxy';
+import { ProxyCertAuthority, ProxyInteractions } from './captures/proxy';
 import { CapturedInteraction } from '../capture/sources/captured-interactions';
 
 export async function captureV1(

--- a/projects/optic/src/commands/oas/captures/proxy.test.ts
+++ b/projects/optic/src/commands/oas/captures/proxy.test.ts
@@ -1,13 +1,13 @@
 import { it, describe, expect, beforeAll, afterAll } from '@jest/globals';
 
-import { ProxyCertAuthority, ProxyInteractions } from '../proxy';
 import * as mockttp from 'mockttp';
 import bent from 'bent';
-import { collect } from '../../../oas/lib/async-tools';
+import { collect } from '../lib/async-tools';
 import fetch from 'node-fetch';
 import https from 'https';
 import UrlJoin from 'url-join';
 import { httpsOverHttp } from 'tunnel';
+import { ProxyInteractions, ProxyCertAuthority } from './proxy';
 
 describe('ProxyInteractions', () => {
   let target: mockttp.Mockttp;

--- a/projects/optic/src/commands/oas/captures/proxy.ts
+++ b/projects/optic/src/commands/oas/captures/proxy.ts
@@ -7,7 +7,7 @@ import {
   TimingEvents,
 } from 'mockttp';
 
-import { Subject } from '../../oas/lib/async-tools';
+import { Subject } from '../lib/async-tools';
 import { pki, md } from 'node-forge';
 import { randomBytes } from 'crypto';
 import { Readable } from 'stream';
@@ -118,6 +118,7 @@ export class ProxyInteractions {
 
     await capturingProxy.forUnmatchedRequest().thenPassThrough({
       beforeRequest(capturedRequest) {
+        console.log(capturedRequest.url);
         log.info('proxying request to ' + capturedRequest.url);
       },
     });

--- a/projects/optic/src/commands/oas/captures/proxy.ts
+++ b/projects/optic/src/commands/oas/captures/proxy.ts
@@ -25,6 +25,7 @@ import chalk from 'chalk';
 import { UserError } from '@useoptic/openapi-utilities';
 import { logger } from '../../../logger';
 import urljoin from 'url-join';
+import { ProxySource } from '../../capture/sources/proxy';
 
 type Logger = typeof globalLog;
 
@@ -269,28 +270,6 @@ export class ProxyInteractions {
 
     return [stream, transparentProxy.url!, capturingProxy.url];
   }
-}
-
-export declare namespace ProxySource {
-  interface Interaction {
-    request: Request;
-    response: Response;
-  }
-
-  interface Request
-    extends Omit<
-      CompletedRequest,
-      'matchedRuleId' | 'remoteIpAddress' | 'remotePort' | 'tags' | 'body'
-    > {
-    timingEvents: TimingEvents;
-    body: Body;
-  }
-  interface Response extends Omit<CompletedResponse, 'tags' | 'body'> {
-    timingEvents: TimingEvents;
-    body: Body;
-  }
-
-  type Body = Pick<CompletedBody, 'buffer'>;
 }
 
 export interface ProxyCertAuthority {

--- a/projects/optic/src/commands/oas/setup-tls.ts
+++ b/projects/optic/src/commands/oas/setup-tls.ts
@@ -9,7 +9,7 @@ import { Option, Some, None } from 'ts-results';
 import chalk from 'chalk';
 import path from 'path';
 import { exitIfNotElevated, platform, runCommand } from './lib/shell-utils';
-import { ProxyCertAuthority } from '../capture/sources/proxy';
+import { ProxyCertAuthority } from './captures/proxy';
 
 export async function setupTlsCommand(): Promise<Command> {
   const command = new Command('setup-tls');

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.49.1-2",
+  "version": "0.49.1-3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.49.1-1",
+  "version": "0.49.1-2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.49.1-1",
+  "version": "0.49.1-2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.49.1-2",
+  "version": "0.49.1-3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

A curl request like: `curl -H "host: useoptic.com" localhost:8000/pets` when running something like `optic capture --server-override example.com` results in our proxy server forwarding a request to the set host header, instead of the proxy target

Note that I've _only_ fixed the capture 2.0 flow, since the code that was handling this I think was related to the system proxy code. I've forked the proxy code so capture 2.0 should fix this behavior.

Running something like this with the capture config should now work
```
# shell
optic capture pets.yml --server-override https://vr0yklzhdl.execute-api.us-east-1.amazonaws.com/dev
# optic.yml
capture:
  pets.yml:
    server:
      command: your-server-command
      url: http://localhost:8080
    requests:
      run:
        command: "sh -c \"curl $OPTIC_PROXY/pets --header 'Authorization: redacted' -H 'host: useoptic.com' --header 'content-type: application/json'\""
    config:
      request_concurrency: 4

```

publishing `0.49.1-3` which we can use to test this

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
