### PR TITLE
Throw error on diff --base when file doesnt exist

### DIFF
--- a/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`diff file doesn't exist 1`] = `
+"[31mError opening file "$workspace$/doesnt-exist.json" [39m
+[31mENOENT: no such file or directory, open '$workspace$/doesnt-exist.json'[39m
+"
+`;
+
 exports[`diff petstore diff 1`] = `
 "[31mx [39m[1mSwagger Petstore Updated[22m [90mpetstore-base.json[39m
 [1mOperations: [22m5 operations added, 16 changed, 1 removed

--- a/projects/optic/src/__tests__/integration/diff.test.ts
+++ b/projects/optic/src/__tests__/integration/diff.test.ts
@@ -52,6 +52,25 @@ describe('diff', () => {
     expect(code).toBe(0);
   });
 
+  test("file doesn't exist", async () => {
+    const workspace = await setupWorkspace('diff/files-no-repo', {
+      repo: false,
+    });
+
+    await run(
+      `touch abc.txt && git add . && git commit -m 'add abc.txt'`,
+      false,
+      workspace
+    );
+
+    const { combined, code } = await runOptic(
+      workspace,
+      'diff doesnt-exist.json --base HEAD~1'
+    );
+    expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
+    expect(code).toBe(1);
+  });
+
   test('reads optic.dev.yml for rulesets', async () => {
     const workspace = await setupWorkspace('diff/basic-rules-dev-yml', {
       repo: true,

--- a/projects/optic/src/utils/spec-loaders.ts
+++ b/projects/optic/src/utils/spec-loaders.ts
@@ -320,20 +320,10 @@ export const parseFilesFromRef = async (
   pathFromGitRoot: string;
 }> => {
   await Git.assertRefExists(base);
-  const absolutePath = path.resolve(filePath);
   const gitFileName = filePathToGitPath(rootGitPath, filePath);
-  const fileExistsOnBasePromise = exec(`git show ${base}:${gitFileName}`)
+  const existsOnBase = await exec(`git show ${base}:${gitFileName}`)
     .then(() => true)
     .catch(() => false);
-  const fileExistsOnHeadPromise = fs
-    .access(absolutePath)
-    .then(() => true)
-    .catch(() => false);
-
-  const [existsOnBase, existsOnHead] = await Promise.all([
-    fileExistsOnBasePromise,
-    fileExistsOnHeadPromise,
-  ]);
 
   return {
     baseFile: await parseSpecAndDereference(
@@ -345,10 +335,7 @@ export const parseFilesFromRef = async (
         strict: false,
       });
     }),
-    headFile: await parseSpecAndDereference(
-      existsOnHead ? absolutePath : undefined,
-      config
-    ).then((file) => {
+    headFile: await parseSpecAndDereference(filePath, config).then((file) => {
       return validateAndDenormalize(file, {
         denormalize: options.denormalize,
         strict: options.headStrict,


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Before `optic diff doesnt-exist.yml --base HEAD~1` did not throw an error - this PR fixes that so we raise an error

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
