### PR TITLE
chore(cli): use echo service in `capture init` and simplify

### DIFF
--- a/projects/optic/src/__tests__/integration/__snapshots__/capture-init.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/capture-init.test.ts.snap
@@ -63,42 +63,24 @@ capture:
         - path: /authors
           method: GET
   abc.yml:
-    # 🔧 Runnable example with simple get requests. 
-    # Run with "optic capture abc.yml --update interactive" 
-    # You can change the server and the 'requests' section to experiment
+    # Complete reference documentation for this configuration file is available:
+    #   https://www.useoptic.com/docs/capturing-traffic#configuration-reference
+
+    # Run with "optic capture openapi.yml --update interactive"
     server:
-      url: https://api.github.com
+      url: https://echo.o3c.org
     requests:
       send:
-        - path: /users/mojombo
-          method: GET
-        - path: /users/defunkt
-          method: GET
-        - path: /users/pjhyett/repos
-          method: GET
-        - path: /users/pjhyett/followers
-          method: GET
-        - path: /orgs/opticdev/repos
-          method: GET
-        - path: /orgs/facebook/repos
-          method: GET
-        - path: /orgs/github/repos
-          method: GET
-    # When you are ready, set up an actual integration that run your test suite
-    # Read reference docs here: https://www.useoptic.com/docs/capturing-traffic#configuration-reference
-    # server:
-    #   # 🔧 Update this to the command to run your server.
-    #   # Optional: If omitted, Optic assumes the server is running or started elsewhere.
-    #   command: npm dev 
-    #   # 🔧 Update this url to where your server can be reached.
-    #   url: http://localhost:8080
-    # requests:
-    #   # ℹ️ Requests should be sent to the Optic proxy, the address of which is injected into 'run.command's env as OPTIC_PROXY (or the value of 'run.proxy_variable').
-    #   run:
-    #     # 🔧 Specify a command that will generate traffic
-    #     command: test
-    #     # 🔧 OPTIC_PROXY is added to your command's env and contains the URL of an Optic's local reverse proxy. Your command should send its requests to this URL.
-    #     proxy_variable: OPTIC_PROXY
+        - path: /users
+          headers:
+            x-response-json: '[{"id":0, "name":"aidan"}]'
+        - path: /users/create
+          method: POST
+          data:
+            name: nic
+          headers:
+            x-response-json: '{"id":1, "name":"nic"}'
+            x-response-code: "201"
 "
 `;
 

--- a/projects/optic/src/__tests__/integration/__snapshots__/capture-init.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/capture-init.test.ts.snap
@@ -3,42 +3,24 @@
 exports[`capture init init with --stdout 1`] = `
 "capture:
   abc.yml:
-    # 🔧 Runnable example with simple get requests. 
-    # Run with "optic capture abc.yml --update interactive" 
-    # You can change the server and the 'requests' section to experiment
+    # Complete reference documentation for this configuration file is available:
+    #   https://www.useoptic.com/docs/capturing-traffic#configuration-reference
+
+    # Run with "optic capture openapi.yml --update interactive"
     server:
-      url: https://api.github.com
+      url: https://echo.o3c.org
     requests:
       send:
-        - path: /users/mojombo
-          method: GET
-        - path: /users/defunkt
-          method: GET
-        - path: /users/pjhyett/repos
-          method: GET
-        - path: /users/pjhyett/followers
-          method: GET
-        - path: /orgs/opticdev/repos
-          method: GET
-        - path: /orgs/facebook/repos
-          method: GET
-        - path: /orgs/github/repos
-          method: GET
-    # When you are ready, set up an actual integration that run your test suite
-    # Read reference docs here: https://www.useoptic.com/docs/capturing-traffic#configuration-reference
-    # server:
-    #   # 🔧 Update this to the command to run your server.
-    #   # Optional: If omitted, Optic assumes the server is running or started elsewhere.
-    #   command: npm dev 
-    #   # 🔧 Update this url to where your server can be reached.
-    #   url: http://localhost:8080
-    # requests:
-    #   # ℹ️ Requests should be sent to the Optic proxy, the address of which is injected into 'run.command's env as OPTIC_PROXY (or the value of 'run.proxy_variable').
-    #   run:
-    #     # 🔧 Specify a command that will generate traffic
-    #     command: test
-    #     # 🔧 OPTIC_PROXY is added to your command's env and contains the URL of an Optic's local reverse proxy. Your command should send its requests to this URL.
-    #     proxy_variable: OPTIC_PROXY
+        - path: /users
+          headers:
+            x-response-json: '[{"id":0, "name":"aidan"}]'
+        - path: /users/create
+          method: POST
+          data:
+            name: nic
+          headers:
+            x-response-json: '{"id":1, "name":"nic"}'
+            x-response-code: "201"
 
 
 "

