### PR TITLE
have patches regenerate after becoming nullable

### DIFF
--- a/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/type.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/type.ts
@@ -198,7 +198,7 @@ export function* typePatches(
             value: schemaType,
           }),
         ],
-        shouldRegeneratePatches: false,
+        shouldRegeneratePatches: true,
         interaction,
       };
     } else {


### PR DESCRIPTION
## 🍗 Description
Null patches on 3.1 were leading to duplicate entries in the `type` array which is invalid JSON schema. We were not regenerating the diffs so every `null` example was adding a new `"null"` entry to type arrays.
Fixes https://github.com/opticdev/monorail/issues/4931
![image](https://github.com/opticdev/optic/assets/5900338/6239a727-9d4e-4f8f-86ef-130a6ada0cf7)


## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
