### PR TITLE
Fix capture patching polymorphic array

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.49.1-3",
+  "version": "0.49.1",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",
@@ -27,6 +27,5 @@
     "**/*.+(js|jsx|ts|tsx|json|css)": [
       "yarn prettier --write"
     ]
-  },
-  "stableVersion": "0.49.0"
+  }
 }

--- a/projects/fastify-capture/package.json
+++ b/projects/fastify-capture/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/fastify-capture",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.49.1-3",
+  "version": "0.49.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -37,6 +37,5 @@
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
     "typescript": "^5.0.4"
-  },
-  "stableVersion": "0.49.0"
+  }
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.49.1-3",
+  "version": "0.49.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -32,6 +32,5 @@
   "dependencies": {
     "jsonpointer": "^5.0.1",
     "minimatch": "9.0.3"
-  },
-  "stableVersion": "0.49.0"
+  }
 }

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.49.1-3",
+  "version": "0.49.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -57,6 +57,5 @@
     "upath": "^2.0.1",
     "yaml": "^2.2.2",
     "yaml-ast-parser": "^0.0.43"
-  },
-  "stableVersion": "0.49.0"
+  }
 }

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.49.1-3",
+  "version": "0.49.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -52,6 +52,5 @@
     "openapi-types": "^12.0.2",
     "ts-invariant": "^0.9.3",
     "yaml-ast-parser": "^0.0.43"
-  },
-  "stableVersion": "0.49.0"
+  }
 }

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.49.1-3",
+  "version": "0.49.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -138,6 +138,5 @@
       "node18-win-x64"
     ],
     "outputPath": "../../dist"
-  },
-  "stableVersion": "0.49.0"
+  }
 }

