### PR TITLE
Surface unpatchable diffs

### DIFF
--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -51,6 +51,7 @@
     "node-machine-id": "^1.1.12",
     "openapi-types": "^12.0.2",
     "ts-invariant": "^0.9.3",
+    "url-join": "^4.0.1",
     "yaml-ast-parser": "^0.0.43"
   }
 }

--- a/projects/openapi-utilities/src/index.ts
+++ b/projects/openapi-utilities/src/index.ts
@@ -47,7 +47,11 @@ import {
   isChangeVariant,
   isFactOrChangeVariant,
 } from './openapi3/sdk/isType';
-import { sourcemapReader } from './openapi3/implementations/openapi3/sourcemap-reader';
+import {
+  sourcemapReader,
+  getSourcemapLink,
+  GetSourcemapOptions,
+} from './openapi3/implementations/openapi3/sourcemap-reader';
 
 export { defaultEmptySpec } from './openapi3/constants';
 export * from './legacy-ci-types';
@@ -99,6 +103,8 @@ export { OpenApiV3Traverser } from './openapi3/traverser';
 
 export {
   sourcemapReader,
+  GetSourcemapOptions,
+  getSourcemapLink,
   OpenApiFact,
   OpenAPITraverser,
   factsToChangelog,

--- a/projects/openapi-utilities/src/openapi3/implementations/openapi3/types.ts
+++ b/projects/openapi-utilities/src/openapi3/implementations/openapi3/types.ts
@@ -55,3 +55,11 @@ export type FileWithSerializedSourcemap = {
   jsonLike: OpenAPIV3.Document;
   sourcemap: SerializedSourcemap;
 };
+
+export type SourcemapLine = {
+  filePath: string;
+  startLine: number;
+  endLine: number;
+  startPosition: number;
+  endPosition: number;
+};

--- a/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
@@ -1564,8 +1564,9 @@ GET /books
   [32m[200 response body] 'created_at' has been added (/properties/books/items/properties/created_at)[39m
   [32m[200 response body] 'updated_at' has been added (/properties/books/items/properties/updated_at)[39m
   [33m[200 response body] 'author_id' is now type number (/properties/books/items/properties/author_id)[39m
-  [33m[200 response body] 'price' is now type string (/properties/books/items/properties/price)[39m
   [33m[200 response body] 'status' now has enum value 'hold' (/properties/books/items/properties/status/enum)[39m
+  [31m[200 response body] schema (/properties/books/items/properties/price/maximum) with keyword 'maximum' and parameters {"comparison":"<=","limit":6} received invalid values 10, 15[39m
+  [31m ⛔️ schema could not be automatically updated[39m
 
 [1m[90mLearning path patterns for unmatched requests...[39m[22m
 [1m[90mDocumenting new operations:[39m[22m
@@ -1661,9 +1662,9 @@ components:
                   - not_ready
                   - hold
               price:
-                oneOf:
-                  - type: string
-                  - type: number
+                type: number
+                maximum: 6
+                minimum: 2
               name:
                 type: string
               created_at:
@@ -1748,8 +1749,9 @@ GET /books
   [32m[200 response body] 'created_at' has been added (/properties/books/items/properties/created_at)[39m
   [32m[200 response body] 'updated_at' has been added (/properties/books/items/properties/updated_at)[39m
   [33m[200 response body] 'author_id' is now type number (/properties/books/items/properties/author_id)[39m
-  [33m[200 response body] 'price' is now type string (/properties/books/items/properties/price)[39m
   [33m[200 response body] 'status' now has enum value 'hold' (/properties/books/items/properties/status/enum)[39m
+  [31m[200 response body] schema (/properties/books/items/properties/price/maximum) with keyword 'maximum' and parameters {"comparison":"<=","limit":6} received invalid values 10, 15[39m
+  [31m ⛔️ schema could not be automatically updated[39m
 
 5 unmatched requests
 [33mNew endpoints are only added in interactive mode. Run 'optic capture openapi.yml --update interactive' to add new endpoints[39m
@@ -1795,9 +1797,9 @@ components:
                   - not_ready
                   - hold
               price:
-                oneOf:
-                  - type: string
-                  - type: number
+                type: number
+                maximum: 6
+                minimum: 2
               name:
                 type: string
               created_at:
@@ -1855,17 +1857,6 @@ GET /books
 [90m31 |[39m     type: string
 [90m$workspace$/openapi.yml[39m
 
-  [31m[200 response body] 'price' does not match type string. Received 10 (/properties/books/items/properties/price)[39m
-  [41m  Diff  [49m 'price' did not match schema
-[90m32 |[39m     enum:
-[90m33 |[39m       - ready
-[90m34 |[39m       - not_ready
-[90m35 |[39m [1m[33m  price:  [41m[Actual] 10[49m[39m[22m
-[90m36 |[39m     type: string
-[90m37 |[39m required:
-[90m38 |[39m   - id
-[90m$workspace$/openapi.yml[39m
-
   [31m[200 response body] 'status' missing enum value 'hold' (/properties/books/items/properties/status/enum)[39m
   [41m  Diff  [49m 'status' does not have enum value hold
 [90m29 |[39m   type: number
@@ -1875,6 +1866,17 @@ GET /books
 [90m33 |[39m     - ready
 [90m34 |[39m     - not_ready
 [90m35 |[39m price:
+[90m$workspace$/openapi.yml[39m
+
+  [31m[200 response body] schema (/properties/books/items/properties/price/maximum) with keyword 'maximum' and parameters {"comparison":"<=","limit":6} received invalid values 10, 15[39m
+  [41m  Diff  [49m interaction did not match schema
+[90m34 |[39m       - not_ready
+[90m35 |[39m   price:
+[90m36 |[39m     type: number
+[90m37 |[39m [1m[33m    maximum: 6  [41m[Actual] 10, 15[49m[39m[22m
+[90m38 |[39m     minimum: 2
+[90m39 |[39m required:
+[90m40 |[39m   - id
 [90m$workspace$/openapi.yml[39m
 
 
@@ -1893,8 +1895,8 @@ GET /books
   [31m[200 response body] 'created_at' is not documented (/properties/books/items/properties)[39m
   [31m[200 response body] 'updated_at' is not documented (/properties/books/items/properties)[39m
   [31m[200 response body] 'author_id' does not match type number. Received 6nTxAFM5ck4Hob77hGQoL (/properties/books/items/properties/author_id)[39m
-  [31m[200 response body] 'price' does not match type string. Received 10 (/properties/books/items/properties/price)[39m
   [31m[200 response body] 'status' missing enum value 'hold' (/properties/books/items/properties/status/enum)[39m
+  [31m[200 response body] schema (/properties/books/items/properties/price/maximum) with keyword 'maximum' and parameters {"comparison":"<=","limit":6} received invalid values 10, 15[39m
 
 100.0% coverage of your documented operations. 5 requests did not match a documented path (6 total requests).
 6 diffs detected in documented operations

--- a/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
@@ -1566,7 +1566,7 @@ GET /books
   [33m[200 response body] 'author_id' is now type number (/properties/books/items/properties/author_id)[39m
   [33m[200 response body] 'status' now has enum value 'hold' (/properties/books/items/properties/status/enum)[39m
   [31m[200 response body] schema (/properties/books/items/properties/price/maximum) with keyword 'maximum' and parameters {"comparison":"<=","limit":6} received invalid values 10, 15[39m
-  [31m ⛔️ schema could not be automatically updated[39m
+  [31m ⛔️ schema could not be automatically updated. Update the schema manually at [4mopenapi.yml:37:799[24m[39m
 
 [1m[90mLearning path patterns for unmatched requests...[39m[22m
 [1m[90mDocumenting new operations:[39m[22m
@@ -1751,7 +1751,7 @@ GET /books
   [33m[200 response body] 'author_id' is now type number (/properties/books/items/properties/author_id)[39m
   [33m[200 response body] 'status' now has enum value 'hold' (/properties/books/items/properties/status/enum)[39m
   [31m[200 response body] schema (/properties/books/items/properties/price/maximum) with keyword 'maximum' and parameters {"comparison":"<=","limit":6} received invalid values 10, 15[39m
-  [31m ⛔️ schema could not be automatically updated[39m
+  [31m ⛔️ schema could not be automatically updated. Update the schema manually at [4mopenapi.yml:37:799[24m[39m
 
 5 unmatched requests
 [33mNew endpoints are only added in interactive mode. Run 'optic capture openapi.yml --update interactive' to add new endpoints[39m

--- a/projects/optic/src/__tests__/integration/workspaces/capture/with-server/openapi.yml
+++ b/projects/optic/src/__tests__/integration/workspaces/capture/with-server/openapi.yml
@@ -33,7 +33,9 @@ components:
                   - ready
                   - not_ready
               price:
-                type: string
+                type: number
+                maximum: 6
+                minimum: 2
             required:
               - id
               - author_id

--- a/projects/optic/src/commands/capture/actions/documented.ts
+++ b/projects/optic/src/commands/capture/actions/documented.ts
@@ -13,7 +13,10 @@ import { writePatchesToFiles } from '../write/file';
 import { logger } from '../../../logger';
 
 import { jsonPointerLogger } from '@useoptic/openapi-io';
-import { ShapeDiffResult } from '../patches/patchers/shapes/diff';
+import {
+  ShapeDiffResult,
+  UnpatchableDiff,
+} from '../patches/patchers/shapes/diff';
 import { SpecPatch } from '../patches/patchers/spec/patches';
 
 function getShapeDiffDetails(
@@ -204,6 +207,7 @@ export async function diffExistingEndpoint(
   }
 ) {
   const patchSummaries: string[] = [];
+  const unpatchableDiffs: UnpatchableDiff[] = [];
 
   const specPatches = AT.tap((patch: SpecPatch) => {
     coverage.shapeDiff(patch);
@@ -224,7 +228,7 @@ export async function diffExistingEndpoint(
       interactions,
       { spec: parseResult.jsonLike },
       endpoint,
-      { coverage }
+      { coverage, unpatchableDiffs }
     )
   );
 
@@ -235,6 +239,8 @@ export async function diffExistingEndpoint(
     for await (const _ of specPatches) {
     }
   }
+
+  // TODO do something with unpatchable diffs
 
   return { patchSummaries, hasDiffs: patchSummaries.length > 0 };
 }

--- a/projects/optic/src/commands/capture/actions/documented.ts
+++ b/projects/optic/src/commands/capture/actions/documented.ts
@@ -13,10 +13,7 @@ import { writePatchesToFiles } from '../write/file';
 import { logger } from '../../../logger';
 
 import { jsonPointerLogger } from '@useoptic/openapi-io';
-import {
-  ShapeDiffResult,
-  UnpatchableDiff,
-} from '../patches/patchers/shapes/diff';
+import { UnpatchableDiff } from '../patches/patchers/shapes/diff';
 import { SpecPatch } from '../patches/patchers/spec/patches';
 
 function getShapeDiffDetails(
@@ -216,7 +213,7 @@ function summarizeUnpatchableDiff(
       ? `could not be automatically updated`
       : `did not match schema`;
 
-  // TODO make this better
+  // TODO use AJV errors or something here
   const lines = [chalk.red(`${location} diff '${diff.bodyPath}' ${action}`)];
   if (options.verbose) {
     lines.push(
@@ -231,7 +228,7 @@ function summarizeUnpatchableDiff(
       )
     );
   }
-  return [];
+  return lines;
 }
 
 export async function diffExistingEndpoint(

--- a/projects/optic/src/commands/capture/coverage/api-coverage.ts
+++ b/projects/optic/src/commands/capture/coverage/api-coverage.ts
@@ -10,8 +10,8 @@ import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
 import { computeEndpointChecksum } from '../../../utils/checksum';
 import { statusRangePattern } from '../../oas/operations';
 import { denormalize } from '@useoptic/openapi-io';
-import { SpecPatch } from '../patches/patchers/spec/patches';
-import { UnpatchableDiff } from '../patches/patchers/shapes/diff';
+import { ShapeDiffResultKind } from '../patches/patchers/shapes/diff';
+import { OperationDiffResultKind } from '../patches/patchers/spec/types';
 
 export class ApiCoverageCounter {
   coverage: ApiCoverage;
@@ -99,7 +99,16 @@ export class ApiCoverageCounter {
     }
   };
 
-  shapeDiff = (patch: SpecPatch | UnpatchableDiff) => {
+  shapeDiff = (
+    patch: { path: string } & (
+      | { unpatchable: boolean }
+      | {
+          diff?: {
+            kind: ShapeDiffResultKind | OperationDiffResultKind | undefined;
+          };
+        }
+    )
+  ) => {
     const parts = jsonPointerHelpers.decode(patch.path);
     const [_, pathPattern, method] = parts;
     const operation = this.coverage.paths[pathPattern]?.[method];

--- a/projects/optic/src/commands/capture/coverage/api-coverage.ts
+++ b/projects/optic/src/commands/capture/coverage/api-coverage.ts
@@ -11,6 +11,7 @@ import { computeEndpointChecksum } from '../../../utils/checksum';
 import { statusRangePattern } from '../../oas/operations';
 import { denormalize } from '@useoptic/openapi-io';
 import { SpecPatch } from '../patches/patchers/spec/patches';
+import { UnpatchableDiff } from '../patches/patchers/shapes/diff';
 
 export class ApiCoverageCounter {
   coverage: ApiCoverage;
@@ -98,12 +99,13 @@ export class ApiCoverageCounter {
     }
   };
 
-  shapeDiff = (patch: SpecPatch) => {
+  shapeDiff = (patch: SpecPatch | UnpatchableDiff) => {
     const parts = jsonPointerHelpers.decode(patch.path);
     const [_, pathPattern, method] = parts;
     const operation = this.coverage.paths[pathPattern]?.[method];
     if (operation) {
       if (
+        'unpatchable' in patch ||
         patch.diff?.kind === 'UnmatchedType' ||
         patch.diff?.kind === 'AdditionalProperty' ||
         patch.diff?.kind === 'MissingRequiredProperty'

--- a/projects/optic/src/commands/capture/patches/__tests__/__snapshots__/patches.test.ts.snap
+++ b/projects/optic/src/commands/capture/patches/__tests__/__snapshots__/patches.test.ts.snap
@@ -492,6 +492,96 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 array with multiple items
 }
 `;
 
+exports[`generateEndpointSpecPatches OAS version 3.0.1 collects unpatchable diffs 1`] = `
+[
+  {
+    "bodyPath": "/paths/~1api~1animals/post/responses/200/content/application~1json",
+    "example": {
+      "data": [
+        {
+          "status": "ok",
+        },
+        {
+          "status": "not-ok",
+        },
+      ],
+    },
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"data":[{"status":"ok"},{"status":"not-ok"}]}",
+          "contentType": "application/json",
+          "size": 46,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/const",
+    "schemaPath": "/properties/data/items/properties/status/const",
+    "unpatchable": true,
+    "validationError": {
+      "instancePath": "/data/1/status",
+      "keyword": "const",
+      "message": "must be equal to constant",
+      "params": {
+        "allowedValue": "ok",
+      },
+      "schemaPath": "#/properties/data/items/properties/status/const",
+    },
+  },
+]
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.0.1 collects unpatchable diffs 2`] = `
+{
+  "info": {},
+  "openapi": "3.0.1",
+  "paths": {
+    "/api/animals": {
+      "post": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "properties": {
+                          "status": {
+                            "const": "ok",
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "status",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
 exports[`generateEndpointSpecPatches OAS version 3.0.1 existing schema that does not match 1`] = `
 [
   {
@@ -3135,54 +3225,6 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 missing required property
 exports[`generateEndpointSpecPatches OAS version 3.0.1 schema with arrays with polymorphic items 1`] = `
 [
   {
-    "description": "update response body: make property status optional",
-    "diff": {
-      "description": "required property 'status' was missing",
-      "example": undefined,
-      "instancePath": "/status",
-      "key": "status",
-      "keyword": "required",
-      "kind": "MissingRequiredProperty",
-      "parentObjectPath": "",
-      "propertyPath": "/properties/status",
-    },
-    "groupedOperations": [
-      {
-        "intent": "remove status from parent's required array",
-        "operations": [
-          {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/0",
-          },
-        ],
-      },
-    ],
-    "impact": [
-      "Addition",
-      "BackwardsIncompatible",
-    ],
-    "interaction": {
-      "request": {
-        "body": null,
-        "headers": [],
-        "host": "localhost:3030",
-        "method": "post",
-        "path": "/api/animals",
-        "query": [],
-      },
-      "response": {
-        "body": {
-          "body": "{"data":[{"status":null},{"status":"something-else"},{"status":"another-thing"},{"status":null},{"status":123}]}",
-          "contentType": "application/json",
-          "size": 112,
-        },
-        "headers": [],
-        "statusCode": "200",
-      },
-    },
-    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-  },
-  {
     "description": "update response body: make status null",
     "diff": {
       "description": "'status' did not match schema",
@@ -3376,12 +3418,14 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 schema with arrays with p
                             ],
                           },
                         },
+                        "required": [
+                          "status",
+                        ],
                         "type": "object",
                       },
                       "type": "array",
                     },
                   },
-                  "required": [],
                   "type": "object",
                 },
               },
@@ -6282,6 +6326,96 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 array with multiple items
 }
 `;
 
+exports[`generateEndpointSpecPatches OAS version 3.1.0 collects unpatchable diffs 1`] = `
+[
+  {
+    "bodyPath": "/paths/~1api~1animals/post/responses/200/content/application~1json",
+    "example": {
+      "data": [
+        {
+          "status": "ok",
+        },
+        {
+          "status": "not-ok",
+        },
+      ],
+    },
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"data":[{"status":"ok"},{"status":"not-ok"}]}",
+          "contentType": "application/json",
+          "size": 46,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/const",
+    "schemaPath": "/properties/data/items/properties/status/const",
+    "unpatchable": true,
+    "validationError": {
+      "instancePath": "/data/1/status",
+      "keyword": "const",
+      "message": "must be equal to constant",
+      "params": {
+        "allowedValue": "ok",
+      },
+      "schemaPath": "#/properties/data/items/properties/status/const",
+    },
+  },
+]
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.1.0 collects unpatchable diffs 2`] = `
+{
+  "info": {},
+  "openapi": "3.1.0",
+  "paths": {
+    "/api/animals": {
+      "post": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "properties": {
+                          "status": {
+                            "const": "ok",
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "status",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
 exports[`generateEndpointSpecPatches OAS version 3.1.0 existing schema that does not match 1`] = `
 [
   {
@@ -8925,54 +9059,6 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 missing required property
 exports[`generateEndpointSpecPatches OAS version 3.1.0 schema with arrays with polymorphic items 1`] = `
 [
   {
-    "description": "update response body: make property status optional",
-    "diff": {
-      "description": "required property 'status' was missing",
-      "example": undefined,
-      "instancePath": "/status",
-      "key": "status",
-      "keyword": "required",
-      "kind": "MissingRequiredProperty",
-      "parentObjectPath": "",
-      "propertyPath": "/properties/status",
-    },
-    "groupedOperations": [
-      {
-        "intent": "remove status from parent's required array",
-        "operations": [
-          {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/0",
-          },
-        ],
-      },
-    ],
-    "impact": [
-      "Addition",
-      "BackwardsIncompatible",
-    ],
-    "interaction": {
-      "request": {
-        "body": null,
-        "headers": [],
-        "host": "localhost:3030",
-        "method": "post",
-        "path": "/api/animals",
-        "query": [],
-      },
-      "response": {
-        "body": {
-          "body": "{"data":[{"status":null},{"status":"something-else"},{"status":"another-thing"},{"status":null},{"status":123}]}",
-          "contentType": "application/json",
-          "size": 112,
-        },
-        "headers": [],
-        "statusCode": "200",
-      },
-    },
-    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-  },
-  {
     "description": "update response body: make status null",
     "diff": {
       "description": "'status' did not match schema",
@@ -9175,12 +9261,14 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 schema with arrays with p
                             ],
                           },
                         },
+                        "required": [
+                          "status",
+                        ],
                         "type": "object",
                       },
                       "type": "array",
                     },
                   },
-                  "required": [],
                   "type": "object",
                 },
               },

--- a/projects/optic/src/commands/capture/patches/__tests__/__snapshots__/patches.test.ts.snap
+++ b/projects/optic/src/commands/capture/patches/__tests__/__snapshots__/patches.test.ts.snap
@@ -496,16 +496,7 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 collects unpatchable diff
 [
   {
     "bodyPath": "/paths/~1api~1animals/post/responses/200/content/application~1json",
-    "example": {
-      "data": [
-        {
-          "status": "ok",
-        },
-        {
-          "status": "not-ok",
-        },
-      ],
-    },
+    "example": "not-ok",
     "interaction": {
       "request": {
         "body": null,
@@ -6330,16 +6321,7 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 collects unpatchable diff
 [
   {
     "bodyPath": "/paths/~1api~1animals/post/responses/200/content/application~1json",
-    "example": {
-      "data": [
-        {
-          "status": "ok",
-        },
-        {
-          "status": "not-ok",
-        },
-      ],
-    },
+    "example": "not-ok",
     "interaction": {
       "request": {
         "body": null,

--- a/projects/optic/src/commands/capture/patches/__tests__/patches.test.ts
+++ b/projects/optic/src/commands/capture/patches/__tests__/patches.test.ts
@@ -534,10 +534,10 @@ describe('generateEndpointSpecPatches', () => {
                           type: 'string',
                         },
                       },
+                      required: ['status'],
                     },
                   },
                 },
-                required: ['status'],
               },
             },
           },
@@ -575,7 +575,55 @@ describe('generateEndpointSpecPatches', () => {
     });
 
     test('collects unpatchable diffs', async () => {
-      throw new Error('todo');
+      specHolder.spec.paths['/api/animals'].post.responses = {
+        '200': {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      properties: {
+                        status: {
+                          type: 'string',
+                          const: 'ok',
+                        },
+                      },
+                      required: ['status'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const interaction = makeInteraction(
+        { method: OpenAPIV3.HttpMethods.POST, path: '/api/animals' },
+        {
+          responseBody: {
+            data: [{ status: 'ok' }, { status: 'not-ok' }],
+          },
+        }
+      );
+
+      const patches = await AT.collect(
+        generateEndpointSpecPatches(
+          GenerateInteractions([interaction]),
+          specHolder,
+          {
+            method: 'post',
+            path: '/api/animals',
+          }
+        )
+      );
+
+      expect(patches).toMatchSnapshot();
+      expect(specHolder.spec).toMatchSnapshot();
     });
   });
 });

--- a/projects/optic/src/commands/capture/patches/__tests__/patches.test.ts
+++ b/projects/optic/src/commands/capture/patches/__tests__/patches.test.ts
@@ -573,6 +573,10 @@ describe('generateEndpointSpecPatches', () => {
       expect(patches).toMatchSnapshot();
       expect(specHolder.spec).toMatchSnapshot();
     });
+
+    test('collects unpatchable diffs', async () => {
+      throw new Error('todo');
+    });
   });
 });
 

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/diff.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/diff.ts
@@ -70,7 +70,7 @@ function* diffVisitors(
       const schemaPath = validationError.schemaPath.substring(1);
       yield {
         validationError,
-        example,
+        example: jsonPointerHelpers.get(example, validationError.instancePath),
         unpatchable: true,
         interaction,
         bodyPath: specJsonPath,

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/diff.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/diff.ts
@@ -1,12 +1,12 @@
 import jsonSchemaTraverse from 'json-schema-traverse';
-import Ajv, { ErrorObject, ValidateFunction, ValidationError } from 'ajv';
+import Ajv, { ErrorObject, ValidateFunction } from 'ajv';
 import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
 import { Ono } from '@jsdevtools/ono';
 import { Result, Ok, Err } from 'ts-results';
 import { JsonPath } from '@useoptic/openapi-io';
 import { OpenAPIV3 } from '@useoptic/openapi-utilities';
 import { SchemaObject } from './schema';
-import { Body, ShapeLocation } from './documented-bodies';
+import { Body } from './documented-bodies';
 import { additionalPropertiesDiffs } from './handlers/additionalProperties';
 import { oneOfKeywordDiffs } from './handlers/oneOf';
 import { requiredKeywordDiffs } from './handlers/required';

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/diff.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/diff.ts
@@ -67,15 +67,18 @@ function* diffVisitors(
       yield* enumKeywordDiffs(validationError, example);
       break;
     default:
+      const schemaPath = validationError.schemaPath.substring(1);
       yield {
         validationError,
         example,
         unpatchable: true,
         interaction,
         bodyPath: specJsonPath,
+        schemaPath,
         path: jsonPointerHelpers.append(
           specJsonPath,
-          validationError.schemaPath.substring(1)
+          'schema',
+          ...jsonPointerHelpers.decode(schemaPath)
         ),
       };
   }
@@ -130,6 +133,7 @@ export type UnpatchableDiff = {
   validationError: ErrorObject;
   path: string;
   bodyPath: string;
+  schemaPath: string;
   example: any;
   unpatchable: true;
   interaction: CapturedInteraction;

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/__tests__/enum.test.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/__tests__/enum.test.ts
@@ -1,5 +1,5 @@
 import { it, describe, expect } from '@jest/globals';
-import { diffBodyBySchema } from '../../diff';
+import { ShapeDiffResult, diffBodyBySchema } from '../../diff';
 import { generateShapePatchesByDiff } from '../../patches';
 import { SchemaObject } from '../../schema';
 import { CapturedInteraction } from '../../../../../sources/captured-interactions';
@@ -28,7 +28,10 @@ describe('enum json schema diff visitor', () => {
     const input = {
       status: 'ready',
     };
-    const diffs = diffBodyBySchema({ value: input }, jsonSchema);
+    const diffs = diffBodyBySchema({ value: input }, jsonSchema, {
+      specJsonPath: '',
+      interaction: mockInteraction,
+    });
     expect([...diffs]).toHaveLength(0);
   });
 
@@ -36,7 +39,12 @@ describe('enum json schema diff visitor', () => {
     const input = {
       status: 'new-field',
     };
-    const diffs = [...diffBodyBySchema({ value: input }, jsonSchema)];
+    const diffs = [
+      ...diffBodyBySchema({ value: input }, jsonSchema, {
+        specJsonPath: '',
+        interaction: mockInteraction,
+      }),
+    ];
     expect(diffs).toHaveLength(1);
     expect(diffs).toMatchSnapshot();
   });
@@ -63,11 +71,16 @@ describe('enum shape patch generator', () => {
     const input = {
       status: 'new-field',
     };
-    const diffs = [...diffBodyBySchema({ value: input }, jsonSchema)];
+    const diffs = [
+      ...diffBodyBySchema({ value: input }, jsonSchema, {
+        specJsonPath: '',
+        interaction: mockInteraction,
+      }),
+    ];
 
     const patches = diffs.flatMap((diff) => [
       ...generateShapePatchesByDiff(
-        diff,
+        diff as ShapeDiffResult,
         jsonSchema,
         mockInteraction,
         {},
@@ -86,11 +99,16 @@ describe('enum shape patch generator', () => {
         },
       ],
     };
-    const diffs = [...diffBodyBySchema({ value: input }, jsonSchema)];
+    const diffs = [
+      ...diffBodyBySchema({ value: input }, jsonSchema, {
+        specJsonPath: '',
+        interaction: mockInteraction,
+      }),
+    ];
 
     const patches = diffs.flatMap((diff) => [
       ...generateShapePatchesByDiff(
-        diff,
+        diff as ShapeDiffResult,
         jsonSchema,
         mockInteraction,
         {},

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/__tests__/oneOf.test.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/__tests__/oneOf.test.ts
@@ -1,7 +1,7 @@
 import { it, describe, expect } from '@jest/globals';
 import { SchemaObject } from '../../schema';
 import { objectOrStringOneOf } from '../../../../../../oas/tests/fixtures/oneof-schemas';
-import { diffBodyBySchema } from '../../diff';
+import { ShapeDiffResult, diffBodyBySchema } from '../../diff';
 import { generateShapePatchesByDiff } from '../../patches';
 import { CapturedInteraction } from '../../../../../sources/captured-interactions';
 import { OpenAPIV3 } from '@useoptic/openapi-utilities';
@@ -29,14 +29,20 @@ describe('one of json schema diff visitor', () => {
     const input = {
       polyProp: 'hello-string',
     };
-    const diffs = diffBodyBySchema({ value: input }, jsonSchema);
+    const diffs = diffBodyBySchema({ value: input }, jsonSchema, {
+      specJsonPath: '',
+      interaction: mockInteraction,
+    });
     expect([...diffs]).toHaveLength(0);
   });
   it('when valid case 2, no diff', () => {
     const input = {
       polyProp: 123,
     };
-    const diffs = diffBodyBySchema({ value: input }, jsonSchema);
+    const diffs = diffBodyBySchema({ value: input }, jsonSchema, {
+      specJsonPath: '',
+      interaction: mockInteraction,
+    });
     expect([...diffs]).toHaveLength(0);
   });
 
@@ -55,7 +61,10 @@ describe('one of json schema diff visitor', () => {
     };
     const input = { id: 'an-identifier' };
 
-    const diffs = diffBodyBySchema({ value: input }, jsonSchema);
+    const diffs = diffBodyBySchema({ value: input }, jsonSchema, {
+      specJsonPath: '',
+      interaction: mockInteraction,
+    });
     expect([...diffs]).toHaveLength(0);
   });
 
@@ -64,7 +73,10 @@ describe('one of json schema diff visitor', () => {
       polyProp: true,
     };
 
-    const diffs = diffBodyBySchema({ value: input }, jsonSchema);
+    const diffs = diffBodyBySchema({ value: input }, jsonSchema, {
+      specJsonPath: '',
+      interaction: mockInteraction,
+    });
 
     // expect(result.totalDiffsAfterPatches).toBe(0);
     expect([...diffs]).toMatchSnapshot();
@@ -84,7 +96,10 @@ describe('one of json schema diff visitor', () => {
       polyProp: { hello: 'world' },
     };
 
-    const diffs = diffBodyBySchema({ value: input }, jsonSchema);
+    const diffs = diffBodyBySchema({ value: input }, jsonSchema, {
+      specJsonPath: '',
+      interaction: mockInteraction,
+    });
     expect([...diffs]).toMatchSnapshot();
   });
 
@@ -107,7 +122,12 @@ describe('one of json schema diff visitor', () => {
 
     const input = ['user1', 'user2', 'user3'];
 
-    const diffs = [...diffBodyBySchema({ value: input }, jsonSchema)];
+    const diffs = [
+      ...diffBodyBySchema({ value: input }, jsonSchema, {
+        specJsonPath: '',
+        interaction: mockInteraction,
+      }),
+    ];
     expect(diffs).toHaveLength(1);
     expect(diffs).toMatchSnapshot();
   });
@@ -122,7 +142,10 @@ describe('one of json schema diff visitor', () => {
 
     const input: any = [];
 
-    const diffs = diffBodyBySchema({ value: input }, jsonSchema);
+    const diffs = diffBodyBySchema({ value: input }, jsonSchema, {
+      specJsonPath: '',
+      interaction: mockInteraction,
+    });
     expect([...diffs]).toMatchSnapshot();
   });
 
@@ -139,7 +162,10 @@ describe('one of json schema diff visitor', () => {
       },
     };
 
-    const diffs = diffBodyBySchema({ value: input }, jsonSchema);
+    const diffs = diffBodyBySchema({ value: input }, jsonSchema, {
+      specJsonPath: '',
+      interaction: mockInteraction,
+    });
     expect([...diffs]).toMatchSnapshot();
   });
 });
@@ -159,11 +185,16 @@ describe('one of shape patch generator', () => {
       polyProp: true,
     };
 
-    const diffs = [...diffBodyBySchema({ value: input }, jsonSchema)];
+    const diffs = [
+      ...diffBodyBySchema({ value: input }, jsonSchema, {
+        specJsonPath: '',
+        interaction: mockInteraction,
+      }),
+    ];
 
     const patches = diffs.flatMap((diff) => [
       ...generateShapePatchesByDiff(
-        diff,
+        diff as ShapeDiffResult,
         jsonSchema,
         mockInteraction,
         {},
@@ -188,11 +219,16 @@ describe('one of shape patch generator', () => {
       polyProp: { hello: 'world' },
     };
 
-    const diffs = [...diffBodyBySchema({ value: input }, jsonSchema)];
+    const diffs = [
+      ...diffBodyBySchema({ value: input }, jsonSchema, {
+        specJsonPath: '',
+        interaction: mockInteraction,
+      }),
+    ];
 
     const patches = diffs.flatMap((diff) => [
       ...generateShapePatchesByDiff(
-        diff,
+        diff as ShapeDiffResult,
         jsonSchema,
         mockInteraction,
         {},
@@ -213,11 +249,16 @@ describe('one of shape patch generator', () => {
 
     const input: any = [];
 
-    const diffs = [...diffBodyBySchema({ value: input }, jsonSchema)];
+    const diffs = [
+      ...diffBodyBySchema({ value: input }, jsonSchema, {
+        specJsonPath: '',
+        interaction: mockInteraction,
+      }),
+    ];
 
     const patches = diffs.flatMap((diff) => [
       ...generateShapePatchesByDiff(
-        diff,
+        diff as ShapeDiffResult,
         jsonSchema,
         mockInteraction,
         {},
@@ -241,11 +282,16 @@ describe('one of shape patch generator', () => {
       },
     };
 
-    const diffs = [...diffBodyBySchema({ value: input }, jsonSchema)];
+    const diffs = [
+      ...diffBodyBySchema({ value: input }, jsonSchema, {
+        specJsonPath: '',
+        interaction: mockInteraction,
+      }),
+    ];
 
     const patches = diffs.flatMap((diff) => [
       ...generateShapePatchesByDiff(
-        diff,
+        diff as ShapeDiffResult,
         jsonSchema,
         mockInteraction,
         {},

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/__tests__/required.test.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/__tests__/required.test.ts
@@ -1,7 +1,7 @@
 import { it, describe, expect } from '@jest/globals';
 import { generateShapePatchesByDiff } from '../../patches';
 import { SchemaObject } from '../../schema';
-import { diffBodyBySchema } from '../../diff';
+import { ShapeDiffResult, diffBodyBySchema } from '../../diff';
 import { CapturedInteraction } from '../../../../../sources/captured-interactions';
 import { OpenAPIV3 } from '@useoptic/openapi-utilities';
 const mockInteraction: CapturedInteraction = {
@@ -35,7 +35,10 @@ describe('required json schema diff visitor', () => {
       hello: { f1: 'value', f2: 122 },
     };
 
-    const diffs = diffBodyBySchema({ value: input }, jsonSchema);
+    const diffs = diffBodyBySchema({ value: input }, jsonSchema, {
+      specJsonPath: '',
+      interaction: mockInteraction,
+    });
 
     expect([...diffs]).toMatchSnapshot();
   });
@@ -61,11 +64,16 @@ describe('required shape patch generator', () => {
     const input = {
       hello: { f1: 'value', f2: 122 },
     };
-    const diffs = [...diffBodyBySchema({ value: input }, jsonSchema)];
+    const diffs = [
+      ...diffBodyBySchema({ value: input }, jsonSchema, {
+        specJsonPath: '',
+        interaction: mockInteraction,
+      }),
+    ];
 
     const patches = diffs.flatMap((diff) => [
       ...generateShapePatchesByDiff(
-        diff,
+        diff as ShapeDiffResult,
         jsonSchema,
         mockInteraction,
         {},

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/__tests__/type.test.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/__tests__/type.test.ts
@@ -2,7 +2,7 @@ import { it, describe, expect } from '@jest/globals';
 
 import { SchemaObject } from '../../schema';
 import { SupportedOpenAPIVersions } from '@useoptic/openapi-io';
-import { diffBodyBySchema } from '../../diff';
+import { ShapeDiffResult, diffBodyBySchema } from '../../diff';
 import { generateShapePatchesByDiff } from '../../patches';
 import { CapturedInteraction } from '../../../../../sources/captured-interactions';
 import { OpenAPIV3 } from '@useoptic/openapi-utilities';
@@ -28,7 +28,10 @@ describe('type json schema diff visitor', () => {
     const input = {
       stringField: 'hello-string',
     };
-    const diffs = diffBodyBySchema({ value: input }, jsonSchema);
+    const diffs = diffBodyBySchema({ value: input }, jsonSchema, {
+      specJsonPath: '',
+      interaction: mockInteraction,
+    });
     expect([...diffs]).toHaveLength(0);
   });
 
@@ -36,7 +39,10 @@ describe('type json schema diff visitor', () => {
     const input = {
       // stringField: "hello-string", // commented to show ommitted
     };
-    const diffs = diffBodyBySchema({ value: input }, jsonSchema);
+    const diffs = diffBodyBySchema({ value: input }, jsonSchema, {
+      specJsonPath: '',
+      interaction: mockInteraction,
+    });
     expect([...diffs]).toHaveLength(0);
   });
 
@@ -45,7 +51,10 @@ describe('type json schema diff visitor', () => {
       stringField: 123,
     };
 
-    const diffs = diffBodyBySchema({ value: input }, jsonSchema);
+    const diffs = diffBodyBySchema({ value: input }, jsonSchema, {
+      specJsonPath: '',
+      interaction: mockInteraction,
+    });
     expect([...diffs]).toMatchSnapshot();
   });
 
@@ -54,7 +63,10 @@ describe('type json schema diff visitor', () => {
       stringField: ['1', '2', '3', true],
     };
 
-    const diffs = diffBodyBySchema({ value: input }, jsonSchema);
+    const diffs = diffBodyBySchema({ value: input }, jsonSchema, {
+      specJsonPath: '',
+      interaction: mockInteraction,
+    });
     expect([...diffs]).toMatchSnapshot();
   });
 
@@ -63,7 +75,10 @@ describe('type json schema diff visitor', () => {
       stringField: { field: 'string' },
     };
 
-    const diffs = diffBodyBySchema({ value: input }, jsonSchema);
+    const diffs = diffBodyBySchema({ value: input }, jsonSchema, {
+      specJsonPath: '',
+      interaction: mockInteraction,
+    });
     expect([...diffs]).toMatchSnapshot();
   });
 
@@ -72,7 +87,10 @@ describe('type json schema diff visitor', () => {
       stringField: null,
     };
 
-    const diffs = diffBodyBySchema({ value: input }, jsonSchema);
+    const diffs = diffBodyBySchema({ value: input }, jsonSchema, {
+      specJsonPath: '',
+      interaction: mockInteraction,
+    });
     expect([...diffs]).toMatchSnapshot();
   });
 });
@@ -93,11 +111,16 @@ describe.each(['3.0.x', '3.1.x'])(
         stringField: 123,
       };
 
-      const diffs = [...diffBodyBySchema({ value: input }, jsonSchema)];
+      const diffs = [
+        ...diffBodyBySchema({ value: input }, jsonSchema, {
+          specJsonPath: '',
+          interaction: mockInteraction,
+        }),
+      ];
 
       const patches = diffs.flatMap((diff) => [
         ...generateShapePatchesByDiff(
-          diff,
+          diff as ShapeDiffResult,
           jsonSchema,
           mockInteraction,
           {},
@@ -113,11 +136,16 @@ describe.each(['3.0.x', '3.1.x'])(
         stringField: ['1', '2', '3', true],
       };
 
-      const diffs = [...diffBodyBySchema({ value: input }, jsonSchema)];
+      const diffs = [
+        ...diffBodyBySchema({ value: input }, jsonSchema, {
+          specJsonPath: '',
+          interaction: mockInteraction,
+        }),
+      ];
 
       const patches = diffs.flatMap((diff) => [
         ...generateShapePatchesByDiff(
-          diff,
+          diff as ShapeDiffResult,
           jsonSchema,
           mockInteraction,
           {},
@@ -133,11 +161,16 @@ describe.each(['3.0.x', '3.1.x'])(
         stringField: { field: 'string' },
       };
 
-      const diffs = [...diffBodyBySchema({ value: input }, jsonSchema)];
+      const diffs = [
+        ...diffBodyBySchema({ value: input }, jsonSchema, {
+          specJsonPath: '',
+          interaction: mockInteraction,
+        }),
+      ];
 
       const patches = diffs.flatMap((diff) => [
         ...generateShapePatchesByDiff(
-          diff,
+          diff as ShapeDiffResult,
           jsonSchema,
           mockInteraction,
           {},
@@ -153,11 +186,16 @@ describe.each(['3.0.x', '3.1.x'])(
         stringField: null,
       };
 
-      const diffs = [...diffBodyBySchema({ value: input }, jsonSchema)];
+      const diffs = [
+        ...diffBodyBySchema({ value: input }, jsonSchema, {
+          specJsonPath: '',
+          interaction: mockInteraction,
+        }),
+      ];
 
       const patches = diffs.flatMap((diff) => [
         ...generateShapePatchesByDiff(
-          diff,
+          diff as ShapeDiffResult,
           jsonSchema,
           mockInteraction,
           {},

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/patches.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/patches.ts
@@ -1,4 +1,4 @@
-import { ShapeDiffResult, diffBodyBySchema } from './diff';
+import { ShapeDiffResult, UnpatchableDiff, diffBodyBySchema } from './diff';
 import { SupportedOpenAPIVersions } from '@useoptic/openapi-io';
 import { oneOfPatches } from './handlers/oneOf';
 import { requiredPatches } from './handlers/required';
@@ -65,7 +65,7 @@ export class ShapePatches {
   static *generateBodyAdditions(
     documentedBody: DocumentedBody,
     openAPIVersion: SupportedOpenAPIVersions
-  ): ShapePatches {
+  ): Iterable<ShapePatch | UnpatchableDiff> {
     let {
       body: optionalBody,
       schema,
@@ -109,6 +109,7 @@ export class ShapePatches {
       let shouldRegenerate = false;
 
       for (let shapeDiff of shapeDiffs) {
+        if ('unpatchable' in shapeDiff) continue;
         let diffPatches = generateShapePatchesByDiff(
           shapeDiff,
           schema,
@@ -132,16 +133,28 @@ export class ShapePatches {
         if (shouldRegenerate) break;
       }
       patchesExhausted = patchCount === 0;
-      if (i === MAX_ITERATIONS) {
-        SentryClient.captureException(
-          new Error('max iterations in shape patches hit'),
-          {
-            extra: {
-              body,
-              schema,
-            },
+      if (patchesExhausted || i === MAX_ITERATIONS) {
+        // diff the final schema + emit the results
+        let shapeDiffsOpt = diffBodyBySchema(body, schema);
+        if (!shapeDiffsOpt.err) {
+          for (const diff of shapeDiffsOpt.val) {
+            if ('unpatchable' in diff) {
+              yield diff;
+            }
           }
-        );
+        }
+
+        if (i === MAX_ITERATIONS) {
+          SentryClient.captureException(
+            new Error('max iterations in shape patches hit'),
+            {
+              extra: {
+                body,
+                schema,
+              },
+            }
+          );
+        }
         break;
       }
     }

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/patches.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/patches.ts
@@ -96,7 +96,10 @@ export class ShapePatches {
         schema = Schema.applyShapePatch(schema, patch);
       }
 
-      let shapeDiffsOpt = diffBodyBySchema(body, schema);
+      let shapeDiffsOpt = diffBodyBySchema(body, schema, {
+        specJsonPath,
+        interaction: documentedBody.interaction,
+      });
       if (shapeDiffsOpt.err) {
         logger.error(`Could not update body at ${specJsonPath}`);
         logger.error(shapeDiffsOpt.val);
@@ -135,7 +138,10 @@ export class ShapePatches {
       patchesExhausted = patchCount === 0;
       if (patchesExhausted || i === MAX_ITERATIONS) {
         // diff the final schema + emit the results
-        let shapeDiffsOpt = diffBodyBySchema(body, schema);
+        let shapeDiffsOpt = diffBodyBySchema(body, schema, {
+          specJsonPath,
+          interaction: documentedBody.interaction,
+        });
         if (!shapeDiffsOpt.err) {
           for (const diff of shapeDiffsOpt.val) {
             if ('unpatchable' in diff) {

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/patches.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/patches.ts
@@ -143,6 +143,7 @@ export class ShapePatches {
           interaction: documentedBody.interaction,
         });
         if (!shapeDiffsOpt.err) {
+          // TODO collect and dedupe by keyword + schema path
           for (const diff of shapeDiffsOpt.val) {
             if ('unpatchable' in diff) {
               yield diff;

--- a/projects/optic/src/commands/capture/patches/patches.ts
+++ b/projects/optic/src/commands/capture/patches/patches.ts
@@ -65,9 +65,8 @@ export async function* generateEndpointSpecPatches(
   opts: {
     coverage?: ApiCoverageCounter;
     schemaAdditionsSet?: Set<string>;
-    unpatchableDiffs?: UnpatchableDiff[];
   } = {}
-) {
+): AsyncIterable<SpecPatch | UnpatchableDiff> {
   // TODO move this to the top level
   const openAPIVersion = checkOpenAPIVersion(specHolder.spec);
   const jsonPath = jsonPointerHelpers.compile([
@@ -116,9 +115,7 @@ export async function* generateEndpointSpecPatches(
     );
 
     for await (let patch of shapePatches) {
-      if ('unpatchable' in patch) {
-        opts.unpatchableDiffs?.push(patch);
-      } else {
+      if (!('unpatchable' in patch)) {
         opts.schemaAdditionsSet?.add(patch.path);
         specHolder.spec = SpecPatch.applyPatch(patch, specHolder.spec);
         yield patch;

--- a/projects/optic/src/commands/capture/patches/patches.ts
+++ b/projects/optic/src/commands/capture/patches/patches.ts
@@ -118,8 +118,8 @@ export async function* generateEndpointSpecPatches(
       if (!('unpatchable' in patch)) {
         opts.schemaAdditionsSet?.add(patch.path);
         specHolder.spec = SpecPatch.applyPatch(patch, specHolder.spec);
-        yield patch;
       }
+      yield patch;
     }
   }
 }

--- a/projects/optic/src/commands/diff/diff-all.ts
+++ b/projects/optic/src/commands/diff/diff-all.ts
@@ -11,7 +11,7 @@ import { compute } from './compute';
 import chalk from 'chalk';
 import { flushEvents, trackEvent } from '../../segment';
 import { compressDataV2 } from './compressResults';
-import { textToSev } from '@useoptic/openapi-utilities';
+import { GetSourcemapOptions, textToSev } from '@useoptic/openapi-utilities';
 import { uploadDiff } from './upload-diff';
 import { getApiFromOpticUrl } from '../../utils/cloud-urls';
 import { writeDataForCi } from '../../utils/ci-data';
@@ -20,10 +20,7 @@ import { checkOpenAPIVersion } from '@useoptic/openapi-io';
 import path from 'path';
 import { getApiUrl } from '../../utils/cloud-urls';
 import { getDetailsForGeneration } from '../../utils/generated';
-import {
-  SourcemapOptions,
-  terminalChangelog,
-} from './changelog-renderers/terminal-changelog';
+import { terminalChangelog } from './changelog-renderers/terminal-changelog';
 import { jsonChangelog } from './changelog-renderers/json-changelog';
 import * as Types from '../../client/optic-backend-types';
 import { openUrl } from '../../utils/open-url';
@@ -401,7 +398,7 @@ async function computeAll(
       changelogUrl = uploadResults?.changelogUrl ?? null;
     }
 
-    let sourcemapOptions: SourcemapOptions = {
+    let sourcemapOptions: GetSourcemapOptions = {
       ciProvider: undefined,
     };
     if (config.isInCi && config.vcs?.type === VCS.Git) {

--- a/projects/optic/src/commands/diff/diff.ts
+++ b/projects/optic/src/commands/diff/diff.ts
@@ -1,5 +1,9 @@
 import { Command, Option } from 'commander';
-import { UserError, textToSev } from '@useoptic/openapi-utilities';
+import {
+  GetSourcemapOptions,
+  UserError,
+  textToSev,
+} from '@useoptic/openapi-utilities';
 
 import {
   parseFilesFromRef,
@@ -10,10 +14,7 @@ import {
 import { ConfigRuleset, OpticCliConfig, VCS } from '../../config';
 import chalk from 'chalk';
 import { flushEvents, trackEvent } from '../../segment';
-import {
-  SourcemapOptions,
-  terminalChangelog,
-} from './changelog-renderers/terminal-changelog';
+import { terminalChangelog } from './changelog-renderers/terminal-changelog';
 import { jsonChangelog } from './changelog-renderers/json-changelog';
 import { compute } from './compute';
 import { compressDataV2 } from './compressResults';
@@ -408,7 +409,7 @@ const getDiffAction =
         logger.warn(warning);
       }
 
-      let sourcemapOptions: SourcemapOptions = {
+      let sourcemapOptions: GetSourcemapOptions = {
         ciProvider: undefined,
       };
       if (config.isInCi && config.vcs?.type === VCS.Git) {

--- a/projects/optic/src/commands/oas/diffing/document.ts
+++ b/projects/optic/src/commands/oas/diffing/document.ts
@@ -463,6 +463,9 @@ export function addOperations(
       const addedPaths = new Set<string>();
 
       for await (let patch of shapePatches) {
+        // For capture v1, we skip unpatchable diffs
+        if ('unpatchable' in patch) continue;
+
         // register additions
         addedPaths.add(patch.path);
         patchedSpec = SpecPatch.applyPatch(patch, patchedSpec);

--- a/projects/optic/src/commands/oas/diffing/patch.ts
+++ b/projects/optic/src/commands/oas/diffing/patch.ts
@@ -304,6 +304,9 @@ export function updateByInteractions(
       );
 
       for await (let patch of shapePatches) {
+        // For capture v1, we skip unpatchable diffs
+        if ('unpatchable' in patch) continue;
+
         patchedSpec = SpecPatch.applyPatch(patch, patchedSpec);
         yield patch;
         observers.interactionPatch(documentedInteraction, patch);

--- a/projects/optic/src/commands/oas/tests/shapes/extend.test.ts
+++ b/projects/optic/src/commands/oas/tests/shapes/extend.test.ts
@@ -18,6 +18,7 @@ function patchSchema(
     let patches = ShapePatches.generateBodyAdditions(body, '3.1.x');
 
     for (let patch of patches) {
+      if ('unpatchable' in patch) continue;
       schema = Schema.applyShapePatch(schema, patch);
     }
   }
@@ -28,7 +29,10 @@ function patchSchema(
 function* diffs(schema: SchemaObject | null, ...inputs: any[]) {
   if (!schema) return;
   for (let input of inputs) {
-    yield* diffBodyBySchema({ value: input }, schema);
+    yield* diffBodyBySchema({ value: input }, schema, {
+      specJsonPath: '',
+      interaction: {} as any,
+    });
   }
 }
 

--- a/projects/optic/src/commands/oas/tests/shapes/generate.test.ts
+++ b/projects/optic/src/commands/oas/tests/shapes/generate.test.ts
@@ -27,6 +27,8 @@ function patchSchema(
     let patches = ShapePatches.generateBodyAdditions(body, openAPIVersion);
 
     for (let patch of patches) {
+      if ('unpatchable' in patch) continue;
+
       schema = Schema.applyShapePatch(schema, patch);
     }
   }
@@ -37,7 +39,10 @@ function patchSchema(
 function* diffs(schema: SchemaObject | null, ...inputs: any[]) {
   if (!schema) return;
   for (let input of inputs) {
-    yield* diffBodyBySchema({ value: input }, schema);
+    yield* diffBodyBySchema({ value: input }, schema, {
+      specJsonPath: '',
+      interaction: {} as any,
+    });
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3657,6 +3657,7 @@ __metadata:
     ts-jest: ^29.0.3
     ts-node: ^10.9.1
     typescript: ^5.0.0
+    url-join: ^4.0.1
     yaml-ast-parser: ^0.0.43
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Under the hood for capture, we create diffs (using AJV) and then use those diffs to patch. In the case where we cannot create a patch (either because Optic hasn't been built for it, or it's impossible to figure out a correct patch for certain schemas like custom formats), optic silently passes even though it detected a diff. This PR fixes that issue and now surfaces unpatchable diffs. For certain diffs (like max / mix length) we can build that into the diff / patching logic.

Because there's a lot of reasons the validation can fail, and we aren't use the shape of it, we have to show somewhat of a generic error message like (schema with keyword ... and parameters ... failed - received xyz interaction). If we want better error messages, we can handle these one by one (by supporting more diff / patches for different AJV errors).


Examples below:
### verify
```
optic capture abe.yml                   
✔ Finished running requests
✖ GET /authors
  × 200 response, 404 response
  [200 response body] schema (/properties/data/items/properties/id/const) with keyword 'const' and parameters {"allowedValue":"123"} received invalid values "6nTxAFM5ck4Hob77hGQoL", "NjpTwgmENj11rGdUgpCQ9", "AcSwiQryWBeQqcNBqBg43" and 1 other values
  [200 response body] schema (/properties/data/items/properties/name/maxLength) with keyword 'maxLength' and parameters {"limit":1} received invalid values "Jane Austen", "F. Scott Fitzgerald", "Harper Lee" and 1 other values
✔ GET /books/{book}
  ✓ 404 response
✔ POST /books/{book}
  ✓ Request Body, ✓ 404 response
✔ GET /books
  ✓ 200 response
...and 1 endpoint that did not receive traffic

75.0% coverage of your documented operations. All requests matched a documented path (4 total requests)
2 diffs detected in documented operations
```

### update
```
optic capture abe.yml --update 
✔ Finished running requests
✔ GET /authors
  ✓ 200 response, ✓ 404 response
  [200 response body] schema (/properties/data/items/properties/id/const) with keyword 'const' and parameters {"allowedValue":"123"} received invalid values "6nTxAFM5ck4Hob77hGQoL", "NjpTwgmENj11rGdUgpCQ9", "AcSwiQryWBeQqcNBqBg43" and 1 other values
   ⛔️ schema could not be automatically updated. Update the schema manually at abe.yml:142:4029
  [200 response body] schema (/properties/data/items/properties/name/maxLength) with keyword 'maxLength' and parameters {"limit":1} received invalid values "Jane Austen", "F. Scott Fitzgerald", "Harper Lee" and 1 other values
   ⛔️ schema could not be automatically updated. Update the schema manually at abe.yml:145:4107
✔ GET /books/{book}
  ✓ 404 response
✔ POST /books/{book}
  ✓ Request Body, ✓ 404 response
✔ GET /books
  ✓ 200 response
...and 1 endpoint that did not receive traffic
```

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
