### PR TITLE
hide most commands

### DIFF
--- a/projects/optic/src/commands/bundle/bundle.ts
+++ b/projects/optic/src/commands/bundle/bundle.ts
@@ -43,7 +43,7 @@ export const registerBundle = (cli: Command, config: OpticCliConfig) => {
   ).hideHelp(true);
 
   cli
-    .command('bundle')
+    .command('bundle', { hidden: true })
     .configureHelp({
       commandUsage: usage,
     })

--- a/projects/optic/src/commands/ci/setup.ts
+++ b/projects/optic/src/commands/ci/setup.ts
@@ -24,7 +24,7 @@ const choices: Provider[] = ['github', 'gitlab'];
 
 export const registerCiSetup = (cli: Command, config: OpticCliConfig) => {
   cli
-    .command('setup')
+    .command('setup', { hidden: true })
     .configureHelp({
       commandUsage: usage,
     })

--- a/projects/optic/src/commands/dereference/dereference.ts
+++ b/projects/optic/src/commands/dereference/dereference.ts
@@ -30,7 +30,7 @@ export const registerDereference = (cli: Command, config: OpticCliConfig) => {
   ).hideHelp(true);
 
   cli
-    .command('dereference')
+    .command('dereference', { hidden: true })
     .configureHelp({
       commandUsage: usage,
     })

--- a/projects/optic/src/commands/diff/diff-all.ts
+++ b/projects/optic/src/commands/diff/diff-all.ts
@@ -44,7 +44,7 @@ Example usage:
 
 export const registerDiffAll = (cli: Command, config: OpticCliConfig) => {
   cli
-    .command('diff-all')
+    .command('diff-all', { hidden: true })
     .configureHelp({
       commandUsage: usage,
     })

--- a/projects/optic/src/commands/diff/diff.ts
+++ b/projects/optic/src/commands/diff/diff.ts
@@ -72,7 +72,7 @@ Example usage:
 
 export const registerDiff = (cli: Command, config: OpticCliConfig) => {
   cli
-    .command('diff')
+    .command('diff', { hidden: true })
     .configureHelp({
       commandUsage: usage,
     })

--- a/projects/optic/src/commands/history.ts
+++ b/projects/optic/src/commands/history.ts
@@ -29,7 +29,7 @@ function short(sha: string) {
 
 export const registerHistory = (cli: Command, config: OpticCliConfig) => {
   cli
-    .command('history')
+    .command('history', { hidden: true })
     .configureHelp({ commandUsage: usage })
     .addHelpText('after', helpText)
     .description('Browse spec history and create a text changelog')

--- a/projects/optic/src/commands/lint/lint.ts
+++ b/projects/optic/src/commands/lint/lint.ts
@@ -20,7 +20,7 @@ const usage = () => `
 
 export const registerLint = (cli: Command, config: OpticCliConfig) => {
   cli
-    .command('lint')
+    .command('lint', { hidden: true })
     .configureHelp({
       commandUsage: usage,
     })

--- a/projects/optic/src/commands/run.ts
+++ b/projects/optic/src/commands/run.ts
@@ -114,7 +114,7 @@ export function registerRunCommand(cli: Command, config: OpticCliConfig) {
   cli
     .command('run')
     .description(
-      `Optic's workflow command: validate your OpenAPI specification files, check API governance policies, search for breaking changes and post a human-readable summary of the changes to your pull request.`
+      `Optic's workflow command: lint OpenAPI specifications, search for breaking changes, enforce custom API governance rules, automatically update your specs to match your tests traffic and post a friendly summary to the PR/MR and .`
     )
     .configureHelp({ commandUsage: usage })
     .option(

--- a/projects/optic/src/init.ts
+++ b/projects/optic/src/init.ts
@@ -121,6 +121,7 @@ export const initCli = async (
   cli.version(packageJson.version);
   cli.addHelpCommand(false);
 
+  registerRunCommand(cli, cliConfig);
   registerDiff(cli, cliConfig);
 
   const betaSubcommands = cli.command('beta', { hidden: true });
@@ -139,7 +140,7 @@ export const initCli = async (
   cli.addCommand(oas, { hidden: true });
 
   // commands for tracking changes with openapi
-  cli.addCommand(await newCommand());
+  cli.addCommand(await newCommand(), { hidden: true });
   cli.addCommand(await setupTlsCommand(), { hidden: true });
   cli.addCommand(verifyCommand(cliConfig), { hidden: true });
   cli.addCommand(updateCommand(), { hidden: true });
@@ -172,12 +173,13 @@ export const initCli = async (
   registerSpecPush(specSubcommands, cliConfig);
   registerSpecAddApiUrl(specSubcommands, cliConfig);
 
-  const ciSubcommands = cli.command('ci').addHelpCommand(false);
+  const ciSubcommands = cli
+    .command('ci', { hidden: true })
+    .addHelpCommand(false);
   registerCiComment(ciSubcommands, cliConfig);
   registerCiSetup(ciSubcommands, cliConfig);
 
   registerHistory(cli, cliConfig);
-  registerRunCommand(cli, cliConfig);
 
   return cli;
 };


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

```
Usage: optic [options] [command]

Options:
  -V, --version                                  output the version number
  -h, --help                                     display help for command

Commands:
  run [options]                                  Optic's complete workflow command: find OpenAPI specifications in your repository, lint them, search for breaking changes, update your Optic cloud specs repository,
                                                 log results and post a human-readable summary of the changes to your pull request.
  capture [options] <openapi-file> [target-url]  capture traffic using the configuration in optic.yml
  login                                          Login to Optic
```

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