--- a/projects/optic/src/__tests__/integration/__snapshots__/update.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/update.test.ts.snap
@@ -53,54 +53,28 @@ exports[`update update an existing spec with prefixed server 2`] = `
             "items": {
               "properties": {
                 "another": {
-                  "oneOf": [
-                    {
-                      "items": {
-                        "properties": {
-                          "max": {
-                            "type": "number",
-                          },
-                          "min": {
-                            "type": "number",
-                          },
-                          "path": {
-                            "type": "string",
-                          },
-                        },
-                        "required": [
-                          "path",
-                          "max",
-                          "min",
-                        ],
-                        "type": "object",
+                  "items": {
+                    "properties": {
+                      "max": {
+                        "type": "number",
                       },
-                      "type": [
-                        "object",
-                        "null",
-                      ],
-                    },
-                    {
-                      "items": {
-                        "properties": {
-                          "max": {
-                            "type": "number",
-                          },
-                          "min": {
-                            "type": "number",
-                          },
-                          "path": {
-                            "type": "string",
-                          },
-                        },
-                        "required": [
-                          "path",
-                          "max",
-                          "min",
-                        ],
-                        "type": "object",
+                      "min": {
+                        "type": "number",
                       },
-                      "type": "array",
+                      "path": {
+                        "type": "string",
+                      },
                     },
+                    "required": [
+                      "path",
+                      "max",
+                      "min",
+                    ],
+                    "type": "object",
+                  },
+                  "type": [
+                    "array",
+                    "null",
                   ],
                 },
                 "name": {
@@ -404,54 +378,28 @@ exports[`update updates an empty spec 2`] = `
             "items": {
               "properties": {
                 "another": {
-                  "oneOf": [
-                    {
-                      "items": {
-                        "properties": {
-                          "max": {
-                            "type": "number",
-                          },
-                          "min": {
-                            "type": "number",
-                          },
-                          "path": {
-                            "type": "string",
-                          },
-                        },
-                        "required": [
-                          "path",
-                          "max",
-                          "min",
-                        ],
-                        "type": "object",
+                  "items": {
+                    "properties": {
+                      "max": {
+                        "type": "number",
                       },
-                      "type": [
-                        "object",
-                        "null",
-                      ],
-                    },
-                    {
-                      "items": {
-                        "properties": {
-                          "max": {
-                            "type": "number",
-                          },
-                          "min": {
-                            "type": "number",
-                          },
-                          "path": {
-                            "type": "string",
-                          },
-                        },
-                        "required": [
-                          "path",
-                          "max",
-                          "min",
-                        ],
-                        "type": "object",
+                      "min": {
+                        "type": "number",
                       },
-                      "type": "array",
+                      "path": {
+                        "type": "string",
+                      },
                     },
+                    "required": [
+                      "path",
+                      "max",
+                      "min",
+                    ],
+                    "type": "object",
+                  },
+                  "type": [
+                    "array",
+                    "null",
                   ],
                 },
                 "name": {
@@ -749,54 +697,28 @@ exports[`update updates an existing spec 2`] = `
             "items": {
               "properties": {
                 "another": {
-                  "oneOf": [
-                    {
-                      "items": {
-                        "properties": {
-                          "max": {
-                            "type": "number",
-                          },
-                          "min": {
-                            "type": "number",
-                          },
-                          "path": {
-                            "type": "string",
-                          },
-                        },
-                        "required": [
-                          "path",
-                          "max",
-                          "min",
-                        ],
-                        "type": "object",
+                  "items": {
+                    "properties": {
+                      "max": {
+                        "type": "number",
                       },
-                      "type": [
-                        "object",
-                        "null",
-                      ],
-                    },
-                    {
-                      "items": {
-                        "properties": {
-                          "max": {
-                            "type": "number",
-                          },
-                          "min": {
-                            "type": "number",
-                          },
-                          "path": {
-                            "type": "string",
-                          },
-                        },
-                        "required": [
-                          "path",
-                          "max",
-                          "min",
-                        ],
-                        "type": "object",
+                      "min": {
+                        "type": "number",
                       },
-                      "type": "array",
+                      "path": {
+                        "type": "string",
+                      },
                     },
+                    "required": [
+                      "path",
+                      "max",
+                      "min",
+                    ],
+                    "type": "object",
+                  },
+                  "type": [
+                    "array",
+                    "null",
                   ],
                 },
                 "name": {

--- a/projects/optic/src/commands/capture/patches/__tests__/__snapshots__/patches.test.ts.snap
+++ b/projects/optic/src/commands/capture/patches/__tests__/__snapshots__/patches.test.ts.snap
@@ -3132,6 +3132,265 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 missing required property
 }
 `;
 
+exports[`generateEndpointSpecPatches OAS version 3.0.1 schema with arrays with polymorphic items 1`] = `
+[
+  {
+    "description": "update response body: make property status optional",
+    "diff": {
+      "description": "required property 'status' was missing",
+      "example": undefined,
+      "instancePath": "/status",
+      "key": "status",
+      "keyword": "required",
+      "kind": "MissingRequiredProperty",
+      "parentObjectPath": "",
+      "propertyPath": "/properties/status",
+    },
+    "groupedOperations": [
+      {
+        "intent": "remove status from parent's required array",
+        "operations": [
+          {
+            "op": "remove",
+            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/0",
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsIncompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"data":[{"status":null},{"status":"something-else"},{"status":"another-thing"},{"status":null},{"status":123}]}",
+          "contentType": "application/json",
+          "size": 112,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+  {
+    "description": "update response body: make status null",
+    "diff": {
+      "description": "'status' did not match schema",
+      "example": null,
+      "expectedType": "string",
+      "instancePath": "/data/0/status",
+      "key": "status",
+      "keyword": "type",
+      "kind": "UnmatchedType",
+      "propertyPath": "/properties/data/items/properties/status",
+    },
+    "groupedOperations": [
+      {
+        "intent": "make status nullable",
+        "operations": [
+          {
+            "op": "replace",
+            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/nullable",
+            "value": true,
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsIncompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"data":[{"status":null},{"status":"something-else"},{"status":"another-thing"},{"status":null},{"status":123}]}",
+          "contentType": "application/json",
+          "size": 112,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+  {
+    "description": "update response body: make status null",
+    "diff": {
+      "description": "'status' did not match schema",
+      "example": null,
+      "expectedType": "string",
+      "instancePath": "/data/3/status",
+      "key": "status",
+      "keyword": "type",
+      "kind": "UnmatchedType",
+      "propertyPath": "/properties/data/items/properties/status",
+    },
+    "groupedOperations": [
+      {
+        "intent": "make status nullable",
+        "operations": [
+          {
+            "op": "replace",
+            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/nullable",
+            "value": true,
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsIncompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"data":[{"status":null},{"status":"something-else"},{"status":"another-thing"},{"status":null},{"status":123}]}",
+          "contentType": "application/json",
+          "size": 112,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+  {
+    "description": "update response body: make status oneOf",
+    "diff": {
+      "description": "'status' did not match schema",
+      "example": 123,
+      "expectedType": "string",
+      "instancePath": "/data/4/status",
+      "key": "status",
+      "keyword": "type",
+      "kind": "UnmatchedType",
+      "propertyPath": "/properties/data/items/properties/status",
+    },
+    "groupedOperations": [
+      {
+        "intent": "replace status with a one of containing both types",
+        "operations": [
+          {
+            "op": "remove",
+            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/type",
+          },
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/oneOf",
+            "value": [
+              {
+                "nullable": true,
+                "type": "string",
+              },
+              {
+                "type": "number",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsIncompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"data":[{"status":null},{"status":"something-else"},{"status":"another-thing"},{"status":null},{"status":123}]}",
+          "contentType": "application/json",
+          "size": 112,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+]
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.0.1 schema with arrays with polymorphic items 2`] = `
+{
+  "info": {},
+  "openapi": "3.0.1",
+  "paths": {
+    "/api/animals": {
+      "post": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "properties": {
+                          "status": {
+                            "nullable": true,
+                            "oneOf": [
+                              {
+                                "nullable": true,
+                                "type": "string",
+                              },
+                              {
+                                "type": "number",
+                              },
+                            ],
+                          },
+                        },
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [],
+                  "type": "object",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
 exports[`generateEndpointSpecPatches OAS version 3.0.1 schema with enum 1`] = `
 [
   {
@@ -8645,6 +8904,328 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 missing required property
                   "properties": {
                     "name": {
                       "type": "string",
+                    },
+                  },
+                  "required": [],
+                  "type": "object",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.1.0 schema with arrays with polymorphic items 1`] = `
+[
+  {
+    "description": "update response body: make property status optional",
+    "diff": {
+      "description": "required property 'status' was missing",
+      "example": undefined,
+      "instancePath": "/status",
+      "key": "status",
+      "keyword": "required",
+      "kind": "MissingRequiredProperty",
+      "parentObjectPath": "",
+      "propertyPath": "/properties/status",
+    },
+    "groupedOperations": [
+      {
+        "intent": "remove status from parent's required array",
+        "operations": [
+          {
+            "op": "remove",
+            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/0",
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsIncompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"data":[{"status":null},{"status":"something-else"},{"status":"another-thing"},{"status":null},{"status":123}]}",
+          "contentType": "application/json",
+          "size": 112,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+  {
+    "description": "update response body: make status null",
+    "diff": {
+      "description": "'status' did not match schema",
+      "example": null,
+      "expectedType": "string",
+      "instancePath": "/data/0/status",
+      "key": "status",
+      "keyword": "type",
+      "kind": "UnmatchedType",
+      "propertyPath": "/properties/data/items/properties/status",
+    },
+    "groupedOperations": [
+      {
+        "intent": "make status null",
+        "operations": [
+          {
+            "op": "replace",
+            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/type",
+            "value": [
+              "object",
+              "null",
+            ],
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsIncompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"data":[{"status":null},{"status":"something-else"},{"status":"another-thing"},{"status":null},{"status":123}]}",
+          "contentType": "application/json",
+          "size": 112,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+  {
+    "description": "update response body: make status null",
+    "diff": {
+      "description": "'status' did not match schema",
+      "example": null,
+      "expectedType": "string",
+      "instancePath": "/data/3/status",
+      "key": "status",
+      "keyword": "type",
+      "kind": "UnmatchedType",
+      "propertyPath": "/properties/data/items/properties/status",
+    },
+    "groupedOperations": [
+      {
+        "intent": "make status null",
+        "operations": [
+          {
+            "op": "replace",
+            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/type",
+            "value": [
+              "object",
+              "null",
+            ],
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsIncompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"data":[{"status":null},{"status":"something-else"},{"status":"another-thing"},{"status":null},{"status":123}]}",
+          "contentType": "application/json",
+          "size": 112,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+  {
+    "description": "update response body: make status oneOf",
+    "diff": {
+      "description": "'status' did not match schema",
+      "example": 123,
+      "expectedType": "string",
+      "instancePath": "/data/4/status",
+      "key": "status",
+      "keyword": "type",
+      "kind": "UnmatchedType",
+      "propertyPath": "/properties/data/items/properties/status",
+    },
+    "groupedOperations": [
+      {
+        "intent": "replace status with a one of containing both types",
+        "operations": [
+          {
+            "op": "remove",
+            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/type",
+          },
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/oneOf",
+            "value": [
+              {
+                "type": [
+                  "object",
+                  "null",
+                ],
+              },
+              {
+                "type": "number",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsIncompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"data":[{"status":null},{"status":"something-else"},{"status":"another-thing"},{"status":null},{"status":123}]}",
+          "contentType": "application/json",
+          "size": 112,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+  {
+    "description": "update response body: expand one of for oneOf",
+    "diff": {
+      "description": "'oneOf' did not match schema",
+      "example": "another-thing",
+      "expectedType": "oneOf schema",
+      "instancePath": "/data/2/status",
+      "key": "oneOf",
+      "keyword": "oneOf",
+      "kind": "UnmatchedType",
+      "propertyPath": "/properties/data/items/properties/status/oneOf",
+    },
+    "groupedOperations": [
+      {
+        "intent": "add new oneOf branch to oneOf",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/oneOf/-",
+            "value": {
+              "type": "string",
+            },
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsIncompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"data":[{"status":null},{"status":"something-else"},{"status":"another-thing"},{"status":null},{"status":123}]}",
+          "contentType": "application/json",
+          "size": 112,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+]
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.1.0 schema with arrays with polymorphic items 2`] = `
+{
+  "info": {},
+  "openapi": "3.1.0",
+  "paths": {
+    "/api/animals": {
+      "post": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "properties": {
+                          "status": {
+                            "oneOf": [
+                              {
+                                "type": [
+                                  "object",
+                                  "null",
+                                ],
+                              },
+                              {
+                                "type": "number",
+                              },
+                              {
+                                "type": "string",
+                              },
+                            ],
+                          },
+                        },
+                        "type": "object",
+                      },
+                      "type": "array",
                     },
                   },
                   "required": [],

--- a/projects/optic/src/commands/capture/patches/__tests__/__snapshots__/patches.test.ts.snap
+++ b/projects/optic/src/commands/capture/patches/__tests__/__snapshots__/patches.test.ts.snap
@@ -3301,6 +3301,10 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 schema with arrays with p
             "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/type",
           },
           {
+            "op": "remove",
+            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/nullable",
+          },
+          {
             "op": "add",
             "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/oneOf",
             "value": [
@@ -3361,7 +3365,6 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 schema with arrays with p
                       "items": {
                         "properties": {
                           "status": {
-                            "nullable": true,
                             "oneOf": [
                               {
                                 "nullable": true,

--- a/projects/optic/src/commands/capture/patches/__tests__/__snapshots__/patches.test.ts.snap
+++ b/projects/optic/src/commands/capture/patches/__tests__/__snapshots__/patches.test.ts.snap
@@ -8992,7 +8992,7 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 schema with arrays with p
             "op": "replace",
             "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/type",
             "value": [
-              "object",
+              "string",
               "null",
             ],
           },
@@ -9044,7 +9044,8 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 schema with arrays with p
             "op": "replace",
             "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/type",
             "value": [
-              "object",
+              "string",
+              "null",
               "null",
             ],
           },
@@ -9102,7 +9103,8 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 schema with arrays with p
             "value": [
               {
                 "type": [
-                  "object",
+                  "string",
+                  "null",
                   "null",
                 ],
               },
@@ -9110,57 +9112,6 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 schema with arrays with p
                 "type": "number",
               },
             ],
-          },
-        ],
-      },
-    ],
-    "impact": [
-      "Addition",
-      "BackwardsIncompatible",
-    ],
-    "interaction": {
-      "request": {
-        "body": null,
-        "headers": [],
-        "host": "localhost:3030",
-        "method": "post",
-        "path": "/api/animals",
-        "query": [],
-      },
-      "response": {
-        "body": {
-          "body": "{"data":[{"status":null},{"status":"something-else"},{"status":"another-thing"},{"status":null},{"status":123}]}",
-          "contentType": "application/json",
-          "size": 112,
-        },
-        "headers": [],
-        "statusCode": "200",
-      },
-    },
-    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-  },
-  {
-    "description": "update response body: expand one of for oneOf",
-    "diff": {
-      "description": "'oneOf' did not match schema",
-      "example": "another-thing",
-      "expectedType": "oneOf schema",
-      "instancePath": "/data/2/status",
-      "key": "oneOf",
-      "keyword": "oneOf",
-      "kind": "UnmatchedType",
-      "propertyPath": "/properties/data/items/properties/status/oneOf",
-    },
-    "groupedOperations": [
-      {
-        "intent": "add new oneOf branch to oneOf",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/oneOf/-",
-            "value": {
-              "type": "string",
-            },
           },
         ],
       },
@@ -9213,15 +9164,13 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 schema with arrays with p
                             "oneOf": [
                               {
                                 "type": [
-                                  "object",
+                                  "string",
+                                  "null",
                                   "null",
                                 ],
                               },
                               {
                                 "type": "number",
-                              },
-                              {
-                                "type": "string",
                               },
                             ],
                           },

--- a/projects/optic/src/commands/capture/patches/__tests__/patches.test.ts
+++ b/projects/optic/src/commands/capture/patches/__tests__/patches.test.ts
@@ -516,6 +516,63 @@ describe('generateEndpointSpecPatches', () => {
       expect(patches).toMatchSnapshot();
       expect(specHolder.spec).toMatchSnapshot();
     });
+
+    test('schema with arrays with polymorphic items', async () => {
+      specHolder.spec.paths['/api/animals'].post.responses = {
+        '200': {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      properties: {
+                        status: {
+                          type: 'string',
+                        },
+                      },
+                    },
+                  },
+                },
+                required: ['status'],
+              },
+            },
+          },
+        },
+      };
+
+      const interaction = makeInteraction(
+        { method: OpenAPIV3.HttpMethods.POST, path: '/api/animals' },
+        {
+          responseBody: {
+            data: [
+              { status: null },
+              { status: 'something-else' },
+              { status: 'another-thing' },
+              { status: null },
+              { status: 123 },
+            ],
+          },
+        }
+      );
+
+      const patches = await AT.collect(
+        generateEndpointSpecPatches(
+          GenerateInteractions([interaction]),
+          specHolder,
+          {
+            method: 'post',
+            path: '/api/animals',
+          }
+        )
+      );
+
+      expect(patches).toMatchSnapshot();
+      expect(specHolder.spec).toMatchSnapshot();
+    });
   });
 });
 

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/diff.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/diff.ts
@@ -222,8 +222,13 @@ function prepareSchemaForDiff(input: SchemaObject): SchemaObject {
 
       // Fix case where nullable is set and there is no type key
       if (!schema.type && schema.nullable) {
-        // We set this to string since we're not sure what the actual type is; this should be fine for us since we'll use this schema for diffing purposes and update
-        schema.type = 'string';
+        if (schema.oneOf || schema.anyOf || schema.allOf) {
+          // in the polymorphic case we have to remove nullable, since type will override and you cannot use
+          delete schema.nullable;
+        } else {
+          // We set this to string since we're not sure what the actual type is; this should be fine for us since we'll use this schema for diffing purposes and update
+          schema.type = 'string';
+        }
       }
     },
   });

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/__tests__/__snapshots__/type.test.ts.snap
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/__tests__/__snapshots__/type.test.ts.snap
@@ -756,7 +756,7 @@ exports[`type shape patch generator for 3.1.x when provided with null value, it 
             "op": "replace",
             "path": "/properties/stringField/type",
             "value": [
-              "object",
+              "string",
               "null",
             ],
           },

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/type.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/type.ts
@@ -172,10 +172,11 @@ export function* typePatches(
     }
   } else if (openAPIVersion === '3.1.x') {
     if (diff.example === null) {
-      const schemaType = Array.isArray(schema.type)
-        ? [...schema.type, 'null']
-        : schema.type
-        ? [schema.type, 'null']
+      const subschema = jsonPointerHelpers.get(schema, diff.propertyPath);
+      const schemaType = Array.isArray(subschema.type)
+        ? [...subschema.type, 'null']
+        : subschema.type
+        ? [subschema.type, 'null']
         : ['null'];
 
       yield {

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/patches.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/patches.ts
@@ -78,7 +78,7 @@ export class ShapePatches {
 
     let patchesExhausted = false;
     let i = 0;
-    while (!patchesExhausted && i < MAX_ITERATIONS) {
+    while (!patchesExhausted) {
       i++;
       if (!schema || (!schema.type && !Schema.isPolymorphic(schema))) {
         let newSchema = Schema.baseFromValue(body.value, openAPIVersion);
@@ -132,6 +132,18 @@ export class ShapePatches {
         if (shouldRegenerate) break;
       }
       patchesExhausted = patchCount === 0;
+      if (i === MAX_ITERATIONS) {
+        SentryClient.captureException(
+          new Error('max iterations in shape patches hit'),
+          {
+            extra: {
+              body,
+              schema,
+            },
+          }
+        );
+        break;
+      }
     }
   }
 }

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/schema.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/schema.ts
@@ -168,7 +168,6 @@ function initialSchema(
 
 export const allowedMetaDataForAll: string[] = [
   'title',
-  'nullable',
   'description',
   'example',
   'examples',
@@ -187,6 +186,7 @@ export const allowedKeysForOneOf: string[] = [
 
 export const allowedKeysForObject: string[] = [
   ...allowedMetaDataForAll,
+  'nullable',
   'additionalProperties',
   'type',
   'maxProperties',
@@ -196,6 +196,7 @@ export const allowedKeysForObject: string[] = [
 ];
 export const allowedKeysForArray: string[] = [
   ...allowedMetaDataForAll,
+  'nullable',
   'type',
   'items',
   'maxItems',
@@ -205,6 +206,7 @@ export const allowedKeysForArray: string[] = [
 
 export const allowedKeysForString: string[] = [
   ...allowedMetaDataForAll,
+  'nullable',
   'type',
   'format',
   'pattern',
@@ -214,6 +216,7 @@ export const allowedKeysForString: string[] = [
 
 export const allowedKeysForInteger: string[] = [
   ...allowedMetaDataForAll,
+  'nullable',
   'type',
   'minimum',
   'maximum',

--- a/projects/optic/src/commands/oas/tests/shapes/__snapshots__/generate.test.ts.snap
+++ b/projects/optic/src/commands/oas/tests/shapes/__snapshots__/generate.test.ts.snap
@@ -505,11 +505,7 @@ exports[`generate shapes from bodies primitives can build JSON from a boolean 1`
 }
 `;
 
-exports[`generate shapes from bodies primitives can build JSON from a null 1`] = `
-{
-  "nullable": true,
-}
-`;
+exports[`generate shapes from bodies primitives can build JSON from a null 1`] = `{}`;
 
 exports[`generate shapes from bodies primitives can build JSON from a number 1`] = `
 {

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.49.1-3",
+  "version": "0.49.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -39,6 +39,5 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
-  },
-  "stableVersion": "0.49.0"
+  }
 }

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.6.1",
-  "version": "0.49.1-3",
+  "version": "0.49.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -38,6 +38,5 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
-  },
-  "stableVersion": "0.49.0"
+  }
 }


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

When passing an interaction like:
```
{ data: [{ status: 'abc', status: null, status: 123}] }
```


Our capture patch code hits an infinite loop and is broken due to max patch iterations for 3.0.1. This happened because:
- Our patching code generated invalid schema `{ nullable: true, oneOf: [...] }` - this throws an error in AJV
- Our prepare schema made an assumption that if nullable && !type, we set the type to string

The way we can fix this is:
- Generate the right schema
- Change prepare schema to drop the nullable if there's a polymorphic type, by adding a string we overwrite the polymorphic type

Also fixes 3.1 polymorphic type patching (was looking at the wrong schema to create the initial type array)
## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
