### PR TITLE
Hide Window shell windows when capturing

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.49.3",
+  "version": "0.49.4-0",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",
@@ -27,5 +27,6 @@
     "**/*.+(js|jsx|ts|tsx|json|css)": [
       "yarn prettier --write"
     ]
-  }
+  },
+  "stableVersion": "0.49.3"
 }

--- a/projects/fastify-capture/package.json
+++ b/projects/fastify-capture/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/fastify-capture",
   "license": "MIT",
   "packageManager": "yarn@3.6.2",
-  "version": "0.49.3",
+  "version": "0.49.4-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -37,5 +37,6 @@
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
     "typescript": "^5.0.4"
-  }
+  },
+  "stableVersion": "0.49.3"
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@3.6.2",
-  "version": "0.49.3",
+  "version": "0.49.4-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -32,5 +32,6 @@
   "dependencies": {
     "jsonpointer": "^5.0.1",
     "minimatch": "9.0.3"
-  }
+  },
+  "stableVersion": "0.49.3"
 }

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@3.6.2",
-  "version": "0.49.3",
+  "version": "0.49.4-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -57,5 +57,6 @@
     "upath": "^2.0.1",
     "yaml": "^2.2.2",
     "yaml-ast-parser": "^0.0.43"
-  }
+  },
+  "stableVersion": "0.49.3"
 }

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@3.6.2",
-  "version": "0.49.3",
+  "version": "0.49.4-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -53,5 +53,6 @@
     "ts-invariant": "^0.9.3",
     "url-join": "^4.0.1",
     "yaml-ast-parser": "^0.0.43"
-  }
+  },
+  "stableVersion": "0.49.3"
 }

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@3.6.2",
-  "version": "0.49.3",
+  "version": "0.49.4-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -138,5 +138,6 @@
       "node18-win-x64"
     ],
     "outputPath": "../../dist"
-  }
+  },
+  "stableVersion": "0.49.3"
 }

--- a/projects/optic/src/commands/capture/actions/captureRequests.ts
+++ b/projects/optic/src/commands/capture/actions/captureRequests.ts
@@ -52,7 +52,7 @@ function startApp(
   let app: ChildProcessWithoutNullStreams;
   try {
     app = spawn(cmd.cmd, cmd.args, {
-      detached: true,
+      detached: false,
       cwd: dir,
       shell: true,
       windowsHide: true,
@@ -207,7 +207,7 @@ async function runRequestsCommand(
         ...process.env,
         [proxyVar]: proxyUrl,
       },
-      detached: true,
+      detached: false,
       shell: true,
       windowsHide: true,
     });

--- a/projects/optic/src/commands/capture/actions/captureRequests.ts
+++ b/projects/optic/src/commands/capture/actions/captureRequests.ts
@@ -51,7 +51,12 @@ function startApp(
   const cmd = commandSplitter(command);
   let app: ChildProcessWithoutNullStreams;
   try {
-    app = spawn(cmd.cmd, cmd.args, { detached: true, cwd: dir, shell: true });
+    app = spawn(cmd.cmd, cmd.args, {
+      detached: true,
+      cwd: dir,
+      shell: true,
+      windowsHide: true,
+    });
   } catch (e) {
     throw new UserError({ message: (e as Error).message });
   }
@@ -204,6 +209,7 @@ async function runRequestsCommand(
       },
       detached: true,
       shell: true,
+      windowsHide: true,
     });
   } catch (e) {
     throw new UserError({ initialError: e as Error });

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@3.6.2",
-  "version": "0.49.3",
+  "version": "0.49.4-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -39,5 +39,6 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
-  }
+  },
+  "stableVersion": "0.49.3"
 }

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@3.6.2",
-  "version": "0.49.3",
+  "version": "0.49.4-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -38,5 +38,6 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
-  }
+  },
+  "stableVersion": "0.49.3"
 }


### PR DESCRIPTION
## 🍗 Description
During capture we spawn 1-2 processes (proxy + test command if it's set). On windows machines that defaults to opening new shell windows. We need to explicitly set it to `false` to prevent this. 

Fixes https://github.com/opticdev/optic/issues/2259

## 📚 References
https://nodejs.org/api/child_process.html

## 👹 QA
Manual test on my windows 10 VM
