### PR TITLE
extend removing examples and descriptions to responses

### DIFF
--- a/projects/standard-rulesets/src/lintgpt/__tests__/__snapshots__/prepare.test.ts.snap
+++ b/projects/standard-rulesets/src/lintgpt/__tests__/__snapshots__/prepare.test.ts.snap
@@ -3,6 +3,12 @@
 exports[`can reduce size of operations by deleting descriptions + examples  1`] = `
 {
   "description": "delete all the orders for this user",
+  "parameters": [
+    {
+      "in": "query",
+      "name": "a",
+    },
+  ],
   "requestBody": {
     "content": {
       "application/json": {

--- a/projects/standard-rulesets/src/lintgpt/__tests__/__snapshots__/prepare.test.ts.snap
+++ b/projects/standard-rulesets/src/lintgpt/__tests__/__snapshots__/prepare.test.ts.snap
@@ -45,3 +45,24 @@ exports[`can reduce size of operations by deleting descriptions + examples  1`] 
   },
 }
 `;
+
+exports[`can reduce size of responses by deleting descriptions + examples  1`] = `
+{
+  "content": {
+    "application/json": {
+      "schema": {
+        "properties": {
+          "description": {
+            "type": "string",
+          },
+          "example": {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+    },
+  },
+  "description": "The response",
+}
+`;

