### PR TITLE
fix dynamic import with binary distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.53.7",
+  "version": "0.53.8",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/fastify-capture/package.json
+++ b/projects/fastify-capture/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/fastify-capture",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.7",
+  "version": "0.53.8",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.7",
+  "version": "0.53.8",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.7",
+  "version": "0.53.8",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.7",
+  "version": "0.53.8",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.7",
+  "version": "0.53.8",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.7",
+  "version": "0.53.8",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.7",
+  "version": "0.53.8",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -23,6 +23,7 @@
     "json-stable-stringify": "^1.1.0",
     "object-hash": "^3.0.0",
     "openai": "^4.7.1",
+    "ora": "5.4.1",
     "whatwg-mimetype": "^4.0.0"
   },
   "devDependencies": {

--- a/projects/standard-rulesets/src/lintgpt/rules-helper.ts
+++ b/projects/standard-rulesets/src/lintgpt/rules-helper.ts
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
 import chunk from 'lodash.chunk';
+import ora from 'ora';
 
 type OpenAPIRuleType =
   | 'OPERATION'
@@ -79,8 +80,6 @@ export class LintgptRulesHelper {
       string,
       { rule: string; rule_checksum: string; prep?: CachedRulePrep }
     >();
-
-    const ora = (await import('ora')).default;
 
     let spinner = ora({
       text: this.getPrepSpinnerText({
@@ -176,8 +175,6 @@ export class LintgptRulesHelper {
         rule_eval?: LintgptEval;
       }
     >();
-
-    const ora = (await import('ora')).default;
 
     let spinner = ora({
       text: this.getEvalSpinnerText({

--- a/yarn.lock
+++ b/yarn.lock
@@ -3905,6 +3905,7 @@ __metadata:
     json-stable-stringify: "npm:^1.1.0"
     object-hash: "npm:^3.0.0"
     openai: "npm:^4.7.1"
+    ora: "npm:5.4.1"
     prettier: "npm:^3.0.0"
     ts-jest: "npm:^29.0.3"
     ts-node: "npm:^10.9.1"


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

I'm not sure why, but dynamic imports here cause the binary package to error - error below. updated to just statically load this

```
optic diff --check test-staging.yml --base HEAD~10
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'ora' imported from /snapshot/optic/projects/standard-rulesets/build/lintgpt/rules-helper.js
Did you mean to import ora/index.js?
    at new NodeError (node:internal/errors:388:5)
    at packageResolve (node:internal/modules/esm/resolve:910:9)
    at moduleResolve (node:internal/modules/esm/resolve:959:20)
    at defaultResolve (node:internal/modules/esm/resolve:1174:11)
    at ESMLoader.resolve (node:internal/modules/esm/loader:605:30)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:318:18)
    at ESMLoader.import (node:internal/modules/esm/loader:404:22)
    at importModuleDynamically (node:internal/modules/cjs/loader:1050:29)
    at importModuleDynamicallyWrapper (node:internal/vm/module:438:21)
    at importModuleDynamically (node:vm:384:46) {
  code: 'ERR_MODULE_NOT_FOUND'
}
```

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
