### PR TITLE
chore(cli): hide deprecated commands

### DIFF
--- a/projects/optic/src/init.ts
+++ b/projects/optic/src/init.ts
@@ -171,9 +171,7 @@ export const initCli = async (
   registerSpecPush(specSubcommands, cliConfig);
   registerSpecAddApiUrl(specSubcommands, cliConfig);
 
-  const ciSubcommands = cli
-    .command('ci', { hidden: true })
-    .addHelpCommand(false);
+  const ciSubcommands = cli.command('ci').addHelpCommand(false);
   registerCiComment(ciSubcommands, cliConfig);
   registerCiSetup(ciSubcommands, cliConfig);
 

--- a/projects/optic/src/init.ts
+++ b/projects/optic/src/init.ts
@@ -158,16 +158,22 @@ export const initCli = async (
   registerRulesetUpload(rulesetSubcommands, cliConfig);
   registerRulesetInit(rulesetSubcommands, cliConfig);
 
-  const apiSubcommands = cli.command('api', { hidden: true }).addHelpCommand(false);
+  const apiSubcommands = cli
+    .command('api', { hidden: true })
+    .addHelpCommand(false);
   registerApiAdd(apiSubcommands, cliConfig);
   registerApiCreate(apiSubcommands, cliConfig);
   registerApiList(apiSubcommands, cliConfig);
 
-  const specSubcommands = cli.command('spec', { hidden: true }).addHelpCommand(false);
+  const specSubcommands = cli
+    .command('spec', { hidden: true })
+    .addHelpCommand(false);
   registerSpecPush(specSubcommands, cliConfig);
   registerSpecAddApiUrl(specSubcommands, cliConfig);
 
-  const ciSubcommands = cli.command('ci', { hidden: true }).addHelpCommand(false);
+  const ciSubcommands = cli
+    .command('ci', { hidden: true })
+    .addHelpCommand(false);
   registerCiComment(ciSubcommands, cliConfig);
   registerCiSetup(ciSubcommands, cliConfig);
 

--- a/projects/optic/src/init.ts
+++ b/projects/optic/src/init.ts
@@ -135,13 +135,13 @@ export const initCli = async (
   oas.addCommand(verifyCommand(cliConfig));
   oas.addCommand(updateCommand());
 
-  cli.addCommand(oas);
+  cli.addCommand(oas, { hidden: true });
 
   // commands for tracking changes with openapi
   cli.addCommand(await newCommand());
-  cli.addCommand(await setupTlsCommand());
-  cli.addCommand(verifyCommand(cliConfig));
-  cli.addCommand(updateCommand());
+  cli.addCommand(await setupTlsCommand(), { hidden: true });
+  cli.addCommand(verifyCommand(cliConfig), { hidden: true });
+  cli.addCommand(updateCommand(), { hidden: true });
 
   registerLint(cli, cliConfig);
   registerDiffAll(cli, cliConfig);
@@ -158,16 +158,16 @@ export const initCli = async (
   registerRulesetUpload(rulesetSubcommands, cliConfig);
   registerRulesetInit(rulesetSubcommands, cliConfig);
 
-  const apiSubcommands = cli.command('api').addHelpCommand(false);
+  const apiSubcommands = cli.command('api', { hidden: true }).addHelpCommand(false);
   registerApiAdd(apiSubcommands, cliConfig);
   registerApiCreate(apiSubcommands, cliConfig);
   registerApiList(apiSubcommands, cliConfig);
 
-  const specSubcommands = cli.command('spec').addHelpCommand(false);
+  const specSubcommands = cli.command('spec', { hidden: true }).addHelpCommand(false);
   registerSpecPush(specSubcommands, cliConfig);
   registerSpecAddApiUrl(specSubcommands, cliConfig);
 
-  const ciSubcommands = cli.command('ci').addHelpCommand(false);
+  const ciSubcommands = cli.command('ci', { hidden: true }).addHelpCommand(false);
   registerCiComment(ciSubcommands, cliConfig);
   registerCiSetup(ciSubcommands, cliConfig);
 


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

hides the following CLI commands:
- oas
- setup-tis
- verify
- update
- api
- spec
- [~~ci~~](https://github.com/opticdev/optic/pull/2244#pullrequestreview-1587821817)

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._
- https://www.notion.so/useoptic/Cleanup-Optic-CLI-Commands-ebfd29f2e15c428c98d5e41a39d3052a

## 👹 QA
_How can other humans verify that this PR is correct?_
