### PR TITLE
add required to request body rule data

### DIFF
--- a/projects/rulesets-base/src/rule-runner/__tests__/__snapshots__/data-constructors.test.ts.snap
+++ b/projects/rulesets-base/src/rule-runner/__tests__/__snapshots__/data-constructors.test.ts.snap
@@ -4539,6 +4539,7 @@ exports[`createRequest request with after key 1`] = `
       },
     },
   },
+  "required": true,
   "value": {
     "contentType": "application/json",
     "flatSchema": {
@@ -5600,6 +5601,7 @@ exports[`createRequest request with before key 1`] = `
       },
     },
   },
+  "required": undefined,
   "value": {
     "contentType": "application/json",
     "flatSchema": {
@@ -9293,7 +9295,6 @@ exports[`createSpecification specification with before key 1`] = `
               },
             },
             "description": "Pet object that needs to be added to the store",
-            "required": true,
           },
           "responses": {
             "400": {

--- a/projects/rulesets-base/src/rule-runner/__tests__/examples/petstore-small.ts
+++ b/projects/rulesets-base/src/rule-runner/__tests__/examples/petstore-small.ts
@@ -257,7 +257,6 @@ export const beforeOpenApiJson: OpenAPIV3.Document = {
               },
             },
           },
-          required: true,
         },
         responses: {
           '400': {

--- a/projects/rulesets-base/src/rule-runner/data-constructors.ts
+++ b/projects/rulesets-base/src/rule-runner/data-constructors.ts
@@ -88,9 +88,18 @@ export const createRequest = (
   if (!requestFact || !requestBody || !requestBodyFact) {
     return null;
   }
+  const requestPointer = jsonPointerHelpers.compile([
+    ...jsonPointerHelpers.decode(requestBodyFact.location.jsonPath).slice(0, 3),
+    'requestBody',
+  ]);
+  const required: boolean | undefined = jsonPointerHelpers.get(
+    openApiSpec,
+    requestPointer
+  ).required;
 
   return {
     ...requestBodyFact,
+    required: required,
     raw: jsonPointerHelpers.get(openApiSpec, requestBodyFact.location.jsonPath),
     contentType,
     properties: createPropertyFactsWithRaw(

--- a/projects/rulesets-base/src/types.ts
+++ b/projects/rulesets-base/src/types.ts
@@ -52,6 +52,7 @@ export type CookieParameter = FactVariant<OpenApiKind.CookieParameter> & {
 
 export type RequestBody = FactVariant<OpenApiKind.Body> & {
   raw: OpenAPIV3.MediaTypeObject;
+  required?: boolean;
   contentType: string;
   properties: Map<string, Property>;
 };


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Adds required to the request body in the fact runner. For rule runner, we only surface the request body fact, not the request fact (which is where required is), and as a result we add required to the request body fact.

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
