### PR TITLE
chore: couple binary modifications

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -38,5 +38,5 @@ jobs:
         run: |
           set -a
           source projects/optic/.env.production
-          task pkg:build -- --no-bytecode --public --public-packages "*"
+          task pkg:build -- --no-bytecode --public --public-packages "*" --compress gzip
           task pkg:archive pkg:upload

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -127,7 +127,6 @@
     ],
     "assets": [
       "../../node_modules/open/xdg-open",
-      "../../node_modules/vm2/lib/setup-sandbox.js",
       "ci/configs/*"
     ],
     "targets": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -126,7 +126,6 @@
       "build/commands/ruleset/upload.js"
     ],
     "assets": [
-      "../../node_modules/open/xdg-open",
       "ci/configs/*"
     ],
     "targets": [


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

- stop copying xdg-open into the binary. this never worked. 
- compresses the app files inside the binary. brotli makes the smallest binary, but takes _forever_ to build. gzip it is!

```
no compression:
➜ ls -lah dist
-rwxr-xr-x@  1 nate  staff   130M Oct  3 10:28 optic-darwin-amd64*
-rwxr-xr-x@  1 nate  staff   125M Oct  3 10:28 optic-darwin-arm64*
-rwxr-xr-x@  1 nate  staff   119M Oct  3 10:28 optic-linux-amd64*
-rwxr-xr-x@  1 nate  staff   116M Oct  3 10:28 optic-linux-arm64*
-rw-r--r--@  1 nate  staff   116M Oct  3 10:28 optic-windows-amd64.exe
-rw-r--r--@  1 nate  staff   106M Oct  3 10:28 optic-windows-arm64.exe

brotli:
➜ ls -lah dist
-rwxr-xr-x@  1 nate  staff    75M Oct  3 10:38 optic-darwin-amd64*
-rwxr-xr-x@  1 nate  staff    70M Oct  3 10:36 optic-darwin-arm64*
-rwxr-xr-x@  1 nate  staff    64M Oct  3 10:42 optic-linux-amd64*
-rwxr-xr-x@  1 nate  staff    62M Oct  3 10:40 optic-linux-arm64*
-rw-r--r--@  1 nate  staff    61M Oct  3 10:45 optic-windows-amd64.exe
-rw-r--r--@  1 nate  staff    51M Oct  3 10:43 optic-windows-arm64.exe

gzip:
➜ ls -lah dist
-rwxr-xr-x@  1 nate  staff    79M Oct  3 10:53 optic-darwin-amd64*
-rwxr-xr-x@  1 nate  staff    74M Oct  3 10:53 optic-darwin-arm64*
-rwxr-xr-x@  1 nate  staff    69M Oct  3 10:53 optic-linux-amd64*
-rwxr-xr-x@  1 nate  staff    66M Oct  3 10:53 optic-linux-arm64*
-rw-r--r--@  1 nate  staff    66M Oct  3 10:54 optic-windows-amd64.exe
-rw-r--r--@  1 nate  staff    56M Oct  3 10:53 optic-windows-arm64.exe
```

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
