### PR TITLE
Spectral rules fix for changed | addedOrChanged

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.52.2",
+  "version": "0.52.3",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/fastify-capture/package.json
+++ b/projects/fastify-capture/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/fastify-capture",
   "license": "MIT",
   "packageManager": "yarn@4.0.1",
-  "version": "0.52.2",
+  "version": "0.52.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@4.0.1",
-  "version": "0.52.2",
+  "version": "0.52.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@4.0.1",
-  "version": "0.52.2",
+  "version": "0.52.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@4.0.1",
-  "version": "0.52.2",
+  "version": "0.52.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@4.0.1",
-  "version": "0.52.2",
+  "version": "0.52.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@4.0.1",
-  "version": "0.52.2",
+  "version": "0.52.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/src/__tests__/__snapshots__/spectral-rule.test.ts.snap
+++ b/projects/rulesets-base/src/__tests__/__snapshots__/spectral-rule.test.ts.snap
@@ -121,3 +121,22 @@ exports[`spectral rule test runs spectral rules on added 1`] = `
   },
 ]
 `;
+
+exports[`spectral rule test runs spectral rules on addedOrChanged 1`] = `
+[
+  {
+    "docsLink": undefined,
+    "error": "Error code: this-rule: readOnly is not supported by API Gateway",
+    "exempted": false,
+    "location": {
+      "jsonPath": "/paths/~1api/get/responses/200/content/application~1json/schema/properties/example",
+      "spec": "after",
+    },
+    "name": "Spectral addedOrChanged rule",
+    "passed": false,
+    "severity": 2,
+    "type": "addedOrChanged",
+    "where": "addedOrChanged ",
+  },
+]
+`;

--- a/projects/rulesets-base/src/extended-rules/spectral-rule.ts
+++ b/projects/rulesets-base/src/extended-rules/spectral-rule.ts
@@ -302,7 +302,12 @@ export class SpectralRule extends ExternalRuleBase {
       } else {
         // find if there is an appropriate change
         let maybeChange: ObjectDiff | undefined =
-          changesByJsonPath[fact.location.jsonPath];
+          changesByJsonPath[fact.location.jsonPath] ||
+          changesByJsonPath[
+            jsonPointerHelpers.compile(
+              spectralResult.path.map((i) => i.toString())
+            )
+          ];
 
         if (
           !maybeChange &&

--- a/projects/rulesets-base/src/extended-rules/spectral-rule.ts
+++ b/projects/rulesets-base/src/extended-rules/spectral-rule.ts
@@ -470,7 +470,12 @@ export class SpectralRule extends ExternalRuleBase {
       } else {
         // find if there is an appropriate change
         const maybeChange: IChange | undefined =
-          changesByJsonPath[fact.location.jsonPath];
+          changesByJsonPath[fact.location.jsonPath] ||
+          changesByJsonPath[
+            jsonPointerHelpers.compile(
+              spectralResult.path.map((i) => i.toString())
+            )
+          ];
         if (maybeChange) {
           if (this.lifecycle === 'added' && maybeChange.added) {
             results.push(

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@4.0.1",
-  "version": "0.52.2",
+  "version": "0.52.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
## 🍗 Description
Spectral rules can be set to run on changed or addedOrChanged. This setting worked when the Spectral rule targeted a node Optic tracked with a fact ie an `operation`, a `parameter`, `property`, etc, but it did not work properly when targeting a node's attribute ie `readOnly` on a `property`. 

Spectral users expect rules to care about the JSON path they target changing, not our facts. 

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