--- a/projects/optic/src/__tests__/integration/__snapshots__/capture-init.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/capture-init.test.ts.snap
@@ -6,7 +6,7 @@ exports[`capture init init with --stdout 1`] = `
     # Complete reference documentation for this configuration file is available:
     #   https://www.useoptic.com/docs/capturing-traffic#configuration-reference
 
-    # Run with "optic capture openapi.yml --update interactive"
+    # Run with "optic capture abc.yml --update interactive"
     server:
       url: https://echo.o3c.org
     requests:
@@ -66,7 +66,7 @@ capture:
     # Complete reference documentation for this configuration file is available:
     #   https://www.useoptic.com/docs/capturing-traffic#configuration-reference
 
-    # Run with "optic capture openapi.yml --update interactive"
+    # Run with "optic capture abc.yml --update interactive"
     server:
       url: https://echo.o3c.org
     requests:
@@ -96,7 +96,7 @@ exports[`capture init init with no optic.yml 2`] = `
     # Complete reference documentation for this configuration file is available:
     #   https://www.useoptic.com/docs/capturing-traffic#configuration-reference
 
-    # Run with "optic capture openapi.yml --update interactive"
+    # Run with "optic capture abc.yml --update interactive"
     server:
       url: https://echo.o3c.org
     requests:

