### PR TITLE
Optic capture in run

### DIFF
--- a/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
@@ -1784,6 +1784,7 @@ GET /books
 [90m...and 1 endpoint that did not receive traffic[39m
 
 5 unmatched requests
+
 [33mNew endpoints are only added in interactive mode. Run 'optic capture openapi.yml --update interactive' to add new endpoints[39m
 "
 `;

--- a/projects/optic/src/commands/capture/actions/captureRequests.ts
+++ b/projects/optic/src/commands/capture/actions/captureRequests.ts
@@ -289,7 +289,12 @@ function makeAllRequests(
 export async function captureRequestsFromProxy(
   config: OpticCliConfig,
   captureConfig: CaptureConfigData,
-  options: { proxyPort?: string; serverOverride?: string; serverUrl: string }
+  options: {
+    proxyPort?: string;
+    serverOverride?: string;
+    serverUrl: string;
+    disableSpinner?: boolean;
+  }
 ) {
   let app: ChildProcessWithoutNullStreams | undefined = undefined;
   let proxy: ProxyServer | undefined = undefined;
@@ -307,10 +312,12 @@ export async function captureRequestsFromProxy(
   const unsubscribeHook = exitHook(() => {
     cleanup();
   });
-  const spinner = getSpinner({
-    text: 'Generating traffic to send to server',
-    color: 'blue',
-  })?.start();
+  const spinner = options.disableSpinner
+    ? undefined
+    : getSpinner({
+        text: 'Generating traffic to send to server',
+        color: 'blue',
+      })?.start();
   let interactions: ProxyInteractions | null = null;
 
   const serverUrl = options.serverUrl;

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -256,6 +256,7 @@ const getCaptureAction =
     );
 
     if (!captureOutput) {
+      process.exitCode = 1;
       return;
     }
     const {
@@ -263,6 +264,7 @@ const getCaptureAction =
       totalInteractions,
       coverage,
       endpointsAdded,
+      hasAnyDiffs,
       endpointCounts,
     } = captureOutput;
 
@@ -331,6 +333,9 @@ const getCaptureAction =
           branchTag ? `for tag '${branchTag}'` : ''
         }. View your spec at ${specUrl}`
       );
+    }
+    if (hasAnyDiffs) {
+      process.exitCode = 1;
     }
 
     if (
@@ -442,12 +447,12 @@ export async function processCaptures(
         ? bufferedOutput.push(JSON.stringify(captureConfig?.requests?.send))
         : logger.error(captureConfig?.requests?.send);
     }
-    process.exitCode = 1;
     return;
   }
 
   // update existing endpoints
   const coverage = new ApiCoverageCounter(spec.jsonLike);
+  let hasAnyDiffs = false;
   let diffCount = 0;
   let endpointsAdded = 0;
   // Handle interactions for documented endpoints first
@@ -492,7 +497,7 @@ export async function processCaptures(
       if (!hasDiffs) {
         spinner?.succeed(endpointText);
       } else {
-        process.exitCode = 1;
+        hasAnyDiffs = true;
         spinner?.fail(endpointText);
       }
     }
@@ -609,5 +614,6 @@ export async function processCaptures(
     endpointsAdded,
     endpointCounts,
     bufferedOutput,
+    hasAnyDiffs,
   };
 }

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -10,13 +10,13 @@ import { errorHandler } from '../../error-handler';
 
 import { createNewSpecFile } from '../../utils/specs';
 import { logger } from '../../logger';
-import { OpticCliConfig, VCS } from '../../config';
+import { CaptureConfigData, OpticCliConfig, VCS } from '../../config';
 import { clearCommand } from '../oas/capture-clear';
 import { initCommand } from './capture-init';
 import { captureV1 } from '../oas/capture';
 
 import { getCaptureStorage } from './storage';
-import { loadSpec } from '../../utils/spec-loaders';
+import { ParseResult, loadSpec } from '../../utils/spec-loaders';
 import { ApiCoverageCounter } from './coverage/api-coverage';
 import { getHarEntriesFromFs } from './sources/har';
 import {
@@ -244,171 +244,28 @@ const getCaptureAction =
       await captures.writeHarFiles();
     }
 
-    const { unmatched: unmatchedInteractions, total: totalInteractions } =
-      captures.interactionCount();
-
-    if (totalInteractions === 0) {
-      logger.error(
-        chalk.red('Error: No requests were captured by the Optic proxy')
-      );
-      if (captureConfig?.requests?.run) {
-        logger.error(
-          `Check that you are sending requests to the Optic proxy. You can see where the Optic proxy is running by using the ${
-            captureConfig?.requests?.run.proxy_variable ?? 'OPTIC_PROXY'
-          } environment variable`
-        );
-      } else if (captureConfig?.requests?.send) {
-        logger.error(
-          `Check that you are sending at least one request in your send configuration. Using config`
-        );
-        logger.error(captureConfig?.requests?.send);
-      }
-      process.exitCode = 1;
-      return;
-    }
-
-    // update existing endpoints
-    const coverage = new ApiCoverageCounter(spec.jsonLike);
-    let diffCount = 0;
-    let endpointsAdded = 0;
-    // Handle interactions for documented endpoints first
-    const interactionsToLog = sortBy(
-      [...captures.getDocumentedEndpointInteractions()],
-      ({ endpoint }) => `${endpoint.path}${endpoint.method}`
+    const captureOutput = await processCaptures(
+      {
+        cliConfig: config,
+        captureConfig: captureConfig,
+        spec,
+        filePath,
+        captures,
+      },
+      { ...options, bufferLogs: false }
     );
 
-    for (const { interactions, endpoint } of interactionsToLog) {
-      const { path, method } = endpoint;
-      const endpointText = `${method.toUpperCase()} ${path}`;
-      const spinner = getSpinner({
-        text: endpointText,
-        color: 'blue',
-      })?.start();
-      const { patchSummaries, hasDiffs } = await diffExistingEndpoint(
-        interactions,
-        spec,
-        coverage,
-        endpoint,
-        options
-      );
-
-      let endpointCoverage = coverage.coverage.paths[path][method];
-      if (options.update) {
-        // Since we flush each endpoint updates to disk, we should reload the spec to get the latest spec and sourcemap which we both use to generate the next set of patches
-        spec = await loadSpec(filePath, config, {
-          strict: false,
-          denormalize: false,
-        });
-        const operation = spec.jsonLike.paths[path]?.[method];
-        if (operation) {
-          coverage.addEndpoint(operation, path, method, {
-            newlyDocumented: true,
-          });
-          endpointCoverage = coverage.coverage.paths[path][method];
-        }
-        spinner?.succeed(endpointText);
-      } else {
-        if (!hasDiffs) {
-          spinner?.succeed(endpointText);
-        } else {
-          process.exitCode = 1;
-          spinner?.fail(endpointText);
-        }
-      }
-      const summaryText = getSummaryText(endpointCoverage);
-      summaryText && logger.info(indent(1) + summaryText);
-      for (const patchSummary of patchSummaries) {
-        logger.info(indent(1) + patchSummary);
-      }
-      diffCount += patchSummaries.length;
+    if (!captureOutput) {
+      return;
     }
-    const endpointCounts = captures.counts();
-    if (endpointCounts.total > 0 && endpointCounts.unmatched > 0) {
-      const unmatchedEndpointsText = `${endpointCounts.unmatched} endpoint${
-        endpointCounts.unmatched === 1 ? '' : 's'
-      }`;
-      if (endpointCounts.matched > 0) {
-        logger.info(
-          chalk.gray(
-            `...and ${unmatchedEndpointsText} that did not receive traffic`
-          )
-        );
-      } else {
-        logger.info(
-          chalk.gray(`${unmatchedEndpointsText} did not receive traffic`)
-        );
-      }
-    }
+    const {
+      unmatchedInteractions,
+      totalInteractions,
+      coverage,
+      endpointsAdded,
+      endpointCounts,
+    } = captureOutput;
 
-    // document new endpoints
-    if (unmatchedInteractions) {
-      if (options.update === 'interactive' || options.update === 'automatic') {
-        logger.info('');
-        logger.info(
-          chalk.bold.gray('Learning path patterns for unmatched requests...')
-        );
-        const inferredPathStructure =
-          await InferPathStructure.fromSpecAndInteractions(
-            spec.jsonLike,
-            captures.getUndocumentedInteractions()
-          );
-        const {
-          interactions: filteredInteractions,
-          ignorePaths: newIgnorePaths,
-          endpointsToAdd,
-        } = await promptUserForPathPattern(
-          captures.getUndocumentedInteractions(),
-          inferredPathStructure,
-          { update: options.update }
-        );
-
-        logger.info(chalk.bold.gray('Documenting new operations:'));
-
-        for (const endpoint of sortBy(
-          endpointsToAdd,
-          (e) => `${e.path}${e.method}`
-        )) {
-          const { path, method } = endpoint;
-          const endpointText = `${method.toUpperCase()} ${path}`;
-          const spinner = getSpinner({
-            text: endpointText,
-            color: 'blue',
-          })?.start();
-
-          await documentNewEndpoint(filteredInteractions, spec, endpoint);
-
-          // Since we flush each endpoint updates to disk, we should reload the spec to get the latest spec and sourcemap which we both use to generate the next set of patches
-          spec = await loadSpec(filePath, config, {
-            strict: false,
-            denormalize: false,
-          });
-          spinner?.succeed();
-        }
-
-        endpointsAdded = endpointsToAdd.length;
-        if (newIgnorePaths.length) {
-          await addIgnorePaths(spec, newIgnorePaths);
-        }
-      }
-    }
-
-    if (!options.update) {
-      const coverageStats = coverage.calculateCoverage();
-      const coverageText = `${coverageStats.percent}% coverage of your documented operations.`;
-      const requestsText =
-        unmatchedInteractions === 0
-          ? `All requests matched a documented path (${totalInteractions} total requests)`
-          : `${unmatchedInteractions} requests did not match a documented path (${totalInteractions} total requests).`;
-
-      logger.info();
-      logger.info(`${coverageText} ${requestsText}`);
-      diffCount !== 0 &&
-        logger.info(`${diffCount} diffs detected in documented operations`);
-      logger.info();
-    } else if (options.update === 'documented' && unmatchedInteractions > 0) {
-      logger.info();
-      logger.info(`${unmatchedInteractions} unmatched requests`);
-    }
     const maybeOrigin =
       config.vcs?.type === VCS.Git ? await Git.guessRemoteOrigin() : null;
     const relativePath = path.relative(config.root, path.resolve(filePath));
@@ -544,4 +401,213 @@ async function setup(filePath: string): Promise<string> {
     }
   }
   return await getCaptureStorage(resolvedPath);
+}
+
+export async function processCaptures(
+  {
+    captureConfig,
+    cliConfig,
+    captures,
+    spec,
+    filePath,
+  }: {
+    filePath: string;
+    spec: ParseResult;
+    captures: GroupedCaptures;
+    captureConfig?: CaptureConfigData;
+    cliConfig: OpticCliConfig;
+  },
+  options: Pick<CaptureActionOptions, 'update' | 'verbose'> & {
+    bufferLogs: boolean;
+  }
+) {
+  const bufferedOutput: string[] = [];
+  const { unmatched: unmatchedInteractions, total: totalInteractions } =
+    captures.interactionCount();
+
+  if (totalInteractions === 0) {
+    const errorMsg = chalk.red(
+      'Error: No requests were captured by the Optic proxy'
+    );
+    options.bufferLogs ? bufferedOutput.push(errorMsg) : logger.error(errorMsg);
+    if (captureConfig?.requests?.run) {
+      const helpMsg = `Check that you are sending requests to the Optic proxy. You can see where the Optic proxy is running by using the ${
+        captureConfig?.requests?.run.proxy_variable ?? 'OPTIC_PROXY'
+      } environment variable`;
+      options.bufferLogs ? bufferedOutput.push(helpMsg) : logger.error(helpMsg);
+    } else if (captureConfig?.requests?.send) {
+      const helpMsg = `Check that you are sending at least one request in your send configuration. Using config`;
+      options.bufferLogs ? bufferedOutput.push(helpMsg) : logger.error(helpMsg);
+      options.bufferLogs
+        ? bufferedOutput.push(JSON.stringify(captureConfig?.requests?.send))
+        : logger.error(captureConfig?.requests?.send);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  // update existing endpoints
+  const coverage = new ApiCoverageCounter(spec.jsonLike);
+  let diffCount = 0;
+  let endpointsAdded = 0;
+  // Handle interactions for documented endpoints first
+  const interactionsToLog = sortBy(
+    [...captures.getDocumentedEndpointInteractions()],
+    ({ endpoint }) => `${endpoint.path}${endpoint.method}`
+  );
+
+  for (const { interactions, endpoint } of interactionsToLog) {
+    const { path, method } = endpoint;
+    const endpointText = `${method.toUpperCase()} ${path}`;
+    const spinner = !options.bufferLogs
+      ? getSpinner({
+          text: endpointText,
+          color: 'blue',
+        })?.start()
+      : (bufferedOutput.push(endpointText), undefined);
+    const { patchSummaries, hasDiffs } = await diffExistingEndpoint(
+      interactions,
+      spec,
+      coverage,
+      endpoint,
+      options
+    );
+
+    let endpointCoverage = coverage.coverage.paths[path][method];
+    if (options.update) {
+      // Since we flush each endpoint updates to disk, we should reload the spec to get the latest spec and sourcemap which we both use to generate the next set of patches
+      spec = await loadSpec(filePath, cliConfig, {
+        strict: false,
+        denormalize: false,
+      });
+      const operation = spec.jsonLike.paths[path]?.[method];
+      if (operation) {
+        coverage.addEndpoint(operation, path, method, {
+          newlyDocumented: true,
+        });
+        endpointCoverage = coverage.coverage.paths[path][method];
+      }
+      spinner?.succeed(endpointText);
+    } else {
+      if (!hasDiffs) {
+        spinner?.succeed(endpointText);
+      } else {
+        process.exitCode = 1;
+        spinner?.fail(endpointText);
+      }
+    }
+    const summaryText = getSummaryText(endpointCoverage);
+    summaryText && options.bufferLogs
+      ? bufferedOutput.push(indent(1) + summaryText)
+      : logger.info(indent(1) + summaryText);
+    for (const patchSummary of patchSummaries) {
+      options.bufferLogs
+        ? bufferedOutput.push(indent(1) + patchSummary)
+        : logger.info(indent(1) + patchSummary);
+    }
+    diffCount += patchSummaries.length;
+  }
+  const endpointCounts = captures.counts();
+  if (endpointCounts.total > 0 && endpointCounts.unmatched > 0) {
+    const unmatchedEndpointsText = `${endpointCounts.unmatched} endpoint${
+      endpointCounts.unmatched === 1 ? '' : 's'
+    }`;
+    if (endpointCounts.matched > 0) {
+      const txt = chalk.gray(
+        `...and ${unmatchedEndpointsText} that did not receive traffic`
+      );
+      options.bufferLogs ? bufferedOutput.push(txt) : logger.info(txt);
+    } else {
+      const txt = chalk.gray(
+        `${unmatchedEndpointsText} did not receive traffic`
+      );
+      options.bufferLogs ? bufferedOutput.push(txt) : logger.info(txt);
+    }
+  }
+
+  // document new endpoints
+  if (unmatchedInteractions) {
+    if (options.update === 'interactive' || options.update === 'automatic') {
+      options.bufferLogs ? bufferedOutput.push('') : logger.info('');
+      const summary = chalk.bold.gray(
+        'Learning path patterns for unmatched requests...'
+      );
+      options.bufferLogs ? bufferedOutput.push(summary) : logger.info(summary);
+      const inferredPathStructure =
+        await InferPathStructure.fromSpecAndInteractions(
+          spec.jsonLike,
+          captures.getUndocumentedInteractions()
+        );
+      const {
+        interactions: filteredInteractions,
+        ignorePaths: newIgnorePaths,
+        endpointsToAdd,
+      } = await promptUserForPathPattern(
+        captures.getUndocumentedInteractions(),
+        inferredPathStructure,
+        { update: options.update }
+      );
+      const header = chalk.bold.gray('Documenting new operations:');
+      options.bufferLogs ? bufferedOutput.push(header) : logger.info(header);
+
+      for (const endpoint of sortBy(
+        endpointsToAdd,
+        (e) => `${e.path}${e.method}`
+      )) {
+        const { path, method } = endpoint;
+        const endpointText = `${method.toUpperCase()} ${path}`;
+        const spinner = getSpinner({
+          text: endpointText,
+          color: 'blue',
+        })?.start();
+
+        await documentNewEndpoint(filteredInteractions, spec, endpoint);
+
+        // Since we flush each endpoint updates to disk, we should reload the spec to get the latest spec and sourcemap which we both use to generate the next set of patches
+        spec = await loadSpec(filePath, cliConfig, {
+          strict: false,
+          denormalize: false,
+        });
+        spinner?.succeed();
+      }
+
+      endpointsAdded = endpointsToAdd.length;
+      if (newIgnorePaths.length) {
+        await addIgnorePaths(spec, newIgnorePaths);
+      }
+    }
+  }
+
+  if (!options.update) {
+    const coverageStats = coverage.calculateCoverage();
+    const coverageText = `${coverageStats.percent}% coverage of your documented operations.`;
+    const requestsText =
+      unmatchedInteractions === 0
+        ? `All requests matched a documented path (${totalInteractions} total requests)`
+        : `${unmatchedInteractions} requests did not match a documented path (${totalInteractions} total requests).`;
+
+    const diffText = `${diffCount} diffs detected in documented operations`;
+    options.bufferLogs ? bufferedOutput.push('') : logger.info();
+    options.bufferLogs
+      ? bufferedOutput.push(`${coverageText} ${requestsText}`)
+      : logger.info(`${coverageText} ${requestsText}`);
+    diffCount !== 0 && options.bufferLogs
+      ? bufferedOutput.push(diffText)
+      : logger.info(diffText);
+  } else if (options.update === 'documented' && unmatchedInteractions > 0) {
+    const unmatchedText = `${unmatchedInteractions} unmatched requests`;
+    options.bufferLogs ? bufferedOutput.push('') : logger.info();
+    options.bufferLogs
+      ? bufferedOutput.push(unmatchedText)
+      : logger.info(unmatchedText);
+  }
+
+  return {
+    unmatchedInteractions,
+    totalInteractions,
+    coverage,
+    endpointsAdded,
+    endpointCounts,
+    bufferedOutput,
+  };
 }

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -255,7 +255,7 @@ const getCaptureAction =
       { ...options, bufferLogs: false }
     );
 
-    if (!captureOutput) {
+    if (!captureOutput.success) {
       process.exitCode = 1;
       return;
     }
@@ -425,7 +425,23 @@ export async function processCaptures(
   options: Pick<CaptureActionOptions, 'update' | 'verbose'> & {
     bufferLogs: boolean;
   }
-) {
+): Promise<
+  | {
+      unmatchedInteractions: number;
+      totalInteractions: number;
+      coverage: ApiCoverageCounter;
+      endpointsAdded: number;
+      endpointCounts: {
+        total: number;
+        unmatched: number;
+        matched: number;
+      };
+      bufferedOutput: string[];
+      hasAnyDiffs: boolean;
+      success: true;
+    }
+  | { success: false; bufferedOutput: string[] }
+> {
   const bufferedOutput: string[] = [];
   const { unmatched: unmatchedInteractions, total: totalInteractions } =
     captures.interactionCount();
@@ -447,7 +463,7 @@ export async function processCaptures(
         ? bufferedOutput.push(JSON.stringify(captureConfig?.requests?.send))
         : logger.error(captureConfig?.requests?.send);
     }
-    return;
+    return { bufferedOutput, success: false };
   }
 
   // update existing endpoints
@@ -615,5 +631,6 @@ export async function processCaptures(
     endpointCounts,
     bufferedOutput,
     hasAnyDiffs,
+    success: true,
   };
 }

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -342,6 +342,7 @@ const getCaptureAction =
       unmatchedInteractions &&
       (options.update === 'documented' || !options.update)
     ) {
+      logger.info('');
       logger.info(
         chalk.yellow(
           `New endpoints are only added in interactive mode. Run 'optic capture ${filePath} --update interactive' to add new endpoints`
@@ -612,9 +613,10 @@ export async function processCaptures(
     options.bufferLogs
       ? bufferedOutput.push(`${coverageText} ${requestsText}`)
       : logger.info(`${coverageText} ${requestsText}`);
-    diffCount !== 0 && options.bufferLogs
-      ? bufferedOutput.push(diffText)
-      : logger.info(diffText);
+    diffCount !== 0 &&
+      (options.bufferLogs
+        ? bufferedOutput.push(diffText)
+        : logger.info(diffText));
   } else if (options.update === 'documented' && unmatchedInteractions > 0) {
     const unmatchedText = `${unmatchedInteractions} unmatched requests`;
     options.bufferLogs ? bufferedOutput.push('') : logger.info();

--- a/projects/optic/src/commands/run.ts
+++ b/projects/optic/src/commands/run.ts
@@ -260,18 +260,17 @@ function report(report: SpecReport) {
   if (report.changelogLink) {
     logger.info(`| View report: ${report.changelogLink}`);
   }
+  logger.info('|');
   if (report.capture) {
-    const { bufferedOutput, coverage, unmatchedInteractions } = report.capture;
-    logger.info(
-      `| ${coverage}% API test coverage ${
-        unmatchedInteractions
-          ? `(${unmatchedInteractions} unmatched interactions)`
-          : ''
-      }`
-    );
+    const { bufferedOutput, coverage } = report.capture;
+    logger.info(`| API Test Coverage Report (${coverage}% coverage)`);
     bufferedOutput.forEach((output) => {
       logger.info(`| ` + output);
     });
+  } else {
+    logger.info(
+      `| Skipping API test verification (set up by running optic capture init ${report.path})`
+    );
   }
   logger.info('');
 }
@@ -535,6 +534,7 @@ export const getRunAction =
           captureConfig,
           {
             serverUrl: captureConfig.server.url,
+            disableSpinner: true,
           }
         );
         if (!harEntries) {


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Adds optic capture to run. Will run when has capture config, and will skip when not.

Had to log out the capture output rather than providing a summary since capture report data isn't included in the diff report (see below). Could be a lot of data but i'm not sure how else we'd want to do this (without that there isn't a way to be able to understand what failed in CI)

With a capture config
```
$ optic run --match abe.yml
Optic matched 1 OpenAPI specification file:
abe.yml.

--------------------------------------------------------------------------------------------------

 ┌─────────────────────────────────┐
 │  [1]      Optic Cloud      [2]  │
 └───┬─────────────────────────▲───┘
     │Compare            Update│
 ┌───▼─────────────────────────┴───┐
 │           Local specs           │
 └─────────────────────────────────┘

 [1]: Comparing your local specifications to their last uploaded Optic cloud version for tag `gitbranch:main`.
      Optic compares local specs against the target branch upon PR/MR events, and the current branch upon push events or local runs.

 [2]: Pushing local specs as latest versions in Optic cloud for tag `gitbranch:main`, the current branch tag.

--------------------------------------------------------------------------------------------------

| Untitled service (abe.yml)
| ☑️  No changes ❌ 6 design issues 
| View report: https://app.useoptic.com/organizations/4a1dfbcd-cf7b-4e6d-86f6-e6cc417ffcc0/apis/EMdeSjVDILC4h6j_BYXwc/runs/bghDDg2fa3F_otlVU7D3p
|
| API Test Coverage Report (75.0% coverage)
| GET /authors
|   × 200 response, 404 response
|   [200 response body] schema (/properties/data/items/properties/name/maxLength) with keyword 'maxLength' and parameters {"limit":1} received invalid values "Jane Austen", "F. Scott Fitzgerald", "Harper Lee" and 1 other values
| GET /books/{book}
|   ✓ 404 response
| POST /books/{book}
|   ✓ Request Body, ✓ 404 response
| GET /books
|   ✓ 200 response
| ...and 1 endpoint that did not receive traffic
| 
| 75.0% coverage of your documented operations. All requests matched a documented path (4 total requests)
| 1 diffs detected in documented operations


🤖 Add Optic to your CI flow: https://www.useoptic.com/docs/setup-ci

Exiting with code 1 as errors were found. Disable this behaviour with the `--severity none` option.
```

Without a capture config
```
$ optic run --match abe.yml
Optic matched 1 OpenAPI specification file:
abe.yml.
--------------------------------------------------------------------------------------------------

 ┌─────────────────────────────────┐
 │  [1]      Optic Cloud      [2]  │
 └───┬─────────────────────────▲───┘
     │Compare            Update│
 ┌───▼─────────────────────────┴───┐
 │           Local specs           │
 └─────────────────────────────────┘

 [1]: Comparing your local specifications to their last uploaded Optic cloud version for tag `gitbranch:main`.
      Optic compares local specs against the target branch upon PR/MR events, and the current branch upon push events or local runs.

 [2]: Pushing local specs as latest versions in Optic cloud for tag `gitbranch:main`, the current branch tag.

--------------------------------------------------------------------------------------------------

| Untitled service (abe.yml)
| ☑️  No changes ❌ 6 design issues 
| View report: https://app.useoptic.com/organizations/4a1dfbcd-cf7b-4e6d-86f6-e6cc417ffcc0/apis/EMdeSjVDILC4h6j_BYXwc/runs/QwhsNEbVGNEXL0caicKVL
|
| Skipping API test verification (set up by running optic capture init abe.yml)


🤖 Add Optic to your CI flow: https://www.useoptic.com/docs/setup-ci
```

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
