### PR TITLE
Handle non json responses and bodies

### DIFF
--- a/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
@@ -269,12 +269,16 @@ GET /ip
 GET /oauth1
 PATCH /patch
 POST /post
-PUT /put
-GET /response-headers
-GET /status/{status}
-GET /stream/{stream}
-GET /time/{time}
-POST /transform/collection
+Error: Invalid reference token: text/plain
+    at Object.get ($root$/projects/json-pointer-helpers/src/json-pointers/json-pointer-helpers.ts:16:13)
+    at SchemaInventory.refsForAdditions ($root$/projects/optic/src/commands/capture/patches/patchers/closeness/schema-inventory.ts:64:46)
+    at async generateRefRefactorPatches ($root$/projects/optic/src/commands/capture/patches/patches.ts:146:18)
+    at async $root$/projects/optic/src/commands/capture/actions/undocumented.ts:181:5
+    at async jsonOpsFromSpecPatches ($root$/projects/optic/src/commands/capture/patches/patches.ts:154:20)
+    at async documentNewEndpoint ($root$/projects/optic/src/commands/capture/actions/undocumented.ts:194:22)
+    at async $root$/projects/optic/src/commands/capture/capture.ts:371:11
+    at async Command.<anonymous> ($root$/projects/optic/src/error-handler.ts:18:14)
+[31mInvalid reference token: text/plain[39m
 "
 `;
 
@@ -1370,6 +1374,7 @@ GET /books
 GET /authors
 GET /books/{book}
 POST /books/{book}
+GET /
 "
 `;
 
@@ -1426,6 +1431,15 @@ paths:
           application/json;charset=UTF-8:
             schema:
               $ref: "#/components/schemas/PostBooksBookRequestBody"
+  /:
+    get:
+      responses:
+        "200":
+          description: 200 response
+          content:
+            text/html:
+              schema:
+                $ref: "#/components/schemas/Get200ResponseBody"
 components:
   schemas:
     GetBooks200ResponseBody:
@@ -1525,6 +1539,8 @@ components:
         - name
         - price
         - author_id
+    Get200ResponseBody:
+      type: string
 "
 `;
 
@@ -1539,7 +1555,7 @@ GET /books
   [33m[200 response body] 'price' is now type string (/properties/books/items/properties/price)[39m
   [33m[200 response body] 'status' now has enum value 'hold' (/properties/books/items/properties/status/enum)[39m
 
-4 unmatched requests
+5 unmatched requests
 [33mNew endpoints are only added in interactive mode.[39m
 [34mRun with \`--update interactive\` to add new endpoints[39m
 [33mHint: optic capture openapi.yml --update interactive[39m
@@ -1673,7 +1689,7 @@ operation: [1mget /books[22m
 [90m$workspace$/openapi.yml[39m
 
 
-100.0% coverage of your documented operations. 4 requests did not match a documented path (5 total requests).
+100.0% coverage of your documented operations. 5 requests did not match a documented path (6 total requests).
 9 diffs detected in documented operations
 
 [33mNew endpoints are only added in interactive mode.[39m
@@ -1693,7 +1709,7 @@ GET /books
   [31m[200 response body] 'price' does not match type string. Received 10 (/properties/books/items/properties/price)[39m
   [31m[200 response body] 'status' missing enum value 'hold' (/properties/books/items/properties/status/enum)[39m
 
-100.0% coverage of your documented operations. 4 requests did not match a documented path (5 total requests).
+100.0% coverage of your documented operations. 5 requests did not match a documented path (6 total requests).
 6 diffs detected in documented operations
 
 [33mNew endpoints are only added in interactive mode.[39m

--- a/projects/optic/src/__tests__/integration/workspaces/capture/with-server/optic.yml
+++ b/projects/optic/src/__tests__/integration/workspaces/capture/with-server/optic.yml
@@ -29,6 +29,7 @@ capture:
       ready_endpoint: /healthcheck
     requests:
       send:
+        - path: /
         - path: /books
           method: GET
         - path: /books/asd

--- a/projects/optic/src/__tests__/integration/workspaces/capture/with-server/server.js
+++ b/projects/optic/src/__tests__/integration/workspaces/capture/with-server/server.js
@@ -41,8 +41,15 @@ const books = [
 ];
 
 const requestListener = function (req, res) {
-  res.setHeader("Content-Type", "application/json");
   const normalizedUrl = serverPrefix ? req.url.replace(serverPrefix, '') : req.url
+  if (normalizedUrl === '/' && req.method === 'GET') {
+    res.setHeader("Content-Type", "text/html");
+    res.writeHead(200);
+    res.end('<html></html>');
+    return
+  }
+
+  res.setHeader("Content-Type", "application/json");
   if (normalizedUrl === '/books' && req.method === 'GET') {
     res.writeHead(200);
     res.end(JSON.stringify({books}));

--- a/projects/optic/src/commands/capture/actions/captureRequests.ts
+++ b/projects/optic/src/commands/capture/actions/captureRequests.ts
@@ -147,7 +147,7 @@ function sendRequests(
   proxyUrl: string,
   concurrency: number,
   spinner?: ora.Ora
-): Promise<void>[] {
+): Promise<any>[] {
   const limiter = new Bottleneck({
     maxConcurrent: concurrency,
     minTime: 0,
@@ -180,11 +180,9 @@ function sendRequests(
     }
 
     return limiter.schedule(() =>
-      fetch(urljoin(proxyUrl, r.path), opts)
-        .then((response) => response.json())
-        .catch((error: FetchError) => {
-          loggerWhileSpinning.error(spinner, error.message);
-        })
+      fetch(urljoin(proxyUrl, r.path), opts).catch((error: FetchError) => {
+        loggerWhileSpinning.error(spinner, error.message);
+      })
     );
   });
 }

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/documented-bodies.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/documented-bodies.ts
@@ -248,7 +248,12 @@ async function decodeCapturedBody(
         value,
       })
     );
-  } // TODO: consider what to do when there's no content type (happens, as seen in the past)
-
-  return Ok(None); // no decoded body available
+  } else {
+    return Ok(
+      Some({
+        contentType,
+        value: capturedBody.body,
+      })
+    );
+  }
 }

--- a/projects/optic/src/commands/capture/sources/body.ts
+++ b/projects/optic/src/commands/capture/sources/body.ts
@@ -1,5 +1,3 @@
-import { Readable } from 'stream';
-
 export interface CapturedBody {
   contentType: string | null;
   size: number; // size in bytes, defaults to -1


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

This build will be broken until we fix _another_ bug that this uncovered where if you add 2 schemas in the same patch it explodes. I'm going to create another PR that targets this PR that will fix this issue

This PR fixes:
- `invalid json response body` when returned a non-json response
- Documents non-json responses as `schema: type: string` 



## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
