### PR TITLE
use different ajv for loading example rulesets

### DIFF
--- a/projects/optic/src/commands/diff/compute.ts
+++ b/projects/optic/src/commands/diff/compute.ts
@@ -9,6 +9,7 @@ import { ParseResult, parseOpticRef } from '../../utils/spec-loaders';
 import { OpticCliConfig } from '../../config';
 import { trackEvent } from '../../segment';
 import { logger } from '../../logger';
+import { checkOpenAPIVersion } from '@useoptic/openapi-io';
 
 let generateContext: (file: string) => any = () => ({});
 
@@ -32,6 +33,9 @@ export async function compute(
         ? baseFile.jsonLike[OPTIC_STANDARD_KEY]
         : headFile.jsonLike[OPTIC_STANDARD_KEY],
       config,
+      specVersion: headFile.isEmptySpec
+        ? checkOpenAPIVersion(baseFile.jsonLike)
+        : checkOpenAPIVersion(headFile.jsonLike),
     },
     options.check
   );

--- a/projects/optic/src/commands/diff/generate-rule-runner.ts
+++ b/projects/optic/src/commands/diff/generate-rule-runner.ts
@@ -10,6 +10,7 @@ import {
 import { loadCliConfig } from '../../config';
 import { logger } from '../../logger';
 import chalk from 'chalk';
+import { SupportedOpenAPIVersions } from '@useoptic/openapi-io';
 
 const injectedRulesets: (Ruleset | ExternalRule)[] = [];
 
@@ -58,6 +59,7 @@ export const generateRuleRunner = async (
     specRuleset?: string;
     rulesetArg?: string;
     config: OpticCliConfig;
+    specVersion: SupportedOpenAPIVersions;
   },
   checksEnabled: boolean
 ): Promise<{
@@ -132,7 +134,10 @@ export const generateRuleRunner = async (
         standardRulesets: StandardRulesets,
         hostedRulesets,
       },
-      options.config.client
+      {
+        client: options.config.client,
+        specVersion: options.specVersion,
+      }
     );
 
     rulesets.push(...results.rulesets);

