### PR TITLE
Improve init output instructions

### DIFF
--- a/projects/optic/src/__tests__/integration/__snapshots__/capture-init.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/capture-init.test.ts.snap
@@ -1,5 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`capture init init with --stdout 1`] = `
+"capture:
+  abc.yml:
+    server:
+      # 🔧 Update this to the command to run your server.
+      # Optional: If omitted, Optic assumes the server is running or started elsewhere.
+      command: your-server-command
+      # 🔧 Update this url to where your server can be reached.
+      # Required: Can be overridden with '--server-override'.
+      url: http://localhost:8080
+      # 🔧 Update the readiness endpoint for Optic to validate before sending requests.
+      # Optional: If omitted, perform no readiness checking.
+      ready_endpoint: /
+
+    # 🔧 Specify either 'requests.run' or 'requests.send' to generate requests to hit your server
+    requests:
+      # ℹ️ Requests should be sent to the Optic proxy, the address of which is injected into 'run.command's env as OPTIC_PROXY (or the value of 'run.proxy_variable').
+      run:
+        # 🔧 Specify a command that will generate traffic
+        command: your-test-command
+        # 🔧 OPTIC_PROXY is added to your command's env and contains the URL of an Optic's local reverse proxy. Your command should send its requests to this URL.
+        proxy_variable: OPTIC_PROXY
+      # 🔧 Or instead, craft requests for Optic send to your server
+      send:
+        - path: /
+          method: GET
+        - path: /users/create
+          method: POST
+          headers:
+            content-type: application/json;charset=UTF-8
+          data:
+            name: Hank
+
+
+"
+`;
+
 exports[`capture init init with existing optic.yml 1`] = `
 "[32m✔[39m Wrote capture config to optic.yml
 

--- a/projects/optic/src/__tests__/integration/__snapshots__/capture-init.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/capture-init.test.ts.snap
@@ -1,0 +1,119 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`capture init init with existing optic.yml 1`] = `
+"[32m✔[39m Wrote capture config to optic.yml
+
+Next:
+- Edit the configuration to match your setup (🔧)
+    A full reference for the configuration can be found at https://www.useoptic.com/docs/capturing-traffic#configuration-reference
+- Then run: optic capture abc.yml --update interaction 
+"
+`;
+
+exports[`capture init init with existing optic.yml 2`] = `
+"ruleset:
+  - breaking-changes
+  - naming:
+      pathComponents: camelCase
+  - '@org/custom-ruleset'
+  - ./rules/local.js
+capture:
+  openapi.yml:
+    server:
+      command: node server.js
+      url: http://localhost:3000
+      ready_endpoint: /healthcheck
+    requests:
+      send:
+        - path: /
+        - path: /books
+          method: GET
+        - path: /books/asd
+          method: GET
+        - path: /books/def
+          method: GET
+        - path: /books/asd
+          method: POST
+          data:
+            name: asd
+            price: 1
+            author_id: 6nTxAFM5ck4Hob77hGQoL
+        - path: /authors
+          method: GET
+  abc.yml:
+    server:
+      # 🔧 Update this to the command to run your server.
+      # Optional: If omitted, Optic assumes the server is running or started elsewhere.
+      command: your-server-command
+      # 🔧 Update this url to where your server can be reached.
+      # Required: Can be overridden with '--server-override'.
+      url: http://localhost:8080
+      # 🔧 Update the readiness endpoint for Optic to validate before sending requests.
+      # Optional: If omitted, perform no readiness checking.
+      ready_endpoint: /
+
+    # 🔧 Specify either 'requests.run' or 'requests.send' to generate requests to hit your server
+    requests:
+      # ℹ️ Requests should be sent to the Optic proxy, the address of which is injected into 'run.command's env as OPTIC_PROXY (or the value of 'run.proxy_variable').
+      run:
+        # 🔧 Specify a command that will generate traffic
+        command: your-test-command
+        # 🔧 OPTIC_PROXY is added to your command's env and contains the URL of an Optic's local reverse proxy. Your command should send its requests to this URL.
+        proxy_variable: OPTIC_PROXY
+      # 🔧 Or instead, craft requests for Optic send to your server
+      send:
+        - path: /
+          method: GET
+        - path: /users/create
+          method: POST
+          headers:
+            content-type: application/json;charset=UTF-8
+          data:
+            name: Hank
+"
+`;
+
+exports[`capture init init with no optic.yml 1`] = `
+"[32m✔[39m Wrote capture config to optic.yml
+
+Next:
+- Edit the configuration to match your setup (🔧)
+    A full reference for the configuration can be found at https://www.useoptic.com/docs/capturing-traffic#configuration-reference
+- Then run: optic capture abc.yml --update interaction 
+"
+`;
+
+exports[`capture init init with no optic.yml 2`] = `
+"capture:
+  abc.yml:
+    server:
+      # 🔧 Update this to the command to run your server.
+      # Optional: If omitted, Optic assumes the server is running or started elsewhere.
+      command: your-server-command
+      # 🔧 Update this url to where your server can be reached.
+      # Required: Can be overridden with '--server-override'.
+      url: http://localhost:8080
+      # 🔧 Update the readiness endpoint for Optic to validate before sending requests.
+      # Optional: If omitted, perform no readiness checking.
+      ready_endpoint: /
+
+    # 🔧 Specify either 'requests.run' or 'requests.send' to generate requests to hit your server
+    requests:
+      # ℹ️ Requests should be sent to the Optic proxy, the address of which is injected into 'run.command's env as OPTIC_PROXY (or the value of 'run.proxy_variable').
+      run:
+        # 🔧 Specify a command that will generate traffic
+        command: your-test-command
+        # 🔧 OPTIC_PROXY is added to your command's env and contains the URL of an Optic's local reverse proxy. Your command should send its requests to this URL.
+        proxy_variable: OPTIC_PROXY
+      # 🔧 Or instead, craft requests for Optic send to your server
+      send:
+        - path: /
+          method: GET
+        - path: /users/create
+          method: POST
+          headers:
+            content-type: application/json;charset=UTF-8
+          data:
+            name: Hank
+"
+`;

--- a/projects/optic/src/__tests__/integration/capture-init.test.ts
+++ b/projects/optic/src/__tests__/integration/capture-init.test.ts
@@ -1,0 +1,57 @@
+import {
+  test,
+  expect,
+  describe,
+  jest,
+  beforeEach,
+  afterEach,
+} from '@jest/globals';
+import fs from 'node:fs/promises';
+import path from 'path';
+import { runOptic, setupWorkspace, normalizeWorkspace } from './integration';
+
+jest.setTimeout(30000);
+
+let oldEnv: any;
+beforeEach(() => {
+  oldEnv = { ...process.env };
+  process.env.LOG_LEVEL = 'info';
+  process.env.OPTIC_ENV = 'local';
+  process.env.CI = 'false';
+});
+
+afterEach(() => {
+  process.env = { ...oldEnv };
+});
+
+describe('capture init', () => {
+  test('init with no optic.yml', async () => {
+    const workspace = await setupWorkspace('capture-init/no-yml', {
+      repo: true,
+    });
+    const { combined, code } = await runOptic(
+      workspace,
+      'capture init abc.yml'
+    );
+    expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
+    expect(code).toBe(0);
+    expect(
+      await fs.readFile(path.join(workspace, 'optic.yml'), 'utf-8')
+    ).toMatchSnapshot();
+  });
+
+  test('init with existing optic.yml', async () => {
+    const workspace = await setupWorkspace('capture-init/yml', {
+      repo: true,
+    });
+    const { combined, code } = await runOptic(
+      workspace,
+      'capture init abc.yml'
+    );
+    expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
+    expect(code).toBe(0);
+    expect(
+      await fs.readFile(path.join(workspace, 'optic.yml'), 'utf-8')
+    ).toMatchSnapshot();
+  });
+});

--- a/projects/optic/src/__tests__/integration/capture-init.test.ts
+++ b/projects/optic/src/__tests__/integration/capture-init.test.ts
@@ -54,4 +54,16 @@ describe('capture init', () => {
       await fs.readFile(path.join(workspace, 'optic.yml'), 'utf-8')
     ).toMatchSnapshot();
   });
+
+  test('init with --stdout', async () => {
+    const workspace = await setupWorkspace('capture-init/no-yml', {
+      repo: true,
+    });
+    const { combined, code } = await runOptic(
+      workspace,
+      'capture init abc.yml --stdout'
+    );
+    expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
+    expect(code).toBe(0);
+  });
 });

--- a/projects/optic/src/__tests__/integration/workspaces/capture-init/yml/optic.yml
+++ b/projects/optic/src/__tests__/integration/workspaces/capture-init/yml/optic.yml
@@ -1,0 +1,29 @@
+ruleset:
+  - breaking-changes
+  - naming:
+      pathComponents: camelCase
+  - '@org/custom-ruleset'
+  - ./rules/local.js
+capture:
+  openapi.yml:
+    server:
+      command: node server.js
+      url: http://localhost:3000
+      ready_endpoint: /healthcheck
+    requests:
+      send:
+        - path: /
+        - path: /books
+          method: GET
+        - path: /books/asd
+          method: GET
+        - path: /books/def
+          method: GET
+        - path: /books/asd
+          method: POST
+          data:
+            name: asd
+            price: 1
+            author_id: 6nTxAFM5ck4Hob77hGQoL
+        - path: /authors
+          method: GET

--- a/projects/optic/src/commands/capture/capture-init.ts
+++ b/projects/optic/src/commands/capture/capture-init.ts
@@ -6,6 +6,10 @@ import { logger } from '../../logger';
 import { OpticCliConfig } from '../../config';
 import { resolveRelativePath } from '../../utils/capture';
 
+type CaptureInitActionOptions = {
+  stdout: boolean;
+};
+
 export function initCommand(config: OpticCliConfig): Command {
   const command = new Command('init');
 
@@ -21,7 +25,7 @@ export function initCommand(config: OpticCliConfig): Command {
       false
     )
     .action(async (specPath) => {
-      const options = command.opts();
+      const options: CaptureInitActionOptions = command.opts();
       if (!config.configPath && !options.stdout) {
         try {
           config.configPath = await createOpticConfig(
@@ -41,14 +45,26 @@ export function initCommand(config: OpticCliConfig): Command {
       try {
         await initCaptureConfig(
           relativeOasFile,
-          options.stdout!,
+          options.stdout,
           config.configPath!
         );
       } catch (err) {
         logger.error(err);
         process.exitCode = 1;
       }
-      return;
+      if (!options.stdout) {
+        // TODO set relative path here
+        logger.info(`Wrote capture config to ${config.configPath}`);
+        logger.info('');
+        logger.info(`Next:`);
+        logger.info(`- Edit the configuration to match your setup (🔧)`);
+        logger.info(
+          `    A full reference for the configuration can be found at https://www.useoptic.com/docs/capturing-traffic#configuration-reference`
+        );
+        logger.info(
+          `- Then run: optic capture ${relativeOasFile} --update interaction`
+        );
+      }
     });
 
   return command;