--- a/projects/standard-rulesets/src/lintgpt/__tests__/prepare.test.ts
+++ b/projects/standard-rulesets/src/lintgpt/__tests__/prepare.test.ts
@@ -1,5 +1,8 @@
-import { test, expect, describe } from '@jest/globals';
-import { removeDocumentationFromOperation } from '../prepare-openapi';
+import { test, expect } from '@jest/globals';
+import {
+  removeDocumentationFromOperation,
+  removeDocumentationFromResponses,
+} from '../prepare-openapi';
 
 test('can reduce size of operations by deleting descriptions + examples ', () => {
   const output = removeDocumentationFromOperation({
@@ -42,6 +45,30 @@ test('can reduce size of operations by deleting descriptions + examples ', () =>
                   description: 'Delete me',
                 },
               },
+            },
+          },
+        },
+      },
+    },
+  });
+  expect(output).toMatchSnapshot();
+});
+
+test('can reduce size of responses by deleting descriptions + examples ', () => {
+  const output = removeDocumentationFromResponses({
+    description: 'The response',
+    content: {
+      'application/json': {
+        schema: {
+          type: 'object',
+          properties: {
+            description: {
+              type: 'string',
+              description: 'Delete me',
+            },
+            example: {
+              type: 'string',
+              example: '123',
             },
           },
         },

--- a/projects/standard-rulesets/src/lintgpt/__tests__/prepare.test.ts
+++ b/projects/standard-rulesets/src/lintgpt/__tests__/prepare.test.ts
@@ -7,6 +7,14 @@ import {
 test('can reduce size of operations by deleting descriptions + examples ', () => {
   const output = removeDocumentationFromOperation({
     description: 'delete all the orders for this user',
+    parameters: [
+      {
+        name: 'a',
+        in: 'query',
+        description: '123',
+        example: '123',
+      },
+    ],
     requestBody: {
       description: 'what to send',
       required: true,

--- a/projects/standard-rulesets/src/lintgpt/index.ts
+++ b/projects/standard-rulesets/src/lintgpt/index.ts
@@ -21,7 +21,10 @@ import { OpenAPIFactNodes } from '@useoptic/rulesets-base/build/rule-runner/rule
 import { OpenAPIV3 } from 'openapi-types';
 import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
 import stableStringify from 'json-stable-stringify';
-import { removeDocumentationFromOperation } from './prepare-openapi';
+import {
+  removeDocumentationFromOperation,
+  removeDocumentationFromResponses,
+} from './prepare-openapi';
 
 export type LintGptConfig = {
   [key: string]: {
@@ -201,11 +204,15 @@ export class LintGpt extends ExternalRuleBase {
           jsonPath,
           value: wasRemoved
             ? undefined
-            : jsonPointerHelpers.get(inputs.toSpec, jsonPath),
+            : removeDocumentationFromResponses(
+                jsonPointerHelpers.get(inputs.toSpec, jsonPath)
+              ),
           before: didChange
-            ? jsonPointerHelpers.get(
-                inputs.fromSpec,
-                response.before?.location.jsonPath!
+            ? removeDocumentationFromResponses(
+                jsonPointerHelpers.get(
+                  inputs.fromSpec,
+                  response.before?.location.jsonPath!
+                )
               )
             : undefined,
         });

--- a/projects/standard-rulesets/src/lintgpt/prepare-openapi.ts
+++ b/projects/standard-rulesets/src/lintgpt/prepare-openapi.ts
@@ -1,6 +1,55 @@
 import { OpenAPIV3 } from 'openapi-types';
 import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
 
+function removeExamplesAndDescriptionsFromProperties(
+  value: any,
+  path: string[]
+) {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) =>
+      removeExamplesAndDescriptionsFromProperties(item, [
+        ...path,
+        index.toString(),
+      ])
+    );
+  } else if (typeof value === 'object' && value !== null) {
+    if (
+      value.hasOwnProperty('description') &&
+      jsonPointerHelpers.endsWith(
+        jsonPointerHelpers.compile([...path, 'description']),
+        ['properties', '**', 'description']
+      )
+    ) {
+      delete value['description'];
+    }
+
+    if (
+      value.hasOwnProperty('example') &&
+      jsonPointerHelpers.endsWith(
+        jsonPointerHelpers.compile([...path, 'example']),
+        ['properties', '**', 'example']
+      )
+    ) {
+      delete value['example'];
+    }
+
+    if (
+      value.hasOwnProperty('examples') &&
+      jsonPointerHelpers.endsWith(
+        jsonPointerHelpers.compile([...path, 'examples']),
+        ['properties', '**', 'examples']
+      )
+    ) {
+      delete value['examples'];
+    }
+
+    Object.keys(value).forEach((key) =>
+      removeExamplesAndDescriptionsFromProperties(value[key], [...path, key])
+    );
+  } else {
+  }
+}
+
 export function removeDocumentationFromOperation(
   operation: OpenAPIV3.OperationObject
 ) {
@@ -8,37 +57,20 @@ export function removeDocumentationFromOperation(
     JSON.stringify(operation)
   );
 
-  function walk(value: any, path: string[]) {
-    if (Array.isArray(value)) {
-      value.forEach((item, index) => walk(item, [...path, index.toString()]));
-    } else if (typeof value === 'object' && value !== null) {
-      if (
-        value.hasOwnProperty('description') &&
-        jsonPointerHelpers.endsWith(
-          jsonPointerHelpers.compile([...path, 'description']),
-          ['properties', '**', 'description']
-        )
-      ) {
-        delete value['description'];
-      }
+  removeExamplesAndDescriptionsFromProperties(copied.responses, ['responses']);
+  removeExamplesAndDescriptionsFromProperties(copied.requestBody, [
+    'requestBody',
+  ]);
 
-      if (
-        value.hasOwnProperty('example') &&
-        jsonPointerHelpers.endsWith(
-          jsonPointerHelpers.compile([...path, 'example']),
-          ['properties', '**', 'example']
-        )
-      ) {
-        delete value['example'];
-      }
+  return copied;
+}
 
-      Object.keys(value).forEach((key) => walk(value[key], [...path, key]));
-    } else {
-    }
-  }
+export function removeDocumentationFromResponses(
+  response: OpenAPIV3.ResponseObject
+) {
+  const copied: OpenAPIV3.ResponseObject = JSON.parse(JSON.stringify(response));
 
-  walk(copied.responses, ['responses']);
-  walk(copied.requestBody, ['requestBody']);
+  removeExamplesAndDescriptionsFromProperties(copied, []);
 
   return copied;
 }

--- a/projects/standard-rulesets/src/lintgpt/prepare-openapi.ts
+++ b/projects/standard-rulesets/src/lintgpt/prepare-openapi.ts
@@ -1,6 +1,25 @@
 import { OpenAPIV3 } from 'openapi-types';
 import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
 
+function removeExamplesAndDescriptionsFromParameters(
+  parameter: OpenAPIV3.ParameterObject | OpenAPIV3.ReferenceObject
+) {
+  if (!parameter) return;
+  if ('$ref' in parameter) return;
+
+  if (parameter.description) {
+    delete parameter.description;
+  }
+
+  if (parameter.example) {
+    delete parameter.example;
+  }
+
+  if (parameter.examples) {
+    delete parameter.examples;
+  }
+}
+
 function removeExamplesAndDescriptionsFromProperties(
   value: any,
   path: string[]
@@ -56,6 +75,12 @@ export function removeDocumentationFromOperation(
   const copied: OpenAPIV3.OperationObject = JSON.parse(
     JSON.stringify(operation)
   );
+
+  if (copied.parameters) {
+    for (const param of copied.parameters) {
+      removeExamplesAndDescriptionsFromParameters(param);
+    }
+  }
 
   removeExamplesAndDescriptionsFromProperties(copied.responses, ['responses']);
   removeExamplesAndDescriptionsFromProperties(copied.requestBody, [


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Extends the remove examples and descriptions to responses (also applies the removal to `examples`). also removes examples and description from parameters

The idea is the same as the operation logic, any rule around description or example should be on the property level

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
