### PR TITLE
fix: display `requests.run.command` errors in the same powershell window

### DIFF
--- a/projects/optic/src/commands/capture/actions/captureRequests.ts
+++ b/projects/optic/src/commands/capture/actions/captureRequests.ts
@@ -202,8 +202,11 @@ async function runRequestsCommand(
         ...process.env,
         [proxyVar]: proxyUrl,
       },
-      detached: true,
+      detached: false,
       shell: true,
+      // hide child process powershell windows on Windows systems. this only works with "detached: false".
+      // https://nodejs.org/api/child_process.html#child_processexeccommand-options-callback
+      windowsHide: true,
     });
   } catch (e) {
     throw new UserError({ initialError: e as Error });


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

fixes the issue mentioned in https://github.com/opticdev/optic/issues/2259, where `requests.run.command` error output is hidden in a new short-lived powershell window.

`server.command` has the same issue, but is more complicated to fix. see [aidan's pr](https://github.com/opticdev/optic/pull/2260) for details there. considering that windows powershell users are a small percentage of our users, i think its fine to fix the reported issue without considering everywhere we use `spawn()`.

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._
- closes https://github.com/opticdev/optic/issues/2259
- obviates https://github.com/opticdev/optic/pull/2260

## 👹 QA
_How can other humans verify that this PR is correct?_