--- a/projects/optic/src/__tests__/integration/__snapshots__/capture-init.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/capture-init.test.ts.snap
@@ -111,41 +111,23 @@ Run [1moptic capture abc.yml --update interactive[22m
 exports[`capture init init with no optic.yml 2`] = `
 "capture:
   abc.yml:
-    # 🔧 Runnable example with simple get requests. 
-    # Run with "optic capture abc.yml --update interactive" 
-    # You can change the server and the 'requests' section to experiment
+    # Complete reference documentation for this configuration file is available:
+    #   https://www.useoptic.com/docs/capturing-traffic#configuration-reference
+
+    # Run with "optic capture openapi.yml --update interactive"
     server:
-      url: https://api.github.com
+      url: https://echo.o3c.org
     requests:
       send:
-        - path: /users/mojombo
-          method: GET
-        - path: /users/defunkt
-          method: GET
-        - path: /users/pjhyett/repos
-          method: GET
-        - path: /users/pjhyett/followers
-          method: GET
-        - path: /orgs/opticdev/repos
-          method: GET
-        - path: /orgs/facebook/repos
-          method: GET
-        - path: /orgs/github/repos
-          method: GET
-    # When you are ready, set up an actual integration that run your test suite
-    # Read reference docs here: https://www.useoptic.com/docs/capturing-traffic#configuration-reference
-    # server:
-    #   # 🔧 Update this to the command to run your server.
-    #   # Optional: If omitted, Optic assumes the server is running or started elsewhere.
-    #   command: npm dev 
-    #   # 🔧 Update this url to where your server can be reached.
-    #   url: http://localhost:8080
-    # requests:
-    #   # ℹ️ Requests should be sent to the Optic proxy, the address of which is injected into 'run.command's env as OPTIC_PROXY (or the value of 'run.proxy_variable').
-    #   run:
-    #     # 🔧 Specify a command that will generate traffic
-    #     command: test
-    #     # 🔧 OPTIC_PROXY is added to your command's env and contains the URL of an Optic's local reverse proxy. Your command should send its requests to this URL.
-    #     proxy_variable: OPTIC_PROXY
+        - path: /users
+          headers:
+            x-response-json: '[{"id":0, "name":"aidan"}]'
+        - path: /users/create
+          method: POST
+          data:
+            name: nic
+          headers:
+            x-response-json: '{"id":1, "name":"nic"}'
+            x-response-code: "201"
 "
 `;

--- a/projects/optic/src/commands/capture/init.ts
+++ b/projects/optic/src/commands/capture/init.ts
@@ -26,42 +26,24 @@ export function captureConfigExample(
   skipConfigUpdate: boolean
 ) {
   return `
-${skipConfigUpdate ? `capture:\n  ${oasFile}:` : ''}
-    # 🔧 Runnable example with simple get requests. 
+${skipConfigUpdate ? `capture:\n  ${oasFile}:` : ''}    
+    # Complete reference documentation for this configuration file is available:
+    #   https://www.useoptic.com/docs/capturing-traffic#configuration-reference
+
     # Run with "optic capture ${oasFile} --update interactive" 
-    # You can change the server and the 'requests' section to experiment
     server:
-      url: https://api.github.com
+      url: https://echo.o3c.org
     requests:
       send: 
-      - path: /users/mojombo
-        method: GET
-      - path: /users/defunkt
-        method: GET
-      - path: /users/pjhyett/repos
-        method: GET
-      - path: /users/pjhyett/followers
-        method: GET
-      - path: /orgs/opticdev/repos
-        method: GET   
-      - path: /orgs/facebook/repos
-        method: GET   
-      - path: /orgs/github/repos
-        method: GET   
-    # When you are ready, set up an actual integration that run your test suite
-    # Read reference docs here: https://www.useoptic.com/docs/capturing-traffic#configuration-reference
-    # server:
-    #   # 🔧 Update this to the command to run your server.
-    #   # Optional: If omitted, Optic assumes the server is running or started elsewhere.
-    #   command: npm dev 
-    #   # 🔧 Update this url to where your server can be reached.
-    #   url: http://localhost:8080
-    # requests:
-    #   # ℹ️ Requests should be sent to the Optic proxy, the address of which is injected into 'run.command's env as OPTIC_PROXY (or the value of 'run.proxy_variable').
-    #   run:
-    #     # 🔧 Specify a command that will generate traffic
-    #     command: test
-    #     # 🔧 OPTIC_PROXY is added to your command's env and contains the URL of an Optic's local reverse proxy. Your command should send its requests to this URL.
-    #     proxy_variable: OPTIC_PROXY
+        - path: /users/aidan
+          headers:
+            - x-response-json: '{"id":0, "name":"aidan"}'
+        - path: /users/create
+          method: POST
+          data:
+            - name: nic
+          headers:
+            - x-response-json: '{"id":1, "name":"nic"}'
+            - x-response-code: "201"
   `;
 }

--- a/projects/optic/src/commands/capture/init.ts
+++ b/projects/optic/src/commands/capture/init.ts
@@ -35,7 +35,7 @@ ${skipConfigUpdate ? `capture:\n  ${oasFile}:` : ''}
       url: https://echo.o3c.org
     requests:
       send: 
-        - path: /users/aidan
+        - path: /users/
           headers:
             - x-response-json: '{"id":0, "name":"aidan"}'
         - path: /users/create

--- a/projects/optic/src/commands/capture/init.ts
+++ b/projects/optic/src/commands/capture/init.ts
@@ -41,9 +41,9 @@ ${skipConfigUpdate ? `capture:\n  ${oasFile}:` : ''}
         - path: /users/create
           method: POST
           data:
-            - name: nic
+            name: nic
           headers:
-            - x-response-json: '{"id":1, "name":"nic"}'
-            - x-response-code: "201"
+            x-response-json: '{"id":1, "name":"nic"}'
+            x-response-code: "201"
   `;
 }

--- a/projects/optic/src/commands/capture/init.ts
+++ b/projects/optic/src/commands/capture/init.ts
@@ -30,7 +30,7 @@ ${skipConfigUpdate ? `capture:\n  ${oasFile}:` : ''}
     # Complete reference documentation for this configuration file is available:
     #   https://www.useoptic.com/docs/capturing-traffic#configuration-reference
 
-    # Run with "optic capture ${oasFile} --update interactive" 
+    # Run with "optic capture ${oasFile} --update interactive"
     server:
       url: https://echo.o3c.org
     requests:

--- a/projects/optic/src/commands/capture/init.ts
+++ b/projects/optic/src/commands/capture/init.ts
@@ -37,7 +37,7 @@ ${skipConfigUpdate ? `capture:\n  ${oasFile}:` : ''}
       send: 
         - path: /users/
           headers:
-            - x-response-json: '[{"id":0, "name":"aidan"}]'
+            x-response-json: '[{"id":0, "name":"aidan"}]'
         - path: /users/create
           method: POST
           data:

--- a/projects/optic/src/commands/capture/init.ts
+++ b/projects/optic/src/commands/capture/init.ts
@@ -35,7 +35,7 @@ ${skipConfigUpdate ? `capture:\n  ${oasFile}:` : ''}
       url: https://echo.o3c.org
     requests:
       send: 
-        - path: /users/
+        - path: /users
           headers:
             x-response-json: '[{"id":0, "name":"aidan"}]'
         - path: /users/create

--- a/projects/optic/src/commands/capture/init.ts
+++ b/projects/optic/src/commands/capture/init.ts
@@ -37,7 +37,7 @@ ${skipConfigUpdate ? `capture:\n  ${oasFile}:` : ''}
       send: 
         - path: /users/
           headers:
-            - x-response-json: '{"id":0, "name":"aidan"}'
+            - x-response-json: '[{"id":0, "name":"aidan"}]'
         - path: /users/create
           method: POST
           data:


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

- uses optic's echo service in the config generated from `capture init`
- removes use of emojis which don't render correctly on windows (closes https://github.com/opticdev/monorail/issues/4949)
- overall simplifies the default config we write and emphasizes consulting the reference documentation

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
