### PR TITLE
fix enum check for responses

### DIFF
--- a/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
@@ -9,7 +9,7 @@ exports[`diff file doesn't exist 1`] = `
 exports[`diff petstore diff 1`] = `
 "[31mx [39m[1mSwagger Petstore Updated[22m [90mpetstore-base.json[39m
 [1mOperations: [22m5 operations added, 16 changed, 1 removed
-[31mx [39m [1mChecks:[22m 192/243 passed 
+[31mx [39m [1mChecks:[22m 185/240 passed 
 
 specification details:
 - /servers/2 [32madded[39m
@@ -84,6 +84,9 @@ specification details:
         [31m[1mx [prevent request property type changes][22m expected request body property 'userStatus' not to be narrowed. This is a breaking change.[39m
         at [4mpetstore-updated.json:1359:48872[24m
         
+        [31m[1mx [request and response property enums][22m cannot add enum or const to request property userStatus. This is a breaking change.[39m
+        at [4mpetstore-updated.json:1359:48872[24m
+        
       - property [1m/schema/properties/lastName[22m: [33mchanged[39m
       - property [1m/schema/properties/username[22m: [33mchanged[39m
       
@@ -155,6 +158,9 @@ specification details:
         [31m[1mx [prevent request property type changes][22m expected request body property 'userStatus' not to be narrowed. This is a breaking change.[39m
         at [4mpetstore-updated.json:1175:42495[24m
         
+        [31m[1mx [request and response property enums][22m cannot add enum or const to request property userStatus. This is a breaking change.[39m
+        at [4mpetstore-updated.json:1175:42495[24m
+        
       - property : [33mchanged[39m
       - property [1m/schema/items/properties/username[22m: 
       
@@ -169,6 +175,9 @@ specification details:
       - property [1m/schema/items/properties/userStatus[22m: [33mchanged[39m
       
         [31m[1mx [prevent request property type changes][22m expected request body property 'userStatus' not to be narrowed. This is a breaking change.[39m
+        at [4mpetstore-updated.json:1134:41010[24m
+        
+        [31m[1mx [request and response property enums][22m cannot add enum or const to request property userStatus. This is a breaking change.[39m
         at [4mpetstore-updated.json:1134:41010[24m
         
       - property : [33mchanged[39m
@@ -187,6 +196,9 @@ specification details:
         [31m[1mx [prevent request property type changes][22m expected request body property 'userStatus' not to be narrowed. This is a breaking change.[39m
         at [4mpetstore-updated.json:1094:39555[24m
         
+        [31m[1mx [request and response property enums][22m cannot add enum or const to request property userStatus. This is a breaking change.[39m
+        at [4mpetstore-updated.json:1094:39555[24m
+        
       - property [1m/schema/properties/lastName[22m: [33mchanged[39m
       - property [1m/schema/properties/username[22m: [33mchanged[39m
       
@@ -203,14 +215,14 @@ specification details:
       - property [1m/schema/properties/summary[22m: [32madded[39m
       - property [1m/schema/properties/status[22m: [33mchanged[39m
       
-        [31m[1mx [request and response property enums][22m cannot remove enum option 'approved' from 'status' property. This is a breaking change.[39m
+        [31m[1mx [request and response property enums][22m cannot add enum option 'canceled' from 'status' property. This is a breaking change.[39m
         at [4mpetstore-updated.json:1006:36426[24m
         
     - body [1mapplication/xml[22m: 
       - property [1m/schema/properties/summary[22m: [32madded[39m
       - property [1m/schema/properties/status[22m: [33mchanged[39m
       
-        [31m[1mx [request and response property enums][22m cannot remove enum option 'approved' from 'status' property. This is a breaking change.[39m
+        [31m[1mx [request and response property enums][22m cannot add enum option 'canceled' from 'status' property. This is a breaking change.[39m
         at [4mpetstore-updated.json:984:35448[24m
         
       - property [1m/schema/properties/petId[22m: [33mchanged[39m
@@ -235,7 +247,7 @@ specification details:
       - property [1m/schema/properties/summary[22m: [32madded[39m
       - property [1m/schema/properties/status[22m: [33mchanged[39m
       
-        [31m[1mx [request and response property enums][22m cannot remove enum option 'approved' from 'status' property. This is a breaking change.[39m
+        [31m[1mx [request and response property enums][22m cannot add enum option 'canceled' from 'status' property. This is a breaking change.[39m
         at [4mpetstore-updated.json:930:33483[24m
         
         - /example [32madded[39m
@@ -244,14 +256,14 @@ specification details:
       - property [1m/schema/properties/summary[22m: [32madded[39m
       - property [1m/schema/properties/status[22m: [33mchanged[39m
       
-        [31m[1mx [request and response property enums][22m cannot remove enum option 'approved' from 'status' property. This is a breaking change.[39m
+        [31m[1mx [request and response property enums][22m cannot add enum option 'canceled' from 'status' property. This is a breaking change.[39m
         at [4mpetstore-updated.json:899:32168[24m
         
 [31mx [1mPOST[22m /pet/{petId}/uploadImage[39m: 
   - cookie parameter [3mdebug[23m: 
     - /schema/enum [32madded[39m
     
-    [31m[1mx [prevent cookie parameters enum breaking changes][22m cannot add an enum to restrict possible values for cookie parameter 'debug'. This is a breaking change.[39m
+    [31m[1mx [prevent cookie parameters enum breaking changes][22m cannot add an enum to restrict possible values for cookie parameter debug. This is a breaking change.[39m
     at [4mpetstore-updated.json:752:27313[24m
     
   - response [1m200[22m: [31mremoved[39m

--- a/projects/standard-rulesets/src/breaking-changes/__tests__/__snapshots__/breaking-changes.test.ts.snap
+++ b/projects/standard-rulesets/src/breaking-changes/__tests__/__snapshots__/breaking-changes.test.ts.snap
@@ -1356,68 +1356,6 @@ exports[`breaking changes ruleset valid changes 1`] = `
     "expected": undefined,
     "isMust": true,
     "isShould": false,
-    "name": "prevent cookie parameters enum breaking changes",
-    "passed": true,
-    "received": undefined,
-    "severity": 2,
-    "type": "changed",
-    "where": "GET /api/users cookie parameter: enum-widening",
-  },
-  {
-    "change": {
-      "changeType": "changed",
-      "changed": {
-        "after": {
-          "in": "cookie",
-          "name": "enum-widening",
-          "schema": {
-            "enum": [
-              1,
-              2,
-              3,
-            ],
-            "type": "number",
-          },
-        },
-        "before": {
-          "in": "cookie",
-          "name": "enum-widening",
-          "schema": {
-            "enum": [
-              1,
-              2,
-            ],
-            "type": "number",
-          },
-        },
-      },
-      "location": {
-        "conceptualLocation": {
-          "inRequest": {
-            "cookie": "enum-widening",
-          },
-          "method": "get",
-          "path": "/api/users",
-        },
-        "conceptualPath": [
-          "operations",
-          "/api/users",
-          "get",
-          "parameters",
-          "cookie",
-          "enum-widening",
-        ],
-        "jsonPath": "/paths/~1api~1users/get/parameters/3",
-        "kind": "cookie-parameter",
-      },
-    },
-    "condition": undefined,
-    "docsLink": undefined,
-    "error": undefined,
-    "exempted": false,
-    "expected": undefined,
-    "isMust": true,
-    "isShould": false,
     "name": "prevent cookie parameters type changes",
     "passed": true,
     "received": undefined,
@@ -1532,123 +1470,12 @@ exports[`breaking changes ruleset valid changes 1`] = `
     "expected": undefined,
     "isMust": true,
     "isShould": false,
-    "name": "prevent header parameters enum breaking changes",
-    "passed": true,
-    "received": undefined,
-    "severity": 2,
-    "type": "changed",
-    "where": "GET /api/users header parameter: enum-removal",
-  },
-  {
-    "change": {
-      "changeType": "changed",
-      "changed": {
-        "after": {
-          "in": "header",
-          "name": "enum-removal",
-          "schema": {
-            "type": "number",
-          },
-        },
-        "before": {
-          "in": "header",
-          "name": "enum-removal",
-          "schema": {
-            "enum": [
-              1,
-              2,
-            ],
-            "type": "number",
-          },
-        },
-      },
-      "location": {
-        "conceptualLocation": {
-          "inRequest": {
-            "header": "enum-removal",
-          },
-          "method": "get",
-          "path": "/api/users",
-        },
-        "conceptualPath": [
-          "operations",
-          "/api/users",
-          "get",
-          "parameters",
-          "header",
-          "enum-removal",
-        ],
-        "jsonPath": "/paths/~1api~1users/get/parameters/4",
-        "kind": "header-parameter",
-      },
-    },
-    "condition": undefined,
-    "docsLink": undefined,
-    "error": undefined,
-    "exempted": false,
-    "expected": undefined,
-    "isMust": true,
-    "isShould": false,
     "name": "prevent header parameters type changes",
     "passed": true,
     "received": undefined,
     "severity": 2,
     "type": "changed",
     "where": "GET /api/users header parameter: enum-removal",
-  },
-  {
-    "change": {
-      "changeType": "changed",
-      "changed": {
-        "after": {
-          "in": "query",
-          "name": "required",
-          "schema": {
-            "type": "string",
-          },
-        },
-        "before": {
-          "in": "query",
-          "name": "required",
-          "required": true,
-          "schema": {
-            "type": "string",
-          },
-        },
-      },
-      "location": {
-        "conceptualLocation": {
-          "inRequest": {
-            "query": "required",
-          },
-          "method": "get",
-          "path": "/api/users",
-        },
-        "conceptualPath": [
-          "operations",
-          "/api/users",
-          "get",
-          "parameters",
-          "query",
-          "required",
-        ],
-        "jsonPath": "/paths/~1api~1users/get/parameters/0",
-        "kind": "query-parameter",
-      },
-    },
-    "condition": undefined,
-    "docsLink": undefined,
-    "error": undefined,
-    "exempted": false,
-    "expected": undefined,
-    "isMust": true,
-    "isShould": false,
-    "name": "prevent query parameters enum breaking changes",
-    "passed": true,
-    "received": undefined,
-    "severity": 2,
-    "type": "changed",
-    "where": "GET /api/users query parameter: required",
   },
   {
     "change": {

--- a/projects/standard-rulesets/src/breaking-changes/__tests__/__snapshots__/enum-breaking-changes.test.ts.snap
+++ b/projects/standard-rulesets/src/breaking-changes/__tests__/__snapshots__/enum-breaking-changes.test.ts.snap
@@ -115,66 +115,6 @@ exports[`breaking changes ruleset - parameter enum change "cookie" parameter enu
     "expected": undefined,
     "isMust": true,
     "isShould": false,
-    "name": "prevent cookie parameters enum breaking changes",
-    "passed": true,
-    "received": undefined,
-    "severity": 2,
-    "type": "changed",
-    "where": "GET /api/users cookie parameter: test",
-  },
-  {
-    "change": {
-      "changeType": "changed",
-      "changed": {
-        "after": {
-          "in": "cookie",
-          "name": "test",
-          "schema": {
-            "enum": [
-              "b",
-            ],
-            "type": "string",
-          },
-        },
-        "before": {
-          "in": "cookie",
-          "name": "test",
-          "schema": {
-            "enum": [
-              "a",
-              "b",
-            ],
-            "type": "string",
-          },
-        },
-      },
-      "location": {
-        "conceptualLocation": {
-          "inRequest": {
-            "cookie": "test",
-          },
-          "method": "get",
-          "path": "/api/users",
-        },
-        "conceptualPath": [
-          "operations",
-          "/api/users",
-          "get",
-          "parameters",
-          "cookie",
-          "test",
-        ],
-        "jsonPath": "/paths/~1api~1users/get/parameters/0",
-        "kind": "cookie-parameter",
-      },
-    },
-    "condition": undefined,
-    "docsLink": undefined,
-    "error": undefined,
-    "exempted": false,
-    "expected": undefined,
-    "isMust": true,
-    "isShould": false,
     "name": "prevent cookie parameters type changes",
     "passed": true,
     "received": undefined,
@@ -302,66 +242,6 @@ exports[`breaking changes ruleset - parameter enum change "header" parameter enu
     "isShould": false,
     "name": "prevent header parameters enum breaking changes",
     "passed": false,
-    "received": undefined,
-    "severity": 2,
-    "type": "changed",
-    "where": "GET /api/users header parameter: test",
-  },
-  {
-    "change": {
-      "changeType": "changed",
-      "changed": {
-        "after": {
-          "in": "header",
-          "name": "test",
-          "schema": {
-            "enum": [
-              "b",
-            ],
-            "type": "string",
-          },
-        },
-        "before": {
-          "in": "header",
-          "name": "test",
-          "schema": {
-            "enum": [
-              "a",
-              "b",
-            ],
-            "type": "string",
-          },
-        },
-      },
-      "location": {
-        "conceptualLocation": {
-          "inRequest": {
-            "header": "test",
-          },
-          "method": "get",
-          "path": "/api/users",
-        },
-        "conceptualPath": [
-          "operations",
-          "/api/users",
-          "get",
-          "parameters",
-          "header",
-          "test",
-        ],
-        "jsonPath": "/paths/~1api~1users/get/parameters/0",
-        "kind": "header-parameter",
-      },
-    },
-    "condition": undefined,
-    "docsLink": undefined,
-    "error": undefined,
-    "exempted": false,
-    "expected": undefined,
-    "isMust": true,
-    "isShould": false,
-    "name": "prevent header parameters enum breaking changes",
-    "passed": true,
     "received": undefined,
     "severity": 2,
     "type": "changed",
@@ -605,66 +485,6 @@ exports[`breaking changes ruleset - parameter enum change "path" parameter enum 
     "expected": undefined,
     "isMust": true,
     "isShould": false,
-    "name": "prevent path parameters enum breaking changes",
-    "passed": true,
-    "received": undefined,
-    "severity": 2,
-    "type": "changed",
-    "where": "GET /api/users path parameter: test",
-  },
-  {
-    "change": {
-      "changeType": "changed",
-      "changed": {
-        "after": {
-          "in": "path",
-          "name": "test",
-          "schema": {
-            "enum": [
-              "b",
-            ],
-            "type": "string",
-          },
-        },
-        "before": {
-          "in": "path",
-          "name": "test",
-          "schema": {
-            "enum": [
-              "a",
-              "b",
-            ],
-            "type": "string",
-          },
-        },
-      },
-      "location": {
-        "conceptualLocation": {
-          "inRequest": {
-            "path": "test",
-          },
-          "method": "get",
-          "path": "/api/users",
-        },
-        "conceptualPath": [
-          "operations",
-          "/api/users",
-          "get",
-          "parameters",
-          "path",
-          "test",
-        ],
-        "jsonPath": "/paths/~1api~1users/get/parameters/0",
-        "kind": "path-parameter",
-      },
-    },
-    "condition": undefined,
-    "docsLink": undefined,
-    "error": undefined,
-    "exempted": false,
-    "expected": undefined,
-    "isMust": true,
-    "isShould": false,
     "name": "prevent path parameters type changes",
     "passed": true,
     "received": undefined,
@@ -732,66 +552,6 @@ exports[`breaking changes ruleset - parameter enum change "query" parameter enum
     "isShould": false,
     "name": "prevent query parameters enum breaking changes",
     "passed": false,
-    "received": undefined,
-    "severity": 2,
-    "type": "changed",
-    "where": "GET /api/users query parameter: test",
-  },
-  {
-    "change": {
-      "changeType": "changed",
-      "changed": {
-        "after": {
-          "in": "query",
-          "name": "test",
-          "schema": {
-            "enum": [
-              "b",
-            ],
-            "type": "string",
-          },
-        },
-        "before": {
-          "in": "query",
-          "name": "test",
-          "schema": {
-            "enum": [
-              "a",
-              "b",
-            ],
-            "type": "string",
-          },
-        },
-      },
-      "location": {
-        "conceptualLocation": {
-          "inRequest": {
-            "query": "test",
-          },
-          "method": "get",
-          "path": "/api/users",
-        },
-        "conceptualPath": [
-          "operations",
-          "/api/users",
-          "get",
-          "parameters",
-          "query",
-          "test",
-        ],
-        "jsonPath": "/paths/~1api~1users/get/parameters/0",
-        "kind": "query-parameter",
-      },
-    },
-    "condition": undefined,
-    "docsLink": undefined,
-    "error": undefined,
-    "exempted": false,
-    "expected": undefined,
-    "isMust": true,
-    "isShould": false,
-    "name": "prevent query parameters enum breaking changes",
-    "passed": true,
     "received": undefined,
     "severity": 2,
     "type": "changed",
@@ -1025,61 +785,6 @@ exports[`breaking changes ruleset - parameter enum change const changes picked u
     "expected": undefined,
     "isMust": true,
     "isShould": false,
-    "name": "prevent cookie parameters enum breaking changes",
-    "passed": true,
-    "received": undefined,
-    "severity": 2,
-    "type": "changed",
-    "where": "GET /api/users cookie parameter: test",
-  },
-  {
-    "change": {
-      "changeType": "changed",
-      "changed": {
-        "after": {
-          "in": "cookie",
-          "name": "test",
-          "schema": {
-            "const": "b",
-            "type": "string",
-          },
-        },
-        "before": {
-          "in": "cookie",
-          "name": "test",
-          "schema": {
-            "const": "a",
-            "type": "string",
-          },
-        },
-      },
-      "location": {
-        "conceptualLocation": {
-          "inRequest": {
-            "cookie": "test",
-          },
-          "method": "get",
-          "path": "/api/users",
-        },
-        "conceptualPath": [
-          "operations",
-          "/api/users",
-          "get",
-          "parameters",
-          "cookie",
-          "test",
-        ],
-        "jsonPath": "/paths/~1api~1users/get/parameters/0",
-        "kind": "cookie-parameter",
-      },
-    },
-    "condition": undefined,
-    "docsLink": undefined,
-    "error": undefined,
-    "exempted": false,
-    "expected": undefined,
-    "isMust": true,
-    "isShould": false,
     "name": "prevent cookie parameters type changes",
     "passed": true,
     "received": undefined,
@@ -1197,61 +902,6 @@ exports[`breaking changes ruleset - parameter enum change const changes picked u
     "isShould": false,
     "name": "prevent header parameters enum breaking changes",
     "passed": false,
-    "received": undefined,
-    "severity": 2,
-    "type": "changed",
-    "where": "GET /api/users header parameter: test",
-  },
-  {
-    "change": {
-      "changeType": "changed",
-      "changed": {
-        "after": {
-          "in": "header",
-          "name": "test",
-          "schema": {
-            "const": "b",
-            "type": "string",
-          },
-        },
-        "before": {
-          "in": "header",
-          "name": "test",
-          "schema": {
-            "const": "a",
-            "type": "string",
-          },
-        },
-      },
-      "location": {
-        "conceptualLocation": {
-          "inRequest": {
-            "header": "test",
-          },
-          "method": "get",
-          "path": "/api/users",
-        },
-        "conceptualPath": [
-          "operations",
-          "/api/users",
-          "get",
-          "parameters",
-          "header",
-          "test",
-        ],
-        "jsonPath": "/paths/~1api~1users/get/parameters/0",
-        "kind": "header-parameter",
-      },
-    },
-    "condition": undefined,
-    "docsLink": undefined,
-    "error": undefined,
-    "exempted": false,
-    "expected": undefined,
-    "isMust": true,
-    "isShould": false,
-    "name": "prevent header parameters enum breaking changes",
-    "passed": true,
     "received": undefined,
     "severity": 2,
     "type": "changed",
@@ -1475,61 +1125,6 @@ exports[`breaking changes ruleset - parameter enum change const changes picked u
     "expected": undefined,
     "isMust": true,
     "isShould": false,
-    "name": "prevent path parameters enum breaking changes",
-    "passed": true,
-    "received": undefined,
-    "severity": 2,
-    "type": "changed",
-    "where": "GET /api/users path parameter: test",
-  },
-  {
-    "change": {
-      "changeType": "changed",
-      "changed": {
-        "after": {
-          "in": "path",
-          "name": "test",
-          "schema": {
-            "const": "b",
-            "type": "string",
-          },
-        },
-        "before": {
-          "in": "path",
-          "name": "test",
-          "schema": {
-            "const": "a",
-            "type": "string",
-          },
-        },
-      },
-      "location": {
-        "conceptualLocation": {
-          "inRequest": {
-            "path": "test",
-          },
-          "method": "get",
-          "path": "/api/users",
-        },
-        "conceptualPath": [
-          "operations",
-          "/api/users",
-          "get",
-          "parameters",
-          "path",
-          "test",
-        ],
-        "jsonPath": "/paths/~1api~1users/get/parameters/0",
-        "kind": "path-parameter",
-      },
-    },
-    "condition": undefined,
-    "docsLink": undefined,
-    "error": undefined,
-    "exempted": false,
-    "expected": undefined,
-    "isMust": true,
-    "isShould": false,
     "name": "prevent path parameters type changes",
     "passed": true,
     "received": undefined,
@@ -1592,61 +1187,6 @@ exports[`breaking changes ruleset - parameter enum change const changes picked u
     "isShould": false,
     "name": "prevent query parameters enum breaking changes",
     "passed": false,
-    "received": undefined,
-    "severity": 2,
-    "type": "changed",
-    "where": "GET /api/users query parameter: test",
-  },
-  {
-    "change": {
-      "changeType": "changed",
-      "changed": {
-        "after": {
-          "in": "query",
-          "name": "test",
-          "schema": {
-            "const": "b",
-            "type": "string",
-          },
-        },
-        "before": {
-          "in": "query",
-          "name": "test",
-          "schema": {
-            "const": "a",
-            "type": "string",
-          },
-        },
-      },
-      "location": {
-        "conceptualLocation": {
-          "inRequest": {
-            "query": "test",
-          },
-          "method": "get",
-          "path": "/api/users",
-        },
-        "conceptualPath": [
-          "operations",
-          "/api/users",
-          "get",
-          "parameters",
-          "query",
-          "test",
-        ],
-        "jsonPath": "/paths/~1api~1users/get/parameters/0",
-        "kind": "query-parameter",
-      },
-    },
-    "condition": undefined,
-    "docsLink": undefined,
-    "error": undefined,
-    "exempted": false,
-    "expected": undefined,
-    "isMust": true,
-    "isShould": false,
-    "name": "prevent query parameters enum breaking changes",
-    "passed": true,
     "received": undefined,
     "severity": 2,
     "type": "changed",
@@ -1812,64 +1352,7 @@ exports[`breaking changes ruleset - parameter enum change enum added to "cookie"
     },
     "condition": undefined,
     "docsLink": undefined,
-    "error": undefined,
-    "exempted": false,
-    "expected": undefined,
-    "isMust": true,
-    "isShould": false,
-    "name": "prevent cookie parameters enum breaking changes",
-    "passed": true,
-    "received": undefined,
-    "severity": 2,
-    "type": "changed",
-    "where": "GET /api/users cookie parameter: test",
-  },
-  {
-    "change": {
-      "changeType": "changed",
-      "changed": {
-        "after": {
-          "in": "cookie",
-          "name": "test",
-          "schema": {
-            "enum": [
-              "a",
-              "b",
-            ],
-            "type": "string",
-          },
-        },
-        "before": {
-          "in": "cookie",
-          "name": "test",
-          "schema": {
-            "type": "string",
-          },
-        },
-      },
-      "location": {
-        "conceptualLocation": {
-          "inRequest": {
-            "cookie": "test",
-          },
-          "method": "get",
-          "path": "/api/users",
-        },
-        "conceptualPath": [
-          "operations",
-          "/api/users",
-          "get",
-          "parameters",
-          "cookie",
-          "test",
-        ],
-        "jsonPath": "/paths/~1api~1users/get/parameters/0",
-        "kind": "cookie-parameter",
-      },
-    },
-    "condition": undefined,
-    "docsLink": undefined,
-    "error": "cannot add an enum to restrict possible values for cookie parameter 'test'. This is a breaking change.",
+    "error": "cannot add an enum to restrict possible values for cookie parameter test. This is a breaking change.",
     "exempted": false,
     "expected": undefined,
     "isMust": true,
@@ -2045,64 +1528,7 @@ exports[`breaking changes ruleset - parameter enum change enum added to "header"
     },
     "condition": undefined,
     "docsLink": undefined,
-    "error": undefined,
-    "exempted": false,
-    "expected": undefined,
-    "isMust": true,
-    "isShould": false,
-    "name": "prevent header parameters enum breaking changes",
-    "passed": true,
-    "received": undefined,
-    "severity": 2,
-    "type": "changed",
-    "where": "GET /api/users header parameter: test",
-  },
-  {
-    "change": {
-      "changeType": "changed",
-      "changed": {
-        "after": {
-          "in": "header",
-          "name": "test",
-          "schema": {
-            "enum": [
-              "a",
-              "b",
-            ],
-            "type": "string",
-          },
-        },
-        "before": {
-          "in": "header",
-          "name": "test",
-          "schema": {
-            "type": "string",
-          },
-        },
-      },
-      "location": {
-        "conceptualLocation": {
-          "inRequest": {
-            "header": "test",
-          },
-          "method": "get",
-          "path": "/api/users",
-        },
-        "conceptualPath": [
-          "operations",
-          "/api/users",
-          "get",
-          "parameters",
-          "header",
-          "test",
-        ],
-        "jsonPath": "/paths/~1api~1users/get/parameters/0",
-        "kind": "header-parameter",
-      },
-    },
-    "condition": undefined,
-    "docsLink": undefined,
-    "error": "cannot add an enum to restrict possible values for header parameter 'test'. This is a breaking change.",
+    "error": "cannot add an enum to restrict possible values for header parameter test. This is a breaking change.",
     "exempted": false,
     "expected": undefined,
     "isMust": true,
@@ -2278,64 +1704,7 @@ exports[`breaking changes ruleset - parameter enum change enum added to "path" p
     },
     "condition": undefined,
     "docsLink": undefined,
-    "error": undefined,
-    "exempted": false,
-    "expected": undefined,
-    "isMust": true,
-    "isShould": false,
-    "name": "prevent path parameters enum breaking changes",
-    "passed": true,
-    "received": undefined,
-    "severity": 2,
-    "type": "changed",
-    "where": "GET /api/users path parameter: test",
-  },
-  {
-    "change": {
-      "changeType": "changed",
-      "changed": {
-        "after": {
-          "in": "path",
-          "name": "test",
-          "schema": {
-            "enum": [
-              "a",
-              "b",
-            ],
-            "type": "string",
-          },
-        },
-        "before": {
-          "in": "path",
-          "name": "test",
-          "schema": {
-            "type": "string",
-          },
-        },
-      },
-      "location": {
-        "conceptualLocation": {
-          "inRequest": {
-            "path": "test",
-          },
-          "method": "get",
-          "path": "/api/users",
-        },
-        "conceptualPath": [
-          "operations",
-          "/api/users",
-          "get",
-          "parameters",
-          "path",
-          "test",
-        ],
-        "jsonPath": "/paths/~1api~1users/get/parameters/0",
-        "kind": "path-parameter",
-      },
-    },
-    "condition": undefined,
-    "docsLink": undefined,
-    "error": "cannot add an enum to restrict possible values for path parameter 'test'. This is a breaking change.",
+    "error": "cannot add an enum to restrict possible values for path parameter test. This is a breaking change.",
     "exempted": false,
     "expected": undefined,
     "isMust": true,
@@ -2454,64 +1823,7 @@ exports[`breaking changes ruleset - parameter enum change enum added to "query" 
     },
     "condition": undefined,
     "docsLink": undefined,
-    "error": undefined,
-    "exempted": false,
-    "expected": undefined,
-    "isMust": true,
-    "isShould": false,
-    "name": "prevent query parameters enum breaking changes",
-    "passed": true,
-    "received": undefined,
-    "severity": 2,
-    "type": "changed",
-    "where": "GET /api/users query parameter: test",
-  },
-  {
-    "change": {
-      "changeType": "changed",
-      "changed": {
-        "after": {
-          "in": "query",
-          "name": "test",
-          "schema": {
-            "enum": [
-              "a",
-              "b",
-            ],
-            "type": "string",
-          },
-        },
-        "before": {
-          "in": "query",
-          "name": "test",
-          "schema": {
-            "type": "string",
-          },
-        },
-      },
-      "location": {
-        "conceptualLocation": {
-          "inRequest": {
-            "query": "test",
-          },
-          "method": "get",
-          "path": "/api/users",
-        },
-        "conceptualPath": [
-          "operations",
-          "/api/users",
-          "get",
-          "parameters",
-          "query",
-          "test",
-        ],
-        "jsonPath": "/paths/~1api~1users/get/parameters/0",
-        "kind": "query-parameter",
-      },
-    },
-    "condition": undefined,
-    "docsLink": undefined,
-    "error": "cannot add an enum to restrict possible values for query parameter 'test'. This is a breaking change.",
+    "error": "cannot add an enum to restrict possible values for query parameter test. This is a breaking change.",
     "exempted": false,
     "expected": undefined,
     "isMust": true,
@@ -2642,63 +1954,6 @@ exports[`breaking changes ruleset - parameter enum change enum added to "query" 
 
 exports[`breaking changes ruleset - parameter enum change enum converted to const "cookie" parameter 1`] = `
 [
-  {
-    "change": {
-      "changeType": "changed",
-      "changed": {
-        "after": {
-          "in": "cookie",
-          "name": "test",
-          "schema": {
-            "enum": [
-              "a",
-            ],
-            "type": "string",
-          },
-        },
-        "before": {
-          "in": "cookie",
-          "name": "test",
-          "schema": {
-            "const": "a",
-            "type": "string",
-          },
-        },
-      },
-      "location": {
-        "conceptualLocation": {
-          "inRequest": {
-            "cookie": "test",
-          },
-          "method": "get",
-          "path": "/api/users",
-        },
-        "conceptualPath": [
-          "operations",
-          "/api/users",
-          "get",
-          "parameters",
-          "cookie",
-          "test",
-        ],
-        "jsonPath": "/paths/~1api~1users/get/parameters/0",
-        "kind": "cookie-parameter",
-      },
-    },
-    "condition": undefined,
-    "docsLink": undefined,
-    "error": undefined,
-    "exempted": false,
-    "expected": undefined,
-    "isMust": true,
-    "isShould": false,
-    "name": "prevent cookie parameters enum breaking changes",
-    "passed": true,
-    "received": undefined,
-    "severity": 2,
-    "type": "changed",
-    "where": "GET /api/users cookie parameter: test",
-  },
   {
     "change": {
       "changeType": "changed",
@@ -2982,63 +2237,6 @@ exports[`breaking changes ruleset - parameter enum change enum converted to cons
     "expected": undefined,
     "isMust": true,
     "isShould": false,
-    "name": "prevent header parameters enum breaking changes",
-    "passed": true,
-    "received": undefined,
-    "severity": 2,
-    "type": "changed",
-    "where": "GET /api/users header parameter: test",
-  },
-  {
-    "change": {
-      "changeType": "changed",
-      "changed": {
-        "after": {
-          "in": "header",
-          "name": "test",
-          "schema": {
-            "enum": [
-              "a",
-            ],
-            "type": "string",
-          },
-        },
-        "before": {
-          "in": "header",
-          "name": "test",
-          "schema": {
-            "const": "a",
-            "type": "string",
-          },
-        },
-      },
-      "location": {
-        "conceptualLocation": {
-          "inRequest": {
-            "header": "test",
-          },
-          "method": "get",
-          "path": "/api/users",
-        },
-        "conceptualPath": [
-          "operations",
-          "/api/users",
-          "get",
-          "parameters",
-          "header",
-          "test",
-        ],
-        "jsonPath": "/paths/~1api~1users/get/parameters/0",
-        "kind": "header-parameter",
-      },
-    },
-    "condition": undefined,
-    "docsLink": undefined,
-    "error": undefined,
-    "exempted": false,
-    "expected": undefined,
-    "isMust": true,
-    "isShould": false,
     "name": "prevent header parameters type changes",
     "passed": true,
     "received": undefined,
@@ -3108,63 +2306,6 @@ exports[`breaking changes ruleset - parameter enum change enum converted to cons
 
 exports[`breaking changes ruleset - parameter enum change enum converted to const "path" parameter 1`] = `
 [
-  {
-    "change": {
-      "changeType": "changed",
-      "changed": {
-        "after": {
-          "in": "path",
-          "name": "test",
-          "schema": {
-            "enum": [
-              "a",
-            ],
-            "type": "string",
-          },
-        },
-        "before": {
-          "in": "path",
-          "name": "test",
-          "schema": {
-            "const": "a",
-            "type": "string",
-          },
-        },
-      },
-      "location": {
-        "conceptualLocation": {
-          "inRequest": {
-            "path": "test",
-          },
-          "method": "get",
-          "path": "/api/users",
-        },
-        "conceptualPath": [
-          "operations",
-          "/api/users",
-          "get",
-          "parameters",
-          "path",
-          "test",
-        ],
-        "jsonPath": "/paths/~1api~1users/get/parameters/0",
-        "kind": "path-parameter",
-      },
-    },
-    "condition": undefined,
-    "docsLink": undefined,
-    "error": undefined,
-    "exempted": false,
-    "expected": undefined,
-    "isMust": true,
-    "isShould": false,
-    "name": "prevent path parameters enum breaking changes",
-    "passed": true,
-    "received": undefined,
-    "severity": 2,
-    "type": "changed",
-    "where": "GET /api/users path parameter: test",
-  },
   {
     "change": {
       "changeType": "changed",
@@ -3391,63 +2532,6 @@ exports[`breaking changes ruleset - parameter enum change enum converted to cons
     "expected": undefined,
     "isMust": true,
     "isShould": false,
-    "name": "prevent query parameters enum breaking changes",
-    "passed": true,
-    "received": undefined,
-    "severity": 2,
-    "type": "changed",
-    "where": "GET /api/users query parameter: test",
-  },
-  {
-    "change": {
-      "changeType": "changed",
-      "changed": {
-        "after": {
-          "in": "query",
-          "name": "test",
-          "schema": {
-            "enum": [
-              "a",
-            ],
-            "type": "string",
-          },
-        },
-        "before": {
-          "in": "query",
-          "name": "test",
-          "schema": {
-            "const": "a",
-            "type": "string",
-          },
-        },
-      },
-      "location": {
-        "conceptualLocation": {
-          "inRequest": {
-            "query": "test",
-          },
-          "method": "get",
-          "path": "/api/users",
-        },
-        "conceptualPath": [
-          "operations",
-          "/api/users",
-          "get",
-          "parameters",
-          "query",
-          "test",
-        ],
-        "jsonPath": "/paths/~1api~1users/get/parameters/0",
-        "kind": "query-parameter",
-      },
-    },
-    "condition": undefined,
-    "docsLink": undefined,
-    "error": undefined,
-    "exempted": false,
-    "expected": undefined,
-    "isMust": true,
-    "isShould": false,
     "name": "prevent query parameters type changes",
     "passed": true,
     "received": undefined,
@@ -3515,7 +2599,7 @@ exports[`breaking changes ruleset - parameter enum change enum converted to cons
 ]
 `;
 
-exports[`breaking changes ruleset - parameter enum change enums in bodies 1`] = `
+exports[`breaking changes ruleset - parameter enum change enums in request bodies 1`] = `
 [
   {
     "change": {
@@ -3525,7 +2609,6 @@ exports[`breaking changes ruleset - parameter enum change enums in bodies 1`] = 
           "flatSchema": {
             "enum": [
               "A",
-              "B",
             ],
             "type": "string",
           },
@@ -3537,7 +2620,265 @@ exports[`breaking changes ruleset - parameter enum change enums in bodies 1`] = 
             "enum": [
               "A",
               "B",
+            ],
+            "type": "string",
+          },
+          "key": "enum",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "enum",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users",
+          "get",
+          "application/json",
+          "enum",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/requestBody/content/application~1json/schema/properties/enum",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent changing request property to required",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /api/users request body: application/json property: enum",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "A",
+            ],
+            "type": "string",
+          },
+          "key": "enum",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "A",
+              "B",
+            ],
+            "type": "string",
+          },
+          "key": "enum",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "enum",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users",
+          "get",
+          "application/json",
+          "enum",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/requestBody/content/application~1json/schema/properties/enum",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent request property type changes",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /api/users request body: application/json property: enum",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "A",
+            ],
+            "type": "string",
+          },
+          "key": "enum",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "A",
+              "B",
+            ],
+            "type": "string",
+          },
+          "key": "enum",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "enum",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users",
+          "get",
+          "application/json",
+          "enum",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/requestBody/content/application~1json/schema/properties/enum",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "prevent expanded in request union types",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /api/users request body: application/json property: enum",
+  },
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "A",
+            ],
+            "type": "string",
+          },
+          "key": "enum",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "A",
+              "B",
+            ],
+            "type": "string",
+          },
+          "key": "enum",
+          "required": false,
+        },
+      },
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "enum",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users",
+          "get",
+          "application/json",
+          "enum",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/requestBody/content/application~1json/schema/properties/enum",
+        "kind": "field",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": "cannot remove enum option 'B' from 'enum' property. This is a breaking change.",
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request and response property enums",
+    "passed": false,
+    "received": undefined,
+    "severity": 2,
+    "type": "changed",
+    "where": "GET /api/users request body: application/json property: enum",
+  },
+]
+`;
+
+exports[`breaking changes ruleset - parameter enum change enums in response bodies 1`] = `
+[
+  {
+    "change": {
+      "changeType": "changed",
+      "changed": {
+        "after": {
+          "flatSchema": {
+            "enum": [
+              "A",
+              "B",
               "C",
+            ],
+            "type": "string",
+          },
+          "key": "enum",
+          "required": false,
+        },
+        "before": {
+          "flatSchema": {
+            "enum": [
+              "A",
+              "B",
             ],
             "type": "string",
           },
@@ -3595,6 +2936,7 @@ exports[`breaking changes ruleset - parameter enum change enums in bodies 1`] = 
             "enum": [
               "A",
               "B",
+              "C",
             ],
             "type": "string",
           },
@@ -3606,7 +2948,6 @@ exports[`breaking changes ruleset - parameter enum change enums in bodies 1`] = 
             "enum": [
               "A",
               "B",
-              "C",
             ],
             "type": "string",
           },
@@ -3664,6 +3005,7 @@ exports[`breaking changes ruleset - parameter enum change enums in bodies 1`] = 
             "enum": [
               "A",
               "B",
+              "C",
             ],
             "type": "string",
           },
@@ -3675,7 +3017,6 @@ exports[`breaking changes ruleset - parameter enum change enums in bodies 1`] = 
             "enum": [
               "A",
               "B",
-              "C",
             ],
             "type": "string",
           },
@@ -3733,6 +3074,7 @@ exports[`breaking changes ruleset - parameter enum change enums in bodies 1`] = 
             "enum": [
               "A",
               "B",
+              "C",
             ],
             "type": "string",
           },
@@ -3744,7 +3086,6 @@ exports[`breaking changes ruleset - parameter enum change enums in bodies 1`] = 
             "enum": [
               "A",
               "B",
-              "C",
             ],
             "type": "string",
           },
@@ -3781,7 +3122,7 @@ exports[`breaking changes ruleset - parameter enum change enums in bodies 1`] = 
     },
     "condition": undefined,
     "docsLink": undefined,
-    "error": "cannot remove enum option 'C' from 'enum' property. This is a breaking change.",
+    "error": "cannot add enum option 'C' from 'enum' property. This is a breaking change.",
     "exempted": false,
     "expected": undefined,
     "isMust": true,

--- a/projects/standard-rulesets/src/breaking-changes/__tests__/__snapshots__/parameter-requirement-breaking-changes.test.ts.snap
+++ b/projects/standard-rulesets/src/breaking-changes/__tests__/__snapshots__/parameter-requirement-breaking-changes.test.ts.snap
@@ -103,60 +103,6 @@ exports[`breaking changes ruleset - parameter requirement change "cookie" parame
     "expected": undefined,
     "isMust": true,
     "isShould": false,
-    "name": "prevent cookie parameters enum breaking changes",
-    "passed": true,
-    "received": undefined,
-    "severity": 2,
-    "type": "changed",
-    "where": "GET /api/users cookie parameter: version",
-  },
-  {
-    "change": {
-      "changeType": "changed",
-      "changed": {
-        "after": {
-          "in": "cookie",
-          "name": "version",
-          "required": true,
-          "schema": {
-            "type": "string",
-          },
-        },
-        "before": {
-          "in": "cookie",
-          "name": "version",
-          "schema": {
-            "type": "string",
-          },
-        },
-      },
-      "location": {
-        "conceptualLocation": {
-          "inRequest": {
-            "cookie": "version",
-          },
-          "method": "get",
-          "path": "/api/users",
-        },
-        "conceptualPath": [
-          "operations",
-          "/api/users",
-          "get",
-          "parameters",
-          "cookie",
-          "version",
-        ],
-        "jsonPath": "/paths/~1api~1users/get/parameters/0",
-        "kind": "cookie-parameter",
-      },
-    },
-    "condition": undefined,
-    "docsLink": undefined,
-    "error": undefined,
-    "exempted": false,
-    "expected": undefined,
-    "isMust": true,
-    "isShould": false,
     "name": "prevent cookie parameters type changes",
     "passed": true,
     "received": undefined,
@@ -324,60 +270,6 @@ exports[`breaking changes ruleset - parameter requirement change "header" parame
     "expected": undefined,
     "isMust": true,
     "isShould": false,
-    "name": "prevent header parameters enum breaking changes",
-    "passed": true,
-    "received": undefined,
-    "severity": 2,
-    "type": "changed",
-    "where": "GET /api/users header parameter: version",
-  },
-  {
-    "change": {
-      "changeType": "changed",
-      "changed": {
-        "after": {
-          "in": "header",
-          "name": "version",
-          "required": true,
-          "schema": {
-            "type": "string",
-          },
-        },
-        "before": {
-          "in": "header",
-          "name": "version",
-          "schema": {
-            "type": "string",
-          },
-        },
-      },
-      "location": {
-        "conceptualLocation": {
-          "inRequest": {
-            "header": "version",
-          },
-          "method": "get",
-          "path": "/api/users",
-        },
-        "conceptualPath": [
-          "operations",
-          "/api/users",
-          "get",
-          "parameters",
-          "header",
-          "version",
-        ],
-        "jsonPath": "/paths/~1api~1users/get/parameters/0",
-        "kind": "header-parameter",
-      },
-    },
-    "condition": undefined,
-    "docsLink": undefined,
-    "error": undefined,
-    "exempted": false,
-    "expected": undefined,
-    "isMust": true,
-    "isShould": false,
     "name": "prevent header parameters type changes",
     "passed": true,
     "received": undefined,
@@ -444,60 +336,6 @@ exports[`breaking changes ruleset - parameter requirement change "header" parame
 
 exports[`breaking changes ruleset - parameter requirement change "query" parameter optional to required 1`] = `
 [
-  {
-    "change": {
-      "changeType": "changed",
-      "changed": {
-        "after": {
-          "in": "query",
-          "name": "version",
-          "required": true,
-          "schema": {
-            "type": "string",
-          },
-        },
-        "before": {
-          "in": "query",
-          "name": "version",
-          "schema": {
-            "type": "string",
-          },
-        },
-      },
-      "location": {
-        "conceptualLocation": {
-          "inRequest": {
-            "query": "version",
-          },
-          "method": "get",
-          "path": "/api/users",
-        },
-        "conceptualPath": [
-          "operations",
-          "/api/users",
-          "get",
-          "parameters",
-          "query",
-          "version",
-        ],
-        "jsonPath": "/paths/~1api~1users/get/parameters/0",
-        "kind": "query-parameter",
-      },
-    },
-    "condition": undefined,
-    "docsLink": undefined,
-    "error": undefined,
-    "exempted": false,
-    "expected": undefined,
-    "isMust": true,
-    "isShould": false,
-    "name": "prevent query parameters enum breaking changes",
-    "passed": true,
-    "received": undefined,
-    "severity": 2,
-    "type": "changed",
-    "where": "GET /api/users query parameter: version",
-  },
   {
     "change": {
       "changeType": "changed",

--- a/projects/standard-rulesets/src/breaking-changes/__tests__/__snapshots__/parameter-type-breaking-changes.test.ts.snap
+++ b/projects/standard-rulesets/src/breaking-changes/__tests__/__snapshots__/parameter-type-breaking-changes.test.ts.snap
@@ -96,59 +96,6 @@ exports[`breaking changes ruleset - parameter type change "cookie" parameter typ
     },
     "condition": undefined,
     "docsLink": undefined,
-    "error": undefined,
-    "exempted": false,
-    "expected": undefined,
-    "isMust": true,
-    "isShould": false,
-    "name": "prevent cookie parameters enum breaking changes",
-    "passed": true,
-    "received": undefined,
-    "severity": 2,
-    "type": "changed",
-    "where": "GET /api/users cookie parameter: version",
-  },
-  {
-    "change": {
-      "changeType": "changed",
-      "changed": {
-        "after": {
-          "in": "cookie",
-          "name": "version",
-          "schema": {
-            "type": "number",
-          },
-        },
-        "before": {
-          "in": "cookie",
-          "name": "version",
-          "schema": {
-            "type": "string",
-          },
-        },
-      },
-      "location": {
-        "conceptualLocation": {
-          "inRequest": {
-            "cookie": "version",
-          },
-          "method": "get",
-          "path": "/api/users",
-        },
-        "conceptualPath": [
-          "operations",
-          "/api/users",
-          "get",
-          "parameters",
-          "cookie",
-          "version",
-        ],
-        "jsonPath": "/paths/~1api~1users/get/parameters/0",
-        "kind": "cookie-parameter",
-      },
-    },
-    "condition": undefined,
-    "docsLink": undefined,
     "error": "expected cookie parameter 'version' not be narrowed. This is a breaking change.",
     "exempted": false,
     "expected": undefined,
@@ -219,59 +166,6 @@ exports[`breaking changes ruleset - parameter type change "cookie" parameter typ
 
 exports[`breaking changes ruleset - parameter type change "header" parameter type change 1`] = `
 [
-  {
-    "change": {
-      "changeType": "changed",
-      "changed": {
-        "after": {
-          "in": "header",
-          "name": "version",
-          "schema": {
-            "type": "number",
-          },
-        },
-        "before": {
-          "in": "header",
-          "name": "version",
-          "schema": {
-            "type": "string",
-          },
-        },
-      },
-      "location": {
-        "conceptualLocation": {
-          "inRequest": {
-            "header": "version",
-          },
-          "method": "get",
-          "path": "/api/users",
-        },
-        "conceptualPath": [
-          "operations",
-          "/api/users",
-          "get",
-          "parameters",
-          "header",
-          "version",
-        ],
-        "jsonPath": "/paths/~1api~1users/get/parameters/0",
-        "kind": "header-parameter",
-      },
-    },
-    "condition": undefined,
-    "docsLink": undefined,
-    "error": undefined,
-    "exempted": false,
-    "expected": undefined,
-    "isMust": true,
-    "isShould": false,
-    "name": "prevent header parameters enum breaking changes",
-    "passed": true,
-    "received": undefined,
-    "severity": 2,
-    "type": "changed",
-    "where": "GET /api/users header parameter: version",
-  },
   {
     "change": {
       "changeType": "changed",
@@ -530,59 +424,6 @@ exports[`breaking changes ruleset - parameter type change "path" parameter type 
     },
     "condition": undefined,
     "docsLink": undefined,
-    "error": undefined,
-    "exempted": false,
-    "expected": undefined,
-    "isMust": true,
-    "isShould": false,
-    "name": "prevent path parameters enum breaking changes",
-    "passed": true,
-    "received": undefined,
-    "severity": 2,
-    "type": "changed",
-    "where": "GET /api/users path parameter: version",
-  },
-  {
-    "change": {
-      "changeType": "changed",
-      "changed": {
-        "after": {
-          "in": "path",
-          "name": "version",
-          "schema": {
-            "type": "number",
-          },
-        },
-        "before": {
-          "in": "path",
-          "name": "version",
-          "schema": {
-            "type": "string",
-          },
-        },
-      },
-      "location": {
-        "conceptualLocation": {
-          "inRequest": {
-            "path": "version",
-          },
-          "method": "get",
-          "path": "/api/users",
-        },
-        "conceptualPath": [
-          "operations",
-          "/api/users",
-          "get",
-          "parameters",
-          "path",
-          "version",
-        ],
-        "jsonPath": "/paths/~1api~1users/get/parameters/0",
-        "kind": "path-parameter",
-      },
-    },
-    "condition": undefined,
-    "docsLink": undefined,
     "error": "expected path parameter 'version' not be narrowed. This is a breaking change.",
     "exempted": false,
     "expected": undefined,
@@ -600,59 +441,6 @@ exports[`breaking changes ruleset - parameter type change "path" parameter type 
 
 exports[`breaking changes ruleset - parameter type change "query" parameter type change 1`] = `
 [
-  {
-    "change": {
-      "changeType": "changed",
-      "changed": {
-        "after": {
-          "in": "query",
-          "name": "version",
-          "schema": {
-            "type": "number",
-          },
-        },
-        "before": {
-          "in": "query",
-          "name": "version",
-          "schema": {
-            "type": "string",
-          },
-        },
-      },
-      "location": {
-        "conceptualLocation": {
-          "inRequest": {
-            "query": "version",
-          },
-          "method": "get",
-          "path": "/api/users",
-        },
-        "conceptualPath": [
-          "operations",
-          "/api/users",
-          "get",
-          "parameters",
-          "query",
-          "version",
-        ],
-        "jsonPath": "/paths/~1api~1users/get/parameters/0",
-        "kind": "query-parameter",
-      },
-    },
-    "condition": undefined,
-    "docsLink": undefined,
-    "error": undefined,
-    "exempted": false,
-    "expected": undefined,
-    "isMust": true,
-    "isShould": false,
-    "name": "prevent query parameters enum breaking changes",
-    "passed": true,
-    "received": undefined,
-    "severity": 2,
-    "type": "changed",
-    "where": "GET /api/users query parameter: version",
-  },
   {
     "change": {
       "changeType": "changed",

--- a/projects/standard-rulesets/src/breaking-changes/__tests__/enum-breaking-changes.test.ts
+++ b/projects/standard-rulesets/src/breaking-changes/__tests__/enum-breaking-changes.test.ts
@@ -223,7 +223,77 @@ describe('breaking changes ruleset - parameter enum change', () => {
       expect(results.some((result) => !result.passed)).toBe(true);
     }
   );
-  test('enums in bodies', async () => {
+
+  test('enums in request bodies', async () => {
+    const beforeJson: OpenAPIV3.Document = {
+      ...TestHelpers.createEmptySpec(),
+      paths: {
+        '/api/users': {
+          get: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      enum: {
+                        type: 'string',
+                        enum: ['A', 'B'],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            responses: {
+              '200': {
+                description: '',
+              },
+            },
+          },
+        },
+      },
+    };
+    const afterJson: OpenAPIV3.Document = {
+      ...TestHelpers.createEmptySpec(),
+      paths: {
+        '/api/users': {
+          get: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      enum: {
+                        type: 'string',
+                        enum: ['A'],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            responses: {
+              '200': {
+                description: '',
+              },
+            },
+          },
+        },
+      },
+    };
+    const results = await TestHelpers.runRulesWithInputs(
+      [new BreakingChangesRuleset()],
+      beforeJson,
+      afterJson
+    );
+    expect(results.length > 0).toBe(true);
+
+    expect(results).toMatchSnapshot();
+    expect(results.some((result) => !result.passed)).toBe(true);
+  });
+  test('enums in response bodies', async () => {
     const beforeJson: OpenAPIV3.Document = {
       ...TestHelpers.createEmptySpec(),
       paths: {
@@ -239,7 +309,7 @@ describe('breaking changes ruleset - parameter enum change', () => {
                       properties: {
                         enum: {
                           type: 'string',
-                          enum: ['A', 'B', 'C'],
+                          enum: ['A', 'B'],
                         },
                       },
                     },
@@ -266,7 +336,7 @@ describe('breaking changes ruleset - parameter enum change', () => {
                       properties: {
                         enum: {
                           type: 'string',
-                          enum: ['A', 'B'],
+                          enum: ['A', 'B', 'C'],
                         },
                       },
                     },

--- a/projects/standard-rulesets/src/breaking-changes/helpers/type-change.ts
+++ b/projects/standard-rulesets/src/breaking-changes/helpers/type-change.ts
@@ -62,8 +62,8 @@ export function computeTypeTransition(
     : null;
   if (beforeEnum && afterEnum) {
     const enumResults = diffSets(new Set(beforeEnum), new Set(afterEnum));
-    if (enumResults.expanded) results.expanded.enum = true;
-    if (enumResults.narrowed) results.narrowed.enum = true;
+    if (enumResults.expanded.length) results.expanded.enum = true;
+    if (enumResults.narrowed.length) results.narrowed.enum = true;
   } else if (beforeEnum && !afterEnum) {
     results.expanded.enum = true;
   } else if (!beforeEnum && afterEnum) {
@@ -82,31 +82,24 @@ export function computeEffectiveTypeChange(
 } {
   const before = typeToSet(beforeType);
   const after = typeToSet(afterType);
-
-  return diffSets(before, after);
+  const diff = diffSets(before, after);
+  return {
+    narrowed: diff.narrowed.length > 0,
+    expanded: diff.expanded.length > 0,
+  };
 }
 
-function diffSets(
+export function diffSets(
   beforeSet: Set<string>,
   afterSet: Set<string>
-): { expanded: boolean; narrowed: boolean } {
-  const results = {
-    expanded: false,
-    narrowed: false,
+): { expanded: string[]; narrowed: string[] } {
+  const narrowedSet = new Set([...beforeSet].filter((x) => !afterSet.has(x)));
+  const expandedSet = new Set([...afterSet].filter((x) => !beforeSet.has(x)));
+
+  return {
+    expanded: [...expandedSet],
+    narrowed: [...narrowedSet],
   };
-
-  for (const a of beforeSet) {
-    if (!afterSet.has(a)) {
-      results.narrowed = true;
-    }
-  }
-  for (const a of afterSet) {
-    if (!beforeSet.has(a)) {
-      results.expanded = true;
-    }
-  }
-
-  return results;
 }
 
 function typeToSet(type?: string | string[]): Set<string> {


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

For breaking changes, we do not allow narrowing of any request level property (headers / cookies / path param / request body) but we do not allow expanding of response level properties.

The enum check was still applying narrowing to response level properties - this PR updates the enum breaking change rule to allow narrowing of response properties but disallow narrowing of response level properties

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
