### PR TITLE
chore(diff): error when branch is missing

### DIFF
--- a/projects/optic/src/commands/diff/diff.ts
+++ b/projects/optic/src/commands/diff/diff.ts
@@ -357,6 +357,13 @@ const getDiffAction =
         process.exitCode = 1;
         return;
       }
+
+      try {
+        await Git.assertRefExists(options.base);
+      } catch (e) {
+        logger.error(`Could not find base ref: ${options.base}`);
+      }
+
       parsedFiles = await getBaseAndHeadFromFileAndBase(
         file1,
         options.base,

--- a/projects/optic/src/commands/diff/diff.ts
+++ b/projects/optic/src/commands/diff/diff.ts
@@ -360,7 +360,7 @@ const getDiffAction =
 
       try {
         await Git.assertRefExists(options.base);
-      } catch (e) {
+      } catch {
         logger.error(`Could not find base ref: ${options.base}`);
       }
 


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

displays an error when running `optic diff` against a base that doesn't exist or hasn't been fetched. i noticed that diff-all was handling with scenario correctly and was happy to see we just needed to do the same check.

before:
```
➜ npx ts-node $HOME/code/optic/projects/optic/src/index.ts diff  openapi.yml --base sdfdsfdsf; echo $status

1
```

after:
```
➜ npx ts-node $HOME/code/optic/projects/optic/src/index.ts diff openapi.yml --base sdfdsfdsf; echo $status
Could not find base ref: sdfdsfdsf

1
```
## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._
- closes https://github.com/opticdev/monorail/issues/4888

## 👹 QA
_How can other humans verify that this PR is correct?_
