### PR TITLE
Fix allOf + refs in capture when patching

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.53.12",
+  "version": "0.53.13",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/fastify-capture/package.json
+++ b/projects/fastify-capture/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/fastify-capture",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.12",
+  "version": "0.53.13",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.12",
+  "version": "0.53.13",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.12",
+  "version": "0.53.13",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-io/src/denormalizers/denormalize.ts
+++ b/projects/openapi-io/src/denormalizers/denormalize.ts
@@ -18,8 +18,8 @@ export function denormalize<
   },
 >(parse: T): T {
   parse = {
+    ...parse,
     jsonLike: JSON.parse(JSON.stringify(parse.jsonLike)),
-    sourcemap: parse.sourcemap,
   } as T;
   for (const [pathKey, path] of Object.entries(parse.jsonLike.paths)) {
     if (path) {

--- a/projects/openapi-io/src/denormalizers/denormalize.ts
+++ b/projects/openapi-io/src/denormalizers/denormalize.ts
@@ -17,6 +17,10 @@ export function denormalize<
     sourcemap?: ParseOpenAPIResult['sourcemap'];
   },
 >(parse: T): T {
+  parse = {
+    jsonLike: JSON.parse(JSON.stringify(parse.jsonLike)),
+    sourcemap: parse.sourcemap,
+  } as T;
   for (const [pathKey, path] of Object.entries(parse.jsonLike.paths)) {
     if (path) {
       denormalizePaths(

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.12",
+  "version": "0.53.13",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.12",
+  "version": "0.53.13",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/src/commands/capture/patches/__tests__/__snapshots__/patches.test.ts.snap
+++ b/projects/optic/src/commands/capture/patches/__tests__/__snapshots__/patches.test.ts.snap
@@ -1,5 +1,610 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf with extra keys in interaction 1`] = `
+[
+  {
+    "description": "update response body: add property name",
+    "diff": {
+      "description": "'name' is not documented",
+      "example": "me",
+      "instancePath": "/name",
+      "key": "name",
+      "keyword": "additionalProperties",
+      "kind": "AdditionalProperty",
+      "parentObjectPath": "/allOf/0/properties",
+      "propertyExamplePath": "/name",
+      "propertyPath": "/allOf/0/properties/name",
+    },
+    "groupedOperations": [
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/required/-",
+        "value": "name",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/properties/name",
+        "value": {
+          "type": "string",
+        },
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"status":"ok","name":"me","age":50}",
+          "contentType": "application/json",
+          "size": 36,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+  {
+    "description": "update response body: add property age",
+    "diff": {
+      "description": "'age' is not documented",
+      "example": 50,
+      "instancePath": "/age",
+      "key": "age",
+      "keyword": "additionalProperties",
+      "kind": "AdditionalProperty",
+      "parentObjectPath": "/allOf/0/properties",
+      "propertyExamplePath": "/age",
+      "propertyPath": "/allOf/0/properties/age",
+    },
+    "groupedOperations": [
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/required/-",
+        "value": "age",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/properties/age",
+        "value": {
+          "type": "number",
+        },
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"status":"ok","name":"me","age":50}",
+          "contentType": "application/json",
+          "size": 36,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+  {
+    "description": "update response body: add property status",
+    "diff": {
+      "description": "'status' is not documented",
+      "example": "ok",
+      "instancePath": "/status",
+      "key": "status",
+      "keyword": "additionalProperties",
+      "kind": "AdditionalProperty",
+      "parentObjectPath": "/allOf/1/properties",
+      "propertyExamplePath": "/status",
+      "propertyPath": "/allOf/1/properties/status",
+    },
+    "groupedOperations": [
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/required",
+        "value": [
+          "status",
+        ],
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/properties/status",
+        "value": {
+          "type": "string",
+        },
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"status":"ok","name":"me","age":50}",
+          "contentType": "application/json",
+          "size": 36,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+  {
+    "description": "update response body: add property age",
+    "diff": {
+      "description": "'age' is not documented",
+      "example": 50,
+      "instancePath": "/age",
+      "key": "age",
+      "keyword": "additionalProperties",
+      "kind": "AdditionalProperty",
+      "parentObjectPath": "/allOf/1/properties",
+      "propertyExamplePath": "/age",
+      "propertyPath": "/allOf/1/properties/age",
+    },
+    "groupedOperations": [
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/required/-",
+        "value": "age",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/properties/age",
+        "value": {
+          "type": "number",
+        },
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"status":"ok","name":"me","age":50}",
+          "contentType": "application/json",
+          "size": 36,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+]
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf with extra keys in interaction 2`] = `
+{
+  "info": {},
+  "openapi": "3.0.1",
+  "paths": {
+    "/api/animals": {
+      "post": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "properties": {
+                        "age": {
+                          "type": "number",
+                        },
+                        "name": {
+                          "type": "string",
+                        },
+                        "status": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "status",
+                        "name",
+                        "age",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "properties": {
+                        "age": {
+                          "type": "number",
+                        },
+                        "name": {
+                          "type": "string",
+                        },
+                        "status": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "status",
+                        "age",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf with missing keys in interaction 1`] = `
+[
+  {
+    "description": "update response body: make property name optional",
+    "diff": {
+      "description": "required property 'name' was missing",
+      "example": undefined,
+      "instancePath": "/name",
+      "key": "name",
+      "keyword": "required",
+      "kind": "MissingRequiredProperty",
+      "parentObjectPath": "/allOf/1",
+      "propertyPath": "/allOf/1/properties/name",
+    },
+    "groupedOperations": [
+      {
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/required/0",
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsIncompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"status":"ok"}",
+          "contentType": "application/json",
+          "size": 15,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+  {
+    "description": "update response body: add property status",
+    "diff": {
+      "description": "'status' is not documented",
+      "example": "ok",
+      "instancePath": "/status",
+      "key": "status",
+      "keyword": "additionalProperties",
+      "kind": "AdditionalProperty",
+      "parentObjectPath": "/allOf/1/properties",
+      "propertyExamplePath": "/status",
+      "propertyPath": "/allOf/1/properties/status",
+    },
+    "groupedOperations": [
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/required/-",
+        "value": "status",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/properties/status",
+        "value": {
+          "type": "string",
+        },
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"status":"ok"}",
+          "contentType": "application/json",
+          "size": 15,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+]
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf with missing keys in interaction 2`] = `
+{
+  "info": {},
+  "openapi": "3.0.1",
+  "paths": {
+    "/api/animals": {
+      "post": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "properties": {
+                        "status": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "status",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                        },
+                        "status": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "status",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf with nested oneOf 1`] = `
+[
+  {
+    "description": "update response body: add property results",
+    "diff": {
+      "description": "'results' is not documented",
+      "example": [
+        "123",
+        "355",
+        34,
+      ],
+      "instancePath": "/results",
+      "key": "results",
+      "keyword": "additionalProperties",
+      "kind": "AdditionalProperty",
+      "parentObjectPath": "/allOf/0/oneOf/0/properties",
+      "propertyExamplePath": "/results",
+      "propertyPath": "/allOf/0/oneOf/0/properties/results",
+    },
+    "groupedOperations": [
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/oneOf/0/required/-",
+        "value": "results",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/oneOf/0/properties/results",
+        "value": {
+          "items": {
+            "type": "string",
+          },
+          "type": "array",
+        },
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"hello":"ok","goodbye":"me","results":["123","355",34]}",
+          "contentType": "application/json",
+          "size": 56,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+  {
+    "description": "update response body: make items oneOf",
+    "diff": {
+      "description": "'items' did not match schema",
+      "example": 34,
+      "expectedType": "string",
+      "instancePath": "/results/2",
+      "key": "items",
+      "keyword": "type",
+      "kind": "UnmatchedType",
+      "propertyPath": "/allOf/0/oneOf/0/properties/results/items",
+    },
+    "groupedOperations": [
+      {
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/oneOf/0/properties/results/items/type",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/oneOf/0/properties/results/items/oneOf",
+        "value": [
+          {
+            "type": "string",
+          },
+          {
+            "type": "number",
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsIncompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"hello":"ok","goodbye":"me","results":["123","355",34]}",
+          "contentType": "application/json",
+          "size": 56,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+]
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf with nested oneOf 2`] = `
+{
+  "info": {},
+  "openapi": "3.0.1",
+  "paths": {
+    "/api/animals": {
+      "post": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "goodbye": {
+                              "type": "string",
+                            },
+                            "hello": {
+                              "type": "string",
+                            },
+                            "results": {
+                              "items": {
+                                "oneOf": [
+                                  {
+                                    "type": "string",
+                                  },
+                                  {
+                                    "type": "number",
+                                  },
+                                ],
+                              },
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "hello",
+                            "goodbye",
+                            "results",
+                          ],
+                          "type": "object",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
 exports[`generateEndpointSpecPatches OAS version 3.0.1 array with multiple items 1`] = `
 [
   {
@@ -5989,6 +6594,611 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented response bod
               },
             },
             "description": "200 response",
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf with extra keys in interaction 1`] = `
+[
+  {
+    "description": "update response body: add property name",
+    "diff": {
+      "description": "'name' is not documented",
+      "example": "me",
+      "instancePath": "/name",
+      "key": "name",
+      "keyword": "additionalProperties",
+      "kind": "AdditionalProperty",
+      "parentObjectPath": "/allOf/0/properties",
+      "propertyExamplePath": "/name",
+      "propertyPath": "/allOf/0/properties/name",
+    },
+    "groupedOperations": [
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/required/-",
+        "value": "name",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/properties/name",
+        "value": {
+          "type": "string",
+        },
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"status":"ok","name":"me","age":50}",
+          "contentType": "application/json",
+          "size": 36,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+  {
+    "description": "update response body: add property age",
+    "diff": {
+      "description": "'age' is not documented",
+      "example": 50,
+      "instancePath": "/age",
+      "key": "age",
+      "keyword": "additionalProperties",
+      "kind": "AdditionalProperty",
+      "parentObjectPath": "/allOf/0/properties",
+      "propertyExamplePath": "/age",
+      "propertyPath": "/allOf/0/properties/age",
+    },
+    "groupedOperations": [
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/required/-",
+        "value": "age",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/properties/age",
+        "value": {
+          "type": "number",
+        },
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"status":"ok","name":"me","age":50}",
+          "contentType": "application/json",
+          "size": 36,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+  {
+    "description": "update response body: add property status",
+    "diff": {
+      "description": "'status' is not documented",
+      "example": "ok",
+      "instancePath": "/status",
+      "key": "status",
+      "keyword": "additionalProperties",
+      "kind": "AdditionalProperty",
+      "parentObjectPath": "/allOf/1/properties",
+      "propertyExamplePath": "/status",
+      "propertyPath": "/allOf/1/properties/status",
+    },
+    "groupedOperations": [
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/required",
+        "value": [
+          "status",
+        ],
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/properties/status",
+        "value": {
+          "type": "string",
+        },
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"status":"ok","name":"me","age":50}",
+          "contentType": "application/json",
+          "size": 36,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+  {
+    "description": "update response body: add property age",
+    "diff": {
+      "description": "'age' is not documented",
+      "example": 50,
+      "instancePath": "/age",
+      "key": "age",
+      "keyword": "additionalProperties",
+      "kind": "AdditionalProperty",
+      "parentObjectPath": "/allOf/1/properties",
+      "propertyExamplePath": "/age",
+      "propertyPath": "/allOf/1/properties/age",
+    },
+    "groupedOperations": [
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/required/-",
+        "value": "age",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/properties/age",
+        "value": {
+          "type": "number",
+        },
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"status":"ok","name":"me","age":50}",
+          "contentType": "application/json",
+          "size": 36,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+]
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf with extra keys in interaction 2`] = `
+{
+  "info": {},
+  "openapi": "3.1.0",
+  "paths": {
+    "/api/animals": {
+      "post": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "properties": {
+                        "age": {
+                          "type": "number",
+                        },
+                        "name": {
+                          "type": "string",
+                        },
+                        "status": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "status",
+                        "name",
+                        "age",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "properties": {
+                        "age": {
+                          "type": "number",
+                        },
+                        "name": {
+                          "type": "string",
+                        },
+                        "status": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "status",
+                        "age",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf with missing keys in interaction 1`] = `
+[
+  {
+    "description": "update response body: make property name optional",
+    "diff": {
+      "description": "required property 'name' was missing",
+      "example": undefined,
+      "instancePath": "/name",
+      "key": "name",
+      "keyword": "required",
+      "kind": "MissingRequiredProperty",
+      "parentObjectPath": "/allOf/1",
+      "propertyPath": "/allOf/1/properties/name",
+    },
+    "groupedOperations": [
+      {
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/required/0",
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsIncompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"status":"ok"}",
+          "contentType": "application/json",
+          "size": 15,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+  {
+    "description": "update response body: add property status",
+    "diff": {
+      "description": "'status' is not documented",
+      "example": "ok",
+      "instancePath": "/status",
+      "key": "status",
+      "keyword": "additionalProperties",
+      "kind": "AdditionalProperty",
+      "parentObjectPath": "/allOf/1/properties",
+      "propertyExamplePath": "/status",
+      "propertyPath": "/allOf/1/properties/status",
+    },
+    "groupedOperations": [
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/required/-",
+        "value": "status",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/properties/status",
+        "value": {
+          "type": "string",
+        },
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"status":"ok"}",
+          "contentType": "application/json",
+          "size": 15,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+]
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf with missing keys in interaction 2`] = `
+{
+  "info": {},
+  "openapi": "3.1.0",
+  "paths": {
+    "/api/animals": {
+      "post": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "properties": {
+                        "status": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "status",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                        },
+                        "status": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "status",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf with nested oneOf 1`] = `
+[
+  {
+    "description": "update response body: add property results",
+    "diff": {
+      "description": "'results' is not documented",
+      "example": [
+        "123",
+        "355",
+        34,
+      ],
+      "instancePath": "/results",
+      "key": "results",
+      "keyword": "additionalProperties",
+      "kind": "AdditionalProperty",
+      "parentObjectPath": "/allOf/0/oneOf/0/properties",
+      "propertyExamplePath": "/results",
+      "propertyPath": "/allOf/0/oneOf/0/properties/results",
+    },
+    "groupedOperations": [
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/oneOf/0/required/-",
+        "value": "results",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/oneOf/0/properties/results",
+        "value": {
+          "items": {
+            "type": "string",
+          },
+          "type": "array",
+        },
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"hello":"ok","goodbye":"me","results":["123","355",34]}",
+          "contentType": "application/json",
+          "size": 56,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+  {
+    "description": "update response body: make items oneOf",
+    "diff": {
+      "description": "'items' did not match schema",
+      "example": 34,
+      "expectedType": "string",
+      "instancePath": "/results/2",
+      "key": "items",
+      "keyword": "type",
+      "kind": "UnmatchedType",
+      "propertyPath": "/allOf/0/oneOf/0/properties/results/items",
+    },
+    "groupedOperations": [
+      {
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/oneOf/0/properties/results/items/type",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/oneOf/0/properties/results/items/oneOf",
+        "value": [
+          {
+            "type": "string",
+          },
+          {
+            "type": "number",
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsIncompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"hello":"ok","goodbye":"me","results":["123","355",34]}",
+          "contentType": "application/json",
+          "size": 56,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+]
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf with nested oneOf 2`] = `
+{
+  "info": {},
+  "openapi": "3.1.0",
+  "paths": {
+    "/api/animals": {
+      "post": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "goodbye": {
+                              "type": "string",
+                            },
+                            "hello": {
+                              "type": "string",
+                            },
+                            "results": {
+                              "items": {
+                                "oneOf": [
+                                  {
+                                    "type": "string",
+                                  },
+                                  {
+                                    "type": "number",
+                                  },
+                                ],
+                              },
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "hello",
+                            "goodbye",
+                            "results",
+                          ],
+                          "type": "object",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            },
           },
         },
       },

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.12",
+  "version": "0.53.13",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.12",
+  "version": "0.53.13",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

When running capture with a `ref` nested inside of an `allOf` 
```yaml
schema:
  allOf:
    - $ref: someref
```

The capture code would break and add invalid schemas. This was because our denormalize step was mutating, rather than creating a copy (i.e. the allOf was being flattened so the json pointer didn't know where to update based on the sourcemap)

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
