### PR TITLE
fix: don't attempt to copy vm2 into binary

### DIFF
--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -127,7 +127,6 @@
     ],
     "assets": [
       "../../node_modules/open/xdg-open",
-      "../../node_modules/vm2/lib/setup-sandbox.js",
       "ci/configs/*"
     ],
     "targets": [


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

- vm2 isnt a dep any more, but we're still attempting to copy it when building the binaries with pkg. 

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
