### PR TITLE
chore(cli): take a pass on run's help output

### DIFF
--- a/projects/optic/src/commands/run.ts
+++ b/projects/optic/src/commands/run.ts
@@ -118,7 +118,7 @@ export function registerRunCommand(cli: Command, config: OpticCliConfig) {
   cli
     .command('run')
     .description(
-      'CI workflow command that tests each OpenAPI specification in your repo and summarizes the results as a pull (or merge) request comment.'
+      'CI workflow command that tests each OpenAPI specification in your repo and summarizes the results as a pull (or merge) request comment'
     )
     .configureHelp({ commandUsage: usage })
     .option(

--- a/projects/optic/src/commands/run.ts
+++ b/projects/optic/src/commands/run.ts
@@ -118,9 +118,7 @@ export function registerRunCommand(cli: Command, config: OpticCliConfig) {
   cli
     .command('run')
     .description(
-      `Optic's CI workflow command.
-Tests that every OpenAPI specification in your repo is accurate, has no breaking changes and follows the standards you defined in the optic.yml file;
-then posts a comment with a report to your PR/MR and exits with code 1 when issues are found.`
+      'CI workflow command that tests each OpenAPI specification in your repo and summarizes the results as a pull (or merge) request comment.'
     )
     .configureHelp({ commandUsage: usage })
     .option(

--- a/projects/optic/src/commands/run.ts
+++ b/projects/optic/src/commands/run.ts
@@ -125,7 +125,7 @@ then posts a comment with a report to your PR/MR and exits with code 1 when issu
     .configureHelp({ commandUsage: usage })
     .option(
       '-i, --ignore <glob_pattern,...>',
-      'Glob patterns matching OpenAPI specifications to ignore'
+      'Glob patterns matching specifications to ignore'
     )
     .addOption(
       new Option(
@@ -145,7 +145,7 @@ then posts a comment with a report to your PR/MR and exits with code 1 when issu
     )
     .argument(
       '[file_paths]',
-      'OpenAPI specifications to process, comma separated globs. Leave empty to match all non-ignored OpenAPI files in your repository'
+      'Specifications to process, comma separated globs. Leave empty to match all non-ignored specifications in your repository'
     )
     .action(errorHandler(getRunAction(config), { command: 'run' }));
 }

--- a/projects/optic/src/commands/run.ts
+++ b/projects/optic/src/commands/run.ts
@@ -144,8 +144,8 @@ then posts a comment with a report to your PR/MR and exits with code 1 when issu
         .default('error')
     )
     .argument(
-      '[glob_pattern,...]',
-      'Glob patterns matching specifications to process. Leave empty to match all non-ignored specifications in your repository.'
+      'file_paths',
+      'Comma-seperated glob patterns matching specifications to process. When omitted, matches all non-ignored specifications.'
     )
     .action(errorHandler(getRunAction(config), { command: 'run' }));
 }

--- a/projects/optic/src/commands/run.ts
+++ b/projects/optic/src/commands/run.ts
@@ -124,25 +124,28 @@ then posts a comment with a report to your PR/MR and exits with code 1 when issu
     )
     .configureHelp({ commandUsage: usage })
     .option(
-      '--ignore <ignore-glob>',
-      'OpenAPI specification files to ignore, comma separated globs.'
-    )
-    .option(
-      '--include-git-ignored',
-      'Set to true to also match Git ignored files.',
-      false
+      '-i, --ignore <glob_pattern,...>',
+      'Glob patterns matching OpenAPI specifications to ignore'
     )
     .addOption(
       new Option(
-        '--severity <severity>',
-        'Set to "none" to prevent Optic from exiting 1 when issues are found.'
+        '-I, --include-git-ignored <bool>',
+        'Include specifications matched in .gitignore'
+      )
+        .choices(['true', 'false'])
+        .default('false')
+    )
+    .addOption(
+      new Option(
+        '-s, --severity <severity>',
+        'Control the exit code when there are issues: error=1, none=0'
       )
         .choices(severities)
         .default('error')
     )
     .argument(
       '[file_paths]',
-      'OpenAPI specification files to handle, comma separated globs. Leave empty to match all non-ignored OpenAPI files in your repository.'
+      'OpenAPI specifications to process, comma separated globs. Leave empty to match all non-ignored OpenAPI files in your repository'
     )
     .action(errorHandler(getRunAction(config), { command: 'run' }));
 }

--- a/projects/optic/src/commands/run.ts
+++ b/projects/optic/src/commands/run.ts
@@ -144,8 +144,8 @@ then posts a comment with a report to your PR/MR and exits with code 1 when issu
         .default('error')
     )
     .argument(
-      '[file_paths]',
-      'Specifications to process, comma separated globs. Leave empty to match all non-ignored specifications in your repository'
+      '[glob_pattern,...]',
+      'Glob patterns matching specifications to process. Leave empty to match all non-ignored specifications in your repository.'
     )
     .action(errorHandler(getRunAction(config), { command: 'run' }));
 }


### PR DESCRIPTION
working on going through all the help output and ensuring formatting and bits are consistent with the brief guidelines we wrote up. starting with `run`, not much to change here, but i tried to be more explicit about what the options are doing.

also, adds short forms for the options. im not sure why we generally dont do this. holler if there's a reason.

before,
```
Arguments:
  file_paths              OpenAPI specification files to handle, comma separated globs. Leave empty to match all
                          non-ignored OpenAPI files in your repository.

Options:
  --ignore <ignore-glob>  OpenAPI specification files to ignore, comma separated globs.
  --include-git-ignored   Set to true to also match Git ignored files. (default: false)
  --severity <severity>   Set to "none" to prevent Optic from exiting 1 when issues are found. (choices: "none",
                          "error", default: "error")
  -h, --help              display help for command
```

after,
```
Arguments:
  file_paths                        Comma-seperated glob patterns matching specifications to process. When
                                    omitted, matches all non-ignored specifications.

Options:
  -i, --ignore <glob_pattern,...>   Glob patterns matching specifications to ignore
  -I, --include-git-ignored <bool>  Include specifications matched in .gitignore (choices: "true", "false",
                                    default: "false")
  -s, --severity <severity>         Control the exit code when there are issues: error=1, none=0 (choices:
                                    "none", "error", default: "error")
  -h, --help                        display help for command
```