--- a/projects/optic/src/commands/capture/capture-init.ts
+++ b/projects/optic/src/commands/capture/capture-init.ts
@@ -38,19 +38,6 @@ export function initCommand(config: OpticCliConfig): Command {
 
       const relativeOasFile = resolveRelativePath(config.root, specPath);
 
-      // if there is already a specific capture config for the oas file specified call that out and do nothing
-      if (
-        config.capture &&
-        config.capture?.[relativeOasFile] &&
-        !options.stdout
-      ) {
-        logger.warn(
-          `optic.yml already contains a capture config for the file ${relativeOasFile}. This command would overwrite the existing configuration. Make changes manually, or view a sample capture configuration with: \`optic capture init optic.yml --stdout\``
-        );
-        process.exitCode = 1;
-        return;
-      }
-
       try {
         await initCaptureConfig(
           relativeOasFile,

--- a/projects/optic/src/commands/capture/init.ts
+++ b/projects/optic/src/commands/capture/init.ts
@@ -10,7 +10,7 @@ export async function initCaptureConfig(
   skipConfigUpdate: boolean,
   config: OpticCliConfig
 ): Promise<string | undefined> {
-  const captureExample = captureConfigExample(oasFile);
+  const captureExample = captureConfigExample(oasFile, skipConfigUpdate);
   const parsedExample = yaml.parseDocument(captureExample);
 
   if (skipConfigUpdate) {
@@ -32,37 +32,40 @@ export async function initCaptureConfig(
 }
 
 // returns a complete Capture block example
-export function captureConfigExample(oasFile: string) {
+export function captureConfigExample(
+  oasFile: string,
+  skipConfigUpdate: boolean
+) {
   return `
-    ${oasFile}:
-      server:
-        # 🔧 Update this to the command to run your server.
-        # Optional: If omitted, Optic assumes the server is running or started elsewhere.
-        command: your-server-command
-        # 🔧 Update this url to where your server can be reached.
-        # Required: Can be overridden with '--server-override'.
-        url: http://localhost:8080
-        # 🔧 Update the readiness endpoint for Optic to validate before sending requests.
-        # Optional: If omitted, perform no readiness checking.
-        ready_endpoint: /
+${skipConfigUpdate ? `${oasFile}:` : ''}
+  server:
+    # 🔧 Update this to the command to run your server.
+    # Optional: If omitted, Optic assumes the server is running or started elsewhere.
+    command: your-server-command
+    # 🔧 Update this url to where your server can be reached.
+    # Required: Can be overridden with '--server-override'.
+    url: http://localhost:8080
+    # 🔧 Update the readiness endpoint for Optic to validate before sending requests.
+    # Optional: If omitted, perform no readiness checking.
+    ready_endpoint: /
 
-      # 🔧 Specify either 'requests.run' or 'requests.send' to generate requests to hit your server
-      requests:
-        # ℹ️ Requests should be sent to the Optic proxy, the address of which is injected into 'run.command's env as OPTIC_PROXY (or the value of 'run.proxy_variable').
-        run:
-          # 🔧 Specify a command that will generate traffic
-          command: your-test-command
-          # 🔧 Ensure your command uses the OPTIC_PROXY environment variable. This ensures test traffic is hit
-          proxy_variable: OPTIC_PROXY
-        # 🔧 Or instead, craft requests for Optic send to your server
-        send:
-          - path: /
-            method: GET
-          - path: /users/create
-            method: POST
-            headers:
-              content-type: application/json;charset=UTF-8
-            data:
-              name: Hank
+  # 🔧 Specify either 'requests.run' or 'requests.send' to generate requests to hit your server
+  requests:
+    # ℹ️ Requests should be sent to the Optic proxy, the address of which is injected into 'run.command's env as OPTIC_PROXY (or the value of 'run.proxy_variable').
+    run:
+      # 🔧 Specify a command that will generate traffic
+      command: your-test-command
+      # 🔧 Ensure your command uses the OPTIC_PROXY environment variable. This ensures test traffic is hit
+      proxy_variable: OPTIC_PROXY
+    # 🔧 Or instead, craft requests for Optic send to your server
+    send:
+      - path: /
+        method: GET
+      - path: /users/create
+        method: POST
+        headers:
+          content-type: application/json;charset=UTF-8
+        data:
+          name: Hank
   `;
 }

--- a/projects/optic/src/commands/capture/init.ts
+++ b/projects/optic/src/commands/capture/init.ts
@@ -1,6 +1,5 @@
 import yaml from 'yaml';
 import { updateOpticConfig } from '../../utils/write-optic-config';
-import { logger } from '../../logger';
 
 export async function initCaptureConfig(
   oasFile: string,
@@ -13,45 +12,36 @@ export async function initCaptureConfig(
   if (skipConfigUpdate) {
     // console.log() to skip any future formatting changes we might make to logger
     console.log(parsedExample.toString());
+    console.log('');
     return;
   }
-  logger.info(`Writing capture config to ${opticConfigPath}`);
   try {
     await updateOpticConfig(parsedExample, oasFile, opticConfigPath);
   } catch (err) {
     throw err;
   }
 }
-// # Configures the 'optic capture' flow. View the documentation for details about how capture works: https://www.useoptic.com/docs/capturing-traffic
 
 // returns a complete Capture block example
 export function captureConfigExample(oasFile: string) {
   return `
     ${oasFile}:
       server:
-        # The command to run your server.
+        # 🔧 Update this to the command to run your server.
         # Optional: If omitted, Optic assumes the server is running or started elsewhere.
         command: your-server-command
-        # The url where your server can be reached once running.
+        # 🔧 Update this url to where your server can be reached.
         # Required: Can be overridden with '--server-override'.
         url: http://localhost:8080
-        # A readiness endpoint for Optic to validate before sending requests.
+        # 🔧 Update the readiness endpoint for Optic to validate before sending requests.
         # Optional: If omitted, perform no readiness checking.
-
         ready_endpoint: /
-        # The interval to check 'ready_endpoint', in ms.
-        # Optional: default: 1000
-        ready_interval: 1000
-        # The length of time in ms to wait for a successful ready check to occur.
-        # Optional: default: 10_000, 10 seconds
-        ready_timeout: 10_000
-      # At least one of 'requests.run' or 'requests.send' is required below.
+
+      # 🔧 Specify either 'requests.run' or 'requests.send' to generate requests to hit your server
       requests:
-        # Run a command to generate traffic. Requests should be sent to the Optic proxy, the address of which is injected
-        # into 'run.command's env as OPTIC_PROXY or the value of 'run.proxy_variable', if set.
+        # Run a command to generate traffic. 
+        # ℹ️ Requests should be sent to the Optic proxy, the address of which is injected into 'run.command's env as OPTIC_PROXY (or the value of 'run.proxy_variable').
         run:
-          # The command that will generate traffic to the Optic proxy. Globbing with '*' is supported.
-          # Required if specifying 'requests.run'.
           command: your-test-command
           # The name of the environment variable injected into the env of the command that contains the address of the Optic proxy.
           # Optional: default: OPTIC_PROXY
@@ -59,10 +49,6 @@ export function captureConfigExample(oasFile: string) {
         # Have Optic generate traffic to the proxy itself by specifying endpoint details. A request's 'data' attribute
         # is converted to JSON and sent along with the request.
         send:
-          # path: Required
-          # method: Optional: default: GET
-          # data: Optional: If omitted on a POST request, default: {}
-          # headers: Optional: If 'content-type' is omitted, it is set to 'application/json;charset=UTF-8'.
           - path: /
             method: GET
           - path: /users/create
@@ -71,9 +57,5 @@ export function captureConfigExample(oasFile: string) {
               content-type: application/json;charset=UTF-8
             data:
               name: Hank
-      config:
-        # The number of parallel requests to make when using 'requests.send'.
-        # Optional: default: 4
-        request_concurrency: 4
   `;
 }

--- a/projects/optic/src/commands/capture/init.ts
+++ b/projects/optic/src/commands/capture/init.ts
@@ -55,7 +55,7 @@ ${skipConfigUpdate ? `${oasFile}:` : ''}
     run:
       # 🔧 Specify a command that will generate traffic
       command: your-test-command
-      # 🔧 Ensure your command uses the OPTIC_PROXY environment variable. This ensures test traffic is hit
+      # 🔧 OPTIC_PROXY is added to your command's env and contains the URL of an Optic's local reverse proxy. Your command should send its requests to this URL.
       proxy_variable: OPTIC_PROXY
     # 🔧 Or instead, craft requests for Optic send to your server
     send:

--- a/projects/optic/src/commands/capture/init.ts
+++ b/projects/optic/src/commands/capture/init.ts
@@ -1,8 +1,5 @@
 import yaml from 'yaml';
-import {
-  createOpticConfig,
-  updateOpticConfig,
-} from '../../utils/write-optic-config';
+import { updateOpticConfig } from '../../utils/write-optic-config';
 import { OpticCliConfig } from '../../config';
 
 export async function initCaptureConfig(
@@ -19,16 +16,8 @@ export async function initCaptureConfig(
     console.log('');
     return;
   }
-  const configPath = config.configPath
-    ? config.configPath
-    : await createOpticConfig(config.root, 'capture', {});
 
-  try {
-    await updateOpticConfig(parsedExample, oasFile, configPath);
-    return configPath;
-  } catch (err) {
-    throw err;
-  }
+  return updateOpticConfig(parsedExample, oasFile, config);
 }
 
 // returns a complete Capture block example

--- a/projects/optic/src/commands/capture/init.ts
+++ b/projects/optic/src/commands/capture/init.ts
@@ -17,64 +17,63 @@ export async function initCaptureConfig(
   }
   logger.info(`Writing capture config to ${opticConfigPath}`);
   try {
-    await updateOpticConfig(parsedExample, opticConfigPath);
+    await updateOpticConfig(parsedExample, oasFile, opticConfigPath);
   } catch (err) {
     throw err;
   }
 }
+// # Configures the 'optic capture' flow. View the documentation for details about how capture works: https://www.useoptic.com/docs/capturing-traffic
 
 // returns a complete Capture block example
 export function captureConfigExample(oasFile: string) {
   return `
-    # Configures the 'optic capture' flow. View the documentation for details about how capture works: https://www.useoptic.com/docs/capturing-traffic
-    capture:
-      ${oasFile}:
-        server:
-          # The command to run your server.
-          # Optional: If omitted, Optic assumes the server is running or started elsewhere.
-          command: your-server-command
-          # The url where your server can be reached once running.
-          # Required: Can be overridden with '--server-override'.
-          url: http://localhost:8080
-          # A readiness endpoint for Optic to validate before sending requests.
-          # Optional: If omitted, perform no readiness checking.
+    ${oasFile}:
+      server:
+        # The command to run your server.
+        # Optional: If omitted, Optic assumes the server is running or started elsewhere.
+        command: your-server-command
+        # The url where your server can be reached once running.
+        # Required: Can be overridden with '--server-override'.
+        url: http://localhost:8080
+        # A readiness endpoint for Optic to validate before sending requests.
+        # Optional: If omitted, perform no readiness checking.
 
-          ready_endpoint: /
-          # The interval to check 'ready_endpoint', in ms.
-          # Optional: default: 1000
-          ready_interval: 1000
-          # The length of time in ms to wait for a successful ready check to occur.
-          # Optional: default: 10_000, 10 seconds
-          ready_timeout: 10_000
-        # At least one of 'requests.run' or 'requests.send' is required below.
-        requests:
-          # Run a command to generate traffic. Requests should be sent to the Optic proxy, the address of which is injected
-          # into 'run.command's env as OPTIC_PROXY or the value of 'run.proxy_variable', if set.
-          run:
-            # The command that will generate traffic to the Optic proxy. Globbing with '*' is supported.
-            # Required if specifying 'requests.run'.
-            command: your-test-command
-            # The name of the environment variable injected into the env of the command that contains the address of the Optic proxy.
-            # Optional: default: OPTIC_PROXY
-            proxy_variable: OPTIC_PROXY
-          # Have Optic generate traffic to the proxy itself by specifying endpoint details. A request's 'data' attribute
-          # is converted to JSON and sent along with the request.
-          send:
-            # path: Required
-            # method: Optional: default: GET
-            # data: Optional: If omitted on a POST request, default: {}
-            # headers: Optional: If 'content-type' is omitted, it is set to 'application/json;charset=UTF-8'.
-            - path: /
-              method: GET
-            - path: /users/create
-              method: POST
-              headers:
-                content-type: application/json;charset=UTF-8
-              data:
-                name: Hank
-        config:
-          # The number of parallel requests to make when using 'requests.send'.
-          # Optional: default: 4
-          request_concurrency: 4
+        ready_endpoint: /
+        # The interval to check 'ready_endpoint', in ms.
+        # Optional: default: 1000
+        ready_interval: 1000
+        # The length of time in ms to wait for a successful ready check to occur.
+        # Optional: default: 10_000, 10 seconds
+        ready_timeout: 10_000
+      # At least one of 'requests.run' or 'requests.send' is required below.
+      requests:
+        # Run a command to generate traffic. Requests should be sent to the Optic proxy, the address of which is injected
+        # into 'run.command's env as OPTIC_PROXY or the value of 'run.proxy_variable', if set.
+        run:
+          # The command that will generate traffic to the Optic proxy. Globbing with '*' is supported.
+          # Required if specifying 'requests.run'.
+          command: your-test-command
+          # The name of the environment variable injected into the env of the command that contains the address of the Optic proxy.
+          # Optional: default: OPTIC_PROXY
+          proxy_variable: OPTIC_PROXY
+        # Have Optic generate traffic to the proxy itself by specifying endpoint details. A request's 'data' attribute
+        # is converted to JSON and sent along with the request.
+        send:
+          # path: Required
+          # method: Optional: default: GET
+          # data: Optional: If omitted on a POST request, default: {}
+          # headers: Optional: If 'content-type' is omitted, it is set to 'application/json;charset=UTF-8'.
+          - path: /
+            method: GET
+          - path: /users/create
+            method: POST
+            headers:
+              content-type: application/json;charset=UTF-8
+            data:
+              name: Hank
+      config:
+        # The number of parallel requests to make when using 'requests.send'.
+        # Optional: default: 4
+        request_concurrency: 4
   `;
 }

--- a/projects/optic/src/commands/capture/init.ts
+++ b/projects/optic/src/commands/capture/init.ts
@@ -1,11 +1,15 @@
 import yaml from 'yaml';
-import { updateOpticConfig } from '../../utils/write-optic-config';
+import {
+  createOpticConfig,
+  updateOpticConfig,
+} from '../../utils/write-optic-config';
+import { OpticCliConfig } from '../../config';
 
 export async function initCaptureConfig(
   oasFile: string,
   skipConfigUpdate: boolean,
-  opticConfigPath: string
-) {
+  config: OpticCliConfig
+): Promise<string | undefined> {
   const captureExample = captureConfigExample(oasFile);
   const parsedExample = yaml.parseDocument(captureExample);
 
@@ -15,8 +19,13 @@ export async function initCaptureConfig(
     console.log('');
     return;
   }
+  const configPath = config.configPath
+    ? config.configPath
+    : await createOpticConfig(config.root, 'capture', {});
+
   try {
-    await updateOpticConfig(parsedExample, oasFile, opticConfigPath);
+    await updateOpticConfig(parsedExample, oasFile, configPath);
+    return configPath;
   } catch (err) {
     throw err;
   }

--- a/projects/optic/src/commands/capture/init.ts
+++ b/projects/optic/src/commands/capture/init.ts
@@ -48,15 +48,13 @@ export function captureConfigExample(oasFile: string) {
 
       # 🔧 Specify either 'requests.run' or 'requests.send' to generate requests to hit your server
       requests:
-        # Run a command to generate traffic. 
         # ℹ️ Requests should be sent to the Optic proxy, the address of which is injected into 'run.command's env as OPTIC_PROXY (or the value of 'run.proxy_variable').
         run:
+          # 🔧 Specify a command that will generate traffic
           command: your-test-command
-          # The name of the environment variable injected into the env of the command that contains the address of the Optic proxy.
-          # Optional: default: OPTIC_PROXY
+          # 🔧 Ensure your command uses the OPTIC_PROXY environment variable. This ensures test traffic is hit
           proxy_variable: OPTIC_PROXY
-        # Have Optic generate traffic to the proxy itself by specifying endpoint details. A request's 'data' attribute
-        # is converted to JSON and sent along with the request.
+        # 🔧 Or instead, craft requests for Optic send to your server
         send:
           - path: /
             method: GET

--- a/projects/optic/src/commands/capture/init.ts
+++ b/projects/optic/src/commands/capture/init.ts
@@ -26,35 +26,35 @@ export function captureConfigExample(
   skipConfigUpdate: boolean
 ) {
   return `
-${skipConfigUpdate ? `${oasFile}:` : ''}
-  server:
-    # 🔧 Update this to the command to run your server.
-    # Optional: If omitted, Optic assumes the server is running or started elsewhere.
-    command: your-server-command
-    # 🔧 Update this url to where your server can be reached.
-    # Required: Can be overridden with '--server-override'.
-    url: http://localhost:8080
-    # 🔧 Update the readiness endpoint for Optic to validate before sending requests.
-    # Optional: If omitted, perform no readiness checking.
-    ready_endpoint: /
+${skipConfigUpdate ? `capture:\n  ${oasFile}:` : ''}
+    server:
+      # 🔧 Update this to the command to run your server.
+      # Optional: If omitted, Optic assumes the server is running or started elsewhere.
+      command: your-server-command
+      # 🔧 Update this url to where your server can be reached.
+      # Required: Can be overridden with '--server-override'.
+      url: http://localhost:8080
+      # 🔧 Update the readiness endpoint for Optic to validate before sending requests.
+      # Optional: If omitted, perform no readiness checking.
+      ready_endpoint: /
 
-  # 🔧 Specify either 'requests.run' or 'requests.send' to generate requests to hit your server
-  requests:
-    # ℹ️ Requests should be sent to the Optic proxy, the address of which is injected into 'run.command's env as OPTIC_PROXY (or the value of 'run.proxy_variable').
-    run:
-      # 🔧 Specify a command that will generate traffic
-      command: your-test-command
-      # 🔧 OPTIC_PROXY is added to your command's env and contains the URL of an Optic's local reverse proxy. Your command should send its requests to this URL.
-      proxy_variable: OPTIC_PROXY
-    # 🔧 Or instead, craft requests for Optic send to your server
-    send:
-      - path: /
-        method: GET
-      - path: /users/create
-        method: POST
-        headers:
-          content-type: application/json;charset=UTF-8
-        data:
-          name: Hank
+    # 🔧 Specify either 'requests.run' or 'requests.send' to generate requests to hit your server
+    requests:
+      # ℹ️ Requests should be sent to the Optic proxy, the address of which is injected into 'run.command's env as OPTIC_PROXY (or the value of 'run.proxy_variable').
+      run:
+        # 🔧 Specify a command that will generate traffic
+        command: your-test-command
+        # 🔧 OPTIC_PROXY is added to your command's env and contains the URL of an Optic's local reverse proxy. Your command should send its requests to this URL.
+        proxy_variable: OPTIC_PROXY
+      # 🔧 Or instead, craft requests for Optic send to your server
+      send:
+        - path: /
+          method: GET
+        - path: /users/create
+          method: POST
+          headers:
+            content-type: application/json;charset=UTF-8
+          data:
+            name: Hank
   `;
 }

--- a/projects/optic/src/utils/write-optic-config.ts
+++ b/projects/optic/src/utils/write-optic-config.ts
@@ -25,16 +25,10 @@ export async function updateOpticConfig(
     let opticYml = yaml.parseDocument(
       await fs.readFile(opticConfigPath, 'utf8')
     );
-
     if (!opticYml.has('capture')) {
       opticYml.set('capture', {});
     }
-
-    (opticYml.get('capture') as yaml.Document.Parsed).set(
-      filePath,
-      newDocument.get(filePath)
-    );
-
+    opticYml.setIn(['capture', filePath], newDocument);
     await fs.writeFile(opticConfigPath, opticYml.toString());
   } catch (err) {
     throw err;

--- a/projects/optic/src/utils/write-optic-config.ts
+++ b/projects/optic/src/utils/write-optic-config.ts
@@ -1,36 +1,25 @@
 import yaml from 'yaml';
 import fs from 'node:fs/promises';
 import path from 'path';
-
-export async function createOpticConfig(
-  filePath: string,
-  key: string,
-  value: any
-): Promise<string> {
-  const opticYmlPath = path.join(filePath, 'optic.yml');
-  const opticYml = new yaml.Document();
-  opticYml.set(key, value);
-  await fs.writeFile(opticYmlPath, opticYml.toString());
-  return opticYmlPath;
-}
+import { OpticCliConfig } from '../config';
 
 // merges a yaml document into the existing optic.yml and writes it to disk. if newDocument's top-level
 // key already exists in the Optic config, it is overwritten.
 export async function updateOpticConfig(
   newDocument: yaml.Document.Parsed,
   filePath: string,
-  opticConfigPath: string
-) {
-  try {
-    let opticYml = yaml.parseDocument(
-      await fs.readFile(opticConfigPath, 'utf8')
-    );
-    if (!opticYml.has('capture')) {
-      opticYml.set('capture', {});
-    }
-    opticYml.setIn(['capture', filePath], newDocument);
-    await fs.writeFile(opticConfigPath, opticYml.toString());
-  } catch (err) {
-    throw err;
+  config: OpticCliConfig
+): Promise<string> {
+  let opticYml = new yaml.Document();
+  let configPath = config.configPath;
+  if (configPath) {
+    opticYml = yaml.parseDocument(await fs.readFile(configPath, 'utf8'));
+  } else {
+    configPath = path.join(config.root, 'optic.yml');
   }
+
+  opticYml.setIn(['capture', filePath], newDocument);
+  await fs.writeFile(configPath, opticYml.toString());
+
+  return configPath;
 }

--- a/projects/optic/src/utils/write-optic-config.ts
+++ b/projects/optic/src/utils/write-optic-config.ts
@@ -10,9 +10,7 @@ export async function createOpticConfig(
   const opticYmlPath = path.join(filePath, 'optic.yml');
   const opticYml = new yaml.Document();
   opticYml.set(key, value);
-  await fs.writeFile(opticYmlPath, opticYml.toString()).catch((err) => {
-    throw err;
-  });
+  await fs.writeFile(opticYmlPath, opticYml.toString());
   return opticYmlPath;
 }
 
@@ -20,6 +18,7 @@ export async function createOpticConfig(
 // key already exists in the Optic config, it is overwritten.
 export async function updateOpticConfig(
   newDocument: yaml.Document.Parsed,
+  filePath: string,
   opticConfigPath: string
 ) {
   try {
@@ -27,10 +26,14 @@ export async function updateOpticConfig(
       await fs.readFile(opticConfigPath, 'utf8')
     );
 
-    // the assumption is that the document being merged only has a single top-level key
-    // so we take the first index
-    const topLevelKey = Object.keys(newDocument.toJSON())[0];
-    opticYml.set(topLevelKey, newDocument.get(topLevelKey));
+    if (!opticYml.has('capture')) {
+      opticYml.set('capture', {});
+    }
+
+    (opticYml.get('capture') as yaml.Document.Parsed).set(
+      filePath,
+      newDocument.get(filePath)
+    );
 
     await fs.writeFile(opticConfigPath, opticYml.toString());
   } catch (err) {


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Having launched capture, we've seen a couple of instances where users haven't gotten from `capture init` -> completing a capture sucessfully.

This PR:
- Removes some of the configuration from the capture example that isn't necessary for your first use. I added a link to the website where the full capture config reference can be found and people can use it
- Updates some of the wording in the generated config to be more actionable + added 🔧 (similar to ci-setup)
- Added explicit next steps when running

Output
```
optic capture init asd.yml
✔ Wrote capture config to optic.yml

Next:
- Edit the configuration to match your setup (🔧)
    A full reference for the configuration can be found at https://www.useoptic.com/docs/capturing-traffic#configuration-reference
- Then run: optic capture asd.yml --update interaction
```

Also fixes:
- `optic capture init` overwriting existing config in optic.yml
- moves around some code so we can rely on TS type inferences

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
