### PR TITLE
fix(ci): release workflows

### DIFF
--- a/.github/workflows/release-container-image.yml
+++ b/.github/workflows/release-container-image.yml
@@ -64,8 +64,10 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.BUILD_BOT_SLACK_WEBHOOK_URL_RELEASES }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
         with:
-          slack-message: '{{ GITHUB_ACTOR }}: ✅ container images `docker.io/useoptic/optic:${{ inputs.optic_version }}`, `public.ecr.aws/optic/optic:${{ inputs.optic_version }}` published!'
-
+          payload: |
+            {
+              "text": "${{github.actor}}: ✅ container images `docker.io/useoptic/optic:${{inputs.optic_version}}`, `public.ecr.aws/optic/optic:${{inputs.optic_version}}` published!"
+            }
       - name: Announce failure
         uses: slackapi/slack-github-action@v1.24.0
         if: failure()
@@ -73,4 +75,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.BUILD_BOT_SLACK_WEBHOOK_URL_RELEASES }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
         with:
-          slack-message: '{{ GITHUB_ACTOR }}: 🚫 container images failed to publish.'
+          payload: |
+            {
+              "text": "${{github.actor}}: 🚫 container images failed to publish."
+            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,10 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.BUILD_BOT_SLACK_WEBHOOK_URL_RELEASES }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
         with:
-          slack-message: '{{ GITHUB_ACTOR }}: ✅ optic v{{ VERSION }} packages published to channel `{{ RELEASE_CHANNEL }}`!'
+          payload: |
+            {
+              "text": "${{github.actor}}: ✅ optic v${{env.VERSION}} packages published to channel `${{env.RELEASE_CHANNEL}}`!"
+            }
 
       - name: Announce failure
         uses: slackapi/slack-github-action@v1.24.0
@@ -150,7 +153,10 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.BUILD_BOT_SLACK_WEBHOOK_URL_RELEASES }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
         with:
-          slack-message: '{{ GITHUB_ACTOR }}: 🚫 optic v{{ VERSION }} failed to publish.'
+          payload: |
+            {
+              "text": "${{github.actor}}: 🚫 optic v${{env.VERSION}} failed to publish."
+            }
 
   publish-binaries:
     needs: release


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

should fix this failure, https://github.com/opticdev/optic/actions/runs/6626784793/job/18000415723

i misunderstood the slack action's docs—turns out that when you're using an incoming web hook you have to use `payload`. i kicked the tires this time on a test workflow (https://github.com/opticdev/optic/tree/chore/ci/slack-test-test) and verified i'm using the action correctly this time 😅 

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
