### PR TITLE
Support query params and missing headers / response headers in capture

### DIFF
--- a/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
@@ -3,12 +3,6 @@
 exports[`capture with inputs --har updating an OpenAPI spec 1`] = `
 "GET /books
   [32m✓ [39m200 response
-  [32m[header parameter] Host has been added[39m
-  [32m[header parameter] User-Agent has been added[39m
-  [32m[header parameter] Accept has been added[39m
-  [32m[200 response header] Host has been added[39m
-  [32m[200 response header] User-Agent has been added[39m
-  [32m[200 response header] Accept has been added[39m
   [32m[200 response body] 'data' has been added (/properties/data)[39m
   [32m[200 response body] 'next' has been added (/properties/next)[39m
   [32m[200 response body] 'has_more_data' has been added (/properties/has_more_data)[39m
@@ -39,38 +33,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetBooks200ResponseBody"
-          headers:
-            Host:
-              schema:
-                type: string
-              name: Host
-              required: true
-            User-Agent:
-              schema:
-                type: string
-              name: User-Agent
-              required: true
-            Accept:
-              schema:
-                type: string
-              name: Accept
-              required: true
-      parameters:
-        - schema:
-            type: string
-          in: header
-          name: Host
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: User-Agent
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept
-          required: true
     post:
       responses:
         "201":
@@ -79,63 +41,11 @@ paths:
             application/json; charset=utf-8:
               schema:
                 $ref: "#/components/schemas/PostBooks201ResponseBody"
-          headers:
-            Host:
-              schema:
-                type: string
-              name: Host
-              required: true
-            User-Agent:
-              schema:
-                type: string
-              name: User-Agent
-              required: true
-            Accept:
-              schema:
-                type: string
-              name: Accept
-              required: true
-            Content-Type:
-              schema:
-                type: string
-              name: Content-Type
-              required: true
-            Content-Length:
-              schema:
-                type: string
-              name: Content-Length
-              required: true
       requestBody:
         content:
           application/json:
             schema:
               $ref: "#/components/schemas/PostBooksRequestBody"
-      parameters:
-        - schema:
-            type: string
-          in: header
-          name: Host
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: User-Agent
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Content-Type
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Content-Length
-          required: true
   /authors/{author}:
     parameters:
       - in: path
@@ -151,38 +61,6 @@ paths:
             application/json; charset=utf-8:
               schema:
                 $ref: "#/components/schemas/GetAuthorsAuthor200ResponseBody"
-          headers:
-            Host:
-              schema:
-                type: string
-              name: Host
-              required: true
-            User-Agent:
-              schema:
-                type: string
-              name: User-Agent
-              required: true
-            Accept:
-              schema:
-                type: string
-              name: Accept
-              required: true
-      parameters:
-        - schema:
-            type: string
-          in: header
-          name: Host
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: User-Agent
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept
-          required: true
   /authors:
     post:
       responses:
@@ -192,63 +70,11 @@ paths:
             application/json; charset=utf-8:
               schema:
                 $ref: "#/components/schemas/PostAuthors201ResponseBody"
-          headers:
-            Host:
-              schema:
-                type: string
-              name: Host
-              required: true
-            User-Agent:
-              schema:
-                type: string
-              name: User-Agent
-              required: true
-            Accept:
-              schema:
-                type: string
-              name: Accept
-              required: true
-            Content-Type:
-              schema:
-                type: string
-              name: Content-Type
-              required: true
-            Content-Length:
-              schema:
-                type: string
-              name: Content-Length
-              required: true
       requestBody:
         content:
           application/json:
             schema:
               $ref: "#/components/schemas/PostAuthorsRequestBody"
-      parameters:
-        - schema:
-            type: string
-          in: header
-          name: Host
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: User-Agent
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Content-Type
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Content-Length
-          required: true
   /books/{book}:
     parameters:
       - in: path
@@ -264,38 +90,6 @@ paths:
             application/json; charset=utf-8:
               schema:
                 $ref: "#/components/schemas/GetAuthorsAuthor200ResponseBody"
-          headers:
-            Host:
-              schema:
-                type: string
-              name: Host
-              required: true
-            User-Agent:
-              schema:
-                type: string
-              name: User-Agent
-              required: true
-            Accept:
-              schema:
-                type: string
-              name: Accept
-              required: true
-      parameters:
-        - schema:
-            type: string
-          in: header
-          name: Host
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: User-Agent
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept
-          required: true
   /some/example:
     get:
       responses:
@@ -305,38 +99,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetSomeExample200ResponseBody"
-          headers:
-            Host:
-              schema:
-                type: string
-              name: Host
-              required: true
-            User-Agent:
-              schema:
-                type: string
-              name: User-Agent
-              required: true
-            Accept:
-              schema:
-                type: string
-              name: Accept
-              required: true
-      parameters:
-        - schema:
-            type: string
-          in: header
-          name: Host
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: User-Agent
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept
-          required: true
 components:
   schemas:
     GetBooks200ResponseBody:
@@ -471,18 +233,12 @@ components:
 exports[`capture with inputs --har verifying OpenAPI spec 1`] = `
 "GET /books
   [31m× [39m200 response
-  [31m[header parameter] Host is not documented[39m
-  [31m[header parameter] User-Agent is not documented[39m
-  [31m[header parameter] Accept is not documented[39m
-  [31m[200 response header] Host is not documented[39m
-  [31m[200 response header] User-Agent is not documented[39m
-  [31m[200 response header] Accept is not documented[39m
   [31m[200 response body] 'data' is not documented (/properties)[39m
   [31m[200 response body] 'next' is not documented (/properties)[39m
   [31m[200 response body] 'has_more_data' is not documented (/properties)[39m
 
 100.0% coverage of your documented operations. 7 requests did not match a documented path (8 total requests).
-9 diffs detected in documented operations
+3 diffs detected in documented operations
 
 [33mNew endpoints are only added in interactive mode. Run 'optic capture openapi.yml --update interactive' to add new endpoints[39m
 "
@@ -545,78 +301,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetAuthHawk200ResponseBody"
-          headers:
-            Access-Control-Allow-Credentials:
-              schema:
-                type: string
-              name: Access-Control-Allow-Credentials
-              required: true
-            Access-Control-Allow-Headers:
-              schema:
-                type: string
-              name: Access-Control-Allow-Headers
-              required: true
-            Access-Control-Allow-Methods:
-              schema:
-                type: string
-              name: Access-Control-Allow-Methods
-              required: true
-            Access-Control-Allow-Origin:
-              schema:
-                type: string
-              name: Access-Control-Allow-Origin
-              required: true
-            Connection:
-              schema:
-                type: string
-              name: Connection
-              required: true
-            Content-Encoding:
-              schema:
-                type: string
-              name: Content-Encoding
-              required: true
-            Content-Type:
-              schema:
-                type: string
-              name: Content-Type
-              required: true
-            Date:
-              schema:
-                type: string
-              name: Date
-              required: true
-            Server:
-              schema:
-                type: string
-              name: Server
-              required: true
-            Server-Authorization:
-              schema:
-                type: string
-              name: Server-Authorization
-              required: true
-            Vary:
-              schema:
-                type: string
-              name: Vary
-              required: true
-            X-Powered-By:
-              schema:
-                type: string
-              name: X-Powered-By
-              required: true
-            transfer-encoding:
-              schema:
-                type: string
-              name: transfer-encoding
-              required: true
-      parameters:
-        - schema:
-            type: string
-          in: header
-          name: Authorization
-          required: true
   /basic-auth:
     get:
       responses:
@@ -665,67 +349,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetDelayDelay200ResponseBody"
-          headers:
-            Access-Control-Allow-Credentials:
-              schema:
-                type: string
-              name: Access-Control-Allow-Credentials
-              required: true
-            Access-Control-Allow-Headers:
-              schema:
-                type: string
-              name: Access-Control-Allow-Headers
-              required: true
-            Access-Control-Allow-Methods:
-              schema:
-                type: string
-              name: Access-Control-Allow-Methods
-              required: true
-            Access-Control-Allow-Origin:
-              schema:
-                type: string
-              name: Access-Control-Allow-Origin
-              required: true
-            Access-Control-Expose-Headers:
-              schema:
-                type: string
-              name: Access-Control-Expose-Headers
-              required: true
-            Connection:
-              schema:
-                type: string
-              name: Connection
-              required: true
-            Content-Length:
-              schema:
-                type: string
-              name: Content-Length
-              required: true
-            Content-Type:
-              schema:
-                type: string
-              name: Content-Type
-              required: true
-            Date:
-              schema:
-                type: string
-              name: Date
-              required: true
-            ETag:
-              schema:
-                type: string
-              name: ETag
-              required: true
-            Server:
-              schema:
-                type: string
-              name: Server
-              required: true
-            Vary:
-              schema:
-                type: string
-              name: Vary
-              required: true
   /delete:
     delete:
       responses:
@@ -739,12 +362,6 @@ paths:
     get:
       responses:
         {}
-      parameters:
-        - schema:
-            type: string
-          in: header
-          name: Authorization
-          required: false
   /encoding/utf8:
     get:
       responses:
@@ -758,67 +375,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Get200ResponseBody"
-          headers:
-            Access-Control-Allow-Credentials:
-              schema:
-                type: string
-              name: Access-Control-Allow-Credentials
-              required: true
-            Access-Control-Allow-Headers:
-              schema:
-                type: string
-              name: Access-Control-Allow-Headers
-              required: true
-            Access-Control-Allow-Methods:
-              schema:
-                type: string
-              name: Access-Control-Allow-Methods
-              required: true
-            Access-Control-Allow-Origin:
-              schema:
-                type: string
-              name: Access-Control-Allow-Origin
-              required: true
-            Connection:
-              schema:
-                type: string
-              name: Connection
-              required: true
-            Content-Encoding:
-              schema:
-                type: string
-              name: Content-Encoding
-              required: true
-            Content-Length:
-              schema:
-                type: string
-              name: Content-Length
-              required: true
-            Content-Type:
-              schema:
-                type: string
-              name: Content-Type
-              required: true
-            Date:
-              schema:
-                type: string
-              name: Date
-              required: true
-            Server:
-              schema:
-                type: string
-              name: Server
-              required: true
-            Vary:
-              schema:
-                type: string
-              name: Vary
-              required: true
-            X-Powered-By:
-              schema:
-                type: string
-              name: X-Powered-By
-              required: true
   /get/hello:
     get:
       responses:
@@ -832,52 +388,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetGet200ResponseBody"
-          headers:
-            Content-Encoding:
-              schema:
-                type: string
-              name: Content-Encoding
-              required: true
-            Content-Type:
-              schema:
-                type: string
-              name: Content-Type
-              required: true
-            Date:
-              schema:
-                type: string
-              name: Date
-              required: true
-            ETag:
-              schema:
-                type: string
-              name: ETag
-              required: true
-            Server:
-              schema:
-                type: string
-              name: Server
-              required: true
-            set-cookie:
-              schema:
-                type: string
-              name: set-cookie
-              required: true
-            Vary:
-              schema:
-                type: string
-              name: Vary
-              required: true
-            Content-Length:
-              schema:
-                type: string
-              name: Content-Length
-              required: true
-            Connection:
-              schema:
-                type: string
-              name: Connection
-              required: true
       parameters:
         - schema:
             type: string
@@ -902,73 +412,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetHeaders200ResponseBody"
-          headers:
-            Access-Control-Allow-Credentials:
-              schema:
-                type: string
-              name: Access-Control-Allow-Credentials
-              required: true
-            Access-Control-Allow-Headers:
-              schema:
-                type: string
-              name: Access-Control-Allow-Headers
-              required: true
-            Access-Control-Allow-Methods:
-              schema:
-                type: string
-              name: Access-Control-Allow-Methods
-              required: true
-            Access-Control-Allow-Origin:
-              schema:
-                type: string
-              name: Access-Control-Allow-Origin
-              required: true
-            Connection:
-              schema:
-                type: string
-              name: Connection
-              required: true
-            Content-Encoding:
-              schema:
-                type: string
-              name: Content-Encoding
-              required: true
-            Content-Length:
-              schema:
-                type: string
-              name: Content-Length
-              required: true
-            Content-Type:
-              schema:
-                type: string
-              name: Content-Type
-              required: true
-            Date:
-              schema:
-                type: string
-              name: Date
-              required: true
-            Server:
-              schema:
-                type: string
-              name: Server
-              required: true
-            Vary:
-              schema:
-                type: string
-              name: Vary
-              required: true
-            X-Powered-By:
-              schema:
-                type: string
-              name: X-Powered-By
-              required: true
-      parameters:
-        - schema:
-            type: string
-          in: header
-          name: my-sample-header
-          required: false
   /ip:
     get:
       responses:
@@ -982,145 +425,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetOauth1401ResponseBody"
-          headers:
-            Access-Control-Allow-Credentials:
-              schema:
-                type: string
-              name: Access-Control-Allow-Credentials
-              required: true
-            Access-Control-Allow-Headers:
-              schema:
-                type: string
-              name: Access-Control-Allow-Headers
-              required: true
-            Access-Control-Allow-Methods:
-              schema:
-                type: string
-              name: Access-Control-Allow-Methods
-              required: true
-            Access-Control-Allow-Origin:
-              schema:
-                type: string
-              name: Access-Control-Allow-Origin
-              required: true
-            Access-Control-Expose-Headers:
-              schema:
-                type: string
-              name: Access-Control-Expose-Headers
-              required: true
-            Connection:
-              schema:
-                type: string
-              name: Connection
-              required: true
-            Content-Length:
-              schema:
-                type: string
-              name: Content-Length
-              required: true
-            Content-Type:
-              schema:
-                type: string
-              name: Content-Type
-              required: true
-            Date:
-              schema:
-                type: string
-              name: Date
-              required: true
-            ETag:
-              schema:
-                type: string
-              name: ETag
-              required: true
-            Server:
-              schema:
-                type: string
-              name: Server
-              required: true
-            Vary:
-              schema:
-                type: string
-              name: Vary
-              required: true
         "200":
           description: 200 response
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetAuthHawk200ResponseBody"
-          headers:
-            Access-Control-Allow-Credentials:
-              schema:
-                type: string
-              name: Access-Control-Allow-Credentials
-              required: true
-            Access-Control-Allow-Headers:
-              schema:
-                type: string
-              name: Access-Control-Allow-Headers
-              required: true
-            Access-Control-Allow-Methods:
-              schema:
-                type: string
-              name: Access-Control-Allow-Methods
-              required: true
-            Access-Control-Allow-Origin:
-              schema:
-                type: string
-              name: Access-Control-Allow-Origin
-              required: true
-            Access-Control-Expose-Headers:
-              schema:
-                type: string
-              name: Access-Control-Expose-Headers
-              required: true
-            Connection:
-              schema:
-                type: string
-              name: Connection
-              required: true
-            Content-Encoding:
-              schema:
-                type: string
-              name: Content-Encoding
-              required: true
-            Content-Length:
-              schema:
-                type: string
-              name: Content-Length
-              required: true
-            Content-Type:
-              schema:
-                type: string
-              name: Content-Type
-              required: true
-            Date:
-              schema:
-                type: string
-              name: Date
-              required: true
-            ETag:
-              schema:
-                type: string
-              name: ETag
-              required: true
-            Server:
-              schema:
-                type: string
-              name: Server
-              required: true
-            Vary:
-              schema:
-                type: string
-              name: Vary
-              required: true
-      parameters:
-        - schema:
-            type: string
-          in: header
-          name: Authorization
-          required: false
   /patch:
     patch:
       responses:
@@ -1163,72 +473,6 @@ paths:
             text/html:
               schema:
                 type: string
-          headers:
-            Access-Control-Allow-Credentials:
-              schema:
-                type: string
-              name: Access-Control-Allow-Credentials
-              required: true
-            Access-Control-Allow-Headers:
-              schema:
-                type: string
-              name: Access-Control-Allow-Headers
-              required: true
-            Access-Control-Allow-Methods:
-              schema:
-                type: string
-              name: Access-Control-Allow-Methods
-              required: true
-            Access-Control-Allow-Origin:
-              schema:
-                type: string
-              name: Access-Control-Allow-Origin
-              required: true
-            Connection:
-              schema:
-                type: string
-              name: Connection
-              required: true
-            Content-Encoding:
-              schema:
-                type: string
-              name: Content-Encoding
-              required: true
-            Content-Length:
-              schema:
-                type: string
-              name: Content-Length
-              required: true
-            Content-Type:
-              schema:
-                type: string
-              name: Content-Type
-              required: true
-            Date:
-              schema:
-                type: string
-              name: Date
-              required: true
-            Server:
-              schema:
-                type: string
-              name: Server
-              required: true
-            Vary:
-              schema:
-                type: string
-              name: Vary
-              required: true
-            X-Powered-By:
-              schema:
-                type: string
-              name: X-Powered-By
-              required: true
-            test:
-              schema:
-                type: string
-              name: test
-              required: true
       parameters:
         - schema:
             type: string
@@ -1265,67 +509,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetStatusStatus200ResponseBody"
-          headers:
-            Access-Control-Allow-Credentials:
-              schema:
-                type: string
-              name: Access-Control-Allow-Credentials
-              required: true
-            Access-Control-Allow-Headers:
-              schema:
-                type: string
-              name: Access-Control-Allow-Headers
-              required: true
-            Access-Control-Allow-Methods:
-              schema:
-                type: string
-              name: Access-Control-Allow-Methods
-              required: true
-            Access-Control-Allow-Origin:
-              schema:
-                type: string
-              name: Access-Control-Allow-Origin
-              required: true
-            Connection:
-              schema:
-                type: string
-              name: Connection
-              required: true
-            Content-Length:
-              schema:
-                type: string
-              name: Content-Length
-              required: true
-            Content-Type:
-              schema:
-                type: string
-              name: Content-Type
-              required: true
-            Date:
-              schema:
-                type: string
-              name: Date
-              required: true
-            ETag:
-              schema:
-                type: string
-              name: ETag
-              required: true
-            Server:
-              schema:
-                type: string
-              name: Server
-              required: true
-            Vary:
-              schema:
-                type: string
-              name: Vary
-              required: true
-            X-Powered-By:
-              schema:
-                type: string
-              name: X-Powered-By
-              required: true
   /stream/{stream}:
     parameters:
       - in: path
@@ -1354,77 +537,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetTimeTime200ResponseBody"
-          headers:
-            Access-Control-Allow-Credentials:
-              schema:
-                type: string
-              name: Access-Control-Allow-Credentials
-              required: true
-            Access-Control-Allow-Headers:
-              schema:
-                type: string
-              name: Access-Control-Allow-Headers
-              required: true
-            Access-Control-Allow-Methods:
-              schema:
-                type: string
-              name: Access-Control-Allow-Methods
-              required: true
-            Access-Control-Allow-Origin:
-              schema:
-                type: string
-              name: Access-Control-Allow-Origin
-              required: true
-            Access-Control-Expose-Headers:
-              schema:
-                type: string
-              name: Access-Control-Expose-Headers
-              required: true
-            Connection:
-              schema:
-                type: string
-              name: Connection
-              required: true
-            Content-Encoding:
-              schema:
-                type: string
-              name: Content-Encoding
-              required: false
-            Content-Length:
-              schema:
-                type: string
-              name: Content-Length
-              required: true
-            Content-Type:
-              schema:
-                type: string
-              name: Content-Type
-              required: true
-            Date:
-              schema:
-                type: string
-              name: Date
-              required: true
-            ETag:
-              schema:
-                type: string
-              name: ETag
-              required: true
-            Server:
-              schema:
-                type: string
-              name: Server
-              required: true
-            Vary:
-              schema:
-                type: string
-              name: Vary
-              required: true
-            set-cookie:
-              schema:
-                type: string
-              name: set-cookie
-              required: true
       parameters:
         - schema:
             type: string
@@ -1470,77 +582,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PostTransformCollection200ResponseBody"
-          headers:
-            Access-Control-Allow-Credentials:
-              schema:
-                type: string
-              name: Access-Control-Allow-Credentials
-              required: true
-            Access-Control-Allow-Headers:
-              schema:
-                type: string
-              name: Access-Control-Allow-Headers
-              required: true
-            Access-Control-Allow-Methods:
-              schema:
-                type: string
-              name: Access-Control-Allow-Methods
-              required: true
-            Access-Control-Allow-Origin:
-              schema:
-                type: string
-              name: Access-Control-Allow-Origin
-              required: true
-            Access-Control-Expose-Headers:
-              schema:
-                type: string
-              name: Access-Control-Expose-Headers
-              required: true
-            Connection:
-              schema:
-                type: string
-              name: Connection
-              required: true
-            Content-Encoding:
-              schema:
-                type: string
-              name: Content-Encoding
-              required: true
-            Content-Type:
-              schema:
-                type: string
-              name: Content-Type
-              required: true
-            Date:
-              schema:
-                type: string
-              name: Date
-              required: true
-            ETag:
-              schema:
-                type: string
-              name: ETag
-              required: true
-            Server:
-              schema:
-                type: string
-              name: Server
-              required: true
-            Vary:
-              schema:
-                type: string
-              name: Vary
-              required: true
-            set-cookie:
-              schema:
-                type: string
-              name: set-cookie
-              required: true
-            transfer-encoding:
-              schema:
-                type: string
-              name: transfer-encoding
-              required: true
       requestBody:
         content:
           application/json:
@@ -1557,11 +598,6 @@ paths:
           in: query
           name: to
           required: true
-        - schema:
-            type: string
-          in: header
-          name: Content-Type
-          required: false
 components:
   schemas:
     GetBooks200ResponseBody:
@@ -2150,68 +1186,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetBooks200ResponseBody"
-          headers:
-            content-type:
-              schema:
-                type: string
-              name: content-type
-              required: true
-            Accept:
-              schema:
-                type: string
-              name: Accept
-              required: true
-            User-Agent:
-              schema:
-                type: string
-              name: User-Agent
-              required: true
-            Accept-Encoding:
-              schema:
-                type: string
-              name: Accept-Encoding
-              required: true
-            Host:
-              schema:
-                type: string
-              name: Host
-              required: true
-            Connection:
-              schema:
-                type: string
-              name: Connection
-              required: true
-      parameters:
-        - schema:
-            type: string
-          in: header
-          name: content-type
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: User-Agent
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept-Encoding
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Host
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Connection
-          required: true
   /authors:
     get:
       responses:
@@ -2221,68 +1195,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetAuthors200ResponseBody"
-          headers:
-            content-type:
-              schema:
-                type: string
-              name: content-type
-              required: true
-            Accept:
-              schema:
-                type: string
-              name: Accept
-              required: true
-            User-Agent:
-              schema:
-                type: string
-              name: User-Agent
-              required: true
-            Accept-Encoding:
-              schema:
-                type: string
-              name: Accept-Encoding
-              required: true
-            Host:
-              schema:
-                type: string
-              name: Host
-              required: true
-            Connection:
-              schema:
-                type: string
-              name: Connection
-              required: true
-      parameters:
-        - schema:
-            type: string
-          in: header
-          name: content-type
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: User-Agent
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept-Encoding
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Host
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Connection
-          required: true
   /books/{book}:
     parameters:
       - in: path
@@ -2298,68 +1210,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetBooksBook200ResponseBody"
-          headers:
-            content-type:
-              schema:
-                type: string
-              name: content-type
-              required: true
-            Accept:
-              schema:
-                type: string
-              name: Accept
-              required: true
-            User-Agent:
-              schema:
-                type: string
-              name: User-Agent
-              required: true
-            Accept-Encoding:
-              schema:
-                type: string
-              name: Accept-Encoding
-              required: true
-            Host:
-              schema:
-                type: string
-              name: Host
-              required: true
-            Connection:
-              schema:
-                type: string
-              name: Connection
-              required: true
-      parameters:
-        - schema:
-            type: string
-          in: header
-          name: content-type
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: User-Agent
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept-Encoding
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Host
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Connection
-          required: true
     post:
       responses:
         "200":
@@ -2368,83 +1218,11 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetBooksBook200ResponseBody"
-          headers:
-            content-type:
-              schema:
-                type: string
-              name: content-type
-              required: true
-            Accept:
-              schema:
-                type: string
-              name: Accept
-              required: true
-            Content-Length:
-              schema:
-                type: string
-              name: Content-Length
-              required: true
-            User-Agent:
-              schema:
-                type: string
-              name: User-Agent
-              required: true
-            Accept-Encoding:
-              schema:
-                type: string
-              name: Accept-Encoding
-              required: true
-            Host:
-              schema:
-                type: string
-              name: Host
-              required: true
-            Connection:
-              schema:
-                type: string
-              name: Connection
-              required: true
       requestBody:
         content:
           application/json;charset=UTF-8:
             schema:
               $ref: "#/components/schemas/PostBooksBookRequestBody"
-      parameters:
-        - schema:
-            type: string
-          in: header
-          name: content-type
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Content-Length
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: User-Agent
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept-Encoding
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Host
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Connection
-          required: true
 components:
   schemas:
     GetBooks200ResponseBody:
@@ -2522,18 +1300,6 @@ exports[`capture with requests update behavior handle servers not at root of hos
 "Generating traffic to send to server
 GET /books
   [32m✓ [39m200 response
-  [32m[header parameter] content-type has been added[39m
-  [32m[header parameter] Accept has been added[39m
-  [32m[header parameter] User-Agent has been added[39m
-  [32m[header parameter] Accept-Encoding has been added[39m
-  [32m[header parameter] Host has been added[39m
-  [32m[header parameter] Connection has been added[39m
-  [32m[200 response header] content-type has been added[39m
-  [32m[200 response header] Accept has been added[39m
-  [32m[200 response header] User-Agent has been added[39m
-  [32m[200 response header] Accept-Encoding has been added[39m
-  [32m[200 response header] Host has been added[39m
-  [32m[200 response header] Connection has been added[39m
   [32m[200 response body] 'name' has been added (/properties/books/items/properties/name)[39m
   [32m[200 response body] 'author_id' has been added (/properties/books/items/properties/author_id)[39m
   [32m[200 response body] 'status' has been added (/properties/books/items/properties/status)[39m
@@ -2565,68 +1331,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetBooks200ResponseBody"
-          headers:
-            content-type:
-              schema:
-                type: string
-              name: content-type
-              required: true
-            Accept:
-              schema:
-                type: string
-              name: Accept
-              required: true
-            User-Agent:
-              schema:
-                type: string
-              name: User-Agent
-              required: true
-            Accept-Encoding:
-              schema:
-                type: string
-              name: Accept-Encoding
-              required: true
-            Host:
-              schema:
-                type: string
-              name: Host
-              required: true
-            Connection:
-              schema:
-                type: string
-              name: Connection
-              required: true
-      parameters:
-        - schema:
-            type: string
-          in: header
-          name: content-type
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: User-Agent
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept-Encoding
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Host
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Connection
-          required: true
   /authors:
     get:
       responses:
@@ -2636,68 +1340,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetAuthors200ResponseBody"
-          headers:
-            content-type:
-              schema:
-                type: string
-              name: content-type
-              required: true
-            Accept:
-              schema:
-                type: string
-              name: Accept
-              required: true
-            User-Agent:
-              schema:
-                type: string
-              name: User-Agent
-              required: true
-            Accept-Encoding:
-              schema:
-                type: string
-              name: Accept-Encoding
-              required: true
-            Host:
-              schema:
-                type: string
-              name: Host
-              required: true
-            Connection:
-              schema:
-                type: string
-              name: Connection
-              required: true
-      parameters:
-        - schema:
-            type: string
-          in: header
-          name: content-type
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: User-Agent
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept-Encoding
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Host
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Connection
-          required: true
   /books/{book}:
     parameters:
       - in: path
@@ -2713,68 +1355,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetBooksBook200ResponseBody"
-          headers:
-            content-type:
-              schema:
-                type: string
-              name: content-type
-              required: true
-            Accept:
-              schema:
-                type: string
-              name: Accept
-              required: true
-            User-Agent:
-              schema:
-                type: string
-              name: User-Agent
-              required: true
-            Accept-Encoding:
-              schema:
-                type: string
-              name: Accept-Encoding
-              required: true
-            Host:
-              schema:
-                type: string
-              name: Host
-              required: true
-            Connection:
-              schema:
-                type: string
-              name: Connection
-              required: true
-      parameters:
-        - schema:
-            type: string
-          in: header
-          name: content-type
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: User-Agent
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept-Encoding
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Host
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Connection
-          required: true
     post:
       responses:
         "200":
@@ -2783,83 +1363,11 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetBooksBook200ResponseBody"
-          headers:
-            content-type:
-              schema:
-                type: string
-              name: content-type
-              required: true
-            Accept:
-              schema:
-                type: string
-              name: Accept
-              required: true
-            Content-Length:
-              schema:
-                type: string
-              name: Content-Length
-              required: true
-            User-Agent:
-              schema:
-                type: string
-              name: User-Agent
-              required: true
-            Accept-Encoding:
-              schema:
-                type: string
-              name: Accept-Encoding
-              required: true
-            Host:
-              schema:
-                type: string
-              name: Host
-              required: true
-            Connection:
-              schema:
-                type: string
-              name: Connection
-              required: true
       requestBody:
         content:
           application/json;charset=UTF-8:
             schema:
               $ref: "#/components/schemas/PostBooksBookRequestBody"
-      parameters:
-        - schema:
-            type: string
-          in: header
-          name: content-type
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Content-Length
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: User-Agent
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept-Encoding
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Host
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Connection
-          required: true
 components:
   schemas:
     GetBooks200ResponseBody:
@@ -2959,18 +1467,6 @@ exports[`capture with requests update behavior handles update in other file 1`] 
 "Generating traffic to send to server
 GET /books
   [32m✓ [39m200 response
-  [32m[header parameter] content-type has been added[39m
-  [32m[header parameter] Accept has been added[39m
-  [32m[header parameter] User-Agent has been added[39m
-  [32m[header parameter] Accept-Encoding has been added[39m
-  [32m[header parameter] Host has been added[39m
-  [32m[header parameter] Connection has been added[39m
-  [32m[200 response header] content-type has been added[39m
-  [32m[200 response header] Accept has been added[39m
-  [32m[200 response header] User-Agent has been added[39m
-  [32m[200 response header] Accept-Encoding has been added[39m
-  [32m[200 response header] Host has been added[39m
-  [32m[200 response header] Connection has been added[39m
   [32m[200 response body] 'name' has been added (/properties/books/items/properties/name)[39m
   [32m[200 response body] 'author_id' has been added (/properties/books/items/properties/author_id)[39m
   [32m[200 response body] 'status' has been added (/properties/books/items/properties/status)[39m
@@ -2996,68 +1492,6 @@ paths:
             application/json:
               schema:
                 $ref: ./components/books.yml#/GetBooks200ResponseBody
-          headers:
-            content-type:
-              schema:
-                type: string
-              name: content-type
-              required: true
-            Accept:
-              schema:
-                type: string
-              name: Accept
-              required: true
-            User-Agent:
-              schema:
-                type: string
-              name: User-Agent
-              required: true
-            Accept-Encoding:
-              schema:
-                type: string
-              name: Accept-Encoding
-              required: true
-            Host:
-              schema:
-                type: string
-              name: Host
-              required: true
-            Connection:
-              schema:
-                type: string
-              name: Connection
-              required: true
-      parameters:
-        - schema:
-            type: string
-          in: header
-          name: content-type
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: User-Agent
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept-Encoding
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Host
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Connection
-          required: true
 "
 `;
 
@@ -3100,18 +1534,6 @@ GET /authors
   [32m✓ [39m200 response
 GET /books
   [32m✓ [39m200 response
-  [32m[header parameter] content-type has been added[39m
-  [32m[header parameter] Accept has been added[39m
-  [32m[header parameter] User-Agent has been added[39m
-  [32m[header parameter] Accept-Encoding has been added[39m
-  [32m[header parameter] Host has been added[39m
-  [32m[header parameter] Connection has been added[39m
-  [32m[200 response header] content-type has been added[39m
-  [32m[200 response header] Accept has been added[39m
-  [32m[200 response header] User-Agent has been added[39m
-  [32m[200 response header] Accept-Encoding has been added[39m
-  [32m[200 response header] Host has been added[39m
-  [32m[200 response header] Connection has been added[39m
   [32m[200 response body] 'name' has been added (/properties/books/items/properties/name)[39m
   [32m[200 response body] 'author_id' has been added (/properties/books/items/properties/author_id)[39m
   [32m[200 response body] 'status' has been added (/properties/books/items/properties/status)[39m
@@ -3145,68 +1567,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetBooks200ResponseBody"
-          headers:
-            content-type:
-              schema:
-                type: string
-              name: content-type
-              required: true
-            Accept:
-              schema:
-                type: string
-              name: Accept
-              required: true
-            User-Agent:
-              schema:
-                type: string
-              name: User-Agent
-              required: true
-            Accept-Encoding:
-              schema:
-                type: string
-              name: Accept-Encoding
-              required: true
-            Host:
-              schema:
-                type: string
-              name: Host
-              required: true
-            Connection:
-              schema:
-                type: string
-              name: Connection
-              required: true
-      parameters:
-        - schema:
-            type: string
-          in: header
-          name: content-type
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: User-Agent
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept-Encoding
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Host
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Connection
-          required: true
   /authors:
     get:
       responses:
@@ -3231,83 +1591,11 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PostBooksBook200ResponseBody"
-          headers:
-            content-type:
-              schema:
-                type: string
-              name: content-type
-              required: true
-            Accept:
-              schema:
-                type: string
-              name: Accept
-              required: true
-            Content-Length:
-              schema:
-                type: string
-              name: Content-Length
-              required: true
-            User-Agent:
-              schema:
-                type: string
-              name: User-Agent
-              required: true
-            Accept-Encoding:
-              schema:
-                type: string
-              name: Accept-Encoding
-              required: true
-            Host:
-              schema:
-                type: string
-              name: Host
-              required: true
-            Connection:
-              schema:
-                type: string
-              name: Connection
-              required: true
       requestBody:
         content:
           application/json;charset=UTF-8:
             schema:
               $ref: "#/components/schemas/PostBooksBookRequestBody"
-      parameters:
-        - schema:
-            type: string
-          in: header
-          name: content-type
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Content-Length
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: User-Agent
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept-Encoding
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Host
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Connection
-          required: true
 components:
   schemas:
     GetBooks200ResponseBody:
@@ -3384,18 +1672,6 @@ exports[`capture with requests update behavior updates all endpoints with --upda
 "Generating traffic to send to server
 GET /books
   [32m✓ [39m200 response
-  [32m[header parameter] content-type has been added[39m
-  [32m[header parameter] Accept has been added[39m
-  [32m[header parameter] User-Agent has been added[39m
-  [32m[header parameter] Accept-Encoding has been added[39m
-  [32m[header parameter] Host has been added[39m
-  [32m[header parameter] Connection has been added[39m
-  [32m[200 response header] content-type has been added[39m
-  [32m[200 response header] Accept has been added[39m
-  [32m[200 response header] User-Agent has been added[39m
-  [32m[200 response header] Accept-Encoding has been added[39m
-  [32m[200 response header] Host has been added[39m
-  [32m[200 response header] Connection has been added[39m
   [32m[200 response body] 'name' has been added (/properties/books/items/properties/name)[39m
   [32m[200 response body] 'created_at' has been added (/properties/books/items/properties/created_at)[39m
   [32m[200 response body] 'updated_at' has been added (/properties/books/items/properties/updated_at)[39m
@@ -3435,68 +1711,6 @@ paths:
               schema:
                 # use the refs here
                 $ref: "#/components/schemas/GetBooks200ResponseBody"
-          headers:
-            content-type:
-              schema:
-                type: string
-              name: content-type
-              required: true
-            Accept:
-              schema:
-                type: string
-              name: Accept
-              required: true
-            User-Agent:
-              schema:
-                type: string
-              name: User-Agent
-              required: true
-            Accept-Encoding:
-              schema:
-                type: string
-              name: Accept-Encoding
-              required: true
-            Host:
-              schema:
-                type: string
-              name: Host
-              required: true
-            Connection:
-              schema:
-                type: string
-              name: Connection
-              required: true
-      parameters:
-        - schema:
-            type: string
-          in: header
-          name: content-type
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: User-Agent
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept-Encoding
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Host
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Connection
-          required: true
   /authors:
     get:
       responses:
@@ -3506,68 +1720,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetAuthors200ResponseBody"
-          headers:
-            content-type:
-              schema:
-                type: string
-              name: content-type
-              required: true
-            Accept:
-              schema:
-                type: string
-              name: Accept
-              required: true
-            User-Agent:
-              schema:
-                type: string
-              name: User-Agent
-              required: true
-            Accept-Encoding:
-              schema:
-                type: string
-              name: Accept-Encoding
-              required: true
-            Host:
-              schema:
-                type: string
-              name: Host
-              required: true
-            Connection:
-              schema:
-                type: string
-              name: Connection
-              required: true
-      parameters:
-        - schema:
-            type: string
-          in: header
-          name: content-type
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: User-Agent
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept-Encoding
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Host
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Connection
-          required: true
   /books/{book}:
     parameters:
       - in: path
@@ -3583,68 +1735,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetBooksBook200ResponseBody"
-          headers:
-            content-type:
-              schema:
-                type: string
-              name: content-type
-              required: true
-            Accept:
-              schema:
-                type: string
-              name: Accept
-              required: true
-            User-Agent:
-              schema:
-                type: string
-              name: User-Agent
-              required: true
-            Accept-Encoding:
-              schema:
-                type: string
-              name: Accept-Encoding
-              required: true
-            Host:
-              schema:
-                type: string
-              name: Host
-              required: true
-            Connection:
-              schema:
-                type: string
-              name: Connection
-              required: true
-      parameters:
-        - schema:
-            type: string
-          in: header
-          name: content-type
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: User-Agent
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept-Encoding
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Host
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Connection
-          required: true
     post:
       responses:
         "200":
@@ -3653,83 +1743,11 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetBooksBook200ResponseBody"
-          headers:
-            content-type:
-              schema:
-                type: string
-              name: content-type
-              required: true
-            Accept:
-              schema:
-                type: string
-              name: Accept
-              required: true
-            Content-Length:
-              schema:
-                type: string
-              name: Content-Length
-              required: true
-            User-Agent:
-              schema:
-                type: string
-              name: User-Agent
-              required: true
-            Accept-Encoding:
-              schema:
-                type: string
-              name: Accept-Encoding
-              required: true
-            Host:
-              schema:
-                type: string
-              name: Host
-              required: true
-            Connection:
-              schema:
-                type: string
-              name: Connection
-              required: true
       requestBody:
         content:
           application/json;charset=UTF-8:
             schema:
               $ref: "#/components/schemas/PostBooksBookRequestBody"
-      parameters:
-        - schema:
-            type: string
-          in: header
-          name: content-type
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Content-Length
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: User-Agent
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept-Encoding
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Host
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Connection
-          required: true
   /:
     get:
       responses:
@@ -3739,68 +1757,6 @@ paths:
             text/html:
               schema:
                 type: string
-          headers:
-            content-type:
-              schema:
-                type: string
-              name: content-type
-              required: true
-            Accept:
-              schema:
-                type: string
-              name: Accept
-              required: true
-            User-Agent:
-              schema:
-                type: string
-              name: User-Agent
-              required: true
-            Accept-Encoding:
-              schema:
-                type: string
-              name: Accept-Encoding
-              required: true
-            Host:
-              schema:
-                type: string
-              name: Host
-              required: true
-            Connection:
-              schema:
-                type: string
-              name: Connection
-              required: true
-      parameters:
-        - schema:
-            type: string
-          in: header
-          name: content-type
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: User-Agent
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept-Encoding
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Host
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Connection
-          required: true
 components:
   schemas:
     # this is a schema
@@ -3908,18 +1864,6 @@ exports[`capture with requests update behavior updates only existing endpoints b
 "Generating traffic to send to server
 GET /books
   [32m✓ [39m200 response
-  [32m[header parameter] content-type has been added[39m
-  [32m[header parameter] Accept has been added[39m
-  [32m[header parameter] User-Agent has been added[39m
-  [32m[header parameter] Accept-Encoding has been added[39m
-  [32m[header parameter] Host has been added[39m
-  [32m[header parameter] Connection has been added[39m
-  [32m[200 response header] content-type has been added[39m
-  [32m[200 response header] Accept has been added[39m
-  [32m[200 response header] User-Agent has been added[39m
-  [32m[200 response header] Accept-Encoding has been added[39m
-  [32m[200 response header] Host has been added[39m
-  [32m[200 response header] Connection has been added[39m
   [32m[200 response body] 'name' has been added (/properties/books/items/properties/name)[39m
   [32m[200 response body] 'created_at' has been added (/properties/books/items/properties/created_at)[39m
   [32m[200 response body] 'updated_at' has been added (/properties/books/items/properties/updated_at)[39m
@@ -3956,68 +1900,6 @@ paths:
               schema:
                 # use the refs here
                 $ref: "#/components/schemas/GetBooks200ResponseBody"
-          headers:
-            content-type:
-              schema:
-                type: string
-              name: content-type
-              required: true
-            Accept:
-              schema:
-                type: string
-              name: Accept
-              required: true
-            User-Agent:
-              schema:
-                type: string
-              name: User-Agent
-              required: true
-            Accept-Encoding:
-              schema:
-                type: string
-              name: Accept-Encoding
-              required: true
-            Host:
-              schema:
-                type: string
-              name: Host
-              required: true
-            Connection:
-              schema:
-                type: string
-              name: Connection
-              required: true
-      parameters:
-        - schema:
-            type: string
-          in: header
-          name: content-type
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: User-Agent
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Accept-Encoding
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Host
-          required: true
-        - schema:
-            type: string
-          in: header
-          name: Connection
-          required: true
 components:
   schemas:
     # this is a schema
@@ -4064,53 +1946,17 @@ exports[`capture with requests verify behavior verifies spec with endpoint speci
 "Generating traffic to send to server
 GET /books/status
   [32m✓ [39m200 response
-  [31m[header parameter] content-type is not documented[39m
-  [31m[header parameter] Accept is not documented[39m
-  [31m[header parameter] User-Agent is not documented[39m
-  [31m[header parameter] Accept-Encoding is not documented[39m
-  [31m[header parameter] Host is not documented[39m
-  [31m[header parameter] Connection is not documented[39m
-  [31m[200 response header] content-type is not documented[39m
-  [31m[200 response header] Accept is not documented[39m
-  [31m[200 response header] User-Agent is not documented[39m
-  [31m[200 response header] Accept-Encoding is not documented[39m
-  [31m[200 response header] Host is not documented[39m
-  [31m[200 response header] Connection is not documented[39m
 GET /books/{bookId}
   [31m× [39m200 response
-  [31m[header parameter] content-type is not documented[39m
-  [31m[header parameter] Accept is not documented[39m
-  [31m[header parameter] User-Agent is not documented[39m
-  [31m[header parameter] Accept-Encoding is not documented[39m
-  [31m[header parameter] Host is not documented[39m
-  [31m[header parameter] Connection is not documented[39m
-  [31m[200 response header] content-type is not documented[39m
-  [31m[200 response header] Accept is not documented[39m
-  [31m[200 response header] User-Agent is not documented[39m
-  [31m[200 response header] Accept-Encoding is not documented[39m
-  [31m[200 response header] Host is not documented[39m
-  [31m[200 response header] Connection is not documented[39m
   [31m[200 response body] 'status' is not documented (/properties)[39m
   [31m[200 response body] 'price' is not documented (/properties)[39m
 GET /books
   200 response
   [31m[404 response body] body is not documented[39m
   [31m[query parameter] list is not documented[39m
-  [31m[header parameter] content-type is not documented[39m
-  [31m[header parameter] Accept is not documented[39m
-  [31m[header parameter] User-Agent is not documented[39m
-  [31m[header parameter] Accept-Encoding is not documented[39m
-  [31m[header parameter] Host is not documented[39m
-  [31m[header parameter] Connection is not documented[39m
-  [31m[404 response header] content-type is not documented[39m
-  [31m[404 response header] Accept is not documented[39m
-  [31m[404 response header] User-Agent is not documented[39m
-  [31m[404 response header] Accept-Encoding is not documented[39m
-  [31m[404 response header] Host is not documented[39m
-  [31m[404 response header] Connection is not documented[39m
 
 83.3% coverage of your documented operations. 2 requests did not match a documented path (6 total requests).
-40 diffs detected in documented operations
+4 diffs detected in documented operations
 
 [33mNew endpoints are only added in interactive mode. Run 'optic capture openapi-with-overlapping-paths.yml --update interactive' to add new endpoints[39m
 "
@@ -4120,18 +1966,6 @@ exports[`capture with requests verify behavior verifies the specification in ver
 "Generating traffic to send to server
 GET /books
   [31m× [39m200 response
-  [31m[header parameter] content-type is not documented[39m
-  [31m[header parameter] Accept is not documented[39m
-  [31m[header parameter] User-Agent is not documented[39m
-  [31m[header parameter] Accept-Encoding is not documented[39m
-  [31m[header parameter] Host is not documented[39m
-  [31m[header parameter] Connection is not documented[39m
-  [31m[200 response header] content-type is not documented[39m
-  [31m[200 response header] Accept is not documented[39m
-  [31m[200 response header] User-Agent is not documented[39m
-  [31m[200 response header] Accept-Encoding is not documented[39m
-  [31m[200 response header] Host is not documented[39m
-  [31m[200 response header] Connection is not documented[39m
   [31m[200 response body] 'name' is not documented (/properties/books/items/properties)[39m
   [31m[200 response body] 'created_at' is not documented (/properties/books/items/properties)[39m
   [31m[200 response body] 'updated_at' is not documented (/properties/books/items/properties)[39m
@@ -4171,7 +2005,7 @@ GET /books
 [90m...and 1 endpoint that did not receive traffic[39m
 
 66.7% coverage of your documented operations. 5 requests did not match a documented path (6 total requests).
-21 diffs detected in documented operations
+9 diffs detected in documented operations
 
 [33mNew endpoints are only added in interactive mode. Run 'optic capture openapi.yml --update interactive' to add new endpoints[39m
 "
@@ -4181,18 +2015,6 @@ exports[`capture with requests verify behavior verifies the specification with c
 "Generating traffic to send to server
 GET /books
   [31m× [39m200 response
-  [31m[header parameter] content-type is not documented[39m
-  [31m[header parameter] Accept is not documented[39m
-  [31m[header parameter] User-Agent is not documented[39m
-  [31m[header parameter] Accept-Encoding is not documented[39m
-  [31m[header parameter] Host is not documented[39m
-  [31m[header parameter] Connection is not documented[39m
-  [31m[200 response header] content-type is not documented[39m
-  [31m[200 response header] Accept is not documented[39m
-  [31m[200 response header] User-Agent is not documented[39m
-  [31m[200 response header] Accept-Encoding is not documented[39m
-  [31m[200 response header] Host is not documented[39m
-  [31m[200 response header] Connection is not documented[39m
   [31m[200 response body] 'name' is not documented (/properties/books/items/properties)[39m
   [31m[200 response body] 'created_at' is not documented (/properties/books/items/properties)[39m
   [31m[200 response body] 'updated_at' is not documented (/properties/books/items/properties)[39m
@@ -4202,7 +2024,7 @@ GET /books
 [90m...and 1 endpoint that did not receive traffic[39m
 
 66.7% coverage of your documented operations. 5 requests did not match a documented path (6 total requests).
-18 diffs detected in documented operations
+6 diffs detected in documented operations
 
 [33mNew endpoints are only added in interactive mode. Run 'optic capture openapi.yml --update interactive' to add new endpoints[39m
 "

--- a/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
@@ -3,6 +3,12 @@
 exports[`capture with inputs --har updating an OpenAPI spec 1`] = `
 "GET /books
   [32m✓ [39m200 response
+  [32m[header parameter] Host has been added[39m
+  [32m[header parameter] User-Agent has been added[39m
+  [32m[header parameter] Accept has been added[39m
+  [32m[200 response header] Host has been added[39m
+  [32m[200 response header] User-Agent has been added[39m
+  [32m[200 response header] Accept has been added[39m
   [32m[200 response body] 'data' has been added (/properties/data)[39m
   [32m[200 response body] 'next' has been added (/properties/next)[39m
   [32m[200 response body] 'has_more_data' has been added (/properties/has_more_data)[39m
@@ -33,6 +39,38 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetBooks200ResponseBody"
+          headers:
+            Host:
+              schema:
+                type: string
+              name: Host
+              required: true
+            User-Agent:
+              schema:
+                type: string
+              name: User-Agent
+              required: true
+            Accept:
+              schema:
+                type: string
+              name: Accept
+              required: true
+      parameters:
+        - schema:
+            type: string
+          in: header
+          name: Host
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: User-Agent
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept
+          required: true
     post:
       responses:
         "201":
@@ -41,11 +79,63 @@ paths:
             application/json; charset=utf-8:
               schema:
                 $ref: "#/components/schemas/PostBooks201ResponseBody"
+          headers:
+            Host:
+              schema:
+                type: string
+              name: Host
+              required: true
+            User-Agent:
+              schema:
+                type: string
+              name: User-Agent
+              required: true
+            Accept:
+              schema:
+                type: string
+              name: Accept
+              required: true
+            Content-Type:
+              schema:
+                type: string
+              name: Content-Type
+              required: true
+            Content-Length:
+              schema:
+                type: string
+              name: Content-Length
+              required: true
       requestBody:
         content:
           application/json:
             schema:
               $ref: "#/components/schemas/PostBooksRequestBody"
+      parameters:
+        - schema:
+            type: string
+          in: header
+          name: Host
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: User-Agent
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Content-Type
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Content-Length
+          required: true
   /authors/{author}:
     parameters:
       - in: path
@@ -61,6 +151,38 @@ paths:
             application/json; charset=utf-8:
               schema:
                 $ref: "#/components/schemas/GetAuthorsAuthor200ResponseBody"
+          headers:
+            Host:
+              schema:
+                type: string
+              name: Host
+              required: true
+            User-Agent:
+              schema:
+                type: string
+              name: User-Agent
+              required: true
+            Accept:
+              schema:
+                type: string
+              name: Accept
+              required: true
+      parameters:
+        - schema:
+            type: string
+          in: header
+          name: Host
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: User-Agent
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept
+          required: true
   /authors:
     post:
       responses:
@@ -70,11 +192,63 @@ paths:
             application/json; charset=utf-8:
               schema:
                 $ref: "#/components/schemas/PostAuthors201ResponseBody"
+          headers:
+            Host:
+              schema:
+                type: string
+              name: Host
+              required: true
+            User-Agent:
+              schema:
+                type: string
+              name: User-Agent
+              required: true
+            Accept:
+              schema:
+                type: string
+              name: Accept
+              required: true
+            Content-Type:
+              schema:
+                type: string
+              name: Content-Type
+              required: true
+            Content-Length:
+              schema:
+                type: string
+              name: Content-Length
+              required: true
       requestBody:
         content:
           application/json:
             schema:
               $ref: "#/components/schemas/PostAuthorsRequestBody"
+      parameters:
+        - schema:
+            type: string
+          in: header
+          name: Host
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: User-Agent
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Content-Type
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Content-Length
+          required: true
   /books/{book}:
     parameters:
       - in: path
@@ -90,6 +264,38 @@ paths:
             application/json; charset=utf-8:
               schema:
                 $ref: "#/components/schemas/GetAuthorsAuthor200ResponseBody"
+          headers:
+            Host:
+              schema:
+                type: string
+              name: Host
+              required: true
+            User-Agent:
+              schema:
+                type: string
+              name: User-Agent
+              required: true
+            Accept:
+              schema:
+                type: string
+              name: Accept
+              required: true
+      parameters:
+        - schema:
+            type: string
+          in: header
+          name: Host
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: User-Agent
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept
+          required: true
   /some/example:
     get:
       responses:
@@ -99,6 +305,38 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetSomeExample200ResponseBody"
+          headers:
+            Host:
+              schema:
+                type: string
+              name: Host
+              required: true
+            User-Agent:
+              schema:
+                type: string
+              name: User-Agent
+              required: true
+            Accept:
+              schema:
+                type: string
+              name: Accept
+              required: true
+      parameters:
+        - schema:
+            type: string
+          in: header
+          name: Host
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: User-Agent
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept
+          required: true
 components:
   schemas:
     GetBooks200ResponseBody:
@@ -233,12 +471,18 @@ components:
 exports[`capture with inputs --har verifying OpenAPI spec 1`] = `
 "GET /books
   [31m× [39m200 response
+  [31m[header parameter] Host is not documented[39m
+  [31m[header parameter] User-Agent is not documented[39m
+  [31m[header parameter] Accept is not documented[39m
+  [31m[200 response header] Host is not documented[39m
+  [31m[200 response header] User-Agent is not documented[39m
+  [31m[200 response header] Accept is not documented[39m
   [31m[200 response body] 'data' is not documented (/properties)[39m
   [31m[200 response body] 'next' is not documented (/properties)[39m
   [31m[200 response body] 'has_more_data' is not documented (/properties)[39m
 
 100.0% coverage of your documented operations. 7 requests did not match a documented path (8 total requests).
-3 diffs detected in documented operations
+9 diffs detected in documented operations
 
 [33mNew endpoints are only added in interactive mode. Run 'optic capture openapi.yml --update interactive' to add new endpoints[39m
 "
@@ -301,6 +545,78 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetAuthHawk200ResponseBody"
+          headers:
+            Access-Control-Allow-Credentials:
+              schema:
+                type: string
+              name: Access-Control-Allow-Credentials
+              required: true
+            Access-Control-Allow-Headers:
+              schema:
+                type: string
+              name: Access-Control-Allow-Headers
+              required: true
+            Access-Control-Allow-Methods:
+              schema:
+                type: string
+              name: Access-Control-Allow-Methods
+              required: true
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+              name: Access-Control-Allow-Origin
+              required: true
+            Connection:
+              schema:
+                type: string
+              name: Connection
+              required: true
+            Content-Encoding:
+              schema:
+                type: string
+              name: Content-Encoding
+              required: true
+            Content-Type:
+              schema:
+                type: string
+              name: Content-Type
+              required: true
+            Date:
+              schema:
+                type: string
+              name: Date
+              required: true
+            Server:
+              schema:
+                type: string
+              name: Server
+              required: true
+            Server-Authorization:
+              schema:
+                type: string
+              name: Server-Authorization
+              required: true
+            Vary:
+              schema:
+                type: string
+              name: Vary
+              required: true
+            X-Powered-By:
+              schema:
+                type: string
+              name: X-Powered-By
+              required: true
+            transfer-encoding:
+              schema:
+                type: string
+              name: transfer-encoding
+              required: true
+      parameters:
+        - schema:
+            type: string
+          in: header
+          name: Authorization
+          required: true
   /basic-auth:
     get:
       responses:
@@ -315,6 +631,17 @@ paths:
     get:
       responses:
         {}
+      parameters:
+        - schema:
+            type: string
+          in: query
+          name: foo1
+          required: true
+        - schema:
+            type: string
+          in: query
+          name: foo2
+          required: true
   /cookies:
     get:
       responses:
@@ -338,6 +665,67 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetDelayDelay200ResponseBody"
+          headers:
+            Access-Control-Allow-Credentials:
+              schema:
+                type: string
+              name: Access-Control-Allow-Credentials
+              required: true
+            Access-Control-Allow-Headers:
+              schema:
+                type: string
+              name: Access-Control-Allow-Headers
+              required: true
+            Access-Control-Allow-Methods:
+              schema:
+                type: string
+              name: Access-Control-Allow-Methods
+              required: true
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+              name: Access-Control-Allow-Origin
+              required: true
+            Access-Control-Expose-Headers:
+              schema:
+                type: string
+              name: Access-Control-Expose-Headers
+              required: true
+            Connection:
+              schema:
+                type: string
+              name: Connection
+              required: true
+            Content-Length:
+              schema:
+                type: string
+              name: Content-Length
+              required: true
+            Content-Type:
+              schema:
+                type: string
+              name: Content-Type
+              required: true
+            Date:
+              schema:
+                type: string
+              name: Date
+              required: true
+            ETag:
+              schema:
+                type: string
+              name: ETag
+              required: true
+            Server:
+              schema:
+                type: string
+              name: Server
+              required: true
+            Vary:
+              schema:
+                type: string
+              name: Vary
+              required: true
   /delete:
     delete:
       responses:
@@ -351,6 +739,12 @@ paths:
     get:
       responses:
         {}
+      parameters:
+        - schema:
+            type: string
+          in: header
+          name: Authorization
+          required: false
   /encoding/utf8:
     get:
       responses:
@@ -364,6 +758,67 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Get200ResponseBody"
+          headers:
+            Access-Control-Allow-Credentials:
+              schema:
+                type: string
+              name: Access-Control-Allow-Credentials
+              required: true
+            Access-Control-Allow-Headers:
+              schema:
+                type: string
+              name: Access-Control-Allow-Headers
+              required: true
+            Access-Control-Allow-Methods:
+              schema:
+                type: string
+              name: Access-Control-Allow-Methods
+              required: true
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+              name: Access-Control-Allow-Origin
+              required: true
+            Connection:
+              schema:
+                type: string
+              name: Connection
+              required: true
+            Content-Encoding:
+              schema:
+                type: string
+              name: Content-Encoding
+              required: true
+            Content-Length:
+              schema:
+                type: string
+              name: Content-Length
+              required: true
+            Content-Type:
+              schema:
+                type: string
+              name: Content-Type
+              required: true
+            Date:
+              schema:
+                type: string
+              name: Date
+              required: true
+            Server:
+              schema:
+                type: string
+              name: Server
+              required: true
+            Vary:
+              schema:
+                type: string
+              name: Vary
+              required: true
+            X-Powered-By:
+              schema:
+                type: string
+              name: X-Powered-By
+              required: true
   /get/hello:
     get:
       responses:
@@ -377,6 +832,63 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetGet200ResponseBody"
+          headers:
+            Content-Encoding:
+              schema:
+                type: string
+              name: Content-Encoding
+              required: true
+            Content-Type:
+              schema:
+                type: string
+              name: Content-Type
+              required: true
+            Date:
+              schema:
+                type: string
+              name: Date
+              required: true
+            ETag:
+              schema:
+                type: string
+              name: ETag
+              required: true
+            Server:
+              schema:
+                type: string
+              name: Server
+              required: true
+            set-cookie:
+              schema:
+                type: string
+              name: set-cookie
+              required: true
+            Vary:
+              schema:
+                type: string
+              name: Vary
+              required: true
+            Content-Length:
+              schema:
+                type: string
+              name: Content-Length
+              required: true
+            Connection:
+              schema:
+                type: string
+              name: Connection
+              required: true
+      parameters:
+        - schema:
+            type: string
+          in: query
+          name: foo1
+          required: true
+        - schema:
+            type: string
+          in: query
+          name: foo2
+          required: true
   /gzip:
     get:
       responses:
@@ -390,6 +902,73 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetHeaders200ResponseBody"
+          headers:
+            Access-Control-Allow-Credentials:
+              schema:
+                type: string
+              name: Access-Control-Allow-Credentials
+              required: true
+            Access-Control-Allow-Headers:
+              schema:
+                type: string
+              name: Access-Control-Allow-Headers
+              required: true
+            Access-Control-Allow-Methods:
+              schema:
+                type: string
+              name: Access-Control-Allow-Methods
+              required: true
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+              name: Access-Control-Allow-Origin
+              required: true
+            Connection:
+              schema:
+                type: string
+              name: Connection
+              required: true
+            Content-Encoding:
+              schema:
+                type: string
+              name: Content-Encoding
+              required: true
+            Content-Length:
+              schema:
+                type: string
+              name: Content-Length
+              required: true
+            Content-Type:
+              schema:
+                type: string
+              name: Content-Type
+              required: true
+            Date:
+              schema:
+                type: string
+              name: Date
+              required: true
+            Server:
+              schema:
+                type: string
+              name: Server
+              required: true
+            Vary:
+              schema:
+                type: string
+              name: Vary
+              required: true
+            X-Powered-By:
+              schema:
+                type: string
+              name: X-Powered-By
+              required: true
+      parameters:
+        - schema:
+            type: string
+          in: header
+          name: my-sample-header
+          required: false
   /ip:
     get:
       responses:
@@ -403,12 +982,145 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetOauth1401ResponseBody"
+          headers:
+            Access-Control-Allow-Credentials:
+              schema:
+                type: string
+              name: Access-Control-Allow-Credentials
+              required: true
+            Access-Control-Allow-Headers:
+              schema:
+                type: string
+              name: Access-Control-Allow-Headers
+              required: true
+            Access-Control-Allow-Methods:
+              schema:
+                type: string
+              name: Access-Control-Allow-Methods
+              required: true
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+              name: Access-Control-Allow-Origin
+              required: true
+            Access-Control-Expose-Headers:
+              schema:
+                type: string
+              name: Access-Control-Expose-Headers
+              required: true
+            Connection:
+              schema:
+                type: string
+              name: Connection
+              required: true
+            Content-Length:
+              schema:
+                type: string
+              name: Content-Length
+              required: true
+            Content-Type:
+              schema:
+                type: string
+              name: Content-Type
+              required: true
+            Date:
+              schema:
+                type: string
+              name: Date
+              required: true
+            ETag:
+              schema:
+                type: string
+              name: ETag
+              required: true
+            Server:
+              schema:
+                type: string
+              name: Server
+              required: true
+            Vary:
+              schema:
+                type: string
+              name: Vary
+              required: true
         "200":
           description: 200 response
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetAuthHawk200ResponseBody"
+          headers:
+            Access-Control-Allow-Credentials:
+              schema:
+                type: string
+              name: Access-Control-Allow-Credentials
+              required: true
+            Access-Control-Allow-Headers:
+              schema:
+                type: string
+              name: Access-Control-Allow-Headers
+              required: true
+            Access-Control-Allow-Methods:
+              schema:
+                type: string
+              name: Access-Control-Allow-Methods
+              required: true
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+              name: Access-Control-Allow-Origin
+              required: true
+            Access-Control-Expose-Headers:
+              schema:
+                type: string
+              name: Access-Control-Expose-Headers
+              required: true
+            Connection:
+              schema:
+                type: string
+              name: Connection
+              required: true
+            Content-Encoding:
+              schema:
+                type: string
+              name: Content-Encoding
+              required: true
+            Content-Length:
+              schema:
+                type: string
+              name: Content-Length
+              required: true
+            Content-Type:
+              schema:
+                type: string
+              name: Content-Type
+              required: true
+            Date:
+              schema:
+                type: string
+              name: Date
+              required: true
+            ETag:
+              schema:
+                type: string
+              name: ETag
+              required: true
+            Server:
+              schema:
+                type: string
+              name: Server
+              required: true
+            Vary:
+              schema:
+                type: string
+              name: Vary
+              required: true
+      parameters:
+        - schema:
+            type: string
+          in: header
+          name: Authorization
+          required: false
   /patch:
     patch:
       responses:
@@ -451,6 +1163,93 @@ paths:
             text/html:
               schema:
                 type: string
+          headers:
+            Access-Control-Allow-Credentials:
+              schema:
+                type: string
+              name: Access-Control-Allow-Credentials
+              required: true
+            Access-Control-Allow-Headers:
+              schema:
+                type: string
+              name: Access-Control-Allow-Headers
+              required: true
+            Access-Control-Allow-Methods:
+              schema:
+                type: string
+              name: Access-Control-Allow-Methods
+              required: true
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+              name: Access-Control-Allow-Origin
+              required: true
+            Connection:
+              schema:
+                type: string
+              name: Connection
+              required: true
+            Content-Encoding:
+              schema:
+                type: string
+              name: Content-Encoding
+              required: true
+            Content-Length:
+              schema:
+                type: string
+              name: Content-Length
+              required: true
+            Content-Type:
+              schema:
+                type: string
+              name: Content-Type
+              required: true
+            Date:
+              schema:
+                type: string
+              name: Date
+              required: true
+            Server:
+              schema:
+                type: string
+              name: Server
+              required: true
+            Vary:
+              schema:
+                type: string
+              name: Vary
+              required: true
+            X-Powered-By:
+              schema:
+                type: string
+              name: X-Powered-By
+              required: true
+            test:
+              schema:
+                type: string
+              name: test
+              required: true
+      parameters:
+        - schema:
+            type: string
+          in: query
+          name: foo1
+          required: true
+        - schema:
+            type: string
+          in: query
+          name: foo2
+          required: true
+        - schema:
+            type: string
+          in: query
+          name: Content-Type
+          required: true
+        - schema:
+            type: string
+          in: query
+          name: test
+          required: true
   /status/{status}:
     parameters:
       - in: path
@@ -466,6 +1265,67 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetStatusStatus200ResponseBody"
+          headers:
+            Access-Control-Allow-Credentials:
+              schema:
+                type: string
+              name: Access-Control-Allow-Credentials
+              required: true
+            Access-Control-Allow-Headers:
+              schema:
+                type: string
+              name: Access-Control-Allow-Headers
+              required: true
+            Access-Control-Allow-Methods:
+              schema:
+                type: string
+              name: Access-Control-Allow-Methods
+              required: true
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+              name: Access-Control-Allow-Origin
+              required: true
+            Connection:
+              schema:
+                type: string
+              name: Connection
+              required: true
+            Content-Length:
+              schema:
+                type: string
+              name: Content-Length
+              required: true
+            Content-Type:
+              schema:
+                type: string
+              name: Content-Type
+              required: true
+            Date:
+              schema:
+                type: string
+              name: Date
+              required: true
+            ETag:
+              schema:
+                type: string
+              name: ETag
+              required: true
+            Server:
+              schema:
+                type: string
+              name: Server
+              required: true
+            Vary:
+              schema:
+                type: string
+              name: Vary
+              required: true
+            X-Powered-By:
+              schema:
+                type: string
+              name: X-Powered-By
+              required: true
   /stream/{stream}:
     parameters:
       - in: path
@@ -494,6 +1354,113 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetTimeTime200ResponseBody"
+          headers:
+            Access-Control-Allow-Credentials:
+              schema:
+                type: string
+              name: Access-Control-Allow-Credentials
+              required: true
+            Access-Control-Allow-Headers:
+              schema:
+                type: string
+              name: Access-Control-Allow-Headers
+              required: true
+            Access-Control-Allow-Methods:
+              schema:
+                type: string
+              name: Access-Control-Allow-Methods
+              required: true
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+              name: Access-Control-Allow-Origin
+              required: true
+            Access-Control-Expose-Headers:
+              schema:
+                type: string
+              name: Access-Control-Expose-Headers
+              required: true
+            Connection:
+              schema:
+                type: string
+              name: Connection
+              required: true
+            Content-Encoding:
+              schema:
+                type: string
+              name: Content-Encoding
+              required: false
+            Content-Length:
+              schema:
+                type: string
+              name: Content-Length
+              required: true
+            Content-Type:
+              schema:
+                type: string
+              name: Content-Type
+              required: true
+            Date:
+              schema:
+                type: string
+              name: Date
+              required: true
+            ETag:
+              schema:
+                type: string
+              name: ETag
+              required: true
+            Server:
+              schema:
+                type: string
+              name: Server
+              required: true
+            Vary:
+              schema:
+                type: string
+              name: Vary
+              required: true
+            set-cookie:
+              schema:
+                type: string
+              name: set-cookie
+              required: true
+      parameters:
+        - schema:
+            type: string
+          in: query
+          name: timestamp
+          required: false
+        - schema:
+            type: string
+          in: query
+          name: format
+          required: true
+        - schema:
+            type: string
+          in: query
+          name: unit
+          required: true
+        - schema:
+            type: string
+          in: query
+          name: years
+          required: true
+        - schema:
+            type: string
+          in: query
+          name: target
+          required: true
+        - schema:
+            type: string
+          in: query
+          name: start
+          required: true
+        - schema:
+            type: string
+          in: query
+          name: end
+          required: true
   /transform/collection:
     post:
       responses:
@@ -503,11 +1470,98 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PostTransformCollection200ResponseBody"
+          headers:
+            Access-Control-Allow-Credentials:
+              schema:
+                type: string
+              name: Access-Control-Allow-Credentials
+              required: true
+            Access-Control-Allow-Headers:
+              schema:
+                type: string
+              name: Access-Control-Allow-Headers
+              required: true
+            Access-Control-Allow-Methods:
+              schema:
+                type: string
+              name: Access-Control-Allow-Methods
+              required: true
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+              name: Access-Control-Allow-Origin
+              required: true
+            Access-Control-Expose-Headers:
+              schema:
+                type: string
+              name: Access-Control-Expose-Headers
+              required: true
+            Connection:
+              schema:
+                type: string
+              name: Connection
+              required: true
+            Content-Encoding:
+              schema:
+                type: string
+              name: Content-Encoding
+              required: true
+            Content-Type:
+              schema:
+                type: string
+              name: Content-Type
+              required: true
+            Date:
+              schema:
+                type: string
+              name: Date
+              required: true
+            ETag:
+              schema:
+                type: string
+              name: ETag
+              required: true
+            Server:
+              schema:
+                type: string
+              name: Server
+              required: true
+            Vary:
+              schema:
+                type: string
+              name: Vary
+              required: true
+            set-cookie:
+              schema:
+                type: string
+              name: set-cookie
+              required: true
+            transfer-encoding:
+              schema:
+                type: string
+              name: transfer-encoding
+              required: true
       requestBody:
         content:
           application/json:
             schema:
               $ref: "#/components/schemas/PostTransformCollectionRequestBody"
+      parameters:
+        - schema:
+            type: string
+          in: query
+          name: from
+          required: true
+        - schema:
+            type: string
+          in: query
+          name: to
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Content-Type
+          required: false
 components:
   schemas:
     GetBooks200ResponseBody:
@@ -1096,6 +2150,68 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetBooks200ResponseBody"
+          headers:
+            content-type:
+              schema:
+                type: string
+              name: content-type
+              required: true
+            Accept:
+              schema:
+                type: string
+              name: Accept
+              required: true
+            User-Agent:
+              schema:
+                type: string
+              name: User-Agent
+              required: true
+            Accept-Encoding:
+              schema:
+                type: string
+              name: Accept-Encoding
+              required: true
+            Host:
+              schema:
+                type: string
+              name: Host
+              required: true
+            Connection:
+              schema:
+                type: string
+              name: Connection
+              required: true
+      parameters:
+        - schema:
+            type: string
+          in: header
+          name: content-type
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: User-Agent
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept-Encoding
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Host
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Connection
+          required: true
   /authors:
     get:
       responses:
@@ -1105,6 +2221,68 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetAuthors200ResponseBody"
+          headers:
+            content-type:
+              schema:
+                type: string
+              name: content-type
+              required: true
+            Accept:
+              schema:
+                type: string
+              name: Accept
+              required: true
+            User-Agent:
+              schema:
+                type: string
+              name: User-Agent
+              required: true
+            Accept-Encoding:
+              schema:
+                type: string
+              name: Accept-Encoding
+              required: true
+            Host:
+              schema:
+                type: string
+              name: Host
+              required: true
+            Connection:
+              schema:
+                type: string
+              name: Connection
+              required: true
+      parameters:
+        - schema:
+            type: string
+          in: header
+          name: content-type
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: User-Agent
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept-Encoding
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Host
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Connection
+          required: true
   /books/{book}:
     parameters:
       - in: path
@@ -1120,6 +2298,68 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetBooksBook200ResponseBody"
+          headers:
+            content-type:
+              schema:
+                type: string
+              name: content-type
+              required: true
+            Accept:
+              schema:
+                type: string
+              name: Accept
+              required: true
+            User-Agent:
+              schema:
+                type: string
+              name: User-Agent
+              required: true
+            Accept-Encoding:
+              schema:
+                type: string
+              name: Accept-Encoding
+              required: true
+            Host:
+              schema:
+                type: string
+              name: Host
+              required: true
+            Connection:
+              schema:
+                type: string
+              name: Connection
+              required: true
+      parameters:
+        - schema:
+            type: string
+          in: header
+          name: content-type
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: User-Agent
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept-Encoding
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Host
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Connection
+          required: true
     post:
       responses:
         "200":
@@ -1128,11 +2368,83 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetBooksBook200ResponseBody"
+          headers:
+            content-type:
+              schema:
+                type: string
+              name: content-type
+              required: true
+            Accept:
+              schema:
+                type: string
+              name: Accept
+              required: true
+            Content-Length:
+              schema:
+                type: string
+              name: Content-Length
+              required: true
+            User-Agent:
+              schema:
+                type: string
+              name: User-Agent
+              required: true
+            Accept-Encoding:
+              schema:
+                type: string
+              name: Accept-Encoding
+              required: true
+            Host:
+              schema:
+                type: string
+              name: Host
+              required: true
+            Connection:
+              schema:
+                type: string
+              name: Connection
+              required: true
       requestBody:
         content:
           application/json;charset=UTF-8:
             schema:
               $ref: "#/components/schemas/PostBooksBookRequestBody"
+      parameters:
+        - schema:
+            type: string
+          in: header
+          name: content-type
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Content-Length
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: User-Agent
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept-Encoding
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Host
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Connection
+          required: true
 components:
   schemas:
     GetBooks200ResponseBody:
@@ -1210,6 +2522,18 @@ exports[`capture with requests update behavior handle servers not at root of hos
 "Generating traffic to send to server
 GET /books
   [32m✓ [39m200 response
+  [32m[header parameter] content-type has been added[39m
+  [32m[header parameter] Accept has been added[39m
+  [32m[header parameter] User-Agent has been added[39m
+  [32m[header parameter] Accept-Encoding has been added[39m
+  [32m[header parameter] Host has been added[39m
+  [32m[header parameter] Connection has been added[39m
+  [32m[200 response header] content-type has been added[39m
+  [32m[200 response header] Accept has been added[39m
+  [32m[200 response header] User-Agent has been added[39m
+  [32m[200 response header] Accept-Encoding has been added[39m
+  [32m[200 response header] Host has been added[39m
+  [32m[200 response header] Connection has been added[39m
   [32m[200 response body] 'name' has been added (/properties/books/items/properties/name)[39m
   [32m[200 response body] 'author_id' has been added (/properties/books/items/properties/author_id)[39m
   [32m[200 response body] 'status' has been added (/properties/books/items/properties/status)[39m
@@ -1241,6 +2565,68 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetBooks200ResponseBody"
+          headers:
+            content-type:
+              schema:
+                type: string
+              name: content-type
+              required: true
+            Accept:
+              schema:
+                type: string
+              name: Accept
+              required: true
+            User-Agent:
+              schema:
+                type: string
+              name: User-Agent
+              required: true
+            Accept-Encoding:
+              schema:
+                type: string
+              name: Accept-Encoding
+              required: true
+            Host:
+              schema:
+                type: string
+              name: Host
+              required: true
+            Connection:
+              schema:
+                type: string
+              name: Connection
+              required: true
+      parameters:
+        - schema:
+            type: string
+          in: header
+          name: content-type
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: User-Agent
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept-Encoding
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Host
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Connection
+          required: true
   /authors:
     get:
       responses:
@@ -1250,6 +2636,68 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetAuthors200ResponseBody"
+          headers:
+            content-type:
+              schema:
+                type: string
+              name: content-type
+              required: true
+            Accept:
+              schema:
+                type: string
+              name: Accept
+              required: true
+            User-Agent:
+              schema:
+                type: string
+              name: User-Agent
+              required: true
+            Accept-Encoding:
+              schema:
+                type: string
+              name: Accept-Encoding
+              required: true
+            Host:
+              schema:
+                type: string
+              name: Host
+              required: true
+            Connection:
+              schema:
+                type: string
+              name: Connection
+              required: true
+      parameters:
+        - schema:
+            type: string
+          in: header
+          name: content-type
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: User-Agent
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept-Encoding
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Host
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Connection
+          required: true
   /books/{book}:
     parameters:
       - in: path
@@ -1265,6 +2713,68 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetBooksBook200ResponseBody"
+          headers:
+            content-type:
+              schema:
+                type: string
+              name: content-type
+              required: true
+            Accept:
+              schema:
+                type: string
+              name: Accept
+              required: true
+            User-Agent:
+              schema:
+                type: string
+              name: User-Agent
+              required: true
+            Accept-Encoding:
+              schema:
+                type: string
+              name: Accept-Encoding
+              required: true
+            Host:
+              schema:
+                type: string
+              name: Host
+              required: true
+            Connection:
+              schema:
+                type: string
+              name: Connection
+              required: true
+      parameters:
+        - schema:
+            type: string
+          in: header
+          name: content-type
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: User-Agent
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept-Encoding
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Host
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Connection
+          required: true
     post:
       responses:
         "200":
@@ -1273,11 +2783,83 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetBooksBook200ResponseBody"
+          headers:
+            content-type:
+              schema:
+                type: string
+              name: content-type
+              required: true
+            Accept:
+              schema:
+                type: string
+              name: Accept
+              required: true
+            Content-Length:
+              schema:
+                type: string
+              name: Content-Length
+              required: true
+            User-Agent:
+              schema:
+                type: string
+              name: User-Agent
+              required: true
+            Accept-Encoding:
+              schema:
+                type: string
+              name: Accept-Encoding
+              required: true
+            Host:
+              schema:
+                type: string
+              name: Host
+              required: true
+            Connection:
+              schema:
+                type: string
+              name: Connection
+              required: true
       requestBody:
         content:
           application/json;charset=UTF-8:
             schema:
               $ref: "#/components/schemas/PostBooksBookRequestBody"
+      parameters:
+        - schema:
+            type: string
+          in: header
+          name: content-type
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Content-Length
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: User-Agent
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept-Encoding
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Host
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Connection
+          required: true
 components:
   schemas:
     GetBooks200ResponseBody:
@@ -1377,6 +2959,18 @@ exports[`capture with requests update behavior handles update in other file 1`] 
 "Generating traffic to send to server
 GET /books
   [32m✓ [39m200 response
+  [32m[header parameter] content-type has been added[39m
+  [32m[header parameter] Accept has been added[39m
+  [32m[header parameter] User-Agent has been added[39m
+  [32m[header parameter] Accept-Encoding has been added[39m
+  [32m[header parameter] Host has been added[39m
+  [32m[header parameter] Connection has been added[39m
+  [32m[200 response header] content-type has been added[39m
+  [32m[200 response header] Accept has been added[39m
+  [32m[200 response header] User-Agent has been added[39m
+  [32m[200 response header] Accept-Encoding has been added[39m
+  [32m[200 response header] Host has been added[39m
+  [32m[200 response header] Connection has been added[39m
   [32m[200 response body] 'name' has been added (/properties/books/items/properties/name)[39m
   [32m[200 response body] 'author_id' has been added (/properties/books/items/properties/author_id)[39m
   [32m[200 response body] 'status' has been added (/properties/books/items/properties/status)[39m
@@ -1402,6 +2996,68 @@ paths:
             application/json:
               schema:
                 $ref: ./components/books.yml#/GetBooks200ResponseBody
+          headers:
+            content-type:
+              schema:
+                type: string
+              name: content-type
+              required: true
+            Accept:
+              schema:
+                type: string
+              name: Accept
+              required: true
+            User-Agent:
+              schema:
+                type: string
+              name: User-Agent
+              required: true
+            Accept-Encoding:
+              schema:
+                type: string
+              name: Accept-Encoding
+              required: true
+            Host:
+              schema:
+                type: string
+              name: Host
+              required: true
+            Connection:
+              schema:
+                type: string
+              name: Connection
+              required: true
+      parameters:
+        - schema:
+            type: string
+          in: header
+          name: content-type
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: User-Agent
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept-Encoding
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Host
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Connection
+          required: true
 "
 `;
 
@@ -1444,6 +3100,18 @@ GET /authors
   [32m✓ [39m200 response
 GET /books
   [32m✓ [39m200 response
+  [32m[header parameter] content-type has been added[39m
+  [32m[header parameter] Accept has been added[39m
+  [32m[header parameter] User-Agent has been added[39m
+  [32m[header parameter] Accept-Encoding has been added[39m
+  [32m[header parameter] Host has been added[39m
+  [32m[header parameter] Connection has been added[39m
+  [32m[200 response header] content-type has been added[39m
+  [32m[200 response header] Accept has been added[39m
+  [32m[200 response header] User-Agent has been added[39m
+  [32m[200 response header] Accept-Encoding has been added[39m
+  [32m[200 response header] Host has been added[39m
+  [32m[200 response header] Connection has been added[39m
   [32m[200 response body] 'name' has been added (/properties/books/items/properties/name)[39m
   [32m[200 response body] 'author_id' has been added (/properties/books/items/properties/author_id)[39m
   [32m[200 response body] 'status' has been added (/properties/books/items/properties/status)[39m
@@ -1477,6 +3145,68 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetBooks200ResponseBody"
+          headers:
+            content-type:
+              schema:
+                type: string
+              name: content-type
+              required: true
+            Accept:
+              schema:
+                type: string
+              name: Accept
+              required: true
+            User-Agent:
+              schema:
+                type: string
+              name: User-Agent
+              required: true
+            Accept-Encoding:
+              schema:
+                type: string
+              name: Accept-Encoding
+              required: true
+            Host:
+              schema:
+                type: string
+              name: Host
+              required: true
+            Connection:
+              schema:
+                type: string
+              name: Connection
+              required: true
+      parameters:
+        - schema:
+            type: string
+          in: header
+          name: content-type
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: User-Agent
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept-Encoding
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Host
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Connection
+          required: true
   /authors:
     get:
       responses:
@@ -1501,11 +3231,83 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PostBooksBook200ResponseBody"
+          headers:
+            content-type:
+              schema:
+                type: string
+              name: content-type
+              required: true
+            Accept:
+              schema:
+                type: string
+              name: Accept
+              required: true
+            Content-Length:
+              schema:
+                type: string
+              name: Content-Length
+              required: true
+            User-Agent:
+              schema:
+                type: string
+              name: User-Agent
+              required: true
+            Accept-Encoding:
+              schema:
+                type: string
+              name: Accept-Encoding
+              required: true
+            Host:
+              schema:
+                type: string
+              name: Host
+              required: true
+            Connection:
+              schema:
+                type: string
+              name: Connection
+              required: true
       requestBody:
         content:
           application/json;charset=UTF-8:
             schema:
               $ref: "#/components/schemas/PostBooksBookRequestBody"
+      parameters:
+        - schema:
+            type: string
+          in: header
+          name: content-type
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Content-Length
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: User-Agent
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept-Encoding
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Host
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Connection
+          required: true
 components:
   schemas:
     GetBooks200ResponseBody:
@@ -1582,6 +3384,18 @@ exports[`capture with requests update behavior updates all endpoints with --upda
 "Generating traffic to send to server
 GET /books
   [32m✓ [39m200 response
+  [32m[header parameter] content-type has been added[39m
+  [32m[header parameter] Accept has been added[39m
+  [32m[header parameter] User-Agent has been added[39m
+  [32m[header parameter] Accept-Encoding has been added[39m
+  [32m[header parameter] Host has been added[39m
+  [32m[header parameter] Connection has been added[39m
+  [32m[200 response header] content-type has been added[39m
+  [32m[200 response header] Accept has been added[39m
+  [32m[200 response header] User-Agent has been added[39m
+  [32m[200 response header] Accept-Encoding has been added[39m
+  [32m[200 response header] Host has been added[39m
+  [32m[200 response header] Connection has been added[39m
   [32m[200 response body] 'name' has been added (/properties/books/items/properties/name)[39m
   [32m[200 response body] 'created_at' has been added (/properties/books/items/properties/created_at)[39m
   [32m[200 response body] 'updated_at' has been added (/properties/books/items/properties/updated_at)[39m
@@ -1621,6 +3435,68 @@ paths:
               schema:
                 # use the refs here
                 $ref: "#/components/schemas/GetBooks200ResponseBody"
+          headers:
+            content-type:
+              schema:
+                type: string
+              name: content-type
+              required: true
+            Accept:
+              schema:
+                type: string
+              name: Accept
+              required: true
+            User-Agent:
+              schema:
+                type: string
+              name: User-Agent
+              required: true
+            Accept-Encoding:
+              schema:
+                type: string
+              name: Accept-Encoding
+              required: true
+            Host:
+              schema:
+                type: string
+              name: Host
+              required: true
+            Connection:
+              schema:
+                type: string
+              name: Connection
+              required: true
+      parameters:
+        - schema:
+            type: string
+          in: header
+          name: content-type
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: User-Agent
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept-Encoding
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Host
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Connection
+          required: true
   /authors:
     get:
       responses:
@@ -1630,6 +3506,68 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetAuthors200ResponseBody"
+          headers:
+            content-type:
+              schema:
+                type: string
+              name: content-type
+              required: true
+            Accept:
+              schema:
+                type: string
+              name: Accept
+              required: true
+            User-Agent:
+              schema:
+                type: string
+              name: User-Agent
+              required: true
+            Accept-Encoding:
+              schema:
+                type: string
+              name: Accept-Encoding
+              required: true
+            Host:
+              schema:
+                type: string
+              name: Host
+              required: true
+            Connection:
+              schema:
+                type: string
+              name: Connection
+              required: true
+      parameters:
+        - schema:
+            type: string
+          in: header
+          name: content-type
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: User-Agent
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept-Encoding
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Host
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Connection
+          required: true
   /books/{book}:
     parameters:
       - in: path
@@ -1645,6 +3583,68 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetBooksBook200ResponseBody"
+          headers:
+            content-type:
+              schema:
+                type: string
+              name: content-type
+              required: true
+            Accept:
+              schema:
+                type: string
+              name: Accept
+              required: true
+            User-Agent:
+              schema:
+                type: string
+              name: User-Agent
+              required: true
+            Accept-Encoding:
+              schema:
+                type: string
+              name: Accept-Encoding
+              required: true
+            Host:
+              schema:
+                type: string
+              name: Host
+              required: true
+            Connection:
+              schema:
+                type: string
+              name: Connection
+              required: true
+      parameters:
+        - schema:
+            type: string
+          in: header
+          name: content-type
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: User-Agent
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept-Encoding
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Host
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Connection
+          required: true
     post:
       responses:
         "200":
@@ -1653,11 +3653,83 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GetBooksBook200ResponseBody"
+          headers:
+            content-type:
+              schema:
+                type: string
+              name: content-type
+              required: true
+            Accept:
+              schema:
+                type: string
+              name: Accept
+              required: true
+            Content-Length:
+              schema:
+                type: string
+              name: Content-Length
+              required: true
+            User-Agent:
+              schema:
+                type: string
+              name: User-Agent
+              required: true
+            Accept-Encoding:
+              schema:
+                type: string
+              name: Accept-Encoding
+              required: true
+            Host:
+              schema:
+                type: string
+              name: Host
+              required: true
+            Connection:
+              schema:
+                type: string
+              name: Connection
+              required: true
       requestBody:
         content:
           application/json;charset=UTF-8:
             schema:
               $ref: "#/components/schemas/PostBooksBookRequestBody"
+      parameters:
+        - schema:
+            type: string
+          in: header
+          name: content-type
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Content-Length
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: User-Agent
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept-Encoding
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Host
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Connection
+          required: true
   /:
     get:
       responses:
@@ -1667,6 +3739,68 @@ paths:
             text/html:
               schema:
                 type: string
+          headers:
+            content-type:
+              schema:
+                type: string
+              name: content-type
+              required: true
+            Accept:
+              schema:
+                type: string
+              name: Accept
+              required: true
+            User-Agent:
+              schema:
+                type: string
+              name: User-Agent
+              required: true
+            Accept-Encoding:
+              schema:
+                type: string
+              name: Accept-Encoding
+              required: true
+            Host:
+              schema:
+                type: string
+              name: Host
+              required: true
+            Connection:
+              schema:
+                type: string
+              name: Connection
+              required: true
+      parameters:
+        - schema:
+            type: string
+          in: header
+          name: content-type
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: User-Agent
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept-Encoding
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Host
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Connection
+          required: true
 components:
   schemas:
     # this is a schema
@@ -1774,6 +3908,18 @@ exports[`capture with requests update behavior updates only existing endpoints b
 "Generating traffic to send to server
 GET /books
   [32m✓ [39m200 response
+  [32m[header parameter] content-type has been added[39m
+  [32m[header parameter] Accept has been added[39m
+  [32m[header parameter] User-Agent has been added[39m
+  [32m[header parameter] Accept-Encoding has been added[39m
+  [32m[header parameter] Host has been added[39m
+  [32m[header parameter] Connection has been added[39m
+  [32m[200 response header] content-type has been added[39m
+  [32m[200 response header] Accept has been added[39m
+  [32m[200 response header] User-Agent has been added[39m
+  [32m[200 response header] Accept-Encoding has been added[39m
+  [32m[200 response header] Host has been added[39m
+  [32m[200 response header] Connection has been added[39m
   [32m[200 response body] 'name' has been added (/properties/books/items/properties/name)[39m
   [32m[200 response body] 'created_at' has been added (/properties/books/items/properties/created_at)[39m
   [32m[200 response body] 'updated_at' has been added (/properties/books/items/properties/updated_at)[39m
@@ -1810,6 +3956,68 @@ paths:
               schema:
                 # use the refs here
                 $ref: "#/components/schemas/GetBooks200ResponseBody"
+          headers:
+            content-type:
+              schema:
+                type: string
+              name: content-type
+              required: true
+            Accept:
+              schema:
+                type: string
+              name: Accept
+              required: true
+            User-Agent:
+              schema:
+                type: string
+              name: User-Agent
+              required: true
+            Accept-Encoding:
+              schema:
+                type: string
+              name: Accept-Encoding
+              required: true
+            Host:
+              schema:
+                type: string
+              name: Host
+              required: true
+            Connection:
+              schema:
+                type: string
+              name: Connection
+              required: true
+      parameters:
+        - schema:
+            type: string
+          in: header
+          name: content-type
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: User-Agent
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Accept-Encoding
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Host
+          required: true
+        - schema:
+            type: string
+          in: header
+          name: Connection
+          required: true
 components:
   schemas:
     # this is a schema
@@ -1856,21 +4064,53 @@ exports[`capture with requests verify behavior verifies spec with endpoint speci
 "Generating traffic to send to server
 GET /books/status
   [32m✓ [39m200 response
+  [31m[header parameter] content-type is not documented[39m
+  [31m[header parameter] Accept is not documented[39m
+  [31m[header parameter] User-Agent is not documented[39m
+  [31m[header parameter] Accept-Encoding is not documented[39m
+  [31m[header parameter] Host is not documented[39m
+  [31m[header parameter] Connection is not documented[39m
+  [31m[200 response header] content-type is not documented[39m
+  [31m[200 response header] Accept is not documented[39m
+  [31m[200 response header] User-Agent is not documented[39m
+  [31m[200 response header] Accept-Encoding is not documented[39m
+  [31m[200 response header] Host is not documented[39m
+  [31m[200 response header] Connection is not documented[39m
 GET /books/{bookId}
   [31m× [39m200 response
+  [31m[header parameter] content-type is not documented[39m
+  [31m[header parameter] Accept is not documented[39m
+  [31m[header parameter] User-Agent is not documented[39m
+  [31m[header parameter] Accept-Encoding is not documented[39m
+  [31m[header parameter] Host is not documented[39m
+  [31m[header parameter] Connection is not documented[39m
+  [31m[200 response header] content-type is not documented[39m
+  [31m[200 response header] Accept is not documented[39m
+  [31m[200 response header] User-Agent is not documented[39m
+  [31m[200 response header] Accept-Encoding is not documented[39m
+  [31m[200 response header] Host is not documented[39m
+  [31m[200 response header] Connection is not documented[39m
   [31m[200 response body] 'status' is not documented (/properties)[39m
   [31m[200 response body] 'price' is not documented (/properties)[39m
 GET /books
-  [31m× [39m200 response
-  [31m[200 response body] 'name' is not documented (/properties/books/items/properties)[39m
-  [31m[200 response body] 'author_id' is not documented (/properties/books/items/properties)[39m
-  [31m[200 response body] 'status' is not documented (/properties/books/items/properties)[39m
-  [31m[200 response body] 'price' is not documented (/properties/books/items/properties)[39m
-  [31m[200 response body] 'created_at' is not documented (/properties/books/items/properties)[39m
-  [31m[200 response body] 'updated_at' is not documented (/properties/books/items/properties)[39m
+  200 response
+  [31m[404 response body] body is not documented[39m
+  [31m[query parameter] list is not documented[39m
+  [31m[header parameter] content-type is not documented[39m
+  [31m[header parameter] Accept is not documented[39m
+  [31m[header parameter] User-Agent is not documented[39m
+  [31m[header parameter] Accept-Encoding is not documented[39m
+  [31m[header parameter] Host is not documented[39m
+  [31m[header parameter] Connection is not documented[39m
+  [31m[404 response header] content-type is not documented[39m
+  [31m[404 response header] Accept is not documented[39m
+  [31m[404 response header] User-Agent is not documented[39m
+  [31m[404 response header] Accept-Encoding is not documented[39m
+  [31m[404 response header] Host is not documented[39m
+  [31m[404 response header] Connection is not documented[39m
 
-100.0% coverage of your documented operations. 2 requests did not match a documented path (6 total requests).
-8 diffs detected in documented operations
+83.3% coverage of your documented operations. 2 requests did not match a documented path (6 total requests).
+40 diffs detected in documented operations
 
 [33mNew endpoints are only added in interactive mode. Run 'optic capture openapi-with-overlapping-paths.yml --update interactive' to add new endpoints[39m
 "
@@ -1880,6 +4120,18 @@ exports[`capture with requests verify behavior verifies the specification in ver
 "Generating traffic to send to server
 GET /books
   [31m× [39m200 response
+  [31m[header parameter] content-type is not documented[39m
+  [31m[header parameter] Accept is not documented[39m
+  [31m[header parameter] User-Agent is not documented[39m
+  [31m[header parameter] Accept-Encoding is not documented[39m
+  [31m[header parameter] Host is not documented[39m
+  [31m[header parameter] Connection is not documented[39m
+  [31m[200 response header] content-type is not documented[39m
+  [31m[200 response header] Accept is not documented[39m
+  [31m[200 response header] User-Agent is not documented[39m
+  [31m[200 response header] Accept-Encoding is not documented[39m
+  [31m[200 response header] Host is not documented[39m
+  [31m[200 response header] Connection is not documented[39m
   [31m[200 response body] 'name' is not documented (/properties/books/items/properties)[39m
   [31m[200 response body] 'created_at' is not documented (/properties/books/items/properties)[39m
   [31m[200 response body] 'updated_at' is not documented (/properties/books/items/properties)[39m
@@ -1919,7 +4171,7 @@ GET /books
 [90m...and 1 endpoint that did not receive traffic[39m
 
 66.7% coverage of your documented operations. 5 requests did not match a documented path (6 total requests).
-9 diffs detected in documented operations
+21 diffs detected in documented operations
 
 [33mNew endpoints are only added in interactive mode. Run 'optic capture openapi.yml --update interactive' to add new endpoints[39m
 "
@@ -1929,6 +4181,18 @@ exports[`capture with requests verify behavior verifies the specification with c
 "Generating traffic to send to server
 GET /books
   [31m× [39m200 response
+  [31m[header parameter] content-type is not documented[39m
+  [31m[header parameter] Accept is not documented[39m
+  [31m[header parameter] User-Agent is not documented[39m
+  [31m[header parameter] Accept-Encoding is not documented[39m
+  [31m[header parameter] Host is not documented[39m
+  [31m[header parameter] Connection is not documented[39m
+  [31m[200 response header] content-type is not documented[39m
+  [31m[200 response header] Accept is not documented[39m
+  [31m[200 response header] User-Agent is not documented[39m
+  [31m[200 response header] Accept-Encoding is not documented[39m
+  [31m[200 response header] Host is not documented[39m
+  [31m[200 response header] Connection is not documented[39m
   [31m[200 response body] 'name' is not documented (/properties/books/items/properties)[39m
   [31m[200 response body] 'created_at' is not documented (/properties/books/items/properties)[39m
   [31m[200 response body] 'updated_at' is not documented (/properties/books/items/properties)[39m
@@ -1938,7 +4202,7 @@ GET /books
 [90m...and 1 endpoint that did not receive traffic[39m
 
 66.7% coverage of your documented operations. 5 requests did not match a documented path (6 total requests).
-6 diffs detected in documented operations
+18 diffs detected in documented operations
 
 [33mNew endpoints are only added in interactive mode. Run 'optic capture openapi.yml --update interactive' to add new endpoints[39m
 "

--- a/projects/optic/src/__tests__/integration/workspaces/capture/with-server/optic.yml
+++ b/projects/optic/src/__tests__/integration/workspaces/capture/with-server/optic.yml
@@ -6,7 +6,7 @@ capture:
       ready_endpoint: /healthcheck
     requests:
       send:
-        - path: /books
+        - path: /books?list=all
           method: GET
         - path: /books/asd
           method: GET

--- a/projects/optic/src/commands/capture/actions/documented.ts
+++ b/projects/optic/src/commands/capture/actions/documented.ts
@@ -87,7 +87,7 @@ function summarizePatch(
 
     const action =
       options.mode === 'update' ? 'has been added' : 'is not documented';
-    return [color(`${location} body ${action}`)];
+    return [color(`${location} ${diff.name} ${action}`)];
   } else if (
     diff.kind === 'MissingRequiredRequiredParameter' ||
     diff.kind === 'MissingRequiredResponseHeader'
@@ -98,7 +98,7 @@ function summarizePatch(
         : `[${diff.statusCode} response header]`;
     const action =
       options.mode === 'update' ? 'is now optional' : 'is required and missing';
-    return [color(`${location} body ${action}`)];
+    return [color(`${location} ${diff.name} ${action}`)];
   } else {
     const location = locationFromPath(path);
 

--- a/projects/optic/src/commands/capture/actions/documented.ts
+++ b/projects/optic/src/commands/capture/actions/documented.ts
@@ -1,5 +1,4 @@
 import chalk from 'chalk';
-import path from 'path';
 import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
 import { ParseResult } from '../../../utils/spec-loaders';
 import {

--- a/projects/optic/src/commands/capture/actions/documented.ts
+++ b/projects/optic/src/commands/capture/actions/documented.ts
@@ -63,6 +63,7 @@ function summarizePatch(
   const { jsonLike: spec, sourcemap } = parseResult;
   const pointerLogger = jsonPointerLogger(sourcemap);
   const { diff, path, groupedOperations } = patch;
+  const color = options.mode === 'update' ? chalk.green : chalk.red;
   if (!diff || groupedOperations.length === 0) return [];
   if (
     diff.kind === 'UnmatchdResponseBody' ||
@@ -75,7 +76,29 @@ function summarizePatch(
         : `[${diff.statusCode} response body]`;
     const action =
       options.mode === 'update' ? 'has been added' : 'is not documented';
-    const color = options.mode === 'update' ? chalk.green : chalk.red;
+    return [color(`${location} body ${action}`)];
+  } else if (
+    diff.kind === 'UnmatchedRequestParameter' ||
+    diff.kind === 'UnmatchedResponseHeader'
+  ) {
+    const location =
+      diff.kind === 'UnmatchedRequestParameter'
+        ? `[${diff.in} parameter]`
+        : `[${diff.statusCode} response header]`;
+
+    const action =
+      options.mode === 'update' ? 'has been added' : 'is not documented';
+    return [color(`${location} body ${action}`)];
+  } else if (
+    diff.kind === 'MissingRequiredRequiredParameter' ||
+    diff.kind === 'MissingRequiredResponseHeader'
+  ) {
+    const location =
+      diff.kind === 'MissingRequiredRequiredParameter'
+        ? `[${diff.in} parameter]`
+        : `[${diff.statusCode} response header]`;
+    const action =
+      options.mode === 'update' ? 'is now optional' : 'is required and missing';
     return [color(`${location} body ${action}`)];
   } else {
     const location = locationFromPath(path);
@@ -92,7 +115,6 @@ function summarizePatch(
 
       const action =
         options.mode === 'update' ? 'has been added' : 'is not documented';
-      const color = options.mode === 'update' ? chalk.green : chalk.red;
       const propertyLocation =
         options.mode === 'update'
           ? `(${diff.propertyPath})`

--- a/projects/optic/src/commands/capture/patches/__tests__/__snapshots__/patches.test.ts.snap
+++ b/projects/optic/src/commands/capture/patches/__tests__/__snapshots__/patches.test.ts.snap
@@ -1165,99 +1165,6 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 header parameter not docu
     "path": "/paths/~1api~1animals/post",
   },
   {
-    "description": "add parameters array to operation",
-    "diff": {
-      "kind": "MissingRequestParametersArray",
-    },
-    "groupedOperations": [
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/parameters",
-        "value": [],
-      },
-    ],
-    "impact": [
-      "Addition",
-      "BackwardsCompatible",
-    ],
-    "interaction": {
-      "request": {
-        "body": null,
-        "headers": [
-          {
-            "name": "undocumented",
-            "value": "abc",
-          },
-        ],
-        "host": "localhost:3030",
-        "method": "post",
-        "path": "/api/animals",
-        "query": [],
-      },
-      "response": {
-        "body": {
-          "body": "{}",
-          "contentType": "application/json",
-          "size": 2,
-        },
-        "headers": [],
-        "statusCode": "200",
-      },
-    },
-    "path": "/paths/~1api~1animals/post",
-  },
-  {
-    "description": "add undocumented header parameter",
-    "diff": {
-      "in": "header",
-      "kind": "UnmatchedRequestParameter",
-      "name": "undocumented",
-    },
-    "groupedOperations": [
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/parameters/-",
-        "value": {
-          "in": "header",
-          "name": "undocumented",
-          "required": true,
-          "schema": {
-            "type": "string",
-          },
-        },
-      },
-    ],
-    "impact": [
-      "Addition",
-      "BackwardsCompatible",
-    ],
-    "interaction": {
-      "request": {
-        "body": null,
-        "headers": [
-          {
-            "name": "undocumented",
-            "value": "abc",
-          },
-        ],
-        "host": "localhost:3030",
-        "method": "post",
-        "path": "/api/animals",
-        "query": [],
-      },
-      "response": {
-        "body": {
-          "body": "{}",
-          "contentType": "application/json",
-          "size": 2,
-        },
-        "headers": [],
-        "statusCode": "200",
-      },
-    },
-    "path": "/paths/~1api~1animals/post/parameters",
-  },
-  {
     "description": "update response body: add schema object",
     "diff": undefined,
     "groupedOperations": [
@@ -1312,16 +1219,6 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 header parameter not docu
   "paths": {
     "/api/animals": {
       "post": {
-        "parameters": [
-          {
-            "in": "header",
-            "name": "undocumented",
-            "required": true,
-            "schema": {
-              "type": "string",
-            },
-          },
-        ],
         "responses": {
           "200": {
             "content": {
@@ -3643,99 +3540,6 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 response headers not docu
     "path": "/paths/~1api~1animals/post",
   },
   {
-    "description": "add response headers object to operation",
-    "diff": {
-      "kind": "MissingResponseHeadersObject",
-      "statusCode": "200",
-    },
-    "groupedOperations": [
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/headers",
-        "value": {},
-      },
-    ],
-    "impact": [
-      "Addition",
-      "BackwardsCompatible",
-    ],
-    "interaction": {
-      "request": {
-        "body": null,
-        "headers": [],
-        "host": "localhost:3030",
-        "method": "post",
-        "path": "/api/animals",
-        "query": [],
-      },
-      "response": {
-        "body": {
-          "body": "{}",
-          "contentType": "application/json",
-          "size": 2,
-        },
-        "headers": [
-          {
-            "name": "undocumented",
-            "value": "abc",
-          },
-        ],
-        "statusCode": "200",
-      },
-    },
-    "path": "/paths/~1api~1animals/post/responses/200",
-  },
-  {
-    "description": "add undocumented response header to 200 response",
-    "diff": {
-      "kind": "UnmatchedResponseHeader",
-      "name": "undocumented",
-      "statusCode": "200",
-    },
-    "groupedOperations": [
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/headers/undocumented",
-        "value": {
-          "name": "undocumented",
-          "required": true,
-          "schema": {
-            "type": "string",
-          },
-        },
-      },
-    ],
-    "impact": [
-      "Addition",
-      "BackwardsCompatible",
-    ],
-    "interaction": {
-      "request": {
-        "body": null,
-        "headers": [],
-        "host": "localhost:3030",
-        "method": "post",
-        "path": "/api/animals",
-        "query": [],
-      },
-      "response": {
-        "body": {
-          "body": "{}",
-          "contentType": "application/json",
-          "size": 2,
-        },
-        "headers": [
-          {
-            "name": "undocumented",
-            "value": "abc",
-          },
-        ],
-        "statusCode": "200",
-      },
-    },
-    "path": "/paths/~1api~1animals/post/responses/200/headers/undocumented",
-  },
-  {
     "description": "update response body: add schema object",
     "diff": undefined,
     "groupedOperations": [
@@ -3800,15 +3604,6 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 response headers not docu
               },
             },
             "description": "200 response",
-            "headers": {
-              "undocumented": {
-                "name": "undocumented",
-                "required": true,
-                "schema": {
-                  "type": "string",
-                },
-              },
-            },
           },
         },
       },
@@ -7372,99 +7167,6 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 header parameter not docu
     "path": "/paths/~1api~1animals/post",
   },
   {
-    "description": "add parameters array to operation",
-    "diff": {
-      "kind": "MissingRequestParametersArray",
-    },
-    "groupedOperations": [
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/parameters",
-        "value": [],
-      },
-    ],
-    "impact": [
-      "Addition",
-      "BackwardsCompatible",
-    ],
-    "interaction": {
-      "request": {
-        "body": null,
-        "headers": [
-          {
-            "name": "undocumented",
-            "value": "abc",
-          },
-        ],
-        "host": "localhost:3030",
-        "method": "post",
-        "path": "/api/animals",
-        "query": [],
-      },
-      "response": {
-        "body": {
-          "body": "{}",
-          "contentType": "application/json",
-          "size": 2,
-        },
-        "headers": [],
-        "statusCode": "200",
-      },
-    },
-    "path": "/paths/~1api~1animals/post",
-  },
-  {
-    "description": "add undocumented header parameter",
-    "diff": {
-      "in": "header",
-      "kind": "UnmatchedRequestParameter",
-      "name": "undocumented",
-    },
-    "groupedOperations": [
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/parameters/-",
-        "value": {
-          "in": "header",
-          "name": "undocumented",
-          "required": true,
-          "schema": {
-            "type": "string",
-          },
-        },
-      },
-    ],
-    "impact": [
-      "Addition",
-      "BackwardsCompatible",
-    ],
-    "interaction": {
-      "request": {
-        "body": null,
-        "headers": [
-          {
-            "name": "undocumented",
-            "value": "abc",
-          },
-        ],
-        "host": "localhost:3030",
-        "method": "post",
-        "path": "/api/animals",
-        "query": [],
-      },
-      "response": {
-        "body": {
-          "body": "{}",
-          "contentType": "application/json",
-          "size": 2,
-        },
-        "headers": [],
-        "statusCode": "200",
-      },
-    },
-    "path": "/paths/~1api~1animals/post/parameters",
-  },
-  {
     "description": "update response body: add schema object",
     "diff": undefined,
     "groupedOperations": [
@@ -7519,16 +7221,6 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 header parameter not docu
   "paths": {
     "/api/animals": {
       "post": {
-        "parameters": [
-          {
-            "in": "header",
-            "name": "undocumented",
-            "required": true,
-            "schema": {
-              "type": "string",
-            },
-          },
-        ],
         "responses": {
           "200": {
             "content": {
@@ -9850,99 +9542,6 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 response headers not docu
     "path": "/paths/~1api~1animals/post",
   },
   {
-    "description": "add response headers object to operation",
-    "diff": {
-      "kind": "MissingResponseHeadersObject",
-      "statusCode": "200",
-    },
-    "groupedOperations": [
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/headers",
-        "value": {},
-      },
-    ],
-    "impact": [
-      "Addition",
-      "BackwardsCompatible",
-    ],
-    "interaction": {
-      "request": {
-        "body": null,
-        "headers": [],
-        "host": "localhost:3030",
-        "method": "post",
-        "path": "/api/animals",
-        "query": [],
-      },
-      "response": {
-        "body": {
-          "body": "{}",
-          "contentType": "application/json",
-          "size": 2,
-        },
-        "headers": [
-          {
-            "name": "undocumented",
-            "value": "abc",
-          },
-        ],
-        "statusCode": "200",
-      },
-    },
-    "path": "/paths/~1api~1animals/post/responses/200",
-  },
-  {
-    "description": "add undocumented response header to 200 response",
-    "diff": {
-      "kind": "UnmatchedResponseHeader",
-      "name": "undocumented",
-      "statusCode": "200",
-    },
-    "groupedOperations": [
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/headers/undocumented",
-        "value": {
-          "name": "undocumented",
-          "required": true,
-          "schema": {
-            "type": "string",
-          },
-        },
-      },
-    ],
-    "impact": [
-      "Addition",
-      "BackwardsCompatible",
-    ],
-    "interaction": {
-      "request": {
-        "body": null,
-        "headers": [],
-        "host": "localhost:3030",
-        "method": "post",
-        "path": "/api/animals",
-        "query": [],
-      },
-      "response": {
-        "body": {
-          "body": "{}",
-          "contentType": "application/json",
-          "size": 2,
-        },
-        "headers": [
-          {
-            "name": "undocumented",
-            "value": "abc",
-          },
-        ],
-        "statusCode": "200",
-      },
-    },
-    "path": "/paths/~1api~1animals/post/responses/200/headers/undocumented",
-  },
-  {
     "description": "update response body: add schema object",
     "diff": undefined,
     "groupedOperations": [
@@ -10007,15 +9606,6 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 response headers not docu
               },
             },
             "description": "200 response",
-            "headers": {
-              "undocumented": {
-                "name": "undocumented",
-                "required": true,
-                "schema": {
-                  "type": "string",
-                },
-              },
-            },
           },
         },
       },

--- a/projects/optic/src/commands/capture/patches/__tests__/__snapshots__/patches.test.ts.snap
+++ b/projects/optic/src/commands/capture/patches/__tests__/__snapshots__/patches.test.ts.snap
@@ -1264,6 +1264,448 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 existing schema that does
 }
 `;
 
+exports[`generateEndpointSpecPatches OAS version 3.0.1 header parameter not documented 1`] = `
+[
+  {
+    "description": "operation: add 200 response",
+    "diff": {
+      "contentType": "application/json",
+      "kind": "UnmatchedResponseStatusCode",
+      "statusCode": "200",
+    },
+    "groupedOperations": [
+      {
+        "intent": "add response status code",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200",
+            "value": {
+              "description": "200 response",
+            },
+          },
+        ],
+      },
+      {
+        "intent": "add response body for content type 'application/json'",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/content",
+            "value": {
+              "application/json": {},
+            },
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [
+          {
+            "name": "undocumented",
+            "value": "abc",
+          },
+        ],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post",
+  },
+  {
+    "description": "add parameters array to operation",
+    "diff": {
+      "kind": "MissingRequestParametersArray",
+    },
+    "groupedOperations": [
+      {
+        "intent": "add parameters array",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/parameters",
+            "value": [],
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [
+          {
+            "name": "undocumented",
+            "value": "abc",
+          },
+        ],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post",
+  },
+  {
+    "description": "add undocumented header parameter",
+    "diff": {
+      "in": "header",
+      "kind": "UnmatchedRequestParameter",
+      "name": "undocumented",
+    },
+    "groupedOperations": [
+      {
+        "intent": "add undocumented header parameter",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/parameters/-",
+            "value": {
+              "in": "header",
+              "name": "undocumented",
+              "required": true,
+              "schema": {
+                "type": "string",
+              },
+            },
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [
+          {
+            "name": "undocumented",
+            "value": "abc",
+          },
+        ],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/parameters",
+  },
+  {
+    "description": "update response body: add schema object",
+    "diff": undefined,
+    "groupedOperations": [
+      {
+        "intent": "add schema object",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+            "value": {},
+          },
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
+            "value": "object",
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [
+          {
+            "name": "undocumented",
+            "value": "abc",
+          },
+        ],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+]
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.0.1 header parameter not documented 2`] = `
+{
+  "info": {},
+  "openapi": "3.0.1",
+  "paths": {
+    "/api/animals": {
+      "post": {
+        "parameters": [
+          {
+            "in": "header",
+            "name": "undocumented",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                },
+              },
+            },
+            "description": "200 response",
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.0.1 header parameter required but not seen 1`] = `
+[
+  {
+    "description": "operation: add 200 response",
+    "diff": {
+      "contentType": "application/json",
+      "kind": "UnmatchedResponseStatusCode",
+      "statusCode": "200",
+    },
+    "groupedOperations": [
+      {
+        "intent": "add response status code",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200",
+            "value": {
+              "description": "200 response",
+            },
+          },
+        ],
+      },
+      {
+        "intent": "add response body for content type 'application/json'",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/content",
+            "value": {
+              "application/json": {},
+            },
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post",
+  },
+  {
+    "description": "make required header parameter optional",
+    "diff": {
+      "in": "header",
+      "kind": "MissingRequiredRequiredParameter",
+      "name": "required",
+    },
+    "groupedOperations": [
+      {
+        "intent": "make required header parameter optional",
+        "operations": [
+          {
+            "op": "replace",
+            "path": "/paths/~1api~1animals/post/parameters/0/required",
+            "value": false,
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/parameters/0",
+  },
+  {
+    "description": "update response body: add schema object",
+    "diff": undefined,
+    "groupedOperations": [
+      {
+        "intent": "add schema object",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+            "value": {},
+          },
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
+            "value": "object",
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+]
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.0.1 header parameter required but not seen 2`] = `
+{
+  "info": {},
+  "openapi": "3.0.1",
+  "paths": {
+    "/api/animals": {
+      "post": {
+        "parameters": [
+          {
+            "in": "header",
+            "name": "required",
+            "required": false,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                },
+              },
+            },
+            "description": "200 response",
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
 exports[`generateEndpointSpecPatches OAS version 3.0.1 interactions with non-alphanumeric keys 1`] = `
 [
   {
@@ -3202,6 +3644,801 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 missing required property
                   },
                   "required": [],
                   "type": "object",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.0.1 query parameter not documented 1`] = `
+[
+  {
+    "description": "operation: add 200 response",
+    "diff": {
+      "contentType": "application/json",
+      "kind": "UnmatchedResponseStatusCode",
+      "statusCode": "200",
+    },
+    "groupedOperations": [
+      {
+        "intent": "add response status code",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200",
+            "value": {
+              "description": "200 response",
+            },
+          },
+        ],
+      },
+      {
+        "intent": "add response body for content type 'application/json'",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/content",
+            "value": {
+              "application/json": {},
+            },
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [
+          {
+            "name": "undocumented",
+            "value": "abc",
+          },
+        ],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post",
+  },
+  {
+    "description": "add parameters array to operation",
+    "diff": {
+      "kind": "MissingRequestParametersArray",
+    },
+    "groupedOperations": [
+      {
+        "intent": "add parameters array",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/parameters",
+            "value": [],
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [
+          {
+            "name": "undocumented",
+            "value": "abc",
+          },
+        ],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post",
+  },
+  {
+    "description": "add undocumented query parameter",
+    "diff": {
+      "in": "query",
+      "kind": "UnmatchedRequestParameter",
+      "name": "undocumented",
+    },
+    "groupedOperations": [
+      {
+        "intent": "add undocumented query parameter",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/parameters/-",
+            "value": {
+              "in": "query",
+              "name": "undocumented",
+              "required": true,
+              "schema": {
+                "type": "string",
+              },
+            },
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [
+          {
+            "name": "undocumented",
+            "value": "abc",
+          },
+        ],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/parameters",
+  },
+  {
+    "description": "update response body: add schema object",
+    "diff": undefined,
+    "groupedOperations": [
+      {
+        "intent": "add schema object",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+            "value": {},
+          },
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
+            "value": "object",
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [
+          {
+            "name": "undocumented",
+            "value": "abc",
+          },
+        ],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+]
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.0.1 query parameter not documented 2`] = `
+{
+  "info": {},
+  "openapi": "3.0.1",
+  "paths": {
+    "/api/animals": {
+      "post": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "undocumented",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                },
+              },
+            },
+            "description": "200 response",
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.0.1 query parameter required but not seen 1`] = `
+[
+  {
+    "description": "operation: add 200 response",
+    "diff": {
+      "contentType": "application/json",
+      "kind": "UnmatchedResponseStatusCode",
+      "statusCode": "200",
+    },
+    "groupedOperations": [
+      {
+        "intent": "add response status code",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200",
+            "value": {
+              "description": "200 response",
+            },
+          },
+        ],
+      },
+      {
+        "intent": "add response body for content type 'application/json'",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/content",
+            "value": {
+              "application/json": {},
+            },
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post",
+  },
+  {
+    "description": "make required query parameter optional",
+    "diff": {
+      "in": "query",
+      "kind": "MissingRequiredRequiredParameter",
+      "name": "required",
+    },
+    "groupedOperations": [
+      {
+        "intent": "make required query parameter optional",
+        "operations": [
+          {
+            "op": "replace",
+            "path": "/paths/~1api~1animals/post/parameters/0/required",
+            "value": false,
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/parameters/0",
+  },
+  {
+    "description": "update response body: add schema object",
+    "diff": undefined,
+    "groupedOperations": [
+      {
+        "intent": "add schema object",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+            "value": {},
+          },
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
+            "value": "object",
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+]
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.0.1 query parameter required but not seen 2`] = `
+{
+  "info": {},
+  "openapi": "3.0.1",
+  "paths": {
+    "/api/animals": {
+      "post": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "required",
+            "required": false,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                },
+              },
+            },
+            "description": "200 response",
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.0.1 response headers not documented 1`] = `
+[
+  {
+    "description": "operation: add 200 response",
+    "diff": {
+      "contentType": "application/json",
+      "kind": "UnmatchedResponseStatusCode",
+      "statusCode": "200",
+    },
+    "groupedOperations": [
+      {
+        "intent": "add response status code",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200",
+            "value": {
+              "description": "200 response",
+            },
+          },
+        ],
+      },
+      {
+        "intent": "add response body for content type 'application/json'",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/content",
+            "value": {
+              "application/json": {},
+            },
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [
+          {
+            "name": "undocumented",
+            "value": "abc",
+          },
+        ],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post",
+  },
+  {
+    "description": "add response headers object to operation",
+    "diff": {
+      "kind": "MissingResponseHeadersObject",
+      "statusCode": "200",
+    },
+    "groupedOperations": [
+      {
+        "intent": "add parameters array",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/headers",
+            "value": {},
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [
+          {
+            "name": "undocumented",
+            "value": "abc",
+          },
+        ],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200",
+  },
+  {
+    "description": "add undocumented response header to 200 response",
+    "diff": {
+      "kind": "UnmatchedResponseHeader",
+      "name": "undocumented",
+      "statusCode": "200",
+    },
+    "groupedOperations": [
+      {
+        "intent": "add undocumented response header to 200 response",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/headers/undocumented",
+            "value": {
+              "name": "undocumented",
+              "required": true,
+              "schema": {
+                "type": "string",
+              },
+            },
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [
+          {
+            "name": "undocumented",
+            "value": "abc",
+          },
+        ],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/headers/undocumented",
+  },
+  {
+    "description": "update response body: add schema object",
+    "diff": undefined,
+    "groupedOperations": [
+      {
+        "intent": "add schema object",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+            "value": {},
+          },
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
+            "value": "object",
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [
+          {
+            "name": "undocumented",
+            "value": "abc",
+          },
+        ],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+]
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.0.1 response headers not documented 2`] = `
+{
+  "info": {},
+  "openapi": "3.0.1",
+  "paths": {
+    "/api/animals": {
+      "post": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                },
+              },
+            },
+            "description": "200 response",
+            "headers": {
+              "undocumented": {
+                "name": "undocumented",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.0.1 response headers required but not seen 1`] = `
+[
+  {
+    "description": "make required response header in 200 response optional",
+    "diff": {
+      "kind": "MissingRequiredResponseHeader",
+      "name": "required",
+      "statusCode": "200",
+    },
+    "groupedOperations": [
+      {
+        "intent": "make required response header in 200 response optional",
+        "operations": [
+          {
+            "op": "replace",
+            "path": "/paths/~1api~1animals/post/responses/200/headers/required/required",
+            "value": false,
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/headers/required",
+  },
+]
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.0.1 response headers required but not seen 2`] = `
+{
+  "info": {},
+  "openapi": "3.0.1",
+  "paths": {
+    "/api/animals": {
+      "post": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "properties": {
+                          "status": {
+                            "const": "ok",
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "status",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "headers": {
+              "required": {
+                "name": "required",
+                "required": false,
+                "schema": {
+                  "type": "string",
                 },
               },
             },
@@ -7089,6 +8326,448 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 existing schema that does
 }
 `;
 
+exports[`generateEndpointSpecPatches OAS version 3.1.0 header parameter not documented 1`] = `
+[
+  {
+    "description": "operation: add 200 response",
+    "diff": {
+      "contentType": "application/json",
+      "kind": "UnmatchedResponseStatusCode",
+      "statusCode": "200",
+    },
+    "groupedOperations": [
+      {
+        "intent": "add response status code",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200",
+            "value": {
+              "description": "200 response",
+            },
+          },
+        ],
+      },
+      {
+        "intent": "add response body for content type 'application/json'",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/content",
+            "value": {
+              "application/json": {},
+            },
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [
+          {
+            "name": "undocumented",
+            "value": "abc",
+          },
+        ],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post",
+  },
+  {
+    "description": "add parameters array to operation",
+    "diff": {
+      "kind": "MissingRequestParametersArray",
+    },
+    "groupedOperations": [
+      {
+        "intent": "add parameters array",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/parameters",
+            "value": [],
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [
+          {
+            "name": "undocumented",
+            "value": "abc",
+          },
+        ],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post",
+  },
+  {
+    "description": "add undocumented header parameter",
+    "diff": {
+      "in": "header",
+      "kind": "UnmatchedRequestParameter",
+      "name": "undocumented",
+    },
+    "groupedOperations": [
+      {
+        "intent": "add undocumented header parameter",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/parameters/-",
+            "value": {
+              "in": "header",
+              "name": "undocumented",
+              "required": true,
+              "schema": {
+                "type": "string",
+              },
+            },
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [
+          {
+            "name": "undocumented",
+            "value": "abc",
+          },
+        ],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/parameters",
+  },
+  {
+    "description": "update response body: add schema object",
+    "diff": undefined,
+    "groupedOperations": [
+      {
+        "intent": "add schema object",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+            "value": {},
+          },
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
+            "value": "object",
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [
+          {
+            "name": "undocumented",
+            "value": "abc",
+          },
+        ],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+]
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.1.0 header parameter not documented 2`] = `
+{
+  "info": {},
+  "openapi": "3.1.0",
+  "paths": {
+    "/api/animals": {
+      "post": {
+        "parameters": [
+          {
+            "in": "header",
+            "name": "undocumented",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                },
+              },
+            },
+            "description": "200 response",
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.1.0 header parameter required but not seen 1`] = `
+[
+  {
+    "description": "operation: add 200 response",
+    "diff": {
+      "contentType": "application/json",
+      "kind": "UnmatchedResponseStatusCode",
+      "statusCode": "200",
+    },
+    "groupedOperations": [
+      {
+        "intent": "add response status code",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200",
+            "value": {
+              "description": "200 response",
+            },
+          },
+        ],
+      },
+      {
+        "intent": "add response body for content type 'application/json'",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/content",
+            "value": {
+              "application/json": {},
+            },
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post",
+  },
+  {
+    "description": "make required header parameter optional",
+    "diff": {
+      "in": "header",
+      "kind": "MissingRequiredRequiredParameter",
+      "name": "required",
+    },
+    "groupedOperations": [
+      {
+        "intent": "make required header parameter optional",
+        "operations": [
+          {
+            "op": "replace",
+            "path": "/paths/~1api~1animals/post/parameters/0/required",
+            "value": false,
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/parameters/0",
+  },
+  {
+    "description": "update response body: add schema object",
+    "diff": undefined,
+    "groupedOperations": [
+      {
+        "intent": "add schema object",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+            "value": {},
+          },
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
+            "value": "object",
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+]
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.1.0 header parameter required but not seen 2`] = `
+{
+  "info": {},
+  "openapi": "3.1.0",
+  "paths": {
+    "/api/animals": {
+      "post": {
+        "parameters": [
+          {
+            "in": "header",
+            "name": "required",
+            "required": false,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                },
+              },
+            },
+            "description": "200 response",
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
 exports[`generateEndpointSpecPatches OAS version 3.1.0 interactions with non-alphanumeric keys 1`] = `
 [
   {
@@ -9027,6 +10706,801 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 missing required property
                   },
                   "required": [],
                   "type": "object",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.1.0 query parameter not documented 1`] = `
+[
+  {
+    "description": "operation: add 200 response",
+    "diff": {
+      "contentType": "application/json",
+      "kind": "UnmatchedResponseStatusCode",
+      "statusCode": "200",
+    },
+    "groupedOperations": [
+      {
+        "intent": "add response status code",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200",
+            "value": {
+              "description": "200 response",
+            },
+          },
+        ],
+      },
+      {
+        "intent": "add response body for content type 'application/json'",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/content",
+            "value": {
+              "application/json": {},
+            },
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [
+          {
+            "name": "undocumented",
+            "value": "abc",
+          },
+        ],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post",
+  },
+  {
+    "description": "add parameters array to operation",
+    "diff": {
+      "kind": "MissingRequestParametersArray",
+    },
+    "groupedOperations": [
+      {
+        "intent": "add parameters array",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/parameters",
+            "value": [],
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [
+          {
+            "name": "undocumented",
+            "value": "abc",
+          },
+        ],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post",
+  },
+  {
+    "description": "add undocumented query parameter",
+    "diff": {
+      "in": "query",
+      "kind": "UnmatchedRequestParameter",
+      "name": "undocumented",
+    },
+    "groupedOperations": [
+      {
+        "intent": "add undocumented query parameter",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/parameters/-",
+            "value": {
+              "in": "query",
+              "name": "undocumented",
+              "required": true,
+              "schema": {
+                "type": "string",
+              },
+            },
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [
+          {
+            "name": "undocumented",
+            "value": "abc",
+          },
+        ],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/parameters",
+  },
+  {
+    "description": "update response body: add schema object",
+    "diff": undefined,
+    "groupedOperations": [
+      {
+        "intent": "add schema object",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+            "value": {},
+          },
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
+            "value": "object",
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [
+          {
+            "name": "undocumented",
+            "value": "abc",
+          },
+        ],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+]
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.1.0 query parameter not documented 2`] = `
+{
+  "info": {},
+  "openapi": "3.1.0",
+  "paths": {
+    "/api/animals": {
+      "post": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "undocumented",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                },
+              },
+            },
+            "description": "200 response",
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.1.0 query parameter required but not seen 1`] = `
+[
+  {
+    "description": "operation: add 200 response",
+    "diff": {
+      "contentType": "application/json",
+      "kind": "UnmatchedResponseStatusCode",
+      "statusCode": "200",
+    },
+    "groupedOperations": [
+      {
+        "intent": "add response status code",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200",
+            "value": {
+              "description": "200 response",
+            },
+          },
+        ],
+      },
+      {
+        "intent": "add response body for content type 'application/json'",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/content",
+            "value": {
+              "application/json": {},
+            },
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post",
+  },
+  {
+    "description": "make required query parameter optional",
+    "diff": {
+      "in": "query",
+      "kind": "MissingRequiredRequiredParameter",
+      "name": "required",
+    },
+    "groupedOperations": [
+      {
+        "intent": "make required query parameter optional",
+        "operations": [
+          {
+            "op": "replace",
+            "path": "/paths/~1api~1animals/post/parameters/0/required",
+            "value": false,
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/parameters/0",
+  },
+  {
+    "description": "update response body: add schema object",
+    "diff": undefined,
+    "groupedOperations": [
+      {
+        "intent": "add schema object",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+            "value": {},
+          },
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
+            "value": "object",
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+]
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.1.0 query parameter required but not seen 2`] = `
+{
+  "info": {},
+  "openapi": "3.1.0",
+  "paths": {
+    "/api/animals": {
+      "post": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "required",
+            "required": false,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                },
+              },
+            },
+            "description": "200 response",
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.1.0 response headers not documented 1`] = `
+[
+  {
+    "description": "operation: add 200 response",
+    "diff": {
+      "contentType": "application/json",
+      "kind": "UnmatchedResponseStatusCode",
+      "statusCode": "200",
+    },
+    "groupedOperations": [
+      {
+        "intent": "add response status code",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200",
+            "value": {
+              "description": "200 response",
+            },
+          },
+        ],
+      },
+      {
+        "intent": "add response body for content type 'application/json'",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/content",
+            "value": {
+              "application/json": {},
+            },
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [
+          {
+            "name": "undocumented",
+            "value": "abc",
+          },
+        ],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post",
+  },
+  {
+    "description": "add response headers object to operation",
+    "diff": {
+      "kind": "MissingResponseHeadersObject",
+      "statusCode": "200",
+    },
+    "groupedOperations": [
+      {
+        "intent": "add parameters array",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/headers",
+            "value": {},
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [
+          {
+            "name": "undocumented",
+            "value": "abc",
+          },
+        ],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200",
+  },
+  {
+    "description": "add undocumented response header to 200 response",
+    "diff": {
+      "kind": "UnmatchedResponseHeader",
+      "name": "undocumented",
+      "statusCode": "200",
+    },
+    "groupedOperations": [
+      {
+        "intent": "add undocumented response header to 200 response",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/headers/undocumented",
+            "value": {
+              "name": "undocumented",
+              "required": true,
+              "schema": {
+                "type": "string",
+              },
+            },
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [
+          {
+            "name": "undocumented",
+            "value": "abc",
+          },
+        ],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/headers/undocumented",
+  },
+  {
+    "description": "update response body: add schema object",
+    "diff": undefined,
+    "groupedOperations": [
+      {
+        "intent": "add schema object",
+        "operations": [
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+            "value": {},
+          },
+          {
+            "op": "add",
+            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
+            "value": "object",
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [
+          {
+            "name": "undocumented",
+            "value": "abc",
+          },
+        ],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+]
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.1.0 response headers not documented 2`] = `
+{
+  "info": {},
+  "openapi": "3.1.0",
+  "paths": {
+    "/api/animals": {
+      "post": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                },
+              },
+            },
+            "description": "200 response",
+            "headers": {
+              "undocumented": {
+                "name": "undocumented",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.1.0 response headers required but not seen 1`] = `
+[
+  {
+    "description": "make required response header in 200 response optional",
+    "diff": {
+      "kind": "MissingRequiredResponseHeader",
+      "name": "required",
+      "statusCode": "200",
+    },
+    "groupedOperations": [
+      {
+        "intent": "make required response header in 200 response optional",
+        "operations": [
+          {
+            "op": "replace",
+            "path": "/paths/~1api~1animals/post/responses/200/headers/required/required",
+            "value": false,
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{}",
+          "contentType": "application/json",
+          "size": 2,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/headers/required",
+  },
+]
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.1.0 response headers required but not seen 2`] = `
+{
+  "info": {},
+  "openapi": "3.1.0",
+  "paths": {
+    "/api/animals": {
+      "post": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "properties": {
+                          "status": {
+                            "const": "ok",
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "status",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "headers": {
+              "required": {
+                "name": "required",
+                "required": false,
+                "schema": {
+                  "type": "string",
                 },
               },
             },

--- a/projects/optic/src/commands/capture/patches/__tests__/__snapshots__/patches.test.ts.snap
+++ b/projects/optic/src/commands/capture/patches/__tests__/__snapshots__/patches.test.ts.snap
@@ -32,42 +32,27 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 array with multiple items
     },
     "groupedOperations": [
       {
-        "intent": "add properties {} to parent object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties",
-            "value": {},
-          },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties",
+        "value": {},
+      },
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required",
+        "value": [
+          "books",
         ],
       },
       {
-        "intent": "add required [] to parent object and make books required",
-        "operations": [
-          {
-            "extra": "same",
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required",
-            "value": [
-              "books",
-            ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books",
+        "value": {
+          "items": {
+            "type": "object",
           },
-        ],
-      },
-      {
-        "intent": "add property books schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books",
-            "value": {
-              "items": {
-                "type": "object",
-              },
-              "type": "array",
-            },
-          },
-        ],
+          "type": "array",
+        },
       },
     ],
     "impact": [
@@ -110,39 +95,24 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 array with multiple items
     },
     "groupedOperations": [
       {
-        "intent": "add properties {} to parent object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties",
-            "value": {},
-          },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties",
+        "value": {},
+      },
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required",
+        "value": [
+          "id",
         ],
       },
       {
-        "intent": "add required [] to parent object and make id required",
-        "operations": [
-          {
-            "extra": "same",
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required",
-            "value": [
-              "id",
-            ],
-          },
-        ],
-      },
-      {
-        "intent": "add property id schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/id",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/id",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -185,26 +155,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 array with multiple items
     },
     "groupedOperations": [
       {
-        "intent": "make new property author_id required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/-",
-            "value": "author_id",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/-",
+        "value": "author_id",
       },
       {
-        "intent": "add property author_id schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/author_id",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/author_id",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -247,26 +207,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 array with multiple items
     },
     "groupedOperations": [
       {
-        "intent": "make new property price required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/-",
-            "value": "price",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/-",
+        "value": "price",
       },
       {
-        "intent": "add property price schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/price",
-            "value": {
-              "type": "number",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/price",
+        "value": {
+          "type": "number",
+        },
       },
     ],
     "impact": [
@@ -308,14 +258,9 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 array with multiple items
     },
     "groupedOperations": [
       {
-        "intent": "make items nullable",
-        "operations": [
-          {
-            "op": "replace",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/nullable",
-            "value": true,
-          },
-        ],
+        "op": "replace",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/nullable",
+        "value": true,
       },
     ],
     "impact": [
@@ -357,13 +302,8 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 array with multiple items
     },
     "groupedOperations": [
       {
-        "intent": "remove author_id from parent's required array",
-        "operations": [
-          {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/1",
-          },
-        ],
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/1",
       },
     ],
     "impact": [
@@ -405,13 +345,8 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 array with multiple items
     },
     "groupedOperations": [
       {
-        "intent": "remove price from parent's required array",
-        "operations": [
-          {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/1",
-          },
-        ],
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/1",
       },
     ],
     "impact": [
@@ -589,13 +524,8 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 existing schema that does
     },
     "groupedOperations": [
       {
-        "intent": "remove data from parent's required array",
-        "operations": [
-          {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/0",
-          },
-        ],
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/0",
       },
     ],
     "impact": [
@@ -637,13 +567,8 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 existing schema that does
     },
     "groupedOperations": [
       {
-        "intent": "remove next from parent's required array",
-        "operations": [
-          {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/0",
-          },
-        ],
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/0",
       },
     ],
     "impact": [
@@ -685,13 +610,8 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 existing schema that does
     },
     "groupedOperations": [
       {
-        "intent": "remove has_more_data from parent's required array",
-        "operations": [
-          {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/0",
-          },
-        ],
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/0",
       },
     ],
     "impact": [
@@ -751,29 +671,19 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 existing schema that does
     },
     "groupedOperations": [
       {
-        "intent": "make new property books required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/-",
-            "value": "books",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/-",
+        "value": "books",
       },
       {
-        "intent": "add property books schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books",
-            "value": {
-              "items": {
-                "type": "object",
-              },
-              "type": "array",
-            },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books",
+        "value": {
+          "items": {
+            "type": "object",
           },
-        ],
+          "type": "array",
+        },
       },
     ],
     "impact": [
@@ -816,39 +726,24 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 existing schema that does
     },
     "groupedOperations": [
       {
-        "intent": "add properties {} to parent object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties",
-            "value": {},
-          },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties",
+        "value": {},
+      },
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required",
+        "value": [
+          "id",
         ],
       },
       {
-        "intent": "add required [] to parent object and make id required",
-        "operations": [
-          {
-            "extra": "same",
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required",
-            "value": [
-              "id",
-            ],
-          },
-        ],
-      },
-      {
-        "intent": "add property id schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/id",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/id",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -891,26 +786,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 existing schema that does
     },
     "groupedOperations": [
       {
-        "intent": "make new property name required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/-",
-            "value": "name",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/-",
+        "value": "name",
       },
       {
-        "intent": "add property name schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/name",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/name",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -953,26 +838,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 existing schema that does
     },
     "groupedOperations": [
       {
-        "intent": "make new property author_id required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/-",
-            "value": "author_id",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/-",
+        "value": "author_id",
       },
       {
-        "intent": "add property author_id schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/author_id",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/author_id",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -1015,26 +890,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 existing schema that does
     },
     "groupedOperations": [
       {
-        "intent": "make new property price required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/-",
-            "value": "price",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/-",
+        "value": "price",
       },
       {
-        "intent": "add property price schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/price",
-            "value": {
-              "type": "number",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/price",
+        "value": {
+          "type": "number",
+        },
       },
     ],
     "impact": [
@@ -1077,26 +942,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 existing schema that does
     },
     "groupedOperations": [
       {
-        "intent": "make new property created_at required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/-",
-            "value": "created_at",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/-",
+        "value": "created_at",
       },
       {
-        "intent": "add property created_at schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/created_at",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/created_at",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -1139,26 +994,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 existing schema that does
     },
     "groupedOperations": [
       {
-        "intent": "make new property updated_at required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/-",
-            "value": "updated_at",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/-",
+        "value": "updated_at",
       },
       {
-        "intent": "add property updated_at schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/updated_at",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/updated_at",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -1275,28 +1120,18 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 header parameter not docu
     },
     "groupedOperations": [
       {
-        "intent": "add response status code",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200",
-            "value": {
-              "description": "200 response",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200",
+        "value": {
+          "description": "200 response",
+        },
       },
       {
-        "intent": "add response body for content type 'application/json'",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content",
-            "value": {
-              "application/json": {},
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content",
+        "value": {
+          "application/json": {},
+        },
       },
     ],
     "impact": [
@@ -1336,14 +1171,9 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 header parameter not docu
     },
     "groupedOperations": [
       {
-        "intent": "add parameters array",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/parameters",
-            "value": [],
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/parameters",
+        "value": [],
       },
     ],
     "impact": [
@@ -1385,21 +1215,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 header parameter not docu
     },
     "groupedOperations": [
       {
-        "intent": "add undocumented header parameter",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/parameters/-",
-            "value": {
-              "in": "header",
-              "name": "undocumented",
-              "required": true,
-              "schema": {
-                "type": "string",
-              },
-            },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/parameters/-",
+        "value": {
+          "in": "header",
+          "name": "undocumented",
+          "required": true,
+          "schema": {
+            "type": "string",
           },
-        ],
+        },
       },
     ],
     "impact": [
@@ -1437,19 +1262,14 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 header parameter not docu
     "diff": undefined,
     "groupedOperations": [
       {
-        "intent": "add schema object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-            "value": {},
-          },
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
-            "value": "object",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+        "value": {},
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
+        "value": "object",
       },
     ],
     "impact": [
@@ -1531,28 +1351,18 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 header parameter required
     },
     "groupedOperations": [
       {
-        "intent": "add response status code",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200",
-            "value": {
-              "description": "200 response",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200",
+        "value": {
+          "description": "200 response",
+        },
       },
       {
-        "intent": "add response body for content type 'application/json'",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content",
-            "value": {
-              "application/json": {},
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content",
+        "value": {
+          "application/json": {},
+        },
       },
     ],
     "impact": [
@@ -1589,14 +1399,9 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 header parameter required
     },
     "groupedOperations": [
       {
-        "intent": "make required header parameter optional",
-        "operations": [
-          {
-            "op": "replace",
-            "path": "/paths/~1api~1animals/post/parameters/0/required",
-            "value": false,
-          },
-        ],
+        "op": "replace",
+        "path": "/paths/~1api~1animals/post/parameters/0/required",
+        "value": false,
       },
     ],
     "impact": [
@@ -1628,19 +1433,14 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 header parameter required
     "diff": undefined,
     "groupedOperations": [
       {
-        "intent": "add schema object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-            "value": {},
-          },
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
-            "value": "object",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+        "value": {},
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
+        "value": "object",
       },
     ],
     "impact": [
@@ -1717,28 +1517,18 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "add response status code",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200",
-            "value": {
-              "description": "200 response",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200",
+        "value": {
+          "description": "200 response",
+        },
       },
       {
-        "intent": "add response body for content type 'application/json'",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content",
-            "value": {
-              "application/json": {},
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content",
+        "value": {
+          "application/json": {},
+        },
       },
     ],
     "impact": [
@@ -1771,19 +1561,14 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 interactions with non-alp
     "diff": undefined,
     "groupedOperations": [
       {
-        "intent": "add schema object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-            "value": {},
-          },
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
-            "value": "object",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+        "value": {},
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
+        "value": "object",
       },
     ],
     "impact": [
@@ -1842,42 +1627,27 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "add properties {} to parent object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties",
-            "value": {},
-          },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties",
+        "value": {},
+      },
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required",
+        "value": [
+          "data",
         ],
       },
       {
-        "intent": "add required [] to parent object and make data required",
-        "operations": [
-          {
-            "extra": "same",
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required",
-            "value": [
-              "data",
-            ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data",
+        "value": {
+          "items": {
+            "type": "object",
           },
-        ],
-      },
-      {
-        "intent": "add property data schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data",
-            "value": {
-              "items": {
-                "type": "object",
-              },
-              "type": "array",
-            },
-          },
-        ],
+          "type": "array",
+        },
       },
     ],
     "impact": [
@@ -1937,26 +1707,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "make new property meta required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/-",
-            "value": "meta",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/-",
+        "value": "meta",
       },
       {
-        "intent": "add property meta schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta",
-            "value": {
-              "type": "object",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta",
+        "value": {
+          "type": "object",
+        },
       },
     ],
     "impact": [
@@ -2004,45 +1764,30 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "add properties {} to parent object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties",
-            "value": {},
-          },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties",
+        "value": {},
+      },
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/required",
+        "value": [
+          "tuple(('duration', 300))",
         ],
       },
       {
-        "intent": "add required [] to parent object and make tuple(('duration', 300)) required",
-        "operations": [
-          {
-            "extra": "same",
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/required",
-            "value": [
-              "tuple(('duration', 300))",
-            ],
-          },
-        ],
-      },
-      {
-        "intent": "add property tuple(('duration', 300)) schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/tuple(('duration', 300))",
-            "value": {
-              "items": {
-                "items": {
-                  "type": "string",
-                },
-                "type": "array",
-              },
-              "type": "array",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/tuple(('duration', 300))",
+        "value": {
+          "items": {
+            "items": {
+              "type": "string",
             },
+            "type": "array",
           },
-        ],
+          "type": "array",
+        },
       },
     ],
     "impact": [
@@ -2085,26 +1830,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "make new property tpm() required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/required/-",
-            "value": "tpm()",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/required/-",
+        "value": "tpm()",
       },
       {
-        "intent": "add property tpm() schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/tpm()",
-            "value": {
-              "type": "number",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/tpm()",
+        "value": {
+          "type": "number",
+        },
       },
     ],
     "impact": [
@@ -2147,26 +1882,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "make new property failure_rate() required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/required/-",
-            "value": "failure_rate()",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/required/-",
+        "value": "failure_rate()",
       },
       {
-        "intent": "add property failure_rate() schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/failure_rate()",
-            "value": {
-              "type": "number",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/failure_rate()",
+        "value": {
+          "type": "number",
+        },
       },
     ],
     "impact": [
@@ -2209,26 +1934,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "make new property user_misery() required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/required/-",
-            "value": "user_misery()",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/required/-",
+        "value": "user_misery()",
       },
       {
-        "intent": "add property user_misery() schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/user_misery()",
-            "value": {
-              "type": "number",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/user_misery()",
+        "value": {
+          "type": "number",
+        },
       },
     ],
     "impact": [
@@ -2274,29 +1989,19 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "make new property 😃things required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/required/-",
-            "value": "😃things",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/required/-",
+        "value": "😃things",
       },
       {
-        "intent": "add property 😃things schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/😃things",
-            "value": {
-              "items": {
-                "type": "string",
-              },
-              "type": "array",
-            },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/😃things",
+        "value": {
+          "items": {
+            "type": "string",
           },
-        ],
+          "type": "array",
+        },
       },
     ],
     "impact": [
@@ -2343,39 +2048,24 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "add properties {} to parent object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties",
-            "value": {},
-          },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties",
+        "value": {},
+      },
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/required",
+        "value": [
+          "fields",
         ],
       },
       {
-        "intent": "add required [] to parent object and make fields required",
-        "operations": [
-          {
-            "extra": "same",
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/required",
-            "value": [
-              "fields",
-            ],
-          },
-        ],
-      },
-      {
-        "intent": "add property fields schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/fields",
-            "value": {
-              "type": "object",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/fields",
+        "value": {
+          "type": "object",
+        },
       },
     ],
     "impact": [
@@ -2422,26 +2112,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "make new property units required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/required/-",
-            "value": "units",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/required/-",
+        "value": "units",
       },
       {
-        "intent": "add property units schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/units",
-            "value": {
-              "type": "object",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/units",
+        "value": {
+          "type": "object",
+        },
       },
     ],
     "impact": [
@@ -2484,26 +2164,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "make new property isMetricsData required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/required/-",
-            "value": "isMetricsData",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/required/-",
+        "value": "isMetricsData",
       },
       {
-        "intent": "add property isMetricsData schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/isMetricsData",
-            "value": {
-              "type": "boolean",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/isMetricsData",
+        "value": {
+          "type": "boolean",
+        },
       },
     ],
     "impact": [
@@ -2549,26 +2219,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "make new property tips required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/required/-",
-            "value": "tips",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/required/-",
+        "value": "tips",
       },
       {
-        "intent": "add property tips schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/tips",
-            "value": {
-              "type": "object",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/tips",
+        "value": {
+          "type": "object",
+        },
       },
     ],
     "impact": [
@@ -2611,26 +2271,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "make new property dataset required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/required/-",
-            "value": "dataset",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/required/-",
+        "value": "dataset",
       },
       {
-        "intent": "add property dataset schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/dataset",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/dataset",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -2672,23 +2322,18 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "replace items with a one of containing both types",
-        "operations": [
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/tuple(('duration', 300))/items/items/type",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/tuple(('duration', 300))/items/items/oneOf",
+        "value": [
           {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/tuple(('duration', 300))/items/items/type",
+            "type": "string",
           },
           {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/tuple(('duration', 300))/items/items/oneOf",
-            "value": [
-              {
-                "type": "string",
-              },
-              {
-                "type": "number",
-              },
-            ],
+            "type": "number",
           },
         ],
       },
@@ -2732,23 +2377,18 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "replace items with a one of containing both types",
-        "operations": [
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/😃things/items/type",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/😃things/items/oneOf",
+        "value": [
           {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/😃things/items/type",
+            "type": "string",
           },
           {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/😃things/items/oneOf",
-            "value": [
-              {
-                "type": "string",
-              },
-              {
-                "type": "number",
-              },
-            ],
+            "type": "number",
           },
         ],
       },
@@ -2793,39 +2433,24 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "add properties {} to parent object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/fields/properties",
-            "value": {},
-          },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/fields/properties",
+        "value": {},
+      },
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/fields/required",
+        "value": [
+          "tuple(('duration', 300))",
         ],
       },
       {
-        "intent": "add required [] to parent object and make tuple(('duration', 300)) required",
-        "operations": [
-          {
-            "extra": "same",
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/fields/required",
-            "value": [
-              "tuple(('duration', 300))",
-            ],
-          },
-        ],
-      },
-      {
-        "intent": "add property tuple(('duration', 300)) schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/fields/properties/tuple(('duration', 300))",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/fields/properties/tuple(('duration', 300))",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -2868,26 +2493,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "make new property blah() required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/fields/required/-",
-            "value": "blah()",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/fields/required/-",
+        "value": "blah()",
       },
       {
-        "intent": "add property blah() schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/fields/properties/blah()",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/fields/properties/blah()",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -2930,26 +2545,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "make new property project_threshold_config required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/fields/required/-",
-            "value": "project_threshold_config",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/fields/required/-",
+        "value": "project_threshold_config",
       },
       {
-        "intent": "add property project_threshold_config schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/fields/properties/project_threshold_config",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/fields/properties/project_threshold_config",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -2992,39 +2597,24 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "add properties {} to parent object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/units/properties",
-            "value": {},
-          },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/units/properties",
+        "value": {},
+      },
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/units/required",
+        "value": [
+          "tuple(('duration', 300))",
         ],
       },
       {
-        "intent": "add required [] to parent object and make tuple(('duration', 300)) required",
-        "operations": [
-          {
-            "extra": "same",
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/units/required",
-            "value": [
-              "tuple(('duration', 300))",
-            ],
-          },
-        ],
-      },
-      {
-        "intent": "add property tuple(('duration', 300)) schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/units/properties/tuple(('duration', 300))",
-            "value": {
-              "nullable": true,
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/units/properties/tuple(('duration', 300))",
+        "value": {
+          "nullable": true,
+        },
       },
     ],
     "impact": [
@@ -3067,26 +2657,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "make new property blah() required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/units/required/-",
-            "value": "blah()",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/units/required/-",
+        "value": "blah()",
       },
       {
-        "intent": "add property blah() schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/units/properties/blah()",
-            "value": {
-              "nullable": true,
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/units/properties/blah()",
+        "value": {
+          "nullable": true,
+        },
       },
     ],
     "impact": [
@@ -3129,26 +2709,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "make new property 😃things required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/units/required/-",
-            "value": "😃things",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/units/required/-",
+        "value": "😃things",
       },
       {
-        "intent": "add property 😃things schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/units/properties/😃things",
-            "value": {
-              "nullable": true,
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/units/properties/😃things",
+        "value": {
+          "nullable": true,
+        },
       },
     ],
     "impact": [
@@ -3191,39 +2761,24 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "add properties {} to parent object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/tips/properties",
-            "value": {},
-          },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/tips/properties",
+        "value": {},
+      },
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/tips/required",
+        "value": [
+          "query",
         ],
       },
       {
-        "intent": "add required [] to parent object and make query required",
-        "operations": [
-          {
-            "extra": "same",
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/tips/required",
-            "value": [
-              "query",
-            ],
-          },
-        ],
-      },
-      {
-        "intent": "add property query schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/tips/properties/query",
-            "value": {
-              "nullable": true,
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/tips/properties/query",
+        "value": {
+          "nullable": true,
+        },
       },
     ],
     "impact": [
@@ -3266,26 +2821,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "make new property columns required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/tips/required/-",
-            "value": "columns",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/tips/required/-",
+        "value": "columns",
       },
       {
-        "intent": "add property columns schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/tips/properties/columns",
-            "value": {
-              "nullable": true,
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/tips/properties/columns",
+        "value": {
+          "nullable": true,
+        },
       },
     ],
     "impact": [
@@ -3487,23 +3032,18 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 mismatched type in schema
     },
     "groupedOperations": [
       {
-        "intent": "replace name with a one of containing both types",
-        "operations": [
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/name/type",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/name/oneOf",
+        "value": [
           {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/name/type",
+            "type": "number",
           },
           {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/name/oneOf",
-            "value": [
-              {
-                "type": "number",
-              },
-              {
-                "type": "string",
-              },
-            ],
+            "type": "string",
           },
         ],
       },
@@ -3588,13 +3128,8 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 missing required property
     },
     "groupedOperations": [
       {
-        "intent": "remove name from parent's required array",
-        "operations": [
-          {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/0",
-          },
-        ],
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/0",
       },
     ],
     "impact": [
@@ -3666,28 +3201,18 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 query parameter not docum
     },
     "groupedOperations": [
       {
-        "intent": "add response status code",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200",
-            "value": {
-              "description": "200 response",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200",
+        "value": {
+          "description": "200 response",
+        },
       },
       {
-        "intent": "add response body for content type 'application/json'",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content",
-            "value": {
-              "application/json": {},
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content",
+        "value": {
+          "application/json": {},
+        },
       },
     ],
     "impact": [
@@ -3727,14 +3252,9 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 query parameter not docum
     },
     "groupedOperations": [
       {
-        "intent": "add parameters array",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/parameters",
-            "value": [],
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/parameters",
+        "value": [],
       },
     ],
     "impact": [
@@ -3776,21 +3296,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 query parameter not docum
     },
     "groupedOperations": [
       {
-        "intent": "add undocumented query parameter",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/parameters/-",
-            "value": {
-              "in": "query",
-              "name": "undocumented",
-              "required": true,
-              "schema": {
-                "type": "string",
-              },
-            },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/parameters/-",
+        "value": {
+          "in": "query",
+          "name": "undocumented",
+          "required": true,
+          "schema": {
+            "type": "string",
           },
-        ],
+        },
       },
     ],
     "impact": [
@@ -3828,19 +3343,14 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 query parameter not docum
     "diff": undefined,
     "groupedOperations": [
       {
-        "intent": "add schema object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-            "value": {},
-          },
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
-            "value": "object",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+        "value": {},
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
+        "value": "object",
       },
     ],
     "impact": [
@@ -3922,28 +3432,18 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 query parameter required 
     },
     "groupedOperations": [
       {
-        "intent": "add response status code",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200",
-            "value": {
-              "description": "200 response",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200",
+        "value": {
+          "description": "200 response",
+        },
       },
       {
-        "intent": "add response body for content type 'application/json'",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content",
-            "value": {
-              "application/json": {},
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content",
+        "value": {
+          "application/json": {},
+        },
       },
     ],
     "impact": [
@@ -3980,14 +3480,9 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 query parameter required 
     },
     "groupedOperations": [
       {
-        "intent": "make required query parameter optional",
-        "operations": [
-          {
-            "op": "replace",
-            "path": "/paths/~1api~1animals/post/parameters/0/required",
-            "value": false,
-          },
-        ],
+        "op": "replace",
+        "path": "/paths/~1api~1animals/post/parameters/0/required",
+        "value": false,
       },
     ],
     "impact": [
@@ -4019,19 +3514,14 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 query parameter required 
     "diff": undefined,
     "groupedOperations": [
       {
-        "intent": "add schema object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-            "value": {},
-          },
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
-            "value": "object",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+        "value": {},
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
+        "value": "object",
       },
     ],
     "impact": [
@@ -4108,28 +3598,18 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 response headers not docu
     },
     "groupedOperations": [
       {
-        "intent": "add response status code",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200",
-            "value": {
-              "description": "200 response",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200",
+        "value": {
+          "description": "200 response",
+        },
       },
       {
-        "intent": "add response body for content type 'application/json'",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content",
-            "value": {
-              "application/json": {},
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content",
+        "value": {
+          "application/json": {},
+        },
       },
     ],
     "impact": [
@@ -4170,14 +3650,9 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 response headers not docu
     },
     "groupedOperations": [
       {
-        "intent": "add parameters array",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/headers",
-            "value": {},
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/headers",
+        "value": {},
       },
     ],
     "impact": [
@@ -4219,20 +3694,15 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 response headers not docu
     },
     "groupedOperations": [
       {
-        "intent": "add undocumented response header to 200 response",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/headers/undocumented",
-            "value": {
-              "name": "undocumented",
-              "required": true,
-              "schema": {
-                "type": "string",
-              },
-            },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/headers/undocumented",
+        "value": {
+          "name": "undocumented",
+          "required": true,
+          "schema": {
+            "type": "string",
           },
-        ],
+        },
       },
     ],
     "impact": [
@@ -4270,19 +3740,14 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 response headers not docu
     "diff": undefined,
     "groupedOperations": [
       {
-        "intent": "add schema object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-            "value": {},
-          },
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
-            "value": "object",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+        "value": {},
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
+        "value": "object",
       },
     ],
     "impact": [
@@ -4363,14 +3828,9 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 response headers required
     },
     "groupedOperations": [
       {
-        "intent": "make required response header in 200 response optional",
-        "operations": [
-          {
-            "op": "replace",
-            "path": "/paths/~1api~1animals/post/responses/200/headers/required/required",
-            "value": false,
-          },
-        ],
+        "op": "replace",
+        "path": "/paths/~1api~1animals/post/responses/200/headers/required/required",
+        "value": false,
       },
     ],
     "impact": [
@@ -4466,14 +3926,9 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 schema with arrays with p
     },
     "groupedOperations": [
       {
-        "intent": "make status nullable",
-        "operations": [
-          {
-            "op": "replace",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/nullable",
-            "value": true,
-          },
-        ],
+        "op": "replace",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/nullable",
+        "value": true,
       },
     ],
     "impact": [
@@ -4515,14 +3970,9 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 schema with arrays with p
     },
     "groupedOperations": [
       {
-        "intent": "make status nullable",
-        "operations": [
-          {
-            "op": "replace",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/nullable",
-            "value": true,
-          },
-        ],
+        "op": "replace",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/nullable",
+        "value": true,
       },
     ],
     "impact": [
@@ -4564,28 +4014,23 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 schema with arrays with p
     },
     "groupedOperations": [
       {
-        "intent": "replace status with a one of containing both types",
-        "operations": [
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/type",
+      },
+      {
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/nullable",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/oneOf",
+        "value": [
           {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/type",
+            "nullable": true,
+            "type": "string",
           },
           {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/nullable",
-          },
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/oneOf",
-            "value": [
-              {
-                "nullable": true,
-                "type": "string",
-              },
-              {
-                "type": "number",
-              },
-            ],
+            "type": "number",
           },
         ],
       },
@@ -4692,14 +4137,9 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 schema with enum 1`] = `
     },
     "groupedOperations": [
       {
-        "intent": "add new enum value to status",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/status/enum/-",
-            "value": "something-else",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/status/enum/-",
+        "value": "something-else",
       },
     ],
     "impact": [
@@ -4750,14 +4190,9 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 schema with enum 1`] = `
     },
     "groupedOperations": [
       {
-        "intent": "add new enum value to status",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/enum/-",
-            "value": "something-else",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/enum/-",
+        "value": "something-else",
       },
     ],
     "impact": [
@@ -4808,14 +4243,9 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 schema with enum 1`] = `
     },
     "groupedOperations": [
       {
-        "intent": "add new enum value to status",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/enum/-",
-            "value": "another-thing",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/enum/-",
+        "value": "another-thing",
       },
     ],
     "impact": [
@@ -4916,29 +4346,19 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented property in 
     },
     "groupedOperations": [
       {
-        "intent": "add required [] to parent object and make name required",
-        "operations": [
-          {
-            "extra": "same",
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required",
-            "value": [
-              "name",
-            ],
-          },
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required",
+        "value": [
+          "name",
         ],
       },
       {
-        "intent": "add property name schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/name",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/name",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -5011,28 +4431,18 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented request body
     },
     "groupedOperations": [
       {
-        "intent": "add request body to operation",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody",
-            "value": {
-              "content": {},
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody",
+        "value": {
+          "content": {},
+        },
       },
       {
-        "intent": "add application/json as content type",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json",
-            "value": {
-              "schema": {},
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json",
+        "value": {
+          "schema": {},
+        },
       },
     ],
     "impact": [
@@ -5073,28 +4483,18 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented request body
     },
     "groupedOperations": [
       {
-        "intent": "add response status code",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200",
-            "value": {
-              "description": "200 response",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200",
+        "value": {
+          "description": "200 response",
+        },
       },
       {
-        "intent": "add response body for content type 'application/json'",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content",
-            "value": {
-              "application/json": {},
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content",
+        "value": {
+          "application/json": {},
+        },
       },
     ],
     "impact": [
@@ -5131,14 +4531,9 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented request body
     "diff": undefined,
     "groupedOperations": [
       {
-        "intent": "add schema object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/type",
-            "value": "object",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/type",
+        "value": "object",
       },
     ],
     "impact": [
@@ -5185,39 +4580,24 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented request body
     },
     "groupedOperations": [
       {
-        "intent": "add properties {} to parent object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties",
-            "value": {},
-          },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties",
+        "value": {},
+      },
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/required",
+        "value": [
+          "name",
         ],
       },
       {
-        "intent": "add required [] to parent object and make name required",
-        "operations": [
-          {
-            "extra": "same",
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/required",
-            "value": [
-              "name",
-            ],
-          },
-        ],
-      },
-      {
-        "intent": "add property name schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/name",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/name",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -5264,26 +4644,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented request body
     },
     "groupedOperations": [
       {
-        "intent": "make new property age required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/required/-",
-            "value": "age",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/required/-",
+        "value": "age",
       },
       {
-        "intent": "add property age schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/age",
-            "value": {
-              "type": "number",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/age",
+        "value": {
+          "type": "number",
+        },
       },
     ],
     "impact": [
@@ -5330,26 +4700,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented request body
     },
     "groupedOperations": [
       {
-        "intent": "make new property created_at required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/required/-",
-            "value": "created_at",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/required/-",
+        "value": "created_at",
       },
       {
-        "intent": "add property created_at schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/created_at",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/created_at",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -5408,29 +4768,19 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented request body
     },
     "groupedOperations": [
       {
-        "intent": "make new property hobbies required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/required/-",
-            "value": "hobbies",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/required/-",
+        "value": "hobbies",
       },
       {
-        "intent": "add property hobbies schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies",
-            "value": {
-              "items": {
-                "type": "string",
-              },
-              "type": "array",
-            },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies",
+        "value": {
+          "items": {
+            "type": "string",
           },
-        ],
+          "type": "array",
+        },
       },
     ],
     "impact": [
@@ -5477,26 +4827,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented request body
     },
     "groupedOperations": [
       {
-        "intent": "make new property active required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/required/-",
-            "value": "active",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/required/-",
+        "value": "active",
       },
       {
-        "intent": "add property active schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/active",
-            "value": {
-              "type": "boolean",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/active",
+        "value": {
+          "type": "boolean",
+        },
       },
     ],
     "impact": [
@@ -5545,23 +4885,18 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented request body
     },
     "groupedOperations": [
       {
-        "intent": "replace items with a one of containing both types",
-        "operations": [
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/type",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf",
+        "value": [
           {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/type",
+            "type": "string",
           },
           {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf",
-            "value": [
-              {
-                "type": "string",
-              },
-              {
-                "type": "object",
-              },
-            ],
+            "type": "object",
           },
         ],
       },
@@ -5610,39 +4945,24 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented request body
     },
     "groupedOperations": [
       {
-        "intent": "add properties {} to parent object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties",
-            "value": {},
-          },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties",
+        "value": {},
+      },
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/required",
+        "value": [
+          "type",
         ],
       },
       {
-        "intent": "add required [] to parent object and make type required",
-        "operations": [
-          {
-            "extra": "same",
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/required",
-            "value": [
-              "type",
-            ],
-          },
-        ],
-      },
-      {
-        "intent": "add property type schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties/type",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties/type",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -5689,26 +5009,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented request body
     },
     "groupedOperations": [
       {
-        "intent": "make new property name required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/-",
-            "value": "name",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/-",
+        "value": "name",
       },
       {
-        "intent": "add property name schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties/name",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties/name",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -5755,26 +5065,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented request body
     },
     "groupedOperations": [
       {
-        "intent": "make new property skill required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/-",
-            "value": "skill",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/-",
+        "value": "skill",
       },
       {
-        "intent": "add property skill schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties/skill",
-            "value": {
-              "type": "number",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties/skill",
+        "value": {
+          "type": "number",
+        },
       },
     ],
     "impact": [
@@ -5821,26 +5121,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented request body
     },
     "groupedOperations": [
       {
-        "intent": "make new property bad required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/-",
-            "value": "bad",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/-",
+        "value": "bad",
       },
       {
-        "intent": "add property bad schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties/bad",
-            "value": {
-              "nullable": true,
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties/bad",
+        "value": {
+          "nullable": true,
+        },
       },
     ],
     "impact": [
@@ -5886,13 +5176,8 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented request body
     },
     "groupedOperations": [
       {
-        "intent": "remove skill from parent's required array",
-        "operations": [
-          {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/2",
-          },
-        ],
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/2",
       },
     ],
     "impact": [
@@ -5938,13 +5223,8 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented request body
     },
     "groupedOperations": [
       {
-        "intent": "remove bad from parent's required array",
-        "operations": [
-          {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/2",
-          },
-        ],
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/2",
       },
     ],
     "impact": [
@@ -5981,19 +5261,14 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented request body
     "diff": undefined,
     "groupedOperations": [
       {
-        "intent": "add schema object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-            "value": {},
-          },
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
-            "value": "object",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+        "value": {},
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
+        "value": "object",
       },
     ],
     "impact": [
@@ -6125,28 +5400,18 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented response bod
     },
     "groupedOperations": [
       {
-        "intent": "add response status code",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200",
-            "value": {
-              "description": "200 response",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200",
+        "value": {
+          "description": "200 response",
+        },
       },
       {
-        "intent": "add response body for content type 'application/json'",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content",
-            "value": {
-              "application/json": {},
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content",
+        "value": {
+          "application/json": {},
+        },
       },
     ],
     "impact": [
@@ -6179,19 +5444,14 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented response bod
     "diff": undefined,
     "groupedOperations": [
       {
-        "intent": "add schema object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-            "value": {},
-          },
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
-            "value": "object",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+        "value": {},
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
+        "value": "object",
       },
     ],
     "impact": [
@@ -6234,39 +5494,24 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented response bod
     },
     "groupedOperations": [
       {
-        "intent": "add properties {} to parent object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties",
-            "value": {},
-          },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties",
+        "value": {},
+      },
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required",
+        "value": [
+          "name",
         ],
       },
       {
-        "intent": "add required [] to parent object and make name required",
-        "operations": [
-          {
-            "extra": "same",
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required",
-            "value": [
-              "name",
-            ],
-          },
-        ],
-      },
-      {
-        "intent": "add property name schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/name",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/name",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -6309,26 +5554,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented response bod
     },
     "groupedOperations": [
       {
-        "intent": "make new property age required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/-",
-            "value": "age",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/-",
+        "value": "age",
       },
       {
-        "intent": "add property age schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/age",
-            "value": {
-              "type": "number",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/age",
+        "value": {
+          "type": "number",
+        },
       },
     ],
     "impact": [
@@ -6371,26 +5606,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented response bod
     },
     "groupedOperations": [
       {
-        "intent": "make new property created_at required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/-",
-            "value": "created_at",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/-",
+        "value": "created_at",
       },
       {
-        "intent": "add property created_at schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/created_at",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/created_at",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -6445,29 +5670,19 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented response bod
     },
     "groupedOperations": [
       {
-        "intent": "make new property hobbies required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/-",
-            "value": "hobbies",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/-",
+        "value": "hobbies",
       },
       {
-        "intent": "add property hobbies schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies",
-            "value": {
-              "items": {
-                "type": "string",
-              },
-              "type": "array",
-            },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies",
+        "value": {
+          "items": {
+            "type": "string",
           },
-        ],
+          "type": "array",
+        },
       },
     ],
     "impact": [
@@ -6510,26 +5725,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented response bod
     },
     "groupedOperations": [
       {
-        "intent": "make new property active required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/-",
-            "value": "active",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/-",
+        "value": "active",
       },
       {
-        "intent": "add property active schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/active",
-            "value": {
-              "type": "boolean",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/active",
+        "value": {
+          "type": "boolean",
+        },
       },
     ],
     "impact": [
@@ -6574,23 +5779,18 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented response bod
     },
     "groupedOperations": [
       {
-        "intent": "replace items with a one of containing both types",
-        "operations": [
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/type",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf",
+        "value": [
           {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/type",
+            "type": "string",
           },
           {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf",
-            "value": [
-              {
-                "type": "string",
-              },
-              {
-                "type": "object",
-              },
-            ],
+            "type": "object",
           },
         ],
       },
@@ -6635,39 +5835,24 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented response bod
     },
     "groupedOperations": [
       {
-        "intent": "add properties {} to parent object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties",
-            "value": {},
-          },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties",
+        "value": {},
+      },
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/required",
+        "value": [
+          "type",
         ],
       },
       {
-        "intent": "add required [] to parent object and make type required",
-        "operations": [
-          {
-            "extra": "same",
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/required",
-            "value": [
-              "type",
-            ],
-          },
-        ],
-      },
-      {
-        "intent": "add property type schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties/type",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties/type",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -6710,26 +5895,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented response bod
     },
     "groupedOperations": [
       {
-        "intent": "make new property name required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/-",
-            "value": "name",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/-",
+        "value": "name",
       },
       {
-        "intent": "add property name schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties/name",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties/name",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -6772,26 +5947,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented response bod
     },
     "groupedOperations": [
       {
-        "intent": "make new property skill required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/-",
-            "value": "skill",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/-",
+        "value": "skill",
       },
       {
-        "intent": "add property skill schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties/skill",
-            "value": {
-              "type": "number",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties/skill",
+        "value": {
+          "type": "number",
+        },
       },
     ],
     "impact": [
@@ -6834,26 +5999,16 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented response bod
     },
     "groupedOperations": [
       {
-        "intent": "make new property bad required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/-",
-            "value": "bad",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/-",
+        "value": "bad",
       },
       {
-        "intent": "add property bad schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties/bad",
-            "value": {
-              "nullable": true,
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties/bad",
+        "value": {
+          "nullable": true,
+        },
       },
     ],
     "impact": [
@@ -6895,13 +6050,8 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented response bod
     },
     "groupedOperations": [
       {
-        "intent": "remove skill from parent's required array",
-        "operations": [
-          {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/2",
-          },
-        ],
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/2",
       },
     ],
     "impact": [
@@ -6943,13 +6093,8 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented response bod
     },
     "groupedOperations": [
       {
-        "intent": "remove bad from parent's required array",
-        "operations": [
-          {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/2",
-          },
-        ],
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/2",
       },
     ],
     "impact": [
@@ -7089,42 +6234,27 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 array with multiple items
     },
     "groupedOperations": [
       {
-        "intent": "add properties {} to parent object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties",
-            "value": {},
-          },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties",
+        "value": {},
+      },
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required",
+        "value": [
+          "books",
         ],
       },
       {
-        "intent": "add required [] to parent object and make books required",
-        "operations": [
-          {
-            "extra": "same",
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required",
-            "value": [
-              "books",
-            ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books",
+        "value": {
+          "items": {
+            "type": "object",
           },
-        ],
-      },
-      {
-        "intent": "add property books schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books",
-            "value": {
-              "items": {
-                "type": "object",
-              },
-              "type": "array",
-            },
-          },
-        ],
+          "type": "array",
+        },
       },
     ],
     "impact": [
@@ -7167,39 +6297,24 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 array with multiple items
     },
     "groupedOperations": [
       {
-        "intent": "add properties {} to parent object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties",
-            "value": {},
-          },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties",
+        "value": {},
+      },
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required",
+        "value": [
+          "id",
         ],
       },
       {
-        "intent": "add required [] to parent object and make id required",
-        "operations": [
-          {
-            "extra": "same",
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required",
-            "value": [
-              "id",
-            ],
-          },
-        ],
-      },
-      {
-        "intent": "add property id schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/id",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/id",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -7242,26 +6357,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 array with multiple items
     },
     "groupedOperations": [
       {
-        "intent": "make new property author_id required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/-",
-            "value": "author_id",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/-",
+        "value": "author_id",
       },
       {
-        "intent": "add property author_id schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/author_id",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/author_id",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -7304,26 +6409,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 array with multiple items
     },
     "groupedOperations": [
       {
-        "intent": "make new property price required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/-",
-            "value": "price",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/-",
+        "value": "price",
       },
       {
-        "intent": "add property price schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/price",
-            "value": {
-              "type": "number",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/price",
+        "value": {
+          "type": "number",
+        },
       },
     ],
     "impact": [
@@ -7365,16 +6460,11 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 array with multiple items
     },
     "groupedOperations": [
       {
-        "intent": "make items null",
-        "operations": [
-          {
-            "op": "replace",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/type",
-            "value": [
-              "object",
-              "null",
-            ],
-          },
+        "op": "replace",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/type",
+        "value": [
+          "object",
+          "null",
         ],
       },
     ],
@@ -7417,13 +6507,8 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 array with multiple items
     },
     "groupedOperations": [
       {
-        "intent": "remove author_id from parent's required array",
-        "operations": [
-          {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/1",
-          },
-        ],
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/1",
       },
     ],
     "impact": [
@@ -7465,13 +6550,8 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 array with multiple items
     },
     "groupedOperations": [
       {
-        "intent": "remove price from parent's required array",
-        "operations": [
-          {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/1",
-          },
-        ],
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/1",
       },
     ],
     "impact": [
@@ -7651,13 +6731,8 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 existing schema that does
     },
     "groupedOperations": [
       {
-        "intent": "remove data from parent's required array",
-        "operations": [
-          {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/0",
-          },
-        ],
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/0",
       },
     ],
     "impact": [
@@ -7699,13 +6774,8 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 existing schema that does
     },
     "groupedOperations": [
       {
-        "intent": "remove next from parent's required array",
-        "operations": [
-          {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/0",
-          },
-        ],
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/0",
       },
     ],
     "impact": [
@@ -7747,13 +6817,8 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 existing schema that does
     },
     "groupedOperations": [
       {
-        "intent": "remove has_more_data from parent's required array",
-        "operations": [
-          {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/0",
-          },
-        ],
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/0",
       },
     ],
     "impact": [
@@ -7813,29 +6878,19 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 existing schema that does
     },
     "groupedOperations": [
       {
-        "intent": "make new property books required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/-",
-            "value": "books",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/-",
+        "value": "books",
       },
       {
-        "intent": "add property books schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books",
-            "value": {
-              "items": {
-                "type": "object",
-              },
-              "type": "array",
-            },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books",
+        "value": {
+          "items": {
+            "type": "object",
           },
-        ],
+          "type": "array",
+        },
       },
     ],
     "impact": [
@@ -7878,39 +6933,24 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 existing schema that does
     },
     "groupedOperations": [
       {
-        "intent": "add properties {} to parent object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties",
-            "value": {},
-          },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties",
+        "value": {},
+      },
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required",
+        "value": [
+          "id",
         ],
       },
       {
-        "intent": "add required [] to parent object and make id required",
-        "operations": [
-          {
-            "extra": "same",
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required",
-            "value": [
-              "id",
-            ],
-          },
-        ],
-      },
-      {
-        "intent": "add property id schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/id",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/id",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -7953,26 +6993,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 existing schema that does
     },
     "groupedOperations": [
       {
-        "intent": "make new property name required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/-",
-            "value": "name",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/-",
+        "value": "name",
       },
       {
-        "intent": "add property name schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/name",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/name",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -8015,26 +7045,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 existing schema that does
     },
     "groupedOperations": [
       {
-        "intent": "make new property author_id required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/-",
-            "value": "author_id",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/-",
+        "value": "author_id",
       },
       {
-        "intent": "add property author_id schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/author_id",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/author_id",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -8077,26 +7097,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 existing schema that does
     },
     "groupedOperations": [
       {
-        "intent": "make new property price required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/-",
-            "value": "price",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/-",
+        "value": "price",
       },
       {
-        "intent": "add property price schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/price",
-            "value": {
-              "type": "number",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/price",
+        "value": {
+          "type": "number",
+        },
       },
     ],
     "impact": [
@@ -8139,26 +7149,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 existing schema that does
     },
     "groupedOperations": [
       {
-        "intent": "make new property created_at required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/-",
-            "value": "created_at",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/-",
+        "value": "created_at",
       },
       {
-        "intent": "add property created_at schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/created_at",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/created_at",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -8201,26 +7201,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 existing schema that does
     },
     "groupedOperations": [
       {
-        "intent": "make new property updated_at required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/-",
-            "value": "updated_at",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/required/-",
+        "value": "updated_at",
       },
       {
-        "intent": "add property updated_at schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/updated_at",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/books/items/properties/updated_at",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -8337,28 +7327,18 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 header parameter not docu
     },
     "groupedOperations": [
       {
-        "intent": "add response status code",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200",
-            "value": {
-              "description": "200 response",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200",
+        "value": {
+          "description": "200 response",
+        },
       },
       {
-        "intent": "add response body for content type 'application/json'",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content",
-            "value": {
-              "application/json": {},
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content",
+        "value": {
+          "application/json": {},
+        },
       },
     ],
     "impact": [
@@ -8398,14 +7378,9 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 header parameter not docu
     },
     "groupedOperations": [
       {
-        "intent": "add parameters array",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/parameters",
-            "value": [],
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/parameters",
+        "value": [],
       },
     ],
     "impact": [
@@ -8447,21 +7422,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 header parameter not docu
     },
     "groupedOperations": [
       {
-        "intent": "add undocumented header parameter",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/parameters/-",
-            "value": {
-              "in": "header",
-              "name": "undocumented",
-              "required": true,
-              "schema": {
-                "type": "string",
-              },
-            },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/parameters/-",
+        "value": {
+          "in": "header",
+          "name": "undocumented",
+          "required": true,
+          "schema": {
+            "type": "string",
           },
-        ],
+        },
       },
     ],
     "impact": [
@@ -8499,19 +7469,14 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 header parameter not docu
     "diff": undefined,
     "groupedOperations": [
       {
-        "intent": "add schema object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-            "value": {},
-          },
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
-            "value": "object",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+        "value": {},
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
+        "value": "object",
       },
     ],
     "impact": [
@@ -8593,28 +7558,18 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 header parameter required
     },
     "groupedOperations": [
       {
-        "intent": "add response status code",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200",
-            "value": {
-              "description": "200 response",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200",
+        "value": {
+          "description": "200 response",
+        },
       },
       {
-        "intent": "add response body for content type 'application/json'",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content",
-            "value": {
-              "application/json": {},
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content",
+        "value": {
+          "application/json": {},
+        },
       },
     ],
     "impact": [
@@ -8651,14 +7606,9 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 header parameter required
     },
     "groupedOperations": [
       {
-        "intent": "make required header parameter optional",
-        "operations": [
-          {
-            "op": "replace",
-            "path": "/paths/~1api~1animals/post/parameters/0/required",
-            "value": false,
-          },
-        ],
+        "op": "replace",
+        "path": "/paths/~1api~1animals/post/parameters/0/required",
+        "value": false,
       },
     ],
     "impact": [
@@ -8690,19 +7640,14 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 header parameter required
     "diff": undefined,
     "groupedOperations": [
       {
-        "intent": "add schema object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-            "value": {},
-          },
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
-            "value": "object",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+        "value": {},
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
+        "value": "object",
       },
     ],
     "impact": [
@@ -8779,28 +7724,18 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "add response status code",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200",
-            "value": {
-              "description": "200 response",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200",
+        "value": {
+          "description": "200 response",
+        },
       },
       {
-        "intent": "add response body for content type 'application/json'",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content",
-            "value": {
-              "application/json": {},
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content",
+        "value": {
+          "application/json": {},
+        },
       },
     ],
     "impact": [
@@ -8833,19 +7768,14 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 interactions with non-alp
     "diff": undefined,
     "groupedOperations": [
       {
-        "intent": "add schema object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-            "value": {},
-          },
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
-            "value": "object",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+        "value": {},
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
+        "value": "object",
       },
     ],
     "impact": [
@@ -8904,42 +7834,27 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "add properties {} to parent object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties",
-            "value": {},
-          },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties",
+        "value": {},
+      },
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required",
+        "value": [
+          "data",
         ],
       },
       {
-        "intent": "add required [] to parent object and make data required",
-        "operations": [
-          {
-            "extra": "same",
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required",
-            "value": [
-              "data",
-            ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data",
+        "value": {
+          "items": {
+            "type": "object",
           },
-        ],
-      },
-      {
-        "intent": "add property data schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data",
-            "value": {
-              "items": {
-                "type": "object",
-              },
-              "type": "array",
-            },
-          },
-        ],
+          "type": "array",
+        },
       },
     ],
     "impact": [
@@ -8999,26 +7914,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "make new property meta required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/-",
-            "value": "meta",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/-",
+        "value": "meta",
       },
       {
-        "intent": "add property meta schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta",
-            "value": {
-              "type": "object",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta",
+        "value": {
+          "type": "object",
+        },
       },
     ],
     "impact": [
@@ -9066,45 +7971,30 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "add properties {} to parent object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties",
-            "value": {},
-          },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties",
+        "value": {},
+      },
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/required",
+        "value": [
+          "tuple(('duration', 300))",
         ],
       },
       {
-        "intent": "add required [] to parent object and make tuple(('duration', 300)) required",
-        "operations": [
-          {
-            "extra": "same",
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/required",
-            "value": [
-              "tuple(('duration', 300))",
-            ],
-          },
-        ],
-      },
-      {
-        "intent": "add property tuple(('duration', 300)) schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/tuple(('duration', 300))",
-            "value": {
-              "items": {
-                "items": {
-                  "type": "string",
-                },
-                "type": "array",
-              },
-              "type": "array",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/tuple(('duration', 300))",
+        "value": {
+          "items": {
+            "items": {
+              "type": "string",
             },
+            "type": "array",
           },
-        ],
+          "type": "array",
+        },
       },
     ],
     "impact": [
@@ -9147,26 +8037,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "make new property tpm() required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/required/-",
-            "value": "tpm()",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/required/-",
+        "value": "tpm()",
       },
       {
-        "intent": "add property tpm() schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/tpm()",
-            "value": {
-              "type": "number",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/tpm()",
+        "value": {
+          "type": "number",
+        },
       },
     ],
     "impact": [
@@ -9209,26 +8089,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "make new property failure_rate() required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/required/-",
-            "value": "failure_rate()",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/required/-",
+        "value": "failure_rate()",
       },
       {
-        "intent": "add property failure_rate() schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/failure_rate()",
-            "value": {
-              "type": "number",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/failure_rate()",
+        "value": {
+          "type": "number",
+        },
       },
     ],
     "impact": [
@@ -9271,26 +8141,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "make new property user_misery() required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/required/-",
-            "value": "user_misery()",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/required/-",
+        "value": "user_misery()",
       },
       {
-        "intent": "add property user_misery() schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/user_misery()",
-            "value": {
-              "type": "number",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/user_misery()",
+        "value": {
+          "type": "number",
+        },
       },
     ],
     "impact": [
@@ -9336,29 +8196,19 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "make new property 😃things required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/required/-",
-            "value": "😃things",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/required/-",
+        "value": "😃things",
       },
       {
-        "intent": "add property 😃things schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/😃things",
-            "value": {
-              "items": {
-                "type": "string",
-              },
-              "type": "array",
-            },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/😃things",
+        "value": {
+          "items": {
+            "type": "string",
           },
-        ],
+          "type": "array",
+        },
       },
     ],
     "impact": [
@@ -9405,39 +8255,24 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "add properties {} to parent object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties",
-            "value": {},
-          },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties",
+        "value": {},
+      },
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/required",
+        "value": [
+          "fields",
         ],
       },
       {
-        "intent": "add required [] to parent object and make fields required",
-        "operations": [
-          {
-            "extra": "same",
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/required",
-            "value": [
-              "fields",
-            ],
-          },
-        ],
-      },
-      {
-        "intent": "add property fields schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/fields",
-            "value": {
-              "type": "object",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/fields",
+        "value": {
+          "type": "object",
+        },
       },
     ],
     "impact": [
@@ -9484,26 +8319,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "make new property units required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/required/-",
-            "value": "units",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/required/-",
+        "value": "units",
       },
       {
-        "intent": "add property units schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/units",
-            "value": {
-              "type": "object",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/units",
+        "value": {
+          "type": "object",
+        },
       },
     ],
     "impact": [
@@ -9546,26 +8371,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "make new property isMetricsData required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/required/-",
-            "value": "isMetricsData",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/required/-",
+        "value": "isMetricsData",
       },
       {
-        "intent": "add property isMetricsData schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/isMetricsData",
-            "value": {
-              "type": "boolean",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/isMetricsData",
+        "value": {
+          "type": "boolean",
+        },
       },
     ],
     "impact": [
@@ -9611,26 +8426,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "make new property tips required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/required/-",
-            "value": "tips",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/required/-",
+        "value": "tips",
       },
       {
-        "intent": "add property tips schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/tips",
-            "value": {
-              "type": "object",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/tips",
+        "value": {
+          "type": "object",
+        },
       },
     ],
     "impact": [
@@ -9673,26 +8478,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "make new property dataset required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/required/-",
-            "value": "dataset",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/required/-",
+        "value": "dataset",
       },
       {
-        "intent": "add property dataset schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/dataset",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/dataset",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -9734,23 +8529,18 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "replace items with a one of containing both types",
-        "operations": [
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/tuple(('duration', 300))/items/items/type",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/tuple(('duration', 300))/items/items/oneOf",
+        "value": [
           {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/tuple(('duration', 300))/items/items/type",
+            "type": "string",
           },
           {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/tuple(('duration', 300))/items/items/oneOf",
-            "value": [
-              {
-                "type": "string",
-              },
-              {
-                "type": "number",
-              },
-            ],
+            "type": "number",
           },
         ],
       },
@@ -9794,23 +8584,18 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "replace items with a one of containing both types",
-        "operations": [
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/😃things/items/type",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/😃things/items/oneOf",
+        "value": [
           {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/😃things/items/type",
+            "type": "string",
           },
           {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/😃things/items/oneOf",
-            "value": [
-              {
-                "type": "string",
-              },
-              {
-                "type": "number",
-              },
-            ],
+            "type": "number",
           },
         ],
       },
@@ -9855,39 +8640,24 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "add properties {} to parent object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/fields/properties",
-            "value": {},
-          },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/fields/properties",
+        "value": {},
+      },
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/fields/required",
+        "value": [
+          "tuple(('duration', 300))",
         ],
       },
       {
-        "intent": "add required [] to parent object and make tuple(('duration', 300)) required",
-        "operations": [
-          {
-            "extra": "same",
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/fields/required",
-            "value": [
-              "tuple(('duration', 300))",
-            ],
-          },
-        ],
-      },
-      {
-        "intent": "add property tuple(('duration', 300)) schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/fields/properties/tuple(('duration', 300))",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/fields/properties/tuple(('duration', 300))",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -9930,26 +8700,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "make new property blah() required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/fields/required/-",
-            "value": "blah()",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/fields/required/-",
+        "value": "blah()",
       },
       {
-        "intent": "add property blah() schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/fields/properties/blah()",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/fields/properties/blah()",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -9992,26 +8752,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "make new property project_threshold_config required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/fields/required/-",
-            "value": "project_threshold_config",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/fields/required/-",
+        "value": "project_threshold_config",
       },
       {
-        "intent": "add property project_threshold_config schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/fields/properties/project_threshold_config",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/fields/properties/project_threshold_config",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -10054,39 +8804,24 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "add properties {} to parent object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/units/properties",
-            "value": {},
-          },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/units/properties",
+        "value": {},
+      },
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/units/required",
+        "value": [
+          "tuple(('duration', 300))",
         ],
       },
       {
-        "intent": "add required [] to parent object and make tuple(('duration', 300)) required",
-        "operations": [
-          {
-            "extra": "same",
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/units/required",
-            "value": [
-              "tuple(('duration', 300))",
-            ],
-          },
-        ],
-      },
-      {
-        "intent": "add property tuple(('duration', 300)) schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/units/properties/tuple(('duration', 300))",
-            "value": {
-              "type": "null",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/units/properties/tuple(('duration', 300))",
+        "value": {
+          "type": "null",
+        },
       },
     ],
     "impact": [
@@ -10129,26 +8864,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "make new property blah() required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/units/required/-",
-            "value": "blah()",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/units/required/-",
+        "value": "blah()",
       },
       {
-        "intent": "add property blah() schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/units/properties/blah()",
-            "value": {
-              "type": "null",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/units/properties/blah()",
+        "value": {
+          "type": "null",
+        },
       },
     ],
     "impact": [
@@ -10191,26 +8916,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "make new property 😃things required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/units/required/-",
-            "value": "😃things",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/units/required/-",
+        "value": "😃things",
       },
       {
-        "intent": "add property 😃things schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/units/properties/😃things",
-            "value": {
-              "type": "null",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/units/properties/😃things",
+        "value": {
+          "type": "null",
+        },
       },
     ],
     "impact": [
@@ -10253,39 +8968,24 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "add properties {} to parent object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/tips/properties",
-            "value": {},
-          },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/tips/properties",
+        "value": {},
+      },
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/tips/required",
+        "value": [
+          "query",
         ],
       },
       {
-        "intent": "add required [] to parent object and make query required",
-        "operations": [
-          {
-            "extra": "same",
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/tips/required",
-            "value": [
-              "query",
-            ],
-          },
-        ],
-      },
-      {
-        "intent": "add property query schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/tips/properties/query",
-            "value": {
-              "type": "null",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/tips/properties/query",
+        "value": {
+          "type": "null",
+        },
       },
     ],
     "impact": [
@@ -10328,26 +9028,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 interactions with non-alp
     },
     "groupedOperations": [
       {
-        "intent": "make new property columns required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/tips/required/-",
-            "value": "columns",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/tips/required/-",
+        "value": "columns",
       },
       {
-        "intent": "add property columns schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/tips/properties/columns",
-            "value": {
-              "type": "null",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/meta/properties/tips/properties/columns",
+        "value": {
+          "type": "null",
+        },
       },
     ],
     "impact": [
@@ -10549,23 +9239,18 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 mismatched type in schema
     },
     "groupedOperations": [
       {
-        "intent": "replace name with a one of containing both types",
-        "operations": [
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/name/type",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/name/oneOf",
+        "value": [
           {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/name/type",
+            "type": "number",
           },
           {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/name/oneOf",
-            "value": [
-              {
-                "type": "number",
-              },
-              {
-                "type": "string",
-              },
-            ],
+            "type": "string",
           },
         ],
       },
@@ -10650,13 +9335,8 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 missing required property
     },
     "groupedOperations": [
       {
-        "intent": "remove name from parent's required array",
-        "operations": [
-          {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/0",
-          },
-        ],
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/0",
       },
     ],
     "impact": [
@@ -10728,28 +9408,18 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 query parameter not docum
     },
     "groupedOperations": [
       {
-        "intent": "add response status code",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200",
-            "value": {
-              "description": "200 response",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200",
+        "value": {
+          "description": "200 response",
+        },
       },
       {
-        "intent": "add response body for content type 'application/json'",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content",
-            "value": {
-              "application/json": {},
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content",
+        "value": {
+          "application/json": {},
+        },
       },
     ],
     "impact": [
@@ -10789,14 +9459,9 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 query parameter not docum
     },
     "groupedOperations": [
       {
-        "intent": "add parameters array",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/parameters",
-            "value": [],
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/parameters",
+        "value": [],
       },
     ],
     "impact": [
@@ -10838,21 +9503,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 query parameter not docum
     },
     "groupedOperations": [
       {
-        "intent": "add undocumented query parameter",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/parameters/-",
-            "value": {
-              "in": "query",
-              "name": "undocumented",
-              "required": true,
-              "schema": {
-                "type": "string",
-              },
-            },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/parameters/-",
+        "value": {
+          "in": "query",
+          "name": "undocumented",
+          "required": true,
+          "schema": {
+            "type": "string",
           },
-        ],
+        },
       },
     ],
     "impact": [
@@ -10890,19 +9550,14 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 query parameter not docum
     "diff": undefined,
     "groupedOperations": [
       {
-        "intent": "add schema object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-            "value": {},
-          },
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
-            "value": "object",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+        "value": {},
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
+        "value": "object",
       },
     ],
     "impact": [
@@ -10984,28 +9639,18 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 query parameter required 
     },
     "groupedOperations": [
       {
-        "intent": "add response status code",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200",
-            "value": {
-              "description": "200 response",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200",
+        "value": {
+          "description": "200 response",
+        },
       },
       {
-        "intent": "add response body for content type 'application/json'",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content",
-            "value": {
-              "application/json": {},
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content",
+        "value": {
+          "application/json": {},
+        },
       },
     ],
     "impact": [
@@ -11042,14 +9687,9 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 query parameter required 
     },
     "groupedOperations": [
       {
-        "intent": "make required query parameter optional",
-        "operations": [
-          {
-            "op": "replace",
-            "path": "/paths/~1api~1animals/post/parameters/0/required",
-            "value": false,
-          },
-        ],
+        "op": "replace",
+        "path": "/paths/~1api~1animals/post/parameters/0/required",
+        "value": false,
       },
     ],
     "impact": [
@@ -11081,19 +9721,14 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 query parameter required 
     "diff": undefined,
     "groupedOperations": [
       {
-        "intent": "add schema object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-            "value": {},
-          },
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
-            "value": "object",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+        "value": {},
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
+        "value": "object",
       },
     ],
     "impact": [
@@ -11170,28 +9805,18 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 response headers not docu
     },
     "groupedOperations": [
       {
-        "intent": "add response status code",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200",
-            "value": {
-              "description": "200 response",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200",
+        "value": {
+          "description": "200 response",
+        },
       },
       {
-        "intent": "add response body for content type 'application/json'",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content",
-            "value": {
-              "application/json": {},
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content",
+        "value": {
+          "application/json": {},
+        },
       },
     ],
     "impact": [
@@ -11232,14 +9857,9 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 response headers not docu
     },
     "groupedOperations": [
       {
-        "intent": "add parameters array",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/headers",
-            "value": {},
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/headers",
+        "value": {},
       },
     ],
     "impact": [
@@ -11281,20 +9901,15 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 response headers not docu
     },
     "groupedOperations": [
       {
-        "intent": "add undocumented response header to 200 response",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/headers/undocumented",
-            "value": {
-              "name": "undocumented",
-              "required": true,
-              "schema": {
-                "type": "string",
-              },
-            },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/headers/undocumented",
+        "value": {
+          "name": "undocumented",
+          "required": true,
+          "schema": {
+            "type": "string",
           },
-        ],
+        },
       },
     ],
     "impact": [
@@ -11332,19 +9947,14 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 response headers not docu
     "diff": undefined,
     "groupedOperations": [
       {
-        "intent": "add schema object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-            "value": {},
-          },
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
-            "value": "object",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+        "value": {},
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
+        "value": "object",
       },
     ],
     "impact": [
@@ -11425,14 +10035,9 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 response headers required
     },
     "groupedOperations": [
       {
-        "intent": "make required response header in 200 response optional",
-        "operations": [
-          {
-            "op": "replace",
-            "path": "/paths/~1api~1animals/post/responses/200/headers/required/required",
-            "value": false,
-          },
-        ],
+        "op": "replace",
+        "path": "/paths/~1api~1animals/post/responses/200/headers/required/required",
+        "value": false,
       },
     ],
     "impact": [
@@ -11528,16 +10133,11 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 schema with arrays with p
     },
     "groupedOperations": [
       {
-        "intent": "make status null",
-        "operations": [
-          {
-            "op": "replace",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/type",
-            "value": [
-              "string",
-              "null",
-            ],
-          },
+        "op": "replace",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/type",
+        "value": [
+          "string",
+          "null",
         ],
       },
     ],
@@ -11580,26 +10180,21 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 schema with arrays with p
     },
     "groupedOperations": [
       {
-        "intent": "replace status with a one of containing both types",
-        "operations": [
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/type",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/oneOf",
+        "value": [
           {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/type",
+            "type": [
+              "string",
+              "null",
+            ],
           },
           {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/oneOf",
-            "value": [
-              {
-                "type": [
-                  "string",
-                  "null",
-                ],
-              },
-              {
-                "type": "number",
-              },
-            ],
+            "type": "number",
           },
         ],
       },
@@ -11708,14 +10303,9 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 schema with enum 1`] = `
     },
     "groupedOperations": [
       {
-        "intent": "add new enum value to status",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/status/enum/-",
-            "value": "something-else",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/status/enum/-",
+        "value": "something-else",
       },
     ],
     "impact": [
@@ -11766,14 +10356,9 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 schema with enum 1`] = `
     },
     "groupedOperations": [
       {
-        "intent": "add new enum value to status",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/enum/-",
-            "value": "something-else",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/enum/-",
+        "value": "something-else",
       },
     ],
     "impact": [
@@ -11824,14 +10409,9 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 schema with enum 1`] = `
     },
     "groupedOperations": [
       {
-        "intent": "add new enum value to status",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/enum/-",
-            "value": "another-thing",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/status/enum/-",
+        "value": "another-thing",
       },
     ],
     "impact": [
@@ -11932,29 +10512,19 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 undocumented property in 
     },
     "groupedOperations": [
       {
-        "intent": "add required [] to parent object and make name required",
-        "operations": [
-          {
-            "extra": "same",
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required",
-            "value": [
-              "name",
-            ],
-          },
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required",
+        "value": [
+          "name",
         ],
       },
       {
-        "intent": "add property name schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/name",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/name",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -12027,28 +10597,18 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 undocumented request body
     },
     "groupedOperations": [
       {
-        "intent": "add request body to operation",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody",
-            "value": {
-              "content": {},
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody",
+        "value": {
+          "content": {},
+        },
       },
       {
-        "intent": "add application/json as content type",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json",
-            "value": {
-              "schema": {},
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json",
+        "value": {
+          "schema": {},
+        },
       },
     ],
     "impact": [
@@ -12089,28 +10649,18 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 undocumented request body
     },
     "groupedOperations": [
       {
-        "intent": "add response status code",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200",
-            "value": {
-              "description": "200 response",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200",
+        "value": {
+          "description": "200 response",
+        },
       },
       {
-        "intent": "add response body for content type 'application/json'",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content",
-            "value": {
-              "application/json": {},
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content",
+        "value": {
+          "application/json": {},
+        },
       },
     ],
     "impact": [
@@ -12147,14 +10697,9 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 undocumented request body
     "diff": undefined,
     "groupedOperations": [
       {
-        "intent": "add schema object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/type",
-            "value": "object",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/type",
+        "value": "object",
       },
     ],
     "impact": [
@@ -12201,39 +10746,24 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 undocumented request body
     },
     "groupedOperations": [
       {
-        "intent": "add properties {} to parent object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties",
-            "value": {},
-          },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties",
+        "value": {},
+      },
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/required",
+        "value": [
+          "name",
         ],
       },
       {
-        "intent": "add required [] to parent object and make name required",
-        "operations": [
-          {
-            "extra": "same",
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/required",
-            "value": [
-              "name",
-            ],
-          },
-        ],
-      },
-      {
-        "intent": "add property name schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/name",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/name",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -12280,26 +10810,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 undocumented request body
     },
     "groupedOperations": [
       {
-        "intent": "make new property age required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/required/-",
-            "value": "age",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/required/-",
+        "value": "age",
       },
       {
-        "intent": "add property age schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/age",
-            "value": {
-              "type": "number",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/age",
+        "value": {
+          "type": "number",
+        },
       },
     ],
     "impact": [
@@ -12346,26 +10866,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 undocumented request body
     },
     "groupedOperations": [
       {
-        "intent": "make new property created_at required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/required/-",
-            "value": "created_at",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/required/-",
+        "value": "created_at",
       },
       {
-        "intent": "add property created_at schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/created_at",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/created_at",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -12424,29 +10934,19 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 undocumented request body
     },
     "groupedOperations": [
       {
-        "intent": "make new property hobbies required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/required/-",
-            "value": "hobbies",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/required/-",
+        "value": "hobbies",
       },
       {
-        "intent": "add property hobbies schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies",
-            "value": {
-              "items": {
-                "type": "string",
-              },
-              "type": "array",
-            },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies",
+        "value": {
+          "items": {
+            "type": "string",
           },
-        ],
+          "type": "array",
+        },
       },
     ],
     "impact": [
@@ -12493,26 +10993,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 undocumented request body
     },
     "groupedOperations": [
       {
-        "intent": "make new property active required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/required/-",
-            "value": "active",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/required/-",
+        "value": "active",
       },
       {
-        "intent": "add property active schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/active",
-            "value": {
-              "type": "boolean",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/active",
+        "value": {
+          "type": "boolean",
+        },
       },
     ],
     "impact": [
@@ -12561,23 +11051,18 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 undocumented request body
     },
     "groupedOperations": [
       {
-        "intent": "replace items with a one of containing both types",
-        "operations": [
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/type",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf",
+        "value": [
           {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/type",
+            "type": "string",
           },
           {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf",
-            "value": [
-              {
-                "type": "string",
-              },
-              {
-                "type": "object",
-              },
-            ],
+            "type": "object",
           },
         ],
       },
@@ -12626,39 +11111,24 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 undocumented request body
     },
     "groupedOperations": [
       {
-        "intent": "add properties {} to parent object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties",
-            "value": {},
-          },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties",
+        "value": {},
+      },
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/required",
+        "value": [
+          "type",
         ],
       },
       {
-        "intent": "add required [] to parent object and make type required",
-        "operations": [
-          {
-            "extra": "same",
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/required",
-            "value": [
-              "type",
-            ],
-          },
-        ],
-      },
-      {
-        "intent": "add property type schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties/type",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties/type",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -12705,26 +11175,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 undocumented request body
     },
     "groupedOperations": [
       {
-        "intent": "make new property name required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/-",
-            "value": "name",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/-",
+        "value": "name",
       },
       {
-        "intent": "add property name schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties/name",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties/name",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -12771,26 +11231,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 undocumented request body
     },
     "groupedOperations": [
       {
-        "intent": "make new property skill required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/-",
-            "value": "skill",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/-",
+        "value": "skill",
       },
       {
-        "intent": "add property skill schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties/skill",
-            "value": {
-              "type": "number",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties/skill",
+        "value": {
+          "type": "number",
+        },
       },
     ],
     "impact": [
@@ -12837,26 +11287,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 undocumented request body
     },
     "groupedOperations": [
       {
-        "intent": "make new property bad required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/-",
-            "value": "bad",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/-",
+        "value": "bad",
       },
       {
-        "intent": "add property bad schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties/bad",
-            "value": {
-              "type": "null",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties/bad",
+        "value": {
+          "type": "null",
+        },
       },
     ],
     "impact": [
@@ -12902,13 +11342,8 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 undocumented request body
     },
     "groupedOperations": [
       {
-        "intent": "remove skill from parent's required array",
-        "operations": [
-          {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/2",
-          },
-        ],
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/2",
       },
     ],
     "impact": [
@@ -12954,13 +11389,8 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 undocumented request body
     },
     "groupedOperations": [
       {
-        "intent": "remove bad from parent's required array",
-        "operations": [
-          {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/2",
-          },
-        ],
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/2",
       },
     ],
     "impact": [
@@ -12997,19 +11427,14 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 undocumented request body
     "diff": undefined,
     "groupedOperations": [
       {
-        "intent": "add schema object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-            "value": {},
-          },
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
-            "value": "object",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+        "value": {},
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
+        "value": "object",
       },
     ],
     "impact": [
@@ -13141,28 +11566,18 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 undocumented response bod
     },
     "groupedOperations": [
       {
-        "intent": "add response status code",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200",
-            "value": {
-              "description": "200 response",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200",
+        "value": {
+          "description": "200 response",
+        },
       },
       {
-        "intent": "add response body for content type 'application/json'",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content",
-            "value": {
-              "application/json": {},
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content",
+        "value": {
+          "application/json": {},
+        },
       },
     ],
     "impact": [
@@ -13195,19 +11610,14 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 undocumented response bod
     "diff": undefined,
     "groupedOperations": [
       {
-        "intent": "add schema object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-            "value": {},
-          },
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
-            "value": "object",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+        "value": {},
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/type",
+        "value": "object",
       },
     ],
     "impact": [
@@ -13250,39 +11660,24 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 undocumented response bod
     },
     "groupedOperations": [
       {
-        "intent": "add properties {} to parent object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties",
-            "value": {},
-          },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties",
+        "value": {},
+      },
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required",
+        "value": [
+          "name",
         ],
       },
       {
-        "intent": "add required [] to parent object and make name required",
-        "operations": [
-          {
-            "extra": "same",
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required",
-            "value": [
-              "name",
-            ],
-          },
-        ],
-      },
-      {
-        "intent": "add property name schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/name",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/name",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -13325,26 +11720,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 undocumented response bod
     },
     "groupedOperations": [
       {
-        "intent": "make new property age required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/-",
-            "value": "age",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/-",
+        "value": "age",
       },
       {
-        "intent": "add property age schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/age",
-            "value": {
-              "type": "number",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/age",
+        "value": {
+          "type": "number",
+        },
       },
     ],
     "impact": [
@@ -13387,26 +11772,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 undocumented response bod
     },
     "groupedOperations": [
       {
-        "intent": "make new property created_at required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/-",
-            "value": "created_at",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/-",
+        "value": "created_at",
       },
       {
-        "intent": "add property created_at schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/created_at",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/created_at",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -13461,29 +11836,19 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 undocumented response bod
     },
     "groupedOperations": [
       {
-        "intent": "make new property hobbies required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/-",
-            "value": "hobbies",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/-",
+        "value": "hobbies",
       },
       {
-        "intent": "add property hobbies schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies",
-            "value": {
-              "items": {
-                "type": "string",
-              },
-              "type": "array",
-            },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies",
+        "value": {
+          "items": {
+            "type": "string",
           },
-        ],
+          "type": "array",
+        },
       },
     ],
     "impact": [
@@ -13526,26 +11891,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 undocumented response bod
     },
     "groupedOperations": [
       {
-        "intent": "make new property active required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/-",
-            "value": "active",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/required/-",
+        "value": "active",
       },
       {
-        "intent": "add property active schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/active",
-            "value": {
-              "type": "boolean",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/active",
+        "value": {
+          "type": "boolean",
+        },
       },
     ],
     "impact": [
@@ -13590,23 +11945,18 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 undocumented response bod
     },
     "groupedOperations": [
       {
-        "intent": "replace items with a one of containing both types",
-        "operations": [
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/type",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf",
+        "value": [
           {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/type",
+            "type": "string",
           },
           {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf",
-            "value": [
-              {
-                "type": "string",
-              },
-              {
-                "type": "object",
-              },
-            ],
+            "type": "object",
           },
         ],
       },
@@ -13651,39 +12001,24 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 undocumented response bod
     },
     "groupedOperations": [
       {
-        "intent": "add properties {} to parent object",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties",
-            "value": {},
-          },
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties",
+        "value": {},
+      },
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/required",
+        "value": [
+          "type",
         ],
       },
       {
-        "intent": "add required [] to parent object and make type required",
-        "operations": [
-          {
-            "extra": "same",
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/required",
-            "value": [
-              "type",
-            ],
-          },
-        ],
-      },
-      {
-        "intent": "add property type schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties/type",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties/type",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -13726,26 +12061,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 undocumented response bod
     },
     "groupedOperations": [
       {
-        "intent": "make new property name required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/-",
-            "value": "name",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/-",
+        "value": "name",
       },
       {
-        "intent": "add property name schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties/name",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties/name",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -13788,26 +12113,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 undocumented response bod
     },
     "groupedOperations": [
       {
-        "intent": "make new property skill required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/-",
-            "value": "skill",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/-",
+        "value": "skill",
       },
       {
-        "intent": "add property skill schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties/skill",
-            "value": {
-              "type": "number",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties/skill",
+        "value": {
+          "type": "number",
+        },
       },
     ],
     "impact": [
@@ -13850,26 +12165,16 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 undocumented response bod
     },
     "groupedOperations": [
       {
-        "intent": "make new property bad required",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/-",
-            "value": "bad",
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/-",
+        "value": "bad",
       },
       {
-        "intent": "add property bad schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties/bad",
-            "value": {
-              "type": "null",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/properties/bad",
+        "value": {
+          "type": "null",
+        },
       },
     ],
     "impact": [
@@ -13911,13 +12216,8 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 undocumented response bod
     },
     "groupedOperations": [
       {
-        "intent": "remove skill from parent's required array",
-        "operations": [
-          {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/2",
-          },
-        ],
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/2",
       },
     ],
     "impact": [
@@ -13959,13 +12259,8 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 undocumented response bod
     },
     "groupedOperations": [
       {
-        "intent": "remove bad from parent's required array",
-        "operations": [
-          {
-            "op": "remove",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/2",
-          },
-        ],
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/hobbies/items/oneOf/1/required/2",
       },
     ],
     "impact": [
@@ -14084,16 +12379,11 @@ exports[`generatePathAndMethodSpecPatches generates a method if the path exists 
     },
     "groupedOperations": [
       {
-        "intent": "add method",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1animals/post",
-            "value": {
-              "responses": {},
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1animals/post",
+        "value": {
+          "responses": {},
+        },
       },
     ],
     "impact": [
@@ -14131,26 +12421,16 @@ exports[`generatePathAndMethodSpecPatches generates path and method if endpoint 
     },
     "groupedOperations": [
       {
-        "intent": "add path with parameters",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1users",
-            "value": {},
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1users",
+        "value": {},
       },
       {
-        "intent": "add methods",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/paths/~1api~1users/get",
-            "value": {
-              "responses": {},
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/paths/~1api~1users/get",
+        "value": {
+          "responses": {},
+        },
       },
     ],
     "impact": [
@@ -14187,50 +12467,36 @@ exports[`generateRefRefactorPatches adds new component schema if no close schema
     "diff": undefined,
     "groupedOperations": [
       {
-        "intent": "add components.schemas if needed",
-        "operations": [],
-      },
-      {
-        "intent": "create ref at /components/schemas/PostApiAnimals200ResponseBody",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/components/schemas/PostApiAnimals200ResponseBody",
-            "value": {
-              "properties": {
-                "age": {
-                  "type": "number",
-                },
-                "created_at": {
-                  "type": "string",
-                },
-                "id": {
-                  "type": "string",
-                },
-                "name": {
-                  "type": "string",
-                },
-              },
-              "required": [
-                "name",
-                "id",
-              ],
-              "type": "object",
+        "op": "add",
+        "path": "/components/schemas/PostApiAnimals200ResponseBody",
+        "value": {
+          "properties": {
+            "age": {
+              "type": "number",
+            },
+            "created_at": {
+              "type": "string",
+            },
+            "id": {
+              "type": "string",
+            },
+            "name": {
+              "type": "string",
             },
           },
-        ],
+          "required": [
+            "name",
+            "id",
+          ],
+          "type": "object",
+        },
       },
       {
-        "intent": "use new $ref",
-        "operations": [
-          {
-            "op": "replace",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-            "value": {
-              "$ref": "#/components/schemas/PostApiAnimals200ResponseBody",
-            },
-          },
-        ],
+        "op": "replace",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+        "value": {
+          "$ref": "#/components/schemas/PostApiAnimals200ResponseBody",
+        },
       },
     ],
     "impact": [
@@ -14326,46 +12592,31 @@ exports[`generateRefRefactorPatches only tried to add component schema once 1`] 
     "diff": undefined,
     "groupedOperations": [
       {
-        "intent": "add components.schemas if needed",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/components",
-            "value": {
-              "schemas": {},
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/components",
+        "value": {
+          "schemas": {},
+        },
       },
       {
-        "intent": "create ref at /components/schemas/PostApiAnimalsRequestBody",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/components/schemas/PostApiAnimalsRequestBody",
-            "value": {
-              "properties": {
-                "id": {
-                  "format": "int64",
-                  "type": "integer",
-                },
-              },
-              "type": "object",
+        "op": "add",
+        "path": "/components/schemas/PostApiAnimalsRequestBody",
+        "value": {
+          "properties": {
+            "id": {
+              "format": "int64",
+              "type": "integer",
             },
           },
-        ],
+          "type": "object",
+        },
       },
       {
-        "intent": "use new $ref",
-        "operations": [
-          {
-            "op": "replace",
-            "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema",
-            "value": {
-              "$ref": "#/components/schemas/PostApiAnimalsRequestBody",
-            },
-          },
-        ],
+        "op": "replace",
+        "path": "/paths/~1api~1animals/post/requestBody/content/application~1json/schema",
+        "value": {
+          "$ref": "#/components/schemas/PostApiAnimalsRequestBody",
+        },
       },
     ],
     "impact": [
@@ -14378,50 +12629,36 @@ exports[`generateRefRefactorPatches only tried to add component schema once 1`] 
     "diff": undefined,
     "groupedOperations": [
       {
-        "intent": "add components.schemas if needed",
-        "operations": [],
-      },
-      {
-        "intent": "create ref at /components/schemas/PostApiAnimals200ResponseBody",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/components/schemas/PostApiAnimals200ResponseBody",
-            "value": {
-              "properties": {
-                "age": {
-                  "type": "number",
-                },
-                "created_at": {
-                  "type": "string",
-                },
-                "id": {
-                  "type": "string",
-                },
-                "name": {
-                  "type": "string",
-                },
-              },
-              "required": [
-                "name",
-                "id",
-              ],
-              "type": "object",
+        "op": "add",
+        "path": "/components/schemas/PostApiAnimals200ResponseBody",
+        "value": {
+          "properties": {
+            "age": {
+              "type": "number",
+            },
+            "created_at": {
+              "type": "string",
+            },
+            "id": {
+              "type": "string",
+            },
+            "name": {
+              "type": "string",
             },
           },
-        ],
+          "required": [
+            "name",
+            "id",
+          ],
+          "type": "object",
+        },
       },
       {
-        "intent": "use new $ref",
-        "operations": [
-          {
-            "op": "replace",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-            "value": {
-              "$ref": "#/components/schemas/PostApiAnimals200ResponseBody",
-            },
-          },
-        ],
+        "op": "replace",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+        "value": {
+          "$ref": "#/components/schemas/PostApiAnimals200ResponseBody",
+        },
       },
     ],
     "impact": [
@@ -14506,16 +12743,11 @@ exports[`generateRefRefactorPatches uses existing component schema if close enou
     "diff": undefined,
     "groupedOperations": [
       {
-        "intent": "use ref at /paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-        "operations": [
-          {
-            "op": "replace",
-            "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-            "value": {
-              "$ref": "#/components/schemas/MySchema",
-            },
-          },
-        ],
+        "op": "replace",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+        "value": {
+          "$ref": "#/components/schemas/MySchema",
+        },
       },
     ],
     "impact": [

--- a/projects/optic/src/commands/capture/patches/patch-operations.ts
+++ b/projects/optic/src/commands/capture/patches/patch-operations.ts
@@ -1,10 +1,5 @@
 import { Operation as PatchOperation } from 'fast-json-patch';
 
-export interface PatchOperationGroup {
-  intent: string; // human readable
-  operations: PatchOperation[];
-}
-
 export type { PatchOperation };
 
 export enum PatchImpact {
@@ -13,19 +8,4 @@ export enum PatchImpact {
   BackwardsCompatibilityUnknown = 'BackwardsCompatibilityUnknown',
   Addition = 'Addition',
   Refactor = 'Refactor',
-}
-
-export class PatchOperationGroup {
-  static create(
-    intent: string,
-    ...operations: PatchOperation[]
-  ): PatchOperationGroup {
-    return { intent, operations };
-  }
-
-  static *operations(
-    group: PatchOperationGroup
-  ): IterableIterator<PatchOperation> {
-    yield* group.operations;
-  }
 }

--- a/projects/optic/src/commands/capture/patches/patchers/closeness/schema-inventory.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/closeness/schema-inventory.ts
@@ -106,16 +106,11 @@ export class SchemaInventory {
             diff: undefined,
             groupedOperations: [
               {
-                intent: `use ref at ${added}`,
-                operations: [
-                  {
-                    op: 'replace',
-                    path: added,
-                    value: {
-                      $ref: `#${match.ref}`,
-                    },
-                  },
-                ],
+                op: 'replace',
+                path: added,
+                value: {
+                  $ref: `#${match.ref}`,
+                },
               },
             ],
           };
@@ -136,16 +131,11 @@ export class SchemaInventory {
               diff: undefined,
               groupedOperations: [
                 {
-                  intent: `use ref at ${items}`,
-                  operations: [
-                    {
-                      op: 'replace',
-                      path: items,
-                      value: {
-                        $ref: `#${match.ref}`,
-                      },
-                    },
-                  ],
+                  op: 'replace',
+                  path: items,
+                  value: {
+                    $ref: `#${match.ref}`,
+                  },
                 },
               ],
             };
@@ -204,31 +194,18 @@ export class SchemaInventory {
           impact: [PatchImpact.Refactor],
           diff: undefined,
           groupedOperations: [
+            ...schemaOps,
             {
-              intent: 'add components.schemas if needed',
-              operations: schemaOps,
+              op: 'add',
+              path: refPath,
+              value: addedSchema,
             },
             {
-              intent: `create ref at ${refPath}`,
-              operations: [
-                {
-                  op: 'add',
-                  path: refPath,
-                  value: addedSchema,
-                },
-              ],
-            },
-            {
-              intent: 'use new $ref',
-              operations: [
-                {
-                  op: 'replace',
-                  path: added,
-                  value: {
-                    $ref: `#${refPath}`,
-                  },
-                },
-              ],
+              op: 'replace',
+              path: added,
+              value: {
+                $ref: `#${refPath}`,
+              },
             },
           ],
         };

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/__tests__/__snapshots__/enum.test.ts.snap
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/__tests__/__snapshots__/enum.test.ts.snap
@@ -39,14 +39,9 @@ exports[`enum shape patch generator when enum is nested in array 1`] = `
     },
     "groupedOperations": [
       {
-        "intent": "add new enum value to status",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/properties/other/items/properties/status/enum/-",
-            "value": "new-field",
-          },
-        ],
+        "op": "add",
+        "path": "/properties/other/items/properties/status/enum/-",
+        "value": "new-field",
       },
     ],
     "impact": [
@@ -85,14 +80,9 @@ exports[`enum shape patch generator when missing an enum 1`] = `
     },
     "groupedOperations": [
       {
-        "intent": "add new enum value to status",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/properties/status/enum/-",
-            "value": "new-field",
-          },
-        ],
+        "op": "add",
+        "path": "/properties/status/enum/-",
+        "value": "new-field",
       },
     ],
     "impact": [

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/__tests__/__snapshots__/oneOf.test.ts.snap
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/__tests__/__snapshots__/oneOf.test.ts.snap
@@ -104,19 +104,14 @@ exports[`one of shape patch generator can add an additional branch to a complex 
     },
     "groupedOperations": [
       {
-        "intent": "add new oneOf branch to oneOf",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/properties/location/properties/principality/properties/coordinates/oneOf/-",
-            "value": {
-              "items": {
-                "type": "number",
-              },
-              "type": "array",
-            },
+        "op": "add",
+        "path": "/properties/location/properties/principality/properties/coordinates/oneOf/-",
+        "value": {
+          "items": {
+            "type": "number",
           },
-        ],
+          "type": "array",
+        },
       },
     ],
     "impact": [
@@ -155,29 +150,19 @@ exports[`one of shape patch generator when new field in one of object variant of
     },
     "groupedOperations": [
       {
-        "intent": "add required [] to parent object and make hello required",
-        "operations": [
-          {
-            "extra": "same",
-            "op": "add",
-            "path": "/properties/polyProp/oneOf/0/required",
-            "value": [
-              "hello",
-            ],
-          },
+        "extra": "same",
+        "op": "add",
+        "path": "/properties/polyProp/oneOf/0/required",
+        "value": [
+          "hello",
         ],
       },
       {
-        "intent": "add property hello schema to properties",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/properties/polyProp/oneOf/0/properties/hello",
-            "value": {
-              "type": "string",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/properties/polyProp/oneOf/0/properties/hello",
+        "value": {
+          "type": "string",
+        },
       },
     ],
     "impact": [
@@ -215,16 +200,11 @@ exports[`one of shape patch generator when new primitive types provided to exist
     },
     "groupedOperations": [
       {
-        "intent": "add new oneOf branch to oneOf",
-        "operations": [
-          {
-            "op": "add",
-            "path": "/properties/polyProp/oneOf/-",
-            "value": {
-              "type": "boolean",
-            },
-          },
-        ],
+        "op": "add",
+        "path": "/properties/polyProp/oneOf/-",
+        "value": {
+          "type": "boolean",
+        },
       },
     ],
     "impact": [
@@ -262,33 +242,28 @@ exports[`one of shape patch generator when root schema is obejct and is shown an
     },
     "groupedOperations": [
       {
-        "intent": "replace  with a one of containing both types",
-        "operations": [
+        "op": "remove",
+        "path": "/type",
+      },
+      {
+        "op": "remove",
+        "path": "/properties",
+      },
+      {
+        "op": "add",
+        "path": "/oneOf",
+        "value": [
           {
-            "op": "remove",
-            "path": "/type",
+            "properties": {
+              "sup": {
+                "type": "string",
+              },
+            },
+            "type": "object",
           },
           {
-            "op": "remove",
-            "path": "/properties",
-          },
-          {
-            "op": "add",
-            "path": "/oneOf",
-            "value": [
-              {
-                "properties": {
-                  "sup": {
-                    "type": "string",
-                  },
-                },
-                "type": "object",
-              },
-              {
-                "items": {},
-                "type": "array",
-              },
-            ],
+            "items": {},
+            "type": "array",
           },
         ],
       },
@@ -323,17 +298,12 @@ exports[`one of shape patch generator when root schema is obejct and is shown an
     },
     "groupedOperations": [
       {
-        "intent": "change  type",
-        "operations": [
-          {
-            "op": "replace",
-            "path": "",
-            "value": {
-              "items": {},
-              "type": "array",
-            },
-          },
-        ],
+        "op": "replace",
+        "path": "",
+        "value": {
+          "items": {},
+          "type": "array",
+        },
       },
     ],
     "impact": [

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/__tests__/__snapshots__/required.test.ts.snap
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/__tests__/__snapshots__/required.test.ts.snap
@@ -31,13 +31,8 @@ exports[`required shape patch generator missing required fields will patch as 'm
     },
     "groupedOperations": [
       {
-        "intent": "remove f3 from parent's required array",
-        "operations": [
-          {
-            "op": "remove",
-            "path": "/properties/hello/required/2",
-          },
-        ],
+        "op": "remove",
+        "path": "/properties/hello/required/2",
       },
     ],
     "impact": [
@@ -70,22 +65,12 @@ exports[`required shape patch generator missing required fields will patch as 'm
     },
     "groupedOperations": [
       {
-        "intent": "remove f3 from parent's required array",
-        "operations": [
-          {
-            "op": "remove",
-            "path": "/properties/hello/required/2",
-          },
-        ],
+        "op": "remove",
+        "path": "/properties/hello/required/2",
       },
       {
-        "intent": "remove f3 from parent's properties object",
-        "operations": [
-          {
-            "op": "remove",
-            "path": "/properties/hello/properties/f3",
-          },
-        ],
+        "op": "remove",
+        "path": "/properties/hello/properties/f3",
       },
     ],
     "impact": [

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/__tests__/__snapshots__/type.test.ts.snap
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/__tests__/__snapshots__/type.test.ts.snap
@@ -88,26 +88,21 @@ exports[`type shape patch generator for 3.0.x when provided with an array, it ca
     },
     "groupedOperations": [
       {
-        "intent": "replace stringField with a one of containing both types",
-        "operations": [
+        "op": "remove",
+        "path": "/properties/stringField/type",
+      },
+      {
+        "op": "add",
+        "path": "/properties/stringField/oneOf",
+        "value": [
           {
-            "op": "remove",
-            "path": "/properties/stringField/type",
+            "type": "string",
           },
           {
-            "op": "add",
-            "path": "/properties/stringField/oneOf",
-            "value": [
-              {
-                "type": "string",
-              },
-              {
-                "items": {
-                  "type": "string",
-                },
-                "type": "array",
-              },
-            ],
+            "items": {
+              "type": "string",
+            },
+            "type": "array",
           },
         ],
       },
@@ -147,19 +142,14 @@ exports[`type shape patch generator for 3.0.x when provided with an array, it ca
     },
     "groupedOperations": [
       {
-        "intent": "change stringField type",
-        "operations": [
-          {
-            "op": "replace",
-            "path": "/properties/stringField",
-            "value": {
-              "items": {
-                "type": "string",
-              },
-              "type": "array",
-            },
+        "op": "replace",
+        "path": "/properties/stringField",
+        "value": {
+          "items": {
+            "type": "string",
           },
-        ],
+          "type": "array",
+        },
       },
     ],
     "impact": [
@@ -198,23 +188,18 @@ exports[`type shape patch generator for 3.0.x when provided with an object, it c
     },
     "groupedOperations": [
       {
-        "intent": "replace stringField with a one of containing both types",
-        "operations": [
+        "op": "remove",
+        "path": "/properties/stringField/type",
+      },
+      {
+        "op": "add",
+        "path": "/properties/stringField/oneOf",
+        "value": [
           {
-            "op": "remove",
-            "path": "/properties/stringField/type",
+            "type": "string",
           },
           {
-            "op": "add",
-            "path": "/properties/stringField/oneOf",
-            "value": [
-              {
-                "type": "string",
-              },
-              {
-                "type": "object",
-              },
-            ],
+            "type": "object",
           },
         ],
       },
@@ -251,16 +236,11 @@ exports[`type shape patch generator for 3.0.x when provided with an object, it c
     },
     "groupedOperations": [
       {
-        "intent": "change stringField type",
-        "operations": [
-          {
-            "op": "replace",
-            "path": "/properties/stringField",
-            "value": {
-              "type": "object",
-            },
-          },
-        ],
+        "op": "replace",
+        "path": "/properties/stringField",
+        "value": {
+          "type": "object",
+        },
       },
     ],
     "impact": [
@@ -297,23 +277,18 @@ exports[`type shape patch generator for 3.0.x when provided with another primiti
     },
     "groupedOperations": [
       {
-        "intent": "replace stringField with a one of containing both types",
-        "operations": [
+        "op": "remove",
+        "path": "/properties/stringField/type",
+      },
+      {
+        "op": "add",
+        "path": "/properties/stringField/oneOf",
+        "value": [
           {
-            "op": "remove",
-            "path": "/properties/stringField/type",
+            "type": "string",
           },
           {
-            "op": "add",
-            "path": "/properties/stringField/oneOf",
-            "value": [
-              {
-                "type": "string",
-              },
-              {
-                "type": "number",
-              },
-            ],
+            "type": "number",
           },
         ],
       },
@@ -348,16 +323,11 @@ exports[`type shape patch generator for 3.0.x when provided with another primiti
     },
     "groupedOperations": [
       {
-        "intent": "change stringField type",
-        "operations": [
-          {
-            "op": "replace",
-            "path": "/properties/stringField",
-            "value": {
-              "type": "number",
-            },
-          },
-        ],
+        "op": "replace",
+        "path": "/properties/stringField",
+        "value": {
+          "type": "number",
+        },
       },
     ],
     "impact": [
@@ -394,14 +364,9 @@ exports[`type shape patch generator for 3.0.x when provided with null value, it 
     },
     "groupedOperations": [
       {
-        "intent": "make stringField nullable",
-        "operations": [
-          {
-            "op": "replace",
-            "path": "/properties/stringField/nullable",
-            "value": true,
-          },
-        ],
+        "op": "replace",
+        "path": "/properties/stringField/nullable",
+        "value": true,
       },
     ],
     "impact": [
@@ -444,26 +409,21 @@ exports[`type shape patch generator for 3.1.x when provided with an array, it ca
     },
     "groupedOperations": [
       {
-        "intent": "replace stringField with a one of containing both types",
-        "operations": [
+        "op": "remove",
+        "path": "/properties/stringField/type",
+      },
+      {
+        "op": "add",
+        "path": "/properties/stringField/oneOf",
+        "value": [
           {
-            "op": "remove",
-            "path": "/properties/stringField/type",
+            "type": "string",
           },
           {
-            "op": "add",
-            "path": "/properties/stringField/oneOf",
-            "value": [
-              {
-                "type": "string",
-              },
-              {
-                "items": {
-                  "type": "string",
-                },
-                "type": "array",
-              },
-            ],
+            "items": {
+              "type": "string",
+            },
+            "type": "array",
           },
         ],
       },
@@ -503,19 +463,14 @@ exports[`type shape patch generator for 3.1.x when provided with an array, it ca
     },
     "groupedOperations": [
       {
-        "intent": "change stringField type",
-        "operations": [
-          {
-            "op": "replace",
-            "path": "/properties/stringField",
-            "value": {
-              "items": {
-                "type": "string",
-              },
-              "type": "array",
-            },
+        "op": "replace",
+        "path": "/properties/stringField",
+        "value": {
+          "items": {
+            "type": "string",
           },
-        ],
+          "type": "array",
+        },
       },
     ],
     "impact": [
@@ -554,23 +509,18 @@ exports[`type shape patch generator for 3.1.x when provided with an object, it c
     },
     "groupedOperations": [
       {
-        "intent": "replace stringField with a one of containing both types",
-        "operations": [
+        "op": "remove",
+        "path": "/properties/stringField/type",
+      },
+      {
+        "op": "add",
+        "path": "/properties/stringField/oneOf",
+        "value": [
           {
-            "op": "remove",
-            "path": "/properties/stringField/type",
+            "type": "string",
           },
           {
-            "op": "add",
-            "path": "/properties/stringField/oneOf",
-            "value": [
-              {
-                "type": "string",
-              },
-              {
-                "type": "object",
-              },
-            ],
+            "type": "object",
           },
         ],
       },
@@ -607,16 +557,11 @@ exports[`type shape patch generator for 3.1.x when provided with an object, it c
     },
     "groupedOperations": [
       {
-        "intent": "change stringField type",
-        "operations": [
-          {
-            "op": "replace",
-            "path": "/properties/stringField",
-            "value": {
-              "type": "object",
-            },
-          },
-        ],
+        "op": "replace",
+        "path": "/properties/stringField",
+        "value": {
+          "type": "object",
+        },
       },
     ],
     "impact": [
@@ -653,23 +598,18 @@ exports[`type shape patch generator for 3.1.x when provided with another primiti
     },
     "groupedOperations": [
       {
-        "intent": "replace stringField with a one of containing both types",
-        "operations": [
+        "op": "remove",
+        "path": "/properties/stringField/type",
+      },
+      {
+        "op": "add",
+        "path": "/properties/stringField/oneOf",
+        "value": [
           {
-            "op": "remove",
-            "path": "/properties/stringField/type",
+            "type": "string",
           },
           {
-            "op": "add",
-            "path": "/properties/stringField/oneOf",
-            "value": [
-              {
-                "type": "string",
-              },
-              {
-                "type": "number",
-              },
-            ],
+            "type": "number",
           },
         ],
       },
@@ -704,16 +644,11 @@ exports[`type shape patch generator for 3.1.x when provided with another primiti
     },
     "groupedOperations": [
       {
-        "intent": "change stringField type",
-        "operations": [
-          {
-            "op": "replace",
-            "path": "/properties/stringField",
-            "value": {
-              "type": "number",
-            },
-          },
-        ],
+        "op": "replace",
+        "path": "/properties/stringField",
+        "value": {
+          "type": "number",
+        },
       },
     ],
     "impact": [
@@ -750,16 +685,11 @@ exports[`type shape patch generator for 3.1.x when provided with null value, it 
     },
     "groupedOperations": [
       {
-        "intent": "make stringField null",
-        "operations": [
-          {
-            "op": "replace",
-            "path": "/properties/stringField/type",
-            "value": [
-              "string",
-              "null",
-            ],
-          },
+        "op": "replace",
+        "path": "/properties/stringField/type",
+        "value": [
+          "string",
+          "null",
         ],
       },
     ],

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/enum.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/enum.ts
@@ -8,8 +8,7 @@ import {
 import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
 import { SchemaObject } from '../schema';
 import { CapturedInteraction } from '../../../../sources/captured-interactions';
-import { PatchImpact } from '../../../patch-operations';
-import { OperationGroup } from '../../spec/patches';
+import { PatchImpact, PatchOperation } from '../../../patch-operations';
 
 export function* enumKeywordDiffs(
   validationError: ErrorObject,
@@ -46,15 +45,13 @@ export function* enumPatches(
   )
     return;
 
-  let groupedOperations: OperationGroup[] = [];
+  let groupedOperations: PatchOperation[] = [];
 
-  groupedOperations.push(
-    OperationGroup.create(`add new enum value to ${diff.key}`, {
-      op: 'add',
-      path: jsonPointerHelpers.append(diff.propertyPath, '-'), // "-" indicates append to array
-      value: diff.value,
-    })
-  );
+  groupedOperations.push({
+    op: 'add',
+    path: jsonPointerHelpers.append(diff.propertyPath, '-'), // "-" indicates append to array
+    value: diff.value,
+  });
   yield {
     description: `add enum ${diff.value} to ${diff.key} `,
     diff,

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/newSchema.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/newSchema.ts
@@ -1,7 +1,6 @@
 import { Schema, SchemaObject } from '../schema';
 import { ShapeLocation } from '../documented-bodies';
 import { PatchImpact } from '../../../patch-operations';
-import { OperationGroup } from '../../spec/patches';
 import { ShapePatch } from '../patches';
 import { CapturedInteraction } from '../../../../sources/captured-interactions';
 
@@ -11,12 +10,7 @@ export function newSchemaPatch(
   interaction: CapturedInteraction,
   shapeContext: { location?: ShapeLocation }
 ): ShapePatch {
-  let groupedOperations = [
-    OperationGroup.create(
-      'add schema object',
-      ...Schema.mergeOperations(typelessSchema, schema)
-    ),
-  ];
+  let groupedOperations = [...Schema.mergeOperations(typelessSchema, schema)];
 
   return {
     description: 'add schema object',

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/oneOf.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/oneOf.ts
@@ -8,8 +8,7 @@ import {
   ShapeDiffResultKind,
 } from '../diff';
 import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
-import { PatchImpact } from '../../../patch-operations';
-import { OperationGroup } from '../../spec/patches';
+import { PatchImpact, PatchOperation } from '../../../patch-operations';
 import { ShapePatch } from '../patches';
 import { CapturedInteraction } from '../../../../sources/captured-interactions';
 
@@ -66,15 +65,13 @@ export function* oneOfPatches(
   )
     return;
 
-  let groupedOperations: OperationGroup[] = [];
+  let groupedOperations: PatchOperation[] = [];
 
-  groupedOperations.push(
-    OperationGroup.create(`add new oneOf branch to ${diff.key}`, {
-      op: 'add',
-      path: jsonPointerHelpers.append(diff.propertyPath, '-'), // "-" indicates append to array
-      value: Schema.baseFromValue(diff.example, openAPIVersion),
-    })
-  );
+  groupedOperations.push({
+    op: 'add',
+    path: jsonPointerHelpers.append(diff.propertyPath, '-'), // "-" indicates append to array
+    value: Schema.baseFromValue(diff.example, openAPIVersion),
+  });
 
   // TODO: possibly clean up the newly generated schema, or perhaps try to not make that necessary
 

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/required.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/required.ts
@@ -6,8 +6,7 @@ import {
   ShapeDiffResultKind,
 } from '../diff';
 import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
-import { PatchImpact } from '../../../patch-operations';
-import { OperationGroup } from '../../spec/patches';
+import { PatchImpact, PatchOperation } from '../../../patch-operations';
 import { SchemaObject } from 'ajv';
 import { ShapeLocation } from '../documented-bodies';
 import { ShapePatch } from '../patches';
@@ -60,34 +59,31 @@ export function* requiredPatches(
     requiredPath
   ) as string[];
 
-  function* makeOptionalOperations(indexOfRequired) {
+  function* makeOptionalOperations(indexOfRequired): Generator<PatchOperation> {
     if (indexOfRequired > -1)
-      yield OperationGroup.create(
-        `remove ${diff.key} from parent's required array`,
-        {
-          op: 'remove',
-          path: jsonPointerHelpers.append(
-            requiredPath,
-            indexOfRequired.toString()
-          ),
-        }
-      );
+      yield {
+        op: 'remove',
+        path: jsonPointerHelpers.append(
+          requiredPath,
+          indexOfRequired.toString()
+        ),
+      };
   }
 
-  function* removePropertyOperations(parentObjectPath: string, key: string) {
+  function* removePropertyOperations(
+    parentObjectPath: string,
+    key: string
+  ): Generator<PatchOperation> {
     const propertyPath = jsonPointerHelpers.append(
       parentObjectPath,
       'properties',
       key
     );
 
-    yield OperationGroup.create(
-      `remove ${key} from parent's properties object`,
-      {
-        op: 'remove',
-        path: propertyPath,
-      }
-    );
+    yield {
+      op: 'remove',
+      path: propertyPath,
+    };
   }
   // patch one: make required field optional
   let makeOptionalPatch = {

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/patches.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/patches.ts
@@ -2,11 +2,7 @@ import { ShapeDiffResult, UnpatchableDiff, diffBodyBySchema } from './diff';
 import { SupportedOpenAPIVersions } from '@useoptic/openapi-io';
 import { oneOfPatches } from './handlers/oneOf';
 import { requiredPatches } from './handlers/required';
-import {
-  PatchImpact,
-  PatchOperation,
-  PatchOperationGroup,
-} from '../../patch-operations';
+import { PatchImpact, PatchOperation } from '../../patch-operations';
 import { logger } from '../../../../../logger';
 import { SentryClient } from '../../../../../sentry';
 import { newSchemaPatch } from './handlers/newSchema';
@@ -41,14 +37,14 @@ export interface ShapePatch {
   interaction: CapturedInteraction;
   diff: ShapeDiffResult | OperationDiffResult | undefined;
   impact: PatchImpact[];
-  groupedOperations: PatchOperationGroup[];
+  groupedOperations: PatchOperation[];
   shouldRegeneratePatches?: boolean;
 }
 
 export class ShapePatch {
   static *operations(patch: ShapePatch): IterableIterator<PatchOperation> {
-    for (let group of patch.groupedOperations) {
-      yield* PatchOperationGroup.operations(group);
+    for (let op of patch.groupedOperations) {
+      yield op;
     }
   }
 

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/schema.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/schema.ts
@@ -105,7 +105,7 @@ export class Schema {
     patch: ShapePatch
   ): SchemaObject {
     const operations = JsonPatch.deepClone(
-      patch.groupedOperations.flatMap((operation) => operation.operations)
+      patch.groupedOperations.flatMap((operation) => operation)
     );
     try {
       const result = JsonPatch.applyPatch(

--- a/projects/optic/src/commands/capture/patches/patchers/spec/patches.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/spec/patches.ts
@@ -19,9 +19,10 @@ import { SentryClient } from '../../../../../sentry';
 import { logger } from '../../../../../logger';
 import { SupportedOpenAPIVersions } from '@useoptic/openapi-io';
 import { SchemaObject } from '../shapes/schema';
-import { DocumentedInteraction } from '../../../../oas/operations';
+import { DocumentedInteraction, Operation } from '../../../../oas/operations';
 import { OperationPatch, generateOperationPatches } from './operations';
 import { OperationDiffResult } from './types';
+import { generateRequestParameterPatches } from './request-params';
 
 export interface SpecPatch {
   description: string;
@@ -186,4 +187,16 @@ export class SpecPatches {
       yield specPatch;
     }
   }
+
+  static async *requestAdditions(
+    interaction: CapturedInteraction,
+    operation: Operation
+  ): SpecPatches {
+    yield* generateRequestParameterPatches(interaction, operation);
+  }
+
+  static async *responseAdditions(
+    interaction: CapturedInteraction,
+    operation: Operation
+  ): SpecPatches {}
 }

--- a/projects/optic/src/commands/capture/patches/patchers/spec/patches.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/spec/patches.ts
@@ -23,6 +23,7 @@ import { DocumentedInteraction, Operation } from '../../../../oas/operations';
 import { OperationPatch, generateOperationPatches } from './operations';
 import { OperationDiffResult } from './types';
 import { generateRequestParameterPatches } from './request-params';
+import { generateResponseHeaderPatches } from './response-headers';
 
 export interface SpecPatch {
   description: string;
@@ -198,5 +199,7 @@ export class SpecPatches {
   static async *responseAdditions(
     interaction: CapturedInteraction,
     operation: Operation
-  ): SpecPatches {}
+  ): SpecPatches {
+    yield* generateResponseHeaderPatches(interaction, operation);
+  }
 }

--- a/projects/optic/src/commands/capture/patches/patchers/spec/patches.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/spec/patches.ts
@@ -1,8 +1,4 @@
-import {
-  PatchImpact,
-  PatchOperationGroup,
-  PatchOperation,
-} from '../../patch-operations';
+import { PatchImpact, PatchOperation } from '../../patch-operations';
 import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
 import { OpenAPIV3 } from '@useoptic/openapi-utilities';
 import JsonPatch from 'fast-json-patch';
@@ -30,11 +26,11 @@ export interface SpecPatch {
   path: string;
   diff: ShapeDiffResult | OperationDiffResult | undefined;
   impact: PatchImpact[];
-  groupedOperations: PatchOperationGroup[];
+  groupedOperations: PatchOperation[];
   interaction?: CapturedInteraction;
 }
 
-export { PatchImpact, PatchOperationGroup as OperationGroup };
+export { PatchImpact };
 export type { PatchOperation as Operation };
 
 export class SpecPatch {
@@ -61,15 +57,10 @@ export class SpecPatch {
       impact: shapePatch.impact,
       diff: shapePatch.diff,
       path: schemaPath,
-      groupedOperations: shapePatch.groupedOperations.map((group) => {
-        return {
-          ...group,
-          operations: group.operations.map((op) => ({
-            ...op,
-            path: jsonPointerHelpers.join(schemaPath, op.path),
-          })),
-        };
-      }),
+      groupedOperations: shapePatch.groupedOperations.map((op) => ({
+        ...op,
+        path: jsonPointerHelpers.join(schemaPath, op.path),
+      })),
       interaction: shapePatch.interaction,
     };
   }
@@ -84,15 +75,10 @@ export class SpecPatch {
       impact: operationPatch.impact,
       diff: operationPatch.diff,
       path: operationSpecPath,
-      groupedOperations: operationPatch.groupedOperations.map((group) => {
-        return {
-          ...group,
-          operations: group.operations.map((op) => ({
-            ...op,
-            path: jsonPointerHelpers.join(operationSpecPath, op.path),
-          })),
-        };
-      }),
+      groupedOperations: operationPatch.groupedOperations.map((op) => ({
+        ...op,
+        path: jsonPointerHelpers.join(operationSpecPath, op.path),
+      })),
       interaction,
     };
   }
@@ -127,10 +113,8 @@ export class SpecPatch {
   static *operations(
     patch: Pick<ShapePatch, 'groupedOperations'>
   ): IterableIterator<PatchOperation> {
-    for (let group of patch.groupedOperations) {
-      for (const op of group.operations) {
-        yield op;
-      }
+    for (let op of patch.groupedOperations) {
+      yield op;
     }
   }
 }

--- a/projects/optic/src/commands/capture/patches/patchers/spec/request-params.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/spec/request-params.ts
@@ -60,7 +60,7 @@ export async function* generateRequestParameterPatches(
           groupedOperations: [
             PatchOperationGroup.create(`add ${name} ${location} parameter`, {
               op: 'add',
-              path: jsonPointerHelpers.append(specPath, 'parameters', '/-'),
+              path: jsonPointerHelpers.append(specPath, 'parameters', '-'),
               value: {
                 schema: { type: 'string' }, // we assume everything is a string
                 in: location,
@@ -94,7 +94,7 @@ export async function* generateRequestParameterPatches(
         String(i)
       );
       yield {
-        description: `make ${param.name} ${location} parameter optional`,
+        description: `make ${param.name} ${param.in} parameter optional`,
         impact: [PatchImpact.BackwardsCompatible],
         diff: {
           kind: OperationDiffResultKind.MissingRequiredRequiredParameter,
@@ -104,7 +104,7 @@ export async function* generateRequestParameterPatches(
         path: paramPath,
         groupedOperations: [
           PatchOperationGroup.create(
-            `make ${param.name} ${location} parameter optional`,
+            `make ${param.name} ${param.in} parameter optional`,
             {
               op: 'replace',
               path: jsonPointerHelpers.append(paramPath, 'required'),

--- a/projects/optic/src/commands/capture/patches/patchers/spec/request-params.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/spec/request-params.ts
@@ -2,7 +2,6 @@ import { CapturedInteraction } from '../../../sources/captured-interactions';
 import { PatchImpact, SpecPatches } from './patches';
 import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
 import { Operation } from '../../../../oas/operations';
-import { PatchOperationGroup } from '../../patch-operations';
 import { OperationDiffResultKind } from './types';
 
 export async function* generateRequestParameterPatches(
@@ -27,11 +26,11 @@ export async function* generateRequestParameterPatches(
         },
         path: specPath,
         groupedOperations: [
-          PatchOperationGroup.create('add parameters array', {
+          {
             op: 'add',
             path: jsonPointerHelpers.append(specPath, 'parameters'),
             value: [],
-          }),
+          },
         ],
         interaction,
       };
@@ -58,7 +57,7 @@ export async function* generateRequestParameterPatches(
           },
           path: jsonPointerHelpers.append(specPath, 'parameters'),
           groupedOperations: [
-            PatchOperationGroup.create(`add ${name} ${location} parameter`, {
+            {
               op: 'add',
               path: jsonPointerHelpers.append(specPath, 'parameters', '-'),
               value: {
@@ -67,7 +66,7 @@ export async function* generateRequestParameterPatches(
                 name,
                 required: true, // we assume everything is required until we see something is not required
               },
-            }),
+            },
           ],
           interaction,
         };
@@ -103,14 +102,11 @@ export async function* generateRequestParameterPatches(
         },
         path: paramPath,
         groupedOperations: [
-          PatchOperationGroup.create(
-            `make ${param.name} ${param.in} parameter optional`,
-            {
-              op: 'replace',
-              path: jsonPointerHelpers.append(paramPath, 'required'),
-              value: false,
-            }
-          ),
+          {
+            op: 'replace',
+            path: jsonPointerHelpers.append(paramPath, 'required'),
+            value: false,
+          },
         ],
         interaction,
       };

--- a/projects/optic/src/commands/capture/patches/patchers/spec/request-params.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/spec/request-params.ts
@@ -1,0 +1,81 @@
+import { CapturedInteraction } from '../../../sources/captured-interactions';
+import { PatchImpact, SpecPatches } from './patches';
+import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
+import { Operation } from '../../../../oas/operations';
+import { PatchOperationGroup } from '../../patch-operations';
+import { OperationDiffResultKind } from './types';
+
+export async function* generateRequestParameterPatches(
+  interaction: CapturedInteraction,
+  operation: Operation
+): SpecPatches {
+  const hasAnyQueryOrHeader =
+    interaction.request.query.length > 0 ||
+    interaction.request.headers.length > 0;
+  if (hasAnyQueryOrHeader) {
+    const specPath = jsonPointerHelpers.compile([
+      'paths',
+      operation.pathPattern,
+      operation.method,
+    ]);
+
+    if (!operation.parameters) {
+      yield {
+        description: 'add parameters array to operation',
+        impact: [PatchImpact.Addition, PatchImpact.BackwardsCompatible],
+        diff: {
+          kind: OperationDiffResultKind.MissingRequestParametersArray,
+        },
+        path: specPath,
+        groupedOperations: [
+          PatchOperationGroup.create('add parameters array', {
+            op: 'add',
+            path: jsonPointerHelpers.append(specPath, 'parameters'),
+            value: [],
+          }),
+        ],
+        interaction,
+      };
+    }
+
+    const params = [
+      ...interaction.request.query.map((q) => ({ location: 'query', ...q })),
+      ...interaction.request.headers.map((h) => ({ location: 'header', ...h })),
+    ];
+
+    for (const { location, name } of params) {
+      const existingParam = operation.parameters?.find(
+        (p) => !('$ref' in p) && p.in === location && p.name === name
+      );
+
+      if (!existingParam) {
+        yield {
+          description: `add ${name} ${location} parameter`,
+          impact: [PatchImpact.Addition, PatchImpact.BackwardsCompatible],
+          diff: {
+            kind: OperationDiffResultKind.UnmatchedRequestParameter,
+            in: location as 'query' | 'header',
+            name,
+          },
+          path: specPath,
+          groupedOperations: [
+            PatchOperationGroup.create('add parameters array', {
+              op: 'add',
+              path: jsonPointerHelpers.append(specPath, 'parameters', '/-'),
+              value: {
+                schema: { type: 'string' }, // we assume everything is a string
+                in: location,
+                name,
+                required: true, // we assume everything is required until we see something is not required
+              },
+            }),
+          ],
+          interaction,
+        };
+      }
+      // In the future we can check for parameter type and or format and generate schema diffs here
+    }
+  }
+
+  // TODO look at required params and error if not found
+}

--- a/projects/optic/src/commands/capture/patches/patchers/spec/response-headers.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/spec/response-headers.ts
@@ -20,61 +20,63 @@ export async function* generateResponseHeaderPatches(
     interaction.response.statusCode,
   ]);
 
-  if (interaction.response.headers.length > 0) {
-    if (!responseObject.headers) {
-      yield {
-        description: 'add response headers object to operation',
-        impact: [PatchImpact.Addition, PatchImpact.BackwardsCompatible],
-        diff: {
-          kind: OperationDiffResultKind.MissingResponseHeadersObject,
-          statusCode: interaction.response.statusCode,
-        },
-        path: responsePath,
-        groupedOperations: [
-          {
-            op: 'add',
-            path: jsonPointerHelpers.append(responsePath, 'headers'),
-            value: {},
-          },
-        ],
-        interaction,
-      };
-    }
+  // To learn about new headers, uncomment the block below. The reason we don't learn headers is because there are lots of headers that would be noisy / external to the API
+  // We likely would want to specify an allowlist here that lets a user specify headers that they care about that we would look out for and filter for
+  // if (interaction.response.headers.length > 0) {
+  //   if (!responseObject.headers) {
+  //     yield {
+  //       description: 'add response headers object to operation',
+  //       impact: [PatchImpact.Addition, PatchImpact.BackwardsCompatible],
+  //       diff: {
+  //         kind: OperationDiffResultKind.MissingResponseHeadersObject,
+  //         statusCode: interaction.response.statusCode,
+  //       },
+  //       path: responsePath,
+  //       groupedOperations: [
+  //         {
+  //           op: 'add',
+  //           path: jsonPointerHelpers.append(responsePath, 'headers'),
+  //           value: {},
+  //         },
+  //       ],
+  //       interaction,
+  //     };
+  //   }
 
-    for (const { name } of interaction.response.headers) {
-      const maybeHeader = responseObject.headers?.[name];
-      if (!maybeHeader) {
-        const headerPath = jsonPointerHelpers.append(
-          responsePath,
-          'headers',
-          name
-        );
-        yield {
-          description: `add ${name} response header to ${interaction.response.statusCode} response`,
-          impact: [PatchImpact.Addition, PatchImpact.BackwardsCompatible],
-          diff: {
-            kind: OperationDiffResultKind.UnmatchedResponseHeader,
-            statusCode: interaction.response.statusCode,
-            name,
-          },
-          path: headerPath,
-          groupedOperations: [
-            {
-              op: 'add',
-              path: headerPath,
-              value: {
-                schema: { type: 'string' }, // we assume everything is a string
-                name,
-                required: true, // we assume everything is required until we see something is not required
-              },
-            },
-          ],
-          interaction,
-        };
-      }
-      // In the future we can check for parameter type and or format and generate schema diffs here
-    }
-  }
+  //   for (const { name } of interaction.response.headers) {
+  //     const maybeHeader = responseObject.headers?.[name];
+  //     if (!maybeHeader) {
+  //       const headerPath = jsonPointerHelpers.append(
+  //         responsePath,
+  //         'headers',
+  //         name
+  //       );
+  //       yield {
+  //         description: `add ${name} response header to ${interaction.response.statusCode} response`,
+  //         impact: [PatchImpact.Addition, PatchImpact.BackwardsCompatible],
+  //         diff: {
+  //           kind: OperationDiffResultKind.UnmatchedResponseHeader,
+  //           statusCode: interaction.response.statusCode,
+  //           name,
+  //         },
+  //         path: headerPath,
+  //         groupedOperations: [
+  //           {
+  //             op: 'add',
+  //             path: headerPath,
+  //             value: {
+  //               schema: { type: 'string' }, // we assume everything is a string
+  //               name,
+  //               required: true, // we assume everything is required until we see something is not required
+  //             },
+  //           },
+  //         ],
+  //         interaction,
+  //       };
+  //     }
+  //     // In the future we can check for parameter type and or format and generate schema diffs here
+  //   }
+  // }
 
   for (const [key, value] of Object.entries(responseObject.headers ?? {})) {
     if ('$ref' in value) continue;

--- a/projects/optic/src/commands/capture/patches/patchers/spec/response-headers.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/spec/response-headers.ts
@@ -1,0 +1,115 @@
+import { CapturedInteraction } from '../../../sources/captured-interactions';
+import { PatchImpact, SpecPatches } from './patches';
+import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
+import { Operation } from '../../../../oas/operations';
+import { PatchOperationGroup } from '../../patch-operations';
+import { OperationDiffResultKind } from './types';
+
+export async function* generateResponseHeaderPatches(
+  interaction: CapturedInteraction,
+  operation: Operation
+): SpecPatches {
+  if (!interaction.response) return;
+
+  const responseObject = operation.responses[interaction.response.statusCode];
+  const responsePath = jsonPointerHelpers.compile([
+    'paths',
+    operation.pathPattern,
+    operation.method,
+    'responses',
+    interaction.response.statusCode,
+  ]);
+
+  if (interaction.response.headers.length > 0) {
+    if (!responseObject.headers) {
+      yield {
+        description: 'add response headers object to operation',
+        impact: [PatchImpact.Addition, PatchImpact.BackwardsCompatible],
+        diff: {
+          kind: OperationDiffResultKind.MissingResponseHeadersObject,
+          statusCode: interaction.response.statusCode,
+        },
+        path: responsePath,
+        groupedOperations: [
+          PatchOperationGroup.create('add parameters array', {
+            op: 'add',
+            path: jsonPointerHelpers.append(responsePath, 'headers'),
+            value: {},
+          }),
+        ],
+        interaction,
+      };
+    }
+
+    for (const { name } of interaction.response.headers) {
+      const maybeHeader = responseObject.headers?.[name];
+      if (!maybeHeader) {
+        const headerPath = jsonPointerHelpers.append(
+          responsePath,
+          'headers',
+          name
+        );
+        yield {
+          description: `add ${name} response header to ${interaction.response.statusCode} response`,
+          impact: [PatchImpact.Addition, PatchImpact.BackwardsCompatible],
+          diff: {
+            kind: OperationDiffResultKind.UnmatchedResponseHeader,
+            statusCode: interaction.response.statusCode,
+            name,
+          },
+          path: headerPath,
+          groupedOperations: [
+            PatchOperationGroup.create(
+              `add ${name} response header to ${interaction.response.statusCode} response`,
+              {
+                op: 'add',
+                path: headerPath,
+                value: {
+                  schema: { type: 'string' }, // we assume everything is a string
+                  name,
+                  required: true, // we assume everything is required until we see something is not required
+                },
+              }
+            ),
+          ],
+          interaction,
+        };
+      }
+      // In the future we can check for parameter type and or format and generate schema diffs here
+    }
+  }
+
+  for (const [key, value] of Object.entries(responseObject.headers ?? {})) {
+    if ('$ref' in value) continue;
+    if (!value.required) continue;
+
+    if (!interaction.response.headers.find((h) => h.name === key)) {
+      const headerPath = jsonPointerHelpers.append(
+        responsePath,
+        'headers',
+        key
+      );
+      yield {
+        description: `make ${key} response header in ${interaction.response.statusCode} response optional`,
+        impact: [PatchImpact.BackwardsCompatible],
+        diff: {
+          kind: OperationDiffResultKind.MissingRequiredResponseHeader,
+          statusCode: interaction.response.statusCode,
+          name: key,
+        },
+        path: headerPath,
+        groupedOperations: [
+          PatchOperationGroup.create(
+            `make ${key} response header in ${interaction.response.statusCode} response optional`,
+            {
+              op: 'replace',
+              path: jsonPointerHelpers.append(headerPath, 'required'),
+              value: false,
+            }
+          ),
+        ],
+        interaction,
+      };
+    }
+  }
+}

--- a/projects/optic/src/commands/capture/patches/patchers/spec/response-headers.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/spec/response-headers.ts
@@ -2,7 +2,7 @@ import { CapturedInteraction } from '../../../sources/captured-interactions';
 import { PatchImpact, SpecPatches } from './patches';
 import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
 import { Operation } from '../../../../oas/operations';
-import { PatchOperationGroup } from '../../patch-operations';
+
 import { OperationDiffResultKind } from './types';
 
 export async function* generateResponseHeaderPatches(
@@ -31,11 +31,11 @@ export async function* generateResponseHeaderPatches(
         },
         path: responsePath,
         groupedOperations: [
-          PatchOperationGroup.create('add parameters array', {
+          {
             op: 'add',
             path: jsonPointerHelpers.append(responsePath, 'headers'),
             value: {},
-          }),
+          },
         ],
         interaction,
       };
@@ -59,18 +59,15 @@ export async function* generateResponseHeaderPatches(
           },
           path: headerPath,
           groupedOperations: [
-            PatchOperationGroup.create(
-              `add ${name} response header to ${interaction.response.statusCode} response`,
-              {
-                op: 'add',
-                path: headerPath,
-                value: {
-                  schema: { type: 'string' }, // we assume everything is a string
-                  name,
-                  required: true, // we assume everything is required until we see something is not required
-                },
-              }
-            ),
+            {
+              op: 'add',
+              path: headerPath,
+              value: {
+                schema: { type: 'string' }, // we assume everything is a string
+                name,
+                required: true, // we assume everything is required until we see something is not required
+              },
+            },
           ],
           interaction,
         };
@@ -99,14 +96,11 @@ export async function* generateResponseHeaderPatches(
         },
         path: headerPath,
         groupedOperations: [
-          PatchOperationGroup.create(
-            `make ${key} response header in ${interaction.response.statusCode} response optional`,
-            {
-              op: 'replace',
-              path: jsonPointerHelpers.append(headerPath, 'required'),
-              value: false,
-            }
-          ),
+          {
+            op: 'replace',
+            path: jsonPointerHelpers.append(headerPath, 'required'),
+            value: false,
+          },
         ],
         interaction,
       };

--- a/projects/optic/src/commands/capture/patches/patchers/spec/spec.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/spec/spec.ts
@@ -3,11 +3,7 @@ import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
 import { OPTIC_PATH_IGNORE_KEY } from '../../../../../constants';
 import { Operation } from 'fast-json-patch';
 
-import {
-  PatchImpact,
-  PatchOperation,
-  PatchOperationGroup,
-} from '../../patch-operations';
+import { PatchImpact, PatchOperation } from '../../patch-operations';
 import { SpecPatch } from './patches';
 import {
   UndocumentedOperation,
@@ -43,12 +39,7 @@ export function getIgnorePathPatch(
     description: 'add x-optic-path-ignore values',
     diff: undefined,
     impact: [PatchImpact.Addition],
-    groupedOperations: [
-      {
-        intent: 'add ignore paths to optic',
-        operations,
-      },
-    ],
+    groupedOperations: operations,
     path: basePath,
   };
 }
@@ -62,35 +53,29 @@ export function createMissingPathPatches(
   const { specPath, methods, pathPattern, pathParameters } =
     undocumentedOperation;
 
-  let groupedOperations: PatchOperationGroup[] = [];
+  let groupedOperations: PatchOperation[] = [];
 
-  groupedOperations.push(
-    PatchOperationGroup.create(`add path with parameters`, {
-      op: 'add',
-      path: specPath,
-      value: {},
-    })
-  );
+  groupedOperations.push({
+    op: 'add',
+    path: specPath,
+    value: {},
+  });
 
   if (pathParameters.length > 0) {
-    groupedOperations.push(
-      PatchOperationGroup.create(`add path parameters`, {
-        op: 'add',
-        path: jsonPointerHelpers.append(specPath, 'parameters'),
-        value: pathParameters.map(
-          (parameterName): OpenAPIV3.ParameterObject => {
-            return {
-              in: 'path',
-              name: parameterName,
-              required: true,
-              schema: {
-                type: 'string',
-              },
-            };
-          }
-        ),
-      })
-    );
+    groupedOperations.push({
+      op: 'add',
+      path: jsonPointerHelpers.append(specPath, 'parameters'),
+      value: pathParameters.map((parameterName): OpenAPIV3.ParameterObject => {
+        return {
+          in: 'path',
+          name: parameterName,
+          required: true,
+          schema: {
+            type: 'string',
+          },
+        };
+      }),
+    });
   }
 
   let methodOperations: PatchOperation[] = methods.map((method) => ({
@@ -101,9 +86,7 @@ export function createMissingPathPatches(
     },
   }));
 
-  groupedOperations.push(
-    PatchOperationGroup.create('add methods', ...methodOperations)
-  );
+  groupedOperations.push(...methodOperations);
 
   return {
     diff: {
@@ -127,17 +110,15 @@ export function createMissingMethodPatch(
 ): SpecPatch {
   const { specPath, method, pathPattern } = undocumentedOperation;
 
-  let groupedOperations: PatchOperationGroup[] = [];
+  let groupedOperations: PatchOperation[] = [];
 
-  groupedOperations.push(
-    PatchOperationGroup.create(`add method`, {
-      op: 'add',
-      path: specPath,
-      value: {
-        responses: {},
-      },
-    })
-  );
+  groupedOperations.push({
+    op: 'add',
+    path: specPath,
+    value: {
+      responses: {},
+    },
+  });
 
   return {
     diff: {

--- a/projects/optic/src/commands/capture/patches/patchers/spec/types.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/spec/types.ts
@@ -9,14 +9,20 @@ export enum OperationDiffResultKind {
   // Request Body
   MissingRequestBody = 'MissingRequestBody',
   UnmatchedRequestBody = 'UnmatchedRequestBody',
+  MissingRequestParametersArray = 'MissingRequestParametersArray',
+  UnmatchedRequestParameter = 'UnmatchedRequestParameter',
+  MissingRequiredRequiredParameter = 'MissingRequiredRequiredParameter',
 
   // Response Body
   MissingResponseBody = 'MissingResponseBody',
   UnmatchedResponseStatusCode = 'UnmatchedResponseStatusCode',
   UnmatchedResponseBody = 'UnmatchdResponseBody',
+  MissingResponseHeadersObject = 'MissingResponseHeadersObject',
+  UnmatchedResponseHeader = 'UnmatchedResponseHeader',
+  MissingRequiredResponseHeader = 'MissingRequiredResponseHeader',
 }
 
-export type OperationDiffResult = {} & (
+export type OperationDiffResult =
   | {
       kind: OperationDiffResultKind.UnmatchedPath;
       subject: string;
@@ -51,4 +57,28 @@ export type OperationDiffResult = {} & (
       kind: OperationDiffResultKind.MissingResponseBody;
       statusCode: string;
     }
-);
+  | { kind: OperationDiffResultKind.MissingRequestParametersArray }
+  | {
+      kind: OperationDiffResultKind.UnmatchedRequestParameter;
+      name: string;
+      in: 'header' | 'query';
+    }
+  | {
+      kind: OperationDiffResultKind.MissingRequiredRequiredParameter;
+      name: string;
+      in: 'header' | 'query';
+    }
+  | {
+      kind: OperationDiffResultKind.MissingResponseHeadersObject;
+      statusCode: string;
+    }
+  | {
+      kind: OperationDiffResultKind.UnmatchedResponseHeader;
+      statusCode: string;
+      name: string;
+    }
+  | {
+      kind: OperationDiffResultKind.MissingRequiredResponseHeader;
+      statusCode: string;
+      name: string;
+    };

--- a/projects/optic/src/commands/capture/patches/patches.ts
+++ b/projects/optic/src/commands/capture/patches/patches.ts
@@ -7,7 +7,7 @@ import { OpenAPIV3 } from '@useoptic/openapi-utilities';
 import { ApiCoverageCounter } from '../coverage/api-coverage';
 import { SpecPatch, SpecPatches } from './patchers/spec/patches';
 import { CapturedInteractions } from '../sources/captured-interactions';
-import { DocumentedInteraction, Operation } from '../../oas/operations';
+import { Operation } from '../../oas/operations';
 import { DocumentedBodies } from './patchers/shapes/documented-bodies';
 import { UndocumentedOperationType } from '../../oas/operations';
 import { SchemaInventory } from './patchers/closeness/schema-inventory';
@@ -80,7 +80,7 @@ export async function* generateEndpointSpecPatches(
       endpoint.method,
       jsonPointerHelpers.get(specHolder.spec, jsonPath) as any
     );
-    let documentedInteraction: DocumentedInteraction = {
+    let documentedInteraction = {
       interaction,
       operation,
       specJsonPath: jsonPath,
@@ -128,9 +128,10 @@ export async function* generateEndpointSpecPatches(
     }
 
     // phase three: shape patches, describing request / response bodies in detail
-    documentedInteraction = DocumentedInteraction.updateOperation(
-      documentedInteraction,
-      specHolder.spec
+    documentedInteraction.operation = Operation.fromOperationObject(
+      endpoint.path,
+      endpoint.method,
+      jsonPointerHelpers.get(specHolder.spec, jsonPath) as any
     );
     let documentedBodies = DocumentedBodies.fromDocumentedInteraction(
       documentedInteraction

--- a/projects/optic/src/commands/capture/patches/patches.ts
+++ b/projects/optic/src/commands/capture/patches/patches.ts
@@ -101,6 +101,8 @@ export async function* generateEndpointSpecPatches(
       yield patch;
     }
 
+    // TODO add query, header, response header diffs
+
     // phase two: shape patches, describing request / response bodies in detail
     documentedInteraction = DocumentedInteraction.updateOperation(
       documentedInteraction,

--- a/projects/optic/src/commands/capture/patches/patches.ts
+++ b/projects/optic/src/commands/capture/patches/patches.ts
@@ -101,9 +101,33 @@ export async function* generateEndpointSpecPatches(
       yield patch;
     }
 
-    // TODO add query, header, response header diffs
+    // phase two: request params and response headers
+    let requestPatches = SpecPatches.requestAdditions(
+      interaction,
+      Operation.fromOperationObject(
+        endpoint.path,
+        endpoint.method,
+        jsonPointerHelpers.get(specHolder.spec, jsonPath) as any
+      )
+    );
+    for await (let patch of requestPatches) {
+      specHolder.spec = SpecPatch.applyPatch(patch, specHolder.spec);
+      yield patch;
+    }
+    let responseAdditions = SpecPatches.responseAdditions(
+      interaction,
+      Operation.fromOperationObject(
+        endpoint.path,
+        endpoint.method,
+        jsonPointerHelpers.get(specHolder.spec, jsonPath) as any
+      )
+    );
+    for await (let patch of responseAdditions) {
+      specHolder.spec = SpecPatch.applyPatch(patch, specHolder.spec);
+      yield patch;
+    }
 
-    // phase two: shape patches, describing request / response bodies in detail
+    // phase three: shape patches, describing request / response bodies in detail
     documentedInteraction = DocumentedInteraction.updateOperation(
       documentedInteraction,
       specHolder.spec

--- a/projects/optic/src/commands/capture/patches/patches.ts
+++ b/projects/optic/src/commands/capture/patches/patches.ts
@@ -182,8 +182,8 @@ export async function* generateRefRefactorPatches(
 export async function jsonOpsFromSpecPatches(specPatches: SpecPatches) {
   const ops: JsonOps[] = [];
   for await (const patch of specPatches) {
-    for (const { operations } of patch.groupedOperations) {
-      ops.push(...operations);
+    for (const operation of patch.groupedOperations) {
+      ops.push(operation);
     }
   }
 

--- a/projects/optic/src/commands/capture/sources/__tests__/__snapshots__/interaction.test.ts.snap
+++ b/projects/optic/src/commands/capture/sources/__tests__/__snapshots__/interaction.test.ts.snap
@@ -4,7 +4,76 @@ exports[`CapturedIntearction.fromHarEntry can create a CapturedInteraction from 
 {
   "request": {
     "body": null,
-    "headers": [],
+    "headers": [
+      {
+        "name": ":authority",
+        "value": "petstore.swagger.io",
+      },
+      {
+        "name": ":method",
+        "value": "GET",
+      },
+      {
+        "name": ":path",
+        "value": "/v2/store/inventory",
+      },
+      {
+        "name": ":scheme",
+        "value": "https",
+      },
+      {
+        "name": "accept",
+        "value": "application/json",
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, br",
+      },
+      {
+        "name": "accept-language",
+        "value": "en-GB,en;q=0.9,nl-NL;q=0.8,nl;q=0.7,en-US;q=0.6",
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache",
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache",
+      },
+      {
+        "name": "referer",
+        "value": "https://petstore.swagger.io/",
+      },
+      {
+        "name": "sec-ch-ua",
+        "value": "" Not A;Brand";v="99", "Chromium";v="101", "Google Chrome";v="101"",
+      },
+      {
+        "name": "sec-ch-ua-mobile",
+        "value": "?0",
+      },
+      {
+        "name": "sec-ch-ua-platform",
+        "value": ""macOS"",
+      },
+      {
+        "name": "sec-fetch-dest",
+        "value": "empty",
+      },
+      {
+        "name": "sec-fetch-mode",
+        "value": "cors",
+      },
+      {
+        "name": "sec-fetch-site",
+        "value": "same-origin",
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.54 Safari/537.36",
+      },
+    ],
     "host": "petstore.swagger.io",
     "method": "get",
     "path": "/v2/store/inventory",
@@ -16,7 +85,32 @@ exports[`CapturedIntearction.fromHarEntry can create a CapturedInteraction from 
       "contentType": "application/json",
       "size": 133,
     },
-    "headers": [],
+    "headers": [
+      {
+        "name": "access-control-allow-headers",
+        "value": "Content-Type, api_key, Authorization",
+      },
+      {
+        "name": "access-control-allow-methods",
+        "value": "GET, POST, DELETE, PUT",
+      },
+      {
+        "name": "access-control-allow-origin",
+        "value": "*",
+      },
+      {
+        "name": "content-type",
+        "value": "application/json",
+      },
+      {
+        "name": "date",
+        "value": "Wed, 11 May 2022 11:47:04 GMT",
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.2.9.v20150224)",
+      },
+    ],
     "statusCode": "200",
   },
 }
@@ -30,7 +124,88 @@ exports[`CapturedIntearction.fromHarEntry includes request bodies 1`] = `
       "contentType": "application/json",
       "size": 128,
     },
-    "headers": [],
+    "headers": [
+      {
+        "name": ":authority",
+        "value": "petstore.swagger.io",
+      },
+      {
+        "name": ":method",
+        "value": "POST",
+      },
+      {
+        "name": ":path",
+        "value": "/v2/store/order",
+      },
+      {
+        "name": ":scheme",
+        "value": "https",
+      },
+      {
+        "name": "accept",
+        "value": "application/json",
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, br",
+      },
+      {
+        "name": "accept-language",
+        "value": "en-GB,en;q=0.9,nl-NL;q=0.8,nl;q=0.7,en-US;q=0.6",
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache",
+      },
+      {
+        "name": "content-length",
+        "value": "128",
+      },
+      {
+        "name": "content-type",
+        "value": "application/json",
+      },
+      {
+        "name": "origin",
+        "value": "https://petstore.swagger.io",
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache",
+      },
+      {
+        "name": "referer",
+        "value": "https://petstore.swagger.io/",
+      },
+      {
+        "name": "sec-ch-ua",
+        "value": "" Not A;Brand";v="99", "Chromium";v="101", "Google Chrome";v="101"",
+      },
+      {
+        "name": "sec-ch-ua-mobile",
+        "value": "?0",
+      },
+      {
+        "name": "sec-ch-ua-platform",
+        "value": ""macOS"",
+      },
+      {
+        "name": "sec-fetch-dest",
+        "value": "empty",
+      },
+      {
+        "name": "sec-fetch-mode",
+        "value": "cors",
+      },
+      {
+        "name": "sec-fetch-site",
+        "value": "same-origin",
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.54 Safari/537.36",
+      },
+    ],
     "host": "petstore.swagger.io",
     "method": "post",
     "path": "/v2/store/order",
@@ -42,7 +217,32 @@ exports[`CapturedIntearction.fromHarEntry includes request bodies 1`] = `
       "contentType": "application/json",
       "size": 119,
     },
-    "headers": [],
+    "headers": [
+      {
+        "name": "access-control-allow-headers",
+        "value": "Content-Type, api_key, Authorization",
+      },
+      {
+        "name": "access-control-allow-methods",
+        "value": "GET, POST, DELETE, PUT",
+      },
+      {
+        "name": "access-control-allow-origin",
+        "value": "*",
+      },
+      {
+        "name": "content-type",
+        "value": "application/json",
+      },
+      {
+        "name": "date",
+        "value": "Wed, 11 May 2022 11:48:47 GMT",
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.2.9.v20150224)",
+      },
+    ],
     "statusCode": "200",
   },
 }
@@ -52,7 +252,76 @@ exports[`CapturedIntearction.fromHarEntry includes response bodies 1`] = `
 {
   "request": {
     "body": null,
-    "headers": [],
+    "headers": [
+      {
+        "name": ":authority",
+        "value": "petstore.swagger.io",
+      },
+      {
+        "name": ":method",
+        "value": "GET",
+      },
+      {
+        "name": ":path",
+        "value": "/v2/store/inventory",
+      },
+      {
+        "name": ":scheme",
+        "value": "https",
+      },
+      {
+        "name": "accept",
+        "value": "application/json",
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, br",
+      },
+      {
+        "name": "accept-language",
+        "value": "en-GB,en;q=0.9,nl-NL;q=0.8,nl;q=0.7,en-US;q=0.6",
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache",
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache",
+      },
+      {
+        "name": "referer",
+        "value": "https://petstore.swagger.io/",
+      },
+      {
+        "name": "sec-ch-ua",
+        "value": "" Not A;Brand";v="99", "Chromium";v="101", "Google Chrome";v="101"",
+      },
+      {
+        "name": "sec-ch-ua-mobile",
+        "value": "?0",
+      },
+      {
+        "name": "sec-ch-ua-platform",
+        "value": ""macOS"",
+      },
+      {
+        "name": "sec-fetch-dest",
+        "value": "empty",
+      },
+      {
+        "name": "sec-fetch-mode",
+        "value": "cors",
+      },
+      {
+        "name": "sec-fetch-site",
+        "value": "same-origin",
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.54 Safari/537.36",
+      },
+    ],
     "host": "petstore.swagger.io",
     "method": "get",
     "path": "/v2/store/inventory",
@@ -64,7 +333,32 @@ exports[`CapturedIntearction.fromHarEntry includes response bodies 1`] = `
       "contentType": "application/json",
       "size": 133,
     },
-    "headers": [],
+    "headers": [
+      {
+        "name": "access-control-allow-headers",
+        "value": "Content-Type, api_key, Authorization",
+      },
+      {
+        "name": "access-control-allow-methods",
+        "value": "GET, POST, DELETE, PUT",
+      },
+      {
+        "name": "access-control-allow-origin",
+        "value": "*",
+      },
+      {
+        "name": "content-type",
+        "value": "application/json",
+      },
+      {
+        "name": "date",
+        "value": "Wed, 11 May 2022 11:47:04 GMT",
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.2.9.v20150224)",
+      },
+    ],
     "statusCode": "200",
   },
 }
@@ -78,7 +372,88 @@ exports[`CapturedIntearction.fromHarEntry supports request body encoding for sup
       "contentType": "application/json",
       "size": 128,
     },
-    "headers": [],
+    "headers": [
+      {
+        "name": ":authority",
+        "value": "petstore.swagger.io",
+      },
+      {
+        "name": ":method",
+        "value": "POST",
+      },
+      {
+        "name": ":path",
+        "value": "/v2/store/order",
+      },
+      {
+        "name": ":scheme",
+        "value": "https",
+      },
+      {
+        "name": "accept",
+        "value": "application/json",
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, br",
+      },
+      {
+        "name": "accept-language",
+        "value": "en-GB,en;q=0.9,nl-NL;q=0.8,nl;q=0.7,en-US;q=0.6",
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache",
+      },
+      {
+        "name": "content-length",
+        "value": "128",
+      },
+      {
+        "name": "content-type",
+        "value": "application/json",
+      },
+      {
+        "name": "origin",
+        "value": "https://petstore.swagger.io",
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache",
+      },
+      {
+        "name": "referer",
+        "value": "https://petstore.swagger.io/",
+      },
+      {
+        "name": "sec-ch-ua",
+        "value": "" Not A;Brand";v="99", "Chromium";v="101", "Google Chrome";v="101"",
+      },
+      {
+        "name": "sec-ch-ua-mobile",
+        "value": "?0",
+      },
+      {
+        "name": "sec-ch-ua-platform",
+        "value": ""macOS"",
+      },
+      {
+        "name": "sec-fetch-dest",
+        "value": "empty",
+      },
+      {
+        "name": "sec-fetch-mode",
+        "value": "cors",
+      },
+      {
+        "name": "sec-fetch-site",
+        "value": "same-origin",
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.54 Safari/537.36",
+      },
+    ],
     "host": "petstore.swagger.io",
     "method": "post",
     "path": "/v2/store/order",
@@ -90,7 +465,32 @@ exports[`CapturedIntearction.fromHarEntry supports request body encoding for sup
       "contentType": "application/json",
       "size": 119,
     },
-    "headers": [],
+    "headers": [
+      {
+        "name": "access-control-allow-headers",
+        "value": "Content-Type, api_key, Authorization",
+      },
+      {
+        "name": "access-control-allow-methods",
+        "value": "GET, POST, DELETE, PUT",
+      },
+      {
+        "name": "access-control-allow-origin",
+        "value": "*",
+      },
+      {
+        "name": "content-type",
+        "value": "application/json",
+      },
+      {
+        "name": "date",
+        "value": "Wed, 11 May 2022 11:48:47 GMT",
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.2.9.v20150224)",
+      },
+    ],
     "statusCode": "200",
   },
 }
@@ -100,7 +500,76 @@ exports[`CapturedIntearction.fromHarEntry supports response body encoding for su
 {
   "request": {
     "body": null,
-    "headers": [],
+    "headers": [
+      {
+        "name": ":authority",
+        "value": "petstore.swagger.io",
+      },
+      {
+        "name": ":method",
+        "value": "GET",
+      },
+      {
+        "name": ":path",
+        "value": "/v2/store/inventory",
+      },
+      {
+        "name": ":scheme",
+        "value": "https",
+      },
+      {
+        "name": "accept",
+        "value": "application/json",
+      },
+      {
+        "name": "accept-encoding",
+        "value": "gzip, deflate, br",
+      },
+      {
+        "name": "accept-language",
+        "value": "en-GB,en;q=0.9,nl-NL;q=0.8,nl;q=0.7,en-US;q=0.6",
+      },
+      {
+        "name": "cache-control",
+        "value": "no-cache",
+      },
+      {
+        "name": "pragma",
+        "value": "no-cache",
+      },
+      {
+        "name": "referer",
+        "value": "https://petstore.swagger.io/",
+      },
+      {
+        "name": "sec-ch-ua",
+        "value": "" Not A;Brand";v="99", "Chromium";v="101", "Google Chrome";v="101"",
+      },
+      {
+        "name": "sec-ch-ua-mobile",
+        "value": "?0",
+      },
+      {
+        "name": "sec-ch-ua-platform",
+        "value": ""macOS"",
+      },
+      {
+        "name": "sec-fetch-dest",
+        "value": "empty",
+      },
+      {
+        "name": "sec-fetch-mode",
+        "value": "cors",
+      },
+      {
+        "name": "sec-fetch-site",
+        "value": "same-origin",
+      },
+      {
+        "name": "user-agent",
+        "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.54 Safari/537.36",
+      },
+    ],
     "host": "petstore.swagger.io",
     "method": "get",
     "path": "/v2/store/inventory",
@@ -112,7 +581,32 @@ exports[`CapturedIntearction.fromHarEntry supports response body encoding for su
       "contentType": "application/json",
       "size": 133,
     },
-    "headers": [],
+    "headers": [
+      {
+        "name": "access-control-allow-headers",
+        "value": "Content-Type, api_key, Authorization",
+      },
+      {
+        "name": "access-control-allow-methods",
+        "value": "GET, POST, DELETE, PUT",
+      },
+      {
+        "name": "access-control-allow-origin",
+        "value": "*",
+      },
+      {
+        "name": "content-type",
+        "value": "application/json",
+      },
+      {
+        "name": "date",
+        "value": "Wed, 11 May 2022 11:47:04 GMT",
+      },
+      {
+        "name": "server",
+        "value": "Jetty(9.2.9.v20150224)",
+      },
+    ],
     "statusCode": "200",
   },
 }
@@ -317,68 +811,6 @@ exports[`CapturedInteraction.fromPostmanEntry includes response bodies 1`] = `
         "value": "keep-alive",
       },
     ],
-    "statusCode": "200",
-  },
-}
-`;
-
-exports[`CapturedInteraction.fromProxyInteraction can create a CaturedInteraction from a ProxySource.Interaction 1`] = `
-{
-  "request": {
-    "body": null,
-    "headers": [],
-    "host": "localhost",
-    "method": "get",
-    "path": "/test-path",
-    "query": [],
-  },
-  "response": {
-    "body": null,
-    "headers": [],
-    "statusCode": "200",
-  },
-}
-`;
-
-exports[`CapturedInteraction.fromProxyInteraction includes request bodies 1`] = `
-{
-  "request": {
-    "body": {
-      "body": Anything,
-      "contentType": "text/plain",
-      "size": 9,
-    },
-    "headers": [],
-    "host": "localhost",
-    "method": "get",
-    "path": "/test-path",
-    "query": [],
-  },
-  "response": {
-    "body": null,
-    "headers": [],
-    "statusCode": "200",
-  },
-}
-`;
-
-exports[`CapturedInteraction.fromProxyInteraction includes response bodies 1`] = `
-{
-  "request": {
-    "body": null,
-    "headers": [],
-    "host": "localhost",
-    "method": "get",
-    "path": "/test-path",
-    "query": [],
-  },
-  "response": {
-    "body": {
-      "body": Anything,
-      "contentType": null,
-      "size": 31,
-    },
-    "headers": [],
     "statusCode": "200",
   },
 }

--- a/projects/optic/src/commands/capture/sources/__tests__/interaction.test.ts
+++ b/projects/optic/src/commands/capture/sources/__tests__/interaction.test.ts
@@ -114,50 +114,6 @@ describe('CapturedIntearction.fromHarEntry', () => {
   });
 });
 
-describe('CapturedInteraction.fromProxyInteraction', () => {
-  it('can create a CaturedInteraction from a ProxySource.Interaction', () => {
-    let testInteraction = {
-      request: proxySourceRequest(),
-      response: proxySourceResponse(),
-    };
-    let interaction = CapturedInteraction.fromProxyInteraction(testInteraction);
-
-    expect(interaction).toMatchSnapshot();
-  });
-
-  it('includes request bodies', () => {
-    let testInteraction = {
-      request: proxySourceRequest(Buffer.from('some-body'), 'text/plain'),
-      response: proxySourceResponse(),
-    };
-
-    let interaction = CapturedInteraction.fromProxyInteraction(testInteraction);
-    expect(interaction).toMatchSnapshot({
-      request: { body: matchBody() },
-    });
-
-    let parsingBody = CapturedBody.text(interaction!.request.body!);
-    expect(parsingBody).resolves.toBe('some-body');
-  });
-
-  it('includes response bodies', () => {
-    let testBody = { a: 1, b: true, c: { d: 'ok' } };
-    let testInteraction = {
-      request: proxySourceRequest(),
-      response: proxySourceResponse(200, Buffer.from(JSON.stringify(testBody))),
-    };
-
-    let interaction = CapturedInteraction.fromProxyInteraction(testInteraction);
-
-    expect(interaction).toMatchSnapshot({
-      response: { body: matchBody() },
-    });
-
-    let parsingBody = CapturedBody.json(interaction!.response?.body);
-    expect(parsingBody).resolves.toMatchObject(testBody);
-  });
-});
-
 describe('CapturedInteraction.fromPostmanEntry', () => {
   let testEntries: PostmanEntry[];
 

--- a/projects/optic/src/commands/capture/sources/har.ts
+++ b/projects/optic/src/commands/capture/sources/har.ts
@@ -108,6 +108,15 @@ export class HarEntries {
 
       let requestBodyBuffer = interaction.request.body.buffer;
       let requestContentType = interaction.request.headers['content-type'];
+      let queryString: HttpArchive.Request['queryString'] = [];
+      try {
+        const url = new URL(interaction.request.url);
+        for (const [name, value] of url.searchParams) {
+          queryString.push({ name, value });
+        }
+      } catch (e) {
+        continue;
+      }
 
       const requestBodyEncoded =
         requestContentType &&
@@ -127,7 +136,7 @@ export class HarEntries {
         headersSize: -1, // hard to calculate
         bodySize: interaction.request.body.buffer.length,
         cookies: [], // not available from proxy, but could parse from header
-        queryString: [], // not available from proxy, but could parse from url
+        queryString,
         postData:
           requestContentType && requestBodyEncoded
             ? {

--- a/projects/optic/src/commands/oas/diffing/document.ts
+++ b/projects/optic/src/commands/oas/diffing/document.ts
@@ -4,6 +4,7 @@ import {
   DocumentedInteractions,
   HttpMethod,
   HttpMethods,
+  Operation,
   UndocumentedOperation,
   UndocumentedOperations,
   UndocumentedOperationType,
@@ -446,9 +447,13 @@ export function addOperations(
       }
 
       // phase two: shape patches, describing request / response bodies in detail
-      documentedInteraction = DocumentedInteraction.updateOperation(
-        documentedInteraction,
-        patchedSpec
+      documentedInteraction.operation = Operation.fromOperationObject(
+        documentedInteraction.operation.pathPattern,
+        documentedInteraction.operation.method,
+        jsonPointerHelpers.get(
+          patchedSpec,
+          documentedInteraction.specJsonPath
+        ) as any
       );
       let documentedBodies = DocumentedBodies.fromDocumentedInteraction(
         documentedInteraction

--- a/projects/optic/src/commands/oas/diffing/patch.ts
+++ b/projects/optic/src/commands/oas/diffing/patch.ts
@@ -15,7 +15,11 @@ import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
 import chalk from 'chalk';
 import { OpenAPIV3 } from '@useoptic/openapi-utilities';
 import { Subject, tap } from '../lib/async-tools';
-import { DocumentedInteraction, DocumentedInteractions } from '../operations';
+import {
+  DocumentedInteraction,
+  DocumentedInteractions,
+  Operation,
+} from '../operations';
 import {
   DocumentedBodies,
   DocumentedBody,
@@ -288,10 +292,15 @@ export function updateByInteractions(
       }
 
       // phase two: shape patches, describing request / response bodies in detail
-      documentedInteraction = DocumentedInteraction.updateOperation(
-        documentedInteraction,
-        patchedSpec
+      documentedInteraction.operation = Operation.fromOperationObject(
+        documentedInteraction.operation.pathPattern,
+        documentedInteraction.operation.method,
+        jsonPointerHelpers.get(
+          patchedSpec,
+          documentedInteraction.specJsonPath
+        ) as any
       );
+
       let documentedBodies = DocumentedBodies.fromDocumentedInteraction(
         documentedInteraction
       );

--- a/projects/optic/src/commands/oas/operations/index.ts
+++ b/projects/optic/src/commands/oas/operations/index.ts
@@ -144,30 +144,6 @@ export interface DocumentedInteraction {
   specJsonPath: string;
 }
 
-export class DocumentedInteraction {
-  static updateOperation(
-    self: DocumentedInteraction,
-    spec: OpenAPIV3.Document
-  ) {
-    let operationObject = jsonPointerHelpers.get(spec, self.specJsonPath) as
-      | OpenAPIV3.OperationObject
-      | undefined;
-    invariant(
-      operationObject,
-      'operation object has to exist in spec to update operation of DocumentationInteraction'
-    );
-
-    return {
-      ...self,
-      operation: Operation.fromOperationObject(
-        self.operation.pathPattern,
-        self.operation.method,
-        operationObject
-      ),
-    };
-  }
-}
-
 const HttpMethods = OpenAPIV3.HttpMethods;
 export { HttpMethods };
 export type HttpMethod = OpenAPIV3.HttpMethods;

--- a/projects/optic/src/commands/oas/specs/patches/generators/new-spec.ts
+++ b/projects/optic/src/commands/oas/specs/patches/generators/new-spec.ts
@@ -1,6 +1,5 @@
 import { OpenAPIV3 } from '../../';
 import {
-  OperationGroup,
   PatchImpact,
   SpecPatch,
 } from '../../../../capture/patches/patchers/spec/patches';
@@ -23,11 +22,11 @@ export function* newSpecPatches<T>(
     path: '/',
     diff: undefined,
     groupedOperations: [
-      OperationGroup.create(`setup minimal viable OpenAPI spec file`, {
+      {
         op: 'add',
         path: '',
         value: newSpec,
-      }),
+      },
     ],
   };
 }

--- a/projects/optic/src/commands/oas/specs/patches/generators/template.ts
+++ b/projects/optic/src/commands/oas/specs/patches/generators/template.ts
@@ -2,7 +2,6 @@ import { OpenAPIV3 } from '../..';
 import JsonPatch from 'fast-json-patch';
 import { SpecTemplate } from '../..';
 import {
-  OperationGroup,
   PatchImpact,
   SpecPatch,
 } from '../../../../capture/patches/patchers/spec/patches';
@@ -33,11 +32,6 @@ export function* templatePatches<T>(
     diff: undefined,
     path: '/',
     description: `changes made through applying '${template.name}' template`, // TODO: allow template control more specifically
-    groupedOperations: [
-      OperationGroup.create(
-        `match changes made through applying '${template.name}' template`, // TODO: identify intent of changes
-        ...operations
-      ),
-    ],
+    groupedOperations: [...operations],
   };
 }

--- a/projects/optic/src/commands/oas/specs/streams/patches.ts
+++ b/projects/optic/src/commands/oas/specs/streams/patches.ts
@@ -5,7 +5,6 @@ import { SpecTemplate } from '../templates';
 import { UndocumentedOperation } from '../../operations';
 import {
   Operation,
-  OperationGroup,
   PatchImpact,
   SpecPatch,
   SpecPatches,
@@ -27,8 +26,8 @@ export class LegacySpecPatches {
 
   static async *operations(patches: SpecPatches): AsyncIterable<Operation> {
     yield* flatMap<SpecPatch, Operation>(async function* (patch) {
-      for (let group of patch.groupedOperations) {
-        yield* OperationGroup.operations(group);
+      for (let op of patch.groupedOperations) {
+        yield op;
       }
     })(patches);
   }


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

The key logic changes are in: 
- `projects/optic/src/commands/capture/patches/patchers/spec/request-params.ts`
- `projects/optic/src/commands/capture/patches/patchers/spec/response-headers.ts`

This PR updates Optic capture to support diffing + patching query parameters, headers and response headers. This updates:
- The capture methods (proxy, har, postman) to collect query param, header and response header data
- The diff + patching logic to look at query, header and response headers
- The summarize patch logic to look at specs

I did a bit more refactor to remove the `intent` from groupedOperations from patches since the intent is already at a higher level on the patch which removes another layer of indirection.

I commented out the sections specifically for learning / diffing new headers / response headers. The reason we don't want to automatically create new headers we see is that it's likely going to be very noisy (e.g. every API will have `host`, `accept`, `content-type` and include other things injected from gateways / other infra). If we did want to support this in the future, we could include an allowlist that lets users select which headers / response headers they're specifically looking out for in their API and we can diff / patch them

If a header or response header is defined and marked as required, we'll detect the diff and patch it to optional


## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