--- a/projects/rulesets-base/src/custom-rulesets/__tests__/prepare-ruleset.test.ts
+++ b/projects/rulesets-base/src/custom-rulesets/__tests__/prepare-ruleset.test.ts
@@ -20,32 +20,38 @@ describe('prepareRulesets', () => {
       'local-fake-custom-ruleset.ts'
     );
 
-    const result = await prepareRulesets({
-      ruleset: [
-        { name: 'breaking-changes', config: {} },
-        { name: '@team/custom-ruleset', config: { required_on: 'always' } },
-        { name: localRulesetPath, config: { required_on: 'always' } },
-        { name: 'missing-ruleset', config: {} },
-      ],
-      hostedRulesets: {
-        '@team/custom-ruleset': {
-          url: 'https://some-url.com',
-          uploaded_at: '123',
+    const result = await prepareRulesets(
+      {
+        ruleset: [
+          { name: 'breaking-changes', config: {} },
+          { name: '@team/custom-ruleset', config: { required_on: 'always' } },
+          { name: localRulesetPath, config: { required_on: 'always' } },
+          { name: 'missing-ruleset', config: {} },
+        ],
+        hostedRulesets: {
+          '@team/custom-ruleset': {
+            url: 'https://some-url.com',
+            uploaded_at: '123',
+          },
+        },
+        standardRulesets: {
+          'breaking-changes': {
+            fromOpticConfig: (() =>
+              new Ruleset({
+                name: 'asd',
+                rules: [],
+              })) as any,
+          },
+        },
+        localRulesets: {
+          [localRulesetPath]: localRulesetPath,
         },
       },
-      standardRulesets: {
-        'breaking-changes': {
-          fromOpticConfig: (() =>
-            new Ruleset({
-              name: 'asd',
-              rules: [],
-            })) as any,
-        },
-      },
-      localRulesets: {
-        [localRulesetPath]: localRulesetPath,
-      },
-    });
+      {
+        client: '',
+        specVersion: '3.1.x',
+      }
+    );
 
     expect(result.rulesets.length).toBe(3);
     expect(result.warnings.length).toBe(1);
@@ -84,7 +90,10 @@ describe('prepareRulesets', () => {
       localRulesets: {},
     };
 
-    const result = await prepareRulesets(payload);
+    const result = await prepareRulesets(payload, {
+      client: '',
+      specVersion: '3.1.x',
+    });
 
     expect(result.rulesets.length).toBe(1);
     expect(result.warnings.length).toBe(2);

--- a/projects/rulesets-base/src/custom-rulesets/prepare-rulesets.ts
+++ b/projects/rulesets-base/src/custom-rulesets/prepare-rulesets.ts
@@ -22,7 +22,10 @@ export type RulesetPayload = {
     {
       fromOpticConfig: (
         config: unknown,
-        client?: any
+        options: {
+          client: any;
+          specVersion: '3.1.x' | '3.0.x';
+        }
       ) => Promise<Ruleset | ExternalRule | string>;
     }
   >;
@@ -35,7 +38,10 @@ export type PrepareRulesetsResult = {
 
 export async function prepareRulesets(
   payload: RulesetPayload,
-  client?: any
+  options: {
+    client: any;
+    specVersion: '3.1.x' | '3.0.x';
+  }
 ): Promise<PrepareRulesetsResult> {
   const StandardRulesets = payload.standardRulesets;
   const rulesets: (Ruleset | ExternalRule)[] = [];
@@ -49,7 +55,7 @@ export async function prepareRulesets(
       try {
         instanceOrErrorMsg = await RulesetClass.fromOpticConfig(
           ruleset.config,
-          client
+          { client: options.client, specVersion: options.specVersion }
         );
       } catch (e) {
         console.error(e);

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -19,6 +19,7 @@
     "@useoptic/openapi-utilities": "workspace:*",
     "@useoptic/rulesets-base": "workspace:*",
     "ajv": "^8.6.0",
+    "ajv-draft-04": "^1.0.0",
     "ajv-formats": "~2.1.0",
     "json-stable-stringify": "^1.1.0",
     "object-hash": "^3.0.0",

--- a/projects/standard-rulesets/src/examples/__tests__/__snapshots__/examples-are-valid-rules.test.ts.snap
+++ b/projects/standard-rulesets/src/examples/__tests__/__snapshots__/examples-are-valid-rules.test.ts.snap
@@ -1,6 +1,70 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`examples ruleset invalid parameter example errors 1`] = `
+exports[`3.0.x examples ruleset examples should default to additional properties false ajv config will be strict on additional properties 1`] = `
+{
+  "error": "  - example  must NOT have additional property 'c'",
+  "pass": false,
+}
+`;
+
+exports[`3.0.x examples ruleset examples should default to additional properties false ajv config will not override a user defined value 1`] = `
+{
+  "pass": true,
+}
+`;
+
+exports[`3.0.x examples ruleset examples should default to additional properties false ajv config will work on additional properties with all of at different levels of nesting 1`] = `
+{
+  "error": "  - example /b must NOT have additional property 'l'",
+  "pass": false,
+}
+`;
+
+exports[`3.0.x examples ruleset exclusive maximum 1`] = `
+[
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "statusCode": "200",
+          },
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200",
+        "kind": "response",
+      },
+      "value": {
+        "description": "ok",
+        "statusCode": "200",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response body examples must match schemas",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /api/users response 200",
+  },
+]
+`;
+
+exports[`3.0.x examples ruleset invalid parameter example errors 1`] = `
 [
   {
     "change": {
@@ -137,7 +201,7 @@ exports[`examples ruleset invalid parameter example errors 1`] = `
 ]
 `;
 
-exports[`examples ruleset invalid property example errors 1`] = `
+exports[`3.0.x examples ruleset invalid property example errors 1`] = `
 [
   {
     "change": {
@@ -334,7 +398,7 @@ exports[`examples ruleset invalid property example errors 1`] = `
 ]
 `;
 
-exports[`examples ruleset invalid request named example errors 1`] = `
+exports[`3.0.x examples ruleset invalid request named example errors 1`] = `
 [
   {
     "change": {
@@ -474,7 +538,7 @@ exports[`examples ruleset invalid request named example errors 1`] = `
 ]
 `;
 
-exports[`examples ruleset invalid request top level example errors 1`] = `
+exports[`3.0.x examples ruleset invalid request top level example errors 1`] = `
 [
   {
     "change": {
@@ -614,7 +678,7 @@ exports[`examples ruleset invalid request top level example errors 1`] = `
 ]
 `;
 
-exports[`examples ruleset invalid response named example errors 1`] = `
+exports[`3.0.x examples ruleset invalid response named example errors 1`] = `
 [
   {
     "change": {
@@ -759,7 +823,7 @@ exports[`examples ruleset invalid response named example errors 1`] = `
 ]
 `;
 
-exports[`examples ruleset invalid response top level example errors 1`] = `
+exports[`3.0.x examples ruleset invalid response top level example errors 1`] = `
 [
   {
     "change": {
@@ -904,7 +968,7 @@ exports[`examples ruleset invalid response top level example errors 1`] = `
 ]
 `;
 
-exports[`examples ruleset passing property example 1`] = `
+exports[`3.0.x examples ruleset passing property example 1`] = `
 [
   {
     "change": {
@@ -1104,29 +1168,1133 @@ exports[`examples ruleset passing property example 1`] = `
 ]
 `;
 
-exports[`examples should default to additional properties false ajv config will be strict on additional properties 1`] = `
+exports[`3.1.x examples ruleset examples should default to additional properties false ajv config will be strict on additional properties 1`] = `
 {
   "error": "  - example  must NOT have additional property 'c'",
   "pass": false,
 }
 `;
 
-exports[`examples should default to additional properties false ajv config will not override a user defined value 1`] = `
+exports[`3.1.x examples ruleset examples should default to additional properties false ajv config will not override a user defined value 1`] = `
 {
   "pass": true,
 }
 `;
 
-exports[`examples should default to additional properties false ajv config will work on additional properties with all of 1`] = `
+exports[`3.1.x examples ruleset examples should default to additional properties false ajv config will work on additional properties with all of 1`] = `
 {
   "error": "  - example  must NOT have additional property 'c'",
   "pass": false,
 }
 `;
 
-exports[`examples should default to additional properties false ajv config will work on additional properties with all of at different levels of nesting 1`] = `
+exports[`3.1.x examples ruleset examples should default to additional properties false ajv config will work on additional properties with all of at different levels of nesting 1`] = `
 {
   "error": "  - example /b must NOT have additional property 'l'",
   "pass": false,
 }
+`;
+
+exports[`3.1.x examples ruleset invalid parameter example errors 1`] = `
+[
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "query": "invalidExample",
+          },
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users",
+          "get",
+          "parameters",
+          "query",
+          "invalidExample",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/parameters/0",
+        "kind": "query-parameter",
+      },
+      "value": {
+        "example": 123,
+        "in": "query",
+        "name": "invalidExample",
+        "schema": {
+          "type": "string",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": "query parameter 'invalidExample' example does not match the schema. 
+  - example  must be string ",
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "parameter examples must match schemas",
+    "passed": false,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /api/users query parameter: invalidExample",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "query": "validExample",
+          },
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users",
+          "get",
+          "parameters",
+          "query",
+          "validExample",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/parameters/1",
+        "kind": "query-parameter",
+      },
+      "value": {
+        "example": "123",
+        "in": "query",
+        "name": "validExample",
+        "schema": {
+          "type": "string",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "parameter examples must match schemas",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /api/users query parameter: validExample",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "query": "notSet",
+          },
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users",
+          "get",
+          "parameters",
+          "query",
+          "notSet",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/parameters/2",
+        "kind": "query-parameter",
+      },
+      "value": {
+        "in": "query",
+        "name": "notSet",
+        "schema": {
+          "type": "string",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "parameter examples must match schemas",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /api/users query parameter: notSet",
+  },
+]
+`;
+
+exports[`3.1.x examples ruleset invalid property example errors 1`] = `
+[
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "wrong",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "wrong",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200/content/application~1json/schema/properties/wrong",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "example": 12345,
+          "type": "string",
+        },
+        "key": "wrong",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": "'wrong' example does not match the schema. 
+  - example  must be string ",
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require property examples match schemas",
+    "passed": false,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /api/users response 200 response body: application/json property wrong",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "notSet",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "notSet",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200/content/application~1json/schema/properties/notSet",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "string",
+        },
+        "key": "notSet",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require property examples match schemas",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /api/users response 200 response body: application/json property notSet",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "setAndCorrect",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "setAndCorrect",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200/content/application~1json/schema/properties/setAndCorrect",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "example": "abcdefg",
+          "type": "string",
+        },
+        "key": "setAndCorrect",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require property examples match schemas",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /api/users response 200 response body: application/json property setAndCorrect",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "statusCode": "200",
+          },
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200",
+        "kind": "response",
+      },
+      "value": {
+        "description": "ok",
+        "statusCode": "200",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response body examples must match schemas",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /api/users response 200",
+  },
+]
+`;
+
+exports[`3.1.x examples ruleset invalid request named example errors 1`] = `
+[
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "method": "post",
+          "path": "/api/users",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users",
+          "post",
+          "application/json",
+        ],
+        "jsonPath": "/paths/~1api~1users/post/requestBody/content/application~1json",
+        "kind": "body",
+      },
+      "value": {
+        "contentType": "application/json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": "the example named 'main' does not match the schema. 
+  - example  must have required property 'world' ",
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request body examples must match schema",
+    "passed": false,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /api/users request body: application/json",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "hello",
+          ],
+          "method": "post",
+          "path": "/api/users",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users",
+          "post",
+          "application/json",
+          "hello",
+        ],
+        "jsonPath": "/paths/~1api~1users/post/requestBody/content/application~1json/schema/properties/hello",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "string",
+        },
+        "key": "hello",
+        "required": true,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require property examples match schemas",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /api/users request body: application/json property: hello",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "world",
+          ],
+          "method": "post",
+          "path": "/api/users",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users",
+          "post",
+          "application/json",
+          "world",
+        ],
+        "jsonPath": "/paths/~1api~1users/post/requestBody/content/application~1json/schema/properties/world",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "number",
+        },
+        "key": "world",
+        "required": true,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require property examples match schemas",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /api/users request body: application/json property: world",
+  },
+]
+`;
+
+exports[`3.1.x examples ruleset invalid request top level example errors 1`] = `
+[
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "method": "post",
+          "path": "/api/users",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users",
+          "post",
+          "application/json",
+        ],
+        "jsonPath": "/paths/~1api~1users/post/requestBody/content/application~1json",
+        "kind": "body",
+      },
+      "value": {
+        "contentType": "application/json",
+        "flatSchema": {
+          "type": "object",
+        },
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": "the example does not match the schema. 
+  - example  must have required property 'world' ",
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "request body examples must match schema",
+    "passed": false,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /api/users request body: application/json",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "hello",
+          ],
+          "method": "post",
+          "path": "/api/users",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users",
+          "post",
+          "application/json",
+          "hello",
+        ],
+        "jsonPath": "/paths/~1api~1users/post/requestBody/content/application~1json/schema/properties/hello",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "string",
+        },
+        "key": "hello",
+        "required": true,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require property examples match schemas",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /api/users request body: application/json property: hello",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inRequest": {
+            "body": {
+              "contentType": "application/json",
+            },
+          },
+          "jsonSchemaTrail": [
+            "world",
+          ],
+          "method": "post",
+          "path": "/api/users",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users",
+          "post",
+          "application/json",
+          "world",
+        ],
+        "jsonPath": "/paths/~1api~1users/post/requestBody/content/application~1json/schema/properties/world",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "number",
+        },
+        "key": "world",
+        "required": true,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require property examples match schemas",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "POST /api/users request body: application/json property: world",
+  },
+]
+`;
+
+exports[`3.1.x examples ruleset invalid response named example errors 1`] = `
+[
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "hello",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "hello",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200/content/application~1json/schema/properties/hello",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "string",
+        },
+        "key": "hello",
+        "required": true,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require property examples match schemas",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /api/users response 200 response body: application/json property hello",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "world",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "world",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200/content/application~1json/schema/properties/world",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "number",
+        },
+        "key": "world",
+        "required": true,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require property examples match schemas",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /api/users response 200 response body: application/json property world",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "statusCode": "200",
+          },
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200",
+        "kind": "response",
+      },
+      "value": {
+        "description": "ok",
+        "statusCode": "200",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": "the example named 'main' does not match the schema. 
+  - example  must have required property 'world' ",
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response body examples must match schemas",
+    "passed": false,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /api/users response 200",
+  },
+]
+`;
+
+exports[`3.1.x examples ruleset invalid response top level example errors 1`] = `
+[
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "hello",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "hello",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200/content/application~1json/schema/properties/hello",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "string",
+        },
+        "key": "hello",
+        "required": true,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require property examples match schemas",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /api/users response 200 response body: application/json property hello",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "world",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "world",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200/content/application~1json/schema/properties/world",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "number",
+        },
+        "key": "world",
+        "required": true,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require property examples match schemas",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /api/users response 200 response body: application/json property world",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "statusCode": "200",
+          },
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200",
+        "kind": "response",
+      },
+      "value": {
+        "description": "ok",
+        "statusCode": "200",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": "the example does not match the schema. 
+  - example  must have required property 'world' ",
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response body examples must match schemas",
+    "passed": false,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /api/users response 200",
+  },
+]
+`;
+
+exports[`3.1.x examples ruleset passing property example 1`] = `
+[
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "correctObj",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "correctObj",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200/content/application~1json/schema/properties/correctObj",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "example": {
+            "name": "hello",
+          },
+          "type": "object",
+        },
+        "key": "correctObj",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require property examples match schemas",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /api/users response 200 response body: application/json property correctObj",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "correctObj",
+            "name",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "correctObj",
+          "name",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200/content/application~1json/schema/properties/correctObj/properties/name",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "type": "string",
+        },
+        "key": "name",
+        "required": true,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require property examples match schemas",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /api/users response 200 response body: application/json property correctObj/name",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "body": {
+              "contentType": "application/json",
+            },
+            "statusCode": "200",
+          },
+          "jsonSchemaTrail": [
+            "correctStr",
+          ],
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+          "application/json",
+          "correctStr",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200/content/application~1json/schema/properties/correctStr",
+        "kind": "field",
+      },
+      "value": {
+        "flatSchema": {
+          "example": "abcdefg",
+          "type": "string",
+        },
+        "key": "correctStr",
+        "required": false,
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "require property examples match schemas",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /api/users response 200 response body: application/json property correctStr",
+  },
+  {
+    "change": {
+      "location": {
+        "conceptualLocation": {
+          "inResponse": {
+            "statusCode": "200",
+          },
+          "method": "get",
+          "path": "/api/users",
+        },
+        "conceptualPath": [
+          "operations",
+          "/api/users",
+          "get",
+          "responses",
+          "200",
+        ],
+        "jsonPath": "/paths/~1api~1users/get/responses/200",
+        "kind": "response",
+      },
+      "value": {
+        "description": "ok",
+        "statusCode": "200",
+      },
+    },
+    "condition": undefined,
+    "docsLink": undefined,
+    "error": undefined,
+    "exempted": false,
+    "expected": undefined,
+    "isMust": true,
+    "isShould": false,
+    "name": "response body examples must match schemas",
+    "passed": true,
+    "received": undefined,
+    "severity": 2,
+    "type": "requirement",
+    "where": "GET /api/users response 200",
+  },
+]
 `;

--- a/projects/standard-rulesets/src/examples/__tests__/__snapshots__/examples-are-valid-rules.test.ts.snap
+++ b/projects/standard-rulesets/src/examples/__tests__/__snapshots__/examples-are-valid-rules.test.ts.snap
@@ -20,7 +20,7 @@ exports[`3.0.x examples ruleset examples should default to additional properties
 }
 `;
 
-exports[`3.0.x examples ruleset exclusive maximum 1`] = `
+exports[`3.0.x examples ruleset exclusive maximum boolean 1`] = `
 [
   {
     "change": {

--- a/projects/standard-rulesets/src/examples/__tests__/examples-are-valid-rules.test.ts
+++ b/projects/standard-rulesets/src/examples/__tests__/examples-are-valid-rules.test.ts
@@ -4,36 +4,38 @@ import { TestHelpers } from '@useoptic/rulesets-base';
 import { ExamplesRuleset } from '../index';
 import { defaultAjv, validateSchema } from '../requireValidExamples';
 
-const ajvInstance = defaultAjv();
-
-describe('examples ruleset', () => {
-  test('passing property example', async () => {
-    const input: OpenAPIV3.Document = {
-      ...TestHelpers.createEmptySpec(),
-      paths: {
-        '/api/users': {
-          get: {
-            responses: {
-              '200': {
-                description: 'ok',
-                content: {
-                  'application/json': {
-                    schema: {
-                      type: 'object',
-                      properties: {
-                        correctObj: {
-                          type: 'object',
-                          properties: {
-                            name: { type: 'string' },
+describe.each(['3.0.x', '3.1.x'] as const)(
+  '%s examples ruleset',
+  (version: '3.0.x' | '3.1.x') => {
+    const ajvInstance = defaultAjv(version);
+    test('passing property example', async () => {
+      const input: OpenAPIV3.Document = {
+        ...TestHelpers.createEmptySpec(),
+        paths: {
+          '/api/users': {
+            get: {
+              responses: {
+                '200': {
+                  description: 'ok',
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'object',
+                        properties: {
+                          correctObj: {
+                            type: 'object',
+                            properties: {
+                              name: { type: 'string' },
+                            },
+                            required: ['name'],
+                            example: {
+                              name: 'hello',
+                            },
                           },
-                          required: ['name'],
-                          example: {
-                            name: 'hello',
+                          correctStr: {
+                            type: 'string',
+                            example: 'abcdefg',
                           },
-                        },
-                        correctStr: {
-                          type: 'string',
-                          example: 'abcdefg',
                         },
                       },
                     },
@@ -43,43 +45,43 @@ describe('examples ruleset', () => {
             },
           },
         },
-      },
-    };
-    const results = await TestHelpers.runRulesWithInputs(
-      [new ExamplesRuleset({})],
-      input,
-      input
-    );
-    expect(results.length > 0).toBe(true);
+      };
+      const results = await TestHelpers.runRulesWithInputs(
+        [new ExamplesRuleset({ spec_version: version })],
+        input,
+        input
+      );
+      expect(results.length > 0).toBe(true);
 
-    expect(results).toMatchSnapshot();
-    expect(results.every((result) => result.passed)).toBe(true);
-  });
+      expect(results).toMatchSnapshot();
+      expect(results.every((result) => result.passed)).toBe(true);
+    });
 
-  test('invalid property example errors', async () => {
-    const input: OpenAPIV3.Document = {
-      ...TestHelpers.createEmptySpec(),
-      paths: {
-        '/api/users': {
-          get: {
-            responses: {
-              '200': {
-                description: 'ok',
-                content: {
-                  'application/json': {
-                    schema: {
-                      type: 'object',
-                      properties: {
-                        wrong: {
-                          type: 'string',
-                          example: 12345,
-                        },
-                        notSet: {
-                          type: 'string',
-                        },
-                        setAndCorrect: {
-                          type: 'string',
-                          example: 'abcdefg',
+    test('invalid property example errors', async () => {
+      const input: OpenAPIV3.Document = {
+        ...TestHelpers.createEmptySpec(),
+        paths: {
+          '/api/users': {
+            get: {
+              responses: {
+                '200': {
+                  description: 'ok',
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'object',
+                        properties: {
+                          wrong: {
+                            type: 'string',
+                            example: 12345,
+                          },
+                          notSet: {
+                            type: 'string',
+                          },
+                          setAndCorrect: {
+                            type: 'string',
+                            example: 'abcdefg',
+                          },
                         },
                       },
                     },
@@ -89,86 +91,155 @@ describe('examples ruleset', () => {
             },
           },
         },
-      },
-    };
-    const results = await TestHelpers.runRulesWithInputs(
-      [new ExamplesRuleset({})],
-      input,
-      input
-    );
-    expect(results.length > 0).toBe(true);
+      };
+      const results = await TestHelpers.runRulesWithInputs(
+        [new ExamplesRuleset({ spec_version: version })],
+        input,
+        input
+      );
+      expect(results.length > 0).toBe(true);
 
-    expect(results).toMatchSnapshot();
-    expect(results.some((result) => !result.passed)).toBe(true);
-  });
-  test('invalid parameter example errors', async () => {
-    const input: OpenAPIV3.Document = {
-      ...TestHelpers.createEmptySpec(),
-      paths: {
-        '/api/users': {
-          get: {
-            parameters: [
-              {
-                in: 'query',
-                name: 'invalidExample',
-                schema: { type: 'string' },
-                example: 123,
-              },
-              {
-                in: 'query',
-                name: 'validExample',
-                schema: { type: 'string' },
-                example: '123',
-              },
-              {
-                in: 'query',
-                name: 'notSet',
-                schema: { type: 'string' },
-              },
-            ],
-            responses: {},
+      expect(results).toMatchSnapshot();
+      expect(results.some((result) => !result.passed)).toBe(true);
+    });
+    test('invalid parameter example errors', async () => {
+      const input: OpenAPIV3.Document = {
+        ...TestHelpers.createEmptySpec(),
+        paths: {
+          '/api/users': {
+            get: {
+              parameters: [
+                {
+                  in: 'query',
+                  name: 'invalidExample',
+                  schema: { type: 'string' },
+                  example: 123,
+                },
+                {
+                  in: 'query',
+                  name: 'validExample',
+                  schema: { type: 'string' },
+                  example: '123',
+                },
+                {
+                  in: 'query',
+                  name: 'notSet',
+                  schema: { type: 'string' },
+                },
+              ],
+              responses: {},
+            },
           },
         },
+      };
+      const results = await TestHelpers.runRulesWithInputs(
+        [new ExamplesRuleset({ spec_version: version })],
+        input,
+        input
+      );
+      expect(results.length > 0).toBe(true);
+
+      expect(results).toMatchSnapshot();
+      expect(results.some((result) => !result.passed)).toBe(true);
+    });
+
+    const exampleSchema: OpenAPIV3.SchemaObject = {
+      type: 'object',
+      required: ['hello', 'world'],
+      properties: {
+        hello: { type: 'string' },
+        world: { type: 'number' },
       },
     };
-    const results = await TestHelpers.runRulesWithInputs(
-      [new ExamplesRuleset({})],
-      input,
-      input
-    );
-    expect(results.length > 0).toBe(true);
 
-    expect(results).toMatchSnapshot();
-    expect(results.some((result) => !result.passed)).toBe(true);
-  });
+    const exampleInvalid = {
+      hello: 123,
+    };
 
-  const exampleSchema: OpenAPIV3.SchemaObject = {
-    type: 'object',
-    required: ['hello', 'world'],
-    properties: {
-      hello: { type: 'string' },
-      world: { type: 'number' },
-    },
-  };
+    const exampleValid = {
+      hello: '123',
+      world: 123,
+    };
 
-  const exampleInvalid = {
-    hello: 123,
-  };
+    test('invalid response top level example errors', async () => {
+      const input: OpenAPIV3.Document = {
+        ...TestHelpers.createEmptySpec(),
+        paths: {
+          '/api/users': {
+            get: {
+              responses: {
+                '200': {
+                  description: 'ok',
+                  content: {
+                    'application/json': {
+                      schema: exampleSchema,
+                      example: exampleInvalid,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const results = await TestHelpers.runRulesWithInputs(
+        [new ExamplesRuleset({ spec_version: version })],
+        input,
+        input
+      );
+      expect(results.length > 0).toBe(true);
 
-  const exampleValid = {
-    hello: '123',
-    world: 123,
-  };
+      expect(results).toMatchSnapshot();
+      expect(results.some((result) => !result.passed)).toBe(true);
+    });
+    test('invalid response named example errors', async () => {
+      const input: OpenAPIV3.Document = {
+        ...TestHelpers.createEmptySpec(),
+        paths: {
+          '/api/users': {
+            get: {
+              responses: {
+                '200': {
+                  description: 'ok',
+                  content: {
+                    'application/json': {
+                      schema: exampleSchema,
+                      examples: {
+                        main: {
+                          value: exampleInvalid,
+                        },
+                        other: {
+                          value: exampleValid,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const results = await TestHelpers.runRulesWithInputs(
+        [new ExamplesRuleset({ spec_version: version })],
+        input,
+        input
+      );
+      expect(results.length > 0).toBe(true);
 
-  test('invalid response top level example errors', async () => {
-    const input: OpenAPIV3.Document = {
-      ...TestHelpers.createEmptySpec(),
-      paths: {
-        '/api/users': {
-          get: {
-            responses: {
-              '200': {
-                description: 'ok',
+      expect(results).toMatchSnapshot();
+      expect(results.some((result) => !result.passed)).toBe(true);
+    });
+
+    test('invalid request top level example errors', async () => {
+      const input: OpenAPIV3.Document = {
+        ...TestHelpers.createEmptySpec(),
+        paths: {
+          '/api/users': {
+            post: {
+              responses: {},
+              requestBody: {
+                description: '',
                 content: {
                   'application/json': {
                     schema: exampleSchema,
@@ -179,26 +250,25 @@ describe('examples ruleset', () => {
             },
           },
         },
-      },
-    };
-    const results = await TestHelpers.runRulesWithInputs(
-      [new ExamplesRuleset({})],
-      input,
-      input
-    );
-    expect(results.length > 0).toBe(true);
+      };
+      const results = await TestHelpers.runRulesWithInputs(
+        [new ExamplesRuleset({ spec_version: version })],
+        input,
+        input
+      );
+      expect(results.length > 0).toBe(true);
 
-    expect(results).toMatchSnapshot();
-    expect(results.some((result) => !result.passed)).toBe(true);
-  });
-  test('invalid response named example errors', async () => {
-    const input: OpenAPIV3.Document = {
-      ...TestHelpers.createEmptySpec(),
-      paths: {
-        '/api/users': {
-          get: {
-            responses: {
-              '200': {
+      expect(results).toMatchSnapshot();
+      expect(results.some((result) => !result.passed)).toBe(true);
+    });
+    test('invalid request named example errors', async () => {
+      const input: OpenAPIV3.Document = {
+        ...TestHelpers.createEmptySpec(),
+        paths: {
+          '/api/users': {
+            post: {
+              responses: {},
+              requestBody: {
                 description: 'ok',
                 content: {
                   'application/json': {
@@ -217,67 +287,36 @@ describe('examples ruleset', () => {
             },
           },
         },
-      },
-    };
-    const results = await TestHelpers.runRulesWithInputs(
-      [new ExamplesRuleset({})],
-      input,
-      input
-    );
-    expect(results.length > 0).toBe(true);
+      };
+      const results = await TestHelpers.runRulesWithInputs(
+        [new ExamplesRuleset({ spec_version: version })],
+        input,
+        input
+      );
+      expect(results.length > 0).toBe(true);
 
-    expect(results).toMatchSnapshot();
-    expect(results.some((result) => !result.passed)).toBe(true);
-  });
+      expect(results).toMatchSnapshot();
+      expect(results.some((result) => !result.passed)).toBe(true);
+    });
 
-  test('invalid request top level example errors', async () => {
-    const input: OpenAPIV3.Document = {
-      ...TestHelpers.createEmptySpec(),
-      paths: {
-        '/api/users': {
-          post: {
-            responses: {},
-            requestBody: {
-              description: '',
-              content: {
-                'application/json': {
-                  schema: exampleSchema,
-                  example: exampleInvalid,
-                },
-              },
-            },
-          },
-        },
-      },
-    };
-    const results = await TestHelpers.runRulesWithInputs(
-      [new ExamplesRuleset({})],
-      input,
-      input
-    );
-    expect(results.length > 0).toBe(true);
-
-    expect(results).toMatchSnapshot();
-    expect(results.some((result) => !result.passed)).toBe(true);
-  });
-  test('invalid request named example errors', async () => {
-    const input: OpenAPIV3.Document = {
-      ...TestHelpers.createEmptySpec(),
-      paths: {
-        '/api/users': {
-          post: {
-            responses: {},
-            requestBody: {
-              description: 'ok',
-              content: {
-                'application/json': {
-                  schema: exampleSchema,
-                  examples: {
-                    main: {
-                      value: exampleInvalid,
-                    },
-                    other: {
-                      value: exampleValid,
+    test('exclusive maximum', async () => {
+      if (version === '3.1.x') return;
+      const input: OpenAPIV3.Document = {
+        ...TestHelpers.createEmptySpec(),
+        paths: {
+          '/api/users': {
+            get: {
+              responses: {
+                '200': {
+                  description: 'ok',
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'number',
+                        maximum: 2,
+                        exclusiveMaximum: true,
+                      },
+                      example: 1,
                     },
                   },
                 },
@@ -285,139 +324,139 @@ describe('examples ruleset', () => {
             },
           },
         },
-      },
-    };
-    const results = await TestHelpers.runRulesWithInputs(
-      [new ExamplesRuleset({})],
-      input,
-      input
-    );
-    expect(results.length > 0).toBe(true);
+      };
+      const results = await TestHelpers.runRulesWithInputs(
+        [new ExamplesRuleset({ spec_version: version })],
+        input,
+        input
+      );
+      expect(results.length > 0).toBe(true);
 
-    expect(results).toMatchSnapshot();
-    expect(results.some((result) => !result.passed)).toBe(true);
-  });
-});
+      expect(results).toMatchSnapshot();
+      expect(results.every((result) => result.passed)).toBe(true);
+    });
 
-describe('examples should default to additional properties false', () => {
-  test('ajv config will be strict on additional properties', () => {
-    const result = validateSchema(
-      {
-        type: 'object',
-        properties: {
-          a: { type: 'string' },
-          b: { type: 'string' },
-        },
-      },
-      { a: 'abc', b: 'def', c: 'xyz' },
-      ajvInstance
-    );
-    expect(result.pass).toBe(false);
-    expect(result).toMatchSnapshot();
-  });
-
-  test('ajv config will work on additional properties with all of', () => {
-    const result = validateSchema(
-      {
-        allOf: [
+    describe('examples should default to additional properties false', () => {
+      test('ajv config will be strict on additional properties', () => {
+        const result = validateSchema(
           {
             type: 'object',
             properties: {
               a: { type: 'string' },
-            },
-          },
-          {
-            type: 'object',
-            properties: {
               b: { type: 'string' },
             },
           },
-        ],
-      },
-      { a: 'abc', b: 'def', c: 'A' },
-      ajvInstance
-    );
-    expect(result.pass).toBe(false);
-    expect(result).toMatchSnapshot();
-  });
+          { a: 'abc', b: 'def', c: 'xyz' },
+          ajvInstance
+        );
+        expect(result.pass).toBe(false);
+        expect(result).toMatchSnapshot();
+      });
 
-  test('ajv config will work on additional properties with all of at different levels of nesting', () => {
-    const result = validateSchema(
-      {
-        allOf: [
+      test('ajv config will work on additional properties with all of', () => {
+        const result = validateSchema(
+          {
+            allOf: [
+              {
+                type: 'object',
+                properties: {
+                  a: { type: 'string' },
+                },
+              },
+              {
+                type: 'object',
+                properties: {
+                  b: { type: 'string' },
+                },
+              },
+            ],
+          },
+          { a: 'abc', b: 'def', c: 'A' },
+          ajvInstance
+        );
+        expect(result.pass).toBe(false);
+        expect(result).toMatchSnapshot();
+      });
+
+      test('ajv config will work on additional properties with all of at different levels of nesting', () => {
+        const result = validateSchema(
+          {
+            allOf: [
+              {
+                type: 'object',
+                properties: {
+                  a: { type: 'string' },
+                },
+              },
+              {
+                type: 'object',
+                properties: {
+                  b: { type: 'object' },
+                },
+              },
+            ],
+          },
+          { a: 'abc', b: { l: '' } },
+          ajvInstance
+        );
+        expect(result.pass).toBe(false);
+        expect(result).toMatchSnapshot();
+      });
+
+      test('ajv config will not override a user defined value', () => {
+        const result = validateSchema(
           {
             type: 'object',
+            additionalProperties: true,
             properties: {
               a: { type: 'string' },
+              b: { type: 'string' },
             },
           },
+          { a: 'abc', b: 'def', c: 'xyz' },
+          ajvInstance
+        );
+        expect(result.pass).toBe(true);
+        expect(result).toMatchSnapshot();
+      });
+
+      test('schemas that have existing refs', () => {
+        const result = validateSchema(
           {
             type: 'object',
             properties: {
-              b: { type: 'object' },
+              a: { $ref: './not-important.yml' },
+              b: { additionalProperties: { $ref: './not-important.yml' } },
+              c: { type: 'string' },
+              d: { allOf: [{ $ref: './not-important.yml' }] },
+              e: { oneOf: [{ $ref: './not-important.yml' }] },
+              f: { anyOf: [{ $ref: './not-important.yml' }] },
+              g: { not: { $ref: './not-important.yml' } },
             },
           },
-        ],
-      },
-      { a: 'abc', b: { l: '' } },
-      ajvInstance
-    );
-    expect(result.pass).toBe(false);
-    expect(result).toMatchSnapshot();
-  });
+          { a: 'abc', b: 'def', c: 'xyz', d: '', e: '', f: '' },
+          ajvInstance
+        );
+        expect(result.pass).toBe(true);
 
-  test('ajv config will not override a user defined value', () => {
-    const result = validateSchema(
-      {
-        type: 'object',
-        additionalProperties: true,
-        properties: {
-          a: { type: 'string' },
-          b: { type: 'string' },
-        },
-      },
-      { a: 'abc', b: 'def', c: 'xyz' },
-      ajvInstance
-    );
-    expect(result.pass).toBe(true);
-    expect(result).toMatchSnapshot();
-  });
-
-  test('schemas that have existing refs', () => {
-    const result = validateSchema(
-      {
-        type: 'object',
-        properties: {
-          a: { $ref: './not-important.yml' },
-          b: { additionalProperties: { $ref: './not-important.yml' } },
-          c: { type: 'string' },
-          d: { allOf: [{ $ref: './not-important.yml' }] },
-          e: { oneOf: [{ $ref: './not-important.yml' }] },
-          f: { anyOf: [{ $ref: './not-important.yml' }] },
-          g: { not: { $ref: './not-important.yml' } },
-        },
-      },
-      { a: 'abc', b: 'def', c: 'xyz', d: '', e: '', f: '' },
-      ajvInstance
-    );
-    expect(result.pass).toBe(true);
-
-    const result2 = validateSchema(
-      {
-        type: 'object',
-        properties: {
-          a: { $ref: './not-important.yml' },
-          b: { additionalProperties: { $ref: './not-important.yml' } },
-          c: { type: 'string' },
-          d: { allOf: [{ $ref: './not-important.yml' }] },
-          e: { oneOf: [{ $ref: './not-important.yml' }] },
-          f: { anyOf: [{ $ref: './not-important.yml' }] },
-          g: { not: { $ref: './not-important.yml' } },
-        },
-      },
-      { c: 'xyz', d: '', e: '', f: '' },
-      ajvInstance
-    );
-    expect(result2.pass).toBe(true);
-  });
-});
+        const result2 = validateSchema(
+          {
+            type: 'object',
+            properties: {
+              a: { $ref: './not-important.yml' },
+              b: { additionalProperties: { $ref: './not-important.yml' } },
+              c: { type: 'string' },
+              d: { allOf: [{ $ref: './not-important.yml' }] },
+              e: { oneOf: [{ $ref: './not-important.yml' }] },
+              f: { anyOf: [{ $ref: './not-important.yml' }] },
+              g: { not: { $ref: './not-important.yml' } },
+            },
+          },
+          { c: 'xyz', d: '', e: '', f: '' },
+          ajvInstance
+        );
+        expect(result2.pass).toBe(true);
+      });
+    });
+  }
+);

--- a/projects/standard-rulesets/src/examples/__tests__/examples-are-valid-rules.test.ts
+++ b/projects/standard-rulesets/src/examples/__tests__/examples-are-valid-rules.test.ts
@@ -299,7 +299,8 @@ describe.each(['3.0.x', '3.1.x'] as const)(
       expect(results.some((result) => !result.passed)).toBe(true);
     });
 
-    test('exclusive maximum', async () => {
+    test('exclusive maximum boolean', async () => {
+      // exclusive maximum boolean is not valid in 3.1.x
       if (version === '3.1.x') return;
       const input: OpenAPIV3.Document = {
         ...TestHelpers.createEmptySpec(),
@@ -354,6 +355,8 @@ describe.each(['3.0.x', '3.1.x'] as const)(
       });
 
       test('ajv config will work on additional properties with all of', () => {
+        // 3.0.x does not support unevaluated properties (required for allOf support) - we merge down `allOf` in rule running so this is likely not an issue
+        if (version === '3.0.x') return;
         const result = validateSchema(
           {
             allOf: [

--- a/projects/standard-rulesets/src/examples/index.ts
+++ b/projects/standard-rulesets/src/examples/index.ts
@@ -76,7 +76,7 @@ const validateConfigSchema = ajv.compile(configSchema);
 export class ExamplesRuleset extends Ruleset {
   static async fromOpticConfig(
     config: unknown,
-    { specVersion }: { specVersion: SpecVersion }
+    { specVersion }: { specVersion?: SpecVersion } = {}
   ): Promise<ExamplesRuleset | string> {
     const result = validateConfigSchema(config);
 
@@ -90,6 +90,7 @@ export class ExamplesRuleset extends Ruleset {
     const validatedConfig = config as YamlConfig;
     const constructorConfig: ExampleConstructor = {
       ...validatedConfig,
+      spec_version: specVersion,
       severity: validatedConfig.severity,
     };
 

--- a/projects/standard-rulesets/src/examples/index.ts
+++ b/projects/standard-rulesets/src/examples/index.ts
@@ -15,6 +15,8 @@ import {
   requireValidResponseExamples,
 } from './requireValidExamples';
 
+type SpecVersion = '3.1.x' | '3.0.x';
+
 type YamlConfig = {
   exclude_operations_with_extension?: string;
   docs_link?: string;
@@ -66,13 +68,15 @@ type ExampleConstructor = {
   docsLink?: string;
   configureAjv?: (ajv: Ajv) => void;
   severity?: SeverityText;
+  spec_version?: SpecVersion;
 };
 
 const validateConfigSchema = ajv.compile(configSchema);
 
 export class ExamplesRuleset extends Ruleset {
   static async fromOpticConfig(
-    config: unknown
+    config: unknown,
+    { specVersion }: { specVersion: SpecVersion }
   ): Promise<ExamplesRuleset | string> {
     const result = validateConfigSchema(config);
 
@@ -103,7 +107,8 @@ export class ExamplesRuleset extends Ruleset {
   }
 
   constructor(config: ExampleConstructor) {
-    const customAjv = defaultAjv();
+    const specVersion = config.spec_version ?? '3.1.x';
+    const customAjv = defaultAjv(specVersion);
     if (config.configureAjv) {
       config.configureAjv(customAjv);
     }

--- a/projects/standard-rulesets/src/examples/requireValidExamples.ts
+++ b/projects/standard-rulesets/src/examples/requireValidExamples.ts
@@ -20,7 +20,6 @@ export function defaultAjv(specVersion: '3.1.x' | '3.0.x') {
     specVersion === '3.1.x'
       ? new Ajv2019({ strict: false, unevaluated: true })
       : new AjvDraft4({ strict: false, unevaluated: true });
-  console.log(validator);
   addFormats(validator);
   // override pattern keyword when invalid regex
   validator.removeKeyword('pattern');

--- a/projects/standard-rulesets/src/examples/requireValidExamples.ts
+++ b/projects/standard-rulesets/src/examples/requireValidExamples.ts
@@ -6,14 +6,21 @@ import {
   RuleError,
 } from '@useoptic/rulesets-base';
 import { OpenAPIV3 } from 'openapi-types';
-import Ajv from 'ajv/dist/2019';
+import AjvDraft4 from 'ajv-draft-04';
+import Ajv2019 from 'ajv/dist/2019';
 import addFormats from 'ajv-formats';
 import { OAS3 } from '@useoptic/openapi-utilities';
 
 type SchemaObject = OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject;
 
-export function defaultAjv() {
-  const validator = new Ajv({ strict: false, unevaluated: true });
+type Ajv = AjvDraft4 | Ajv2019;
+
+export function defaultAjv(specVersion: '3.1.x' | '3.0.x') {
+  const validator =
+    specVersion === '3.1.x'
+      ? new Ajv2019({ strict: false, unevaluated: true })
+      : new AjvDraft4({ strict: false, unevaluated: true });
+  console.log(validator);
   addFormats(validator);
   // override pattern keyword when invalid regex
   validator.removeKeyword('pattern');

--- a/projects/standard-rulesets/src/lintgpt/index.ts
+++ b/projects/standard-rulesets/src/lintgpt/index.ts
@@ -67,7 +67,7 @@ const validateConfigSchema = ajv.compile(configSchema);
 export class LintGpt extends ExternalRuleBase {
   static async fromOpticConfig(
     config: unknown,
-    client: LintGptClient
+    { client }: { client: LintGptClient }
   ): Promise<LintGpt | string> {
     const result = validateConfigSchema(config);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3906,6 +3906,7 @@ __metadata:
     "@useoptic/openapi-utilities": "workspace:*"
     "@useoptic/rulesets-base": "workspace:*"
     ajv: "npm:^8.6.0"
+    ajv-draft-04: "npm:^1.0.0"
     ajv-formats: "npm:~2.1.0"
     babel-jest: "npm:^29.3.1"
     jest: "npm:^29.3.1"
@@ -4020,7 +4021,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv-draft-04@npm:~1.0.0":
+"ajv-draft-04@npm:^1.0.0, ajv-draft-04@npm:~1.0.0":
   version: 1.0.0
   resolution: "ajv-draft-04@npm:1.0.0"
   peerDependencies:


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

uses draft 4 for 3.0.x and uses the draft 2019 for 3.1.x

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._
fixes: https://github.com/opticdev/optic/issues/2609
## 👹 QA
_How can other humans verify that this PR is correct?_
