### PR TITLE
Fix server defined path prefixes in spec

### DIFF
--- a/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
@@ -1156,14 +1156,20 @@ exports[`capture with inputs --postman verifying OpenAPI spec 1`] = `
 
 exports[`capture with requests update behavior handle server path prefixes in spec 1`] = `
 "Generating traffic to send to server
-[90m1 endpoint did not receive traffic[39m
+GET /books
+  [32m✓ [39m200 response
+  [32m[200 response body] 'name' has been added (/properties/books/items/properties/name)[39m
+  [32m[200 response body] 'author_id' has been added (/properties/books/items/properties/author_id)[39m
+  [32m[200 response body] 'status' has been added (/properties/books/items/properties/status)[39m
+  [32m[200 response body] 'price' has been added (/properties/books/items/properties/price)[39m
+  [32m[200 response body] 'created_at' has been added (/properties/books/items/properties/created_at)[39m
+  [32m[200 response body] 'updated_at' has been added (/properties/books/items/properties/updated_at)[39m
 
 [1m[90mLearning path patterns for unmatched requests...[39m[22m
 [1m[90mDocumenting new operations:[39m[22m
 GET /authors
 GET /books/{book}
 POST /books/{book}
-GET /books
 "
 `;
 
@@ -1231,7 +1237,199 @@ components:
         books:
           type: array
           items:
-            $ref: "#/components/schemas/GetBooksBook200ResponseBody"
+            type: object
+            properties:
+              id:
+                type: string
+              name:
+                type: string
+              author_id:
+                type: string
+              status:
+                type: string
+              price:
+                type: number
+              created_at:
+                type: string
+              updated_at:
+                type: string
+            required:
+              - name
+              - author_id
+              - status
+              - price
+              - created_at
+              - updated_at
+    GetAuthors200ResponseBody:
+      type: object
+      properties:
+        authors:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              name:
+                type: string
+              created_at:
+                type: string
+              updated_at:
+                type: string
+            required:
+              - id
+              - name
+              - created_at
+              - updated_at
+      required:
+        - authors
+    GetBooksBook200ResponseBody:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        author_id:
+          type: string
+        status:
+          type: string
+        price:
+          type: number
+        created_at:
+          type: string
+        updated_at:
+          type: string
+      required:
+        - id
+        - name
+        - author_id
+        - status
+        - price
+        - created_at
+        - updated_at
+    PostBooksBookRequestBody:
+      type: object
+      properties:
+        name:
+          type: string
+        price:
+          type: number
+        author_id:
+          type: string
+      required:
+        - name
+        - price
+        - author_id
+"
+`;
+
+exports[`capture with requests update behavior handle server path prefixes in spec and in optic.yml 1`] = `
+"Generating traffic to send to server
+GET /books
+  [32m✓ [39m200 response
+  [32m[200 response body] 'name' has been added (/properties/books/items/properties/name)[39m
+  [32m[200 response body] 'author_id' has been added (/properties/books/items/properties/author_id)[39m
+  [32m[200 response body] 'status' has been added (/properties/books/items/properties/status)[39m
+  [32m[200 response body] 'price' has been added (/properties/books/items/properties/price)[39m
+  [32m[200 response body] 'created_at' has been added (/properties/books/items/properties/created_at)[39m
+  [32m[200 response body] 'updated_at' has been added (/properties/books/items/properties/updated_at)[39m
+
+[1m[90mLearning path patterns for unmatched requests...[39m[22m
+[1m[90mDocumenting new operations:[39m[22m
+GET /authors
+GET /books/{book}
+POST /books/{book}
+"
+`;
+
+exports[`capture with requests update behavior handle server path prefixes in spec and in optic.yml 2`] = `
+"openapi: 3.0.3
+info:
+  title: a spec
+  description: The API
+  version: 0.1.0
+servers:
+  - name: server
+    url: http://localhost:PORT/api
+paths:
+  /books:
+    get:
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GetBooks200ResponseBody"
+  /authors:
+    get:
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GetAuthors200ResponseBody"
+  /books/{book}:
+    parameters:
+      - in: path
+        name: book
+        required: true
+        schema:
+          type: string
+    get:
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GetBooksBook200ResponseBody"
+    post:
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GetBooksBook200ResponseBody"
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: "#/components/schemas/PostBooksBookRequestBody"
+components:
+  schemas:
+    GetBooks200ResponseBody:
+      type: object
+      properties:
+        books:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              name:
+                type: string
+              author_id:
+                type: string
+              status:
+                type: string
+              price:
+                type: number
+              created_at:
+                type: string
+              updated_at:
+                type: string
+            required:
+              - name
+              - author_id
+              - status
+              - price
+              - created_at
+              - updated_at
     GetAuthors200ResponseBody:
       type: object
       properties:

--- a/projects/optic/src/__tests__/integration/capture.test.ts
+++ b/projects/optic/src/__tests__/integration/capture.test.ts
@@ -166,6 +166,28 @@ describe('capture with requests', () => {
       ).toMatchSnapshot();
     });
 
+    test('handle server path prefixes in spec and in optic.yml', async () => {
+      process.env.SERVER_PREFIX = '/api';
+      const workspace = await setupWorkspace('capture/with-server');
+      await setPortInFile(workspace, 'optic.yml');
+      await setPortInFile(workspace, 'openapi-prefix-and-server-urls.yml');
+
+      const { combined, code } = await runOptic(
+        workspace,
+        'capture openapi-prefix-and-server-urls.yml --update automatic'
+      );
+      expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
+      expect(code).toBe(0);
+      expect(
+        (
+          await fs.readFile(
+            path.join(workspace, 'openapi-prefix-and-server-urls.yml'),
+            'utf-8'
+          )
+        ).replace(`localhost:${port}`, 'localhost:PORT')
+      ).toMatchSnapshot();
+    });
+
     test('handles update in other file', async () => {
       const workspace = await setupWorkspace('capture/with-server');
       await setPortInFile(workspace, 'optic.yml');

--- a/projects/optic/src/__tests__/integration/workspaces/capture/with-server/openapi-prefix-and-server-urls.yml
+++ b/projects/optic/src/__tests__/integration/workspaces/capture/with-server/openapi-prefix-and-server-urls.yml
@@ -1,0 +1,30 @@
+openapi: 3.0.3
+info:
+  title: a spec
+  description: The API
+  version: 0.1.0
+servers:
+  - name: server
+    url: http://localhost:%PORT/api
+paths:
+  /books:
+    get:
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GetBooks200ResponseBody"
+components:
+  schemas:
+    GetBooks200ResponseBody:
+      type: object
+      properties:
+        books:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string

--- a/projects/optic/src/__tests__/integration/workspaces/capture/with-server/optic.yml
+++ b/projects/optic/src/__tests__/integration/workspaces/capture/with-server/optic.yml
@@ -65,6 +65,27 @@ capture:
             author_id: 6nTxAFM5ck4Hob77hGQoL
         - path: /authors
           method: GET
+  openapi-prefix-and-server-urls.yml:
+    server:
+      command: node server.js
+      url: http://localhost:%PORT/api
+      ready_endpoint: /healthcheck
+    requests:
+      send:
+        - path: /books
+          method: GET
+        - path: /books/asd
+          method: GET
+        - path: /books/def
+          method: GET
+        - path: /books/asd
+          method: POST
+          data:
+            name: asd
+            price: 1
+            author_id: 6nTxAFM5ck4Hob77hGQoL
+        - path: /authors
+          method: GET
   openapi-with-external-ref.yml:
     server:
       command: node server.js

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -157,12 +157,13 @@ const getCaptureAction =
       strict: false,
       denormalize: false,
     });
-    const captures = new GroupedCaptures(trafficDirectory, spec.jsonLike);
+    let serverUrl: string | null = null;
+    let captures: GroupedCaptures;
     const pathFromRoot = resolveRelativePath(config.root, filePath);
     const captureConfig = config.capture?.[pathFromRoot];
-    let serverUrl: string | null = null;
 
     if (options.har) {
+      captures = new GroupedCaptures(trafficDirectory, spec.jsonLike);
       try {
         const harEntries = getHarEntriesFromFs(options.har);
         for await (const harOrErr of harEntries) {
@@ -179,6 +180,7 @@ const getCaptureAction =
         return;
       }
     } else if (options.postman) {
+      captures = new GroupedCaptures(trafficDirectory, spec.jsonLike);
       const postmanEntryResults = PostmanCollectionEntries.fromReadable(
         fsNonPromise.createReadStream(options.postman)
       );
@@ -224,6 +226,9 @@ const getCaptureAction =
         return;
       }
       serverUrl = options.serverOverride || captureConfig.server.url;
+      captures = new GroupedCaptures(trafficDirectory, spec.jsonLike, {
+        baseServerUrl: serverUrl,
+      });
       const harEntries = await captureRequestsFromProxy(config, captureConfig, {
         ...options,
         serverUrl,

--- a/projects/optic/src/commands/capture/sources/proxy.ts
+++ b/projects/optic/src/commands/capture/sources/proxy.ts
@@ -72,7 +72,6 @@ export class ProxyServer {
         stopPort: 8999,
       });
     }
-
     await capturingProxy
       .forAnyRequest()
       .always()
@@ -92,10 +91,11 @@ export class ProxyServer {
           const urlObj = new URL(rest.url);
           urlObj.pathname = urljoin(serverPathnamePrefix, urlObj.pathname);
           const prefixedUrl = urlObj.toString();
+
           logger.debug(
             `Forwarding request ${
               rest.path
-            } ${prefixedUrl} with headers: ${JSON.stringify(
+            } to ${prefixedUrl} with headers: ${JSON.stringify(
               rest.headers
             )}. id: ${capturedRequest.id}`
           );
@@ -104,6 +104,8 @@ export class ProxyServer {
             ...rest,
             body: { buffer: body.buffer },
             timingEvents: timingEvents as TimingEvents,
+            url: prefixedUrl,
+            path: urlObj.pathname,
           };
           requestsById.set(request.id, request);
           return {

--- a/projects/optic/src/commands/oas/captures/getInteractions.ts
+++ b/projects/optic/src/commands/oas/captures/getInteractions.ts
@@ -9,6 +9,7 @@ import { CapturedInteractions } from '../../capture/sources/captured-interaction
 import { PostmanCollectionEntries } from '../../capture/sources/postman';
 import { HarEntries } from '../../capture/sources/har';
 import {
+  createHostBaseMap,
   filterIgnoredInteractions,
   handleServerPathPrefix,
 } from '../../capture/interactions/grouped-interactions';
@@ -90,6 +91,6 @@ export async function getInteractions(
 
   return handleServerPathPrefix(
     filterIgnoredInteractions(AT.merge(...sources), spec),
-    spec
+    createHostBaseMap(spec)
   );
 }

--- a/projects/optic/src/commands/run.ts
+++ b/projects/optic/src/commands/run.ts
@@ -492,7 +492,9 @@ const runCapture = async ({
 
   if (captureConfig) {
     const trafficDirectory = await getCaptureStorage(path.resolve(specPath));
-    const captures = new GroupedCaptures(trafficDirectory, localSpec.jsonLike);
+    const captures = new GroupedCaptures(trafficDirectory, localSpec.jsonLike, {
+      baseServerUrl: captureConfig.server.url,
+    });
 
     let harEntries: any;
     try {


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Updated the capture flow to properly handle when server.url has a prefix and the openapi spec also has a prefix. Example:

```
# openapi.yml
servers:
  - url: http://localhost:3000/api
```

```
# optic.yml
... capture config
server:
  url: http://localhost:3000/api
```

Had to change a couple of parts:
- added interactions / hars should have their paths adjusted (we'll need to figure out how to handle this if we ever decide to reuse cached har files on disk)
- updated the capture proxy to properly add the forwarded url, not the non-prefixed url (e.g. `/api/users` rather than `/users`)

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._
https://github.com/opticdev/optic/issues/2530

## 👹 QA
_How can other humans verify that this PR is correct?_
