### PR TITLE
Fix patching for allOf

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.53.15",
+  "version": "0.53.16-0",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",
@@ -27,5 +27,6 @@
     "**/*.+(js|jsx|ts|tsx|json|css)": [
       "yarn prettier --write"
     ]
-  }
+  },
+  "stableVersion": "0.53.15"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.53.16-0",
+  "version": "0.53.16",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",
@@ -27,6 +27,5 @@
     "**/*.+(js|jsx|ts|tsx|json|css)": [
       "yarn prettier --write"
     ]
-  },
-  "stableVersion": "0.53.15"
+  }
 }

--- a/projects/fastify-capture/package.json
+++ b/projects/fastify-capture/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/fastify-capture",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.15",
+  "version": "0.53.16-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -37,5 +37,6 @@
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
     "typescript": "^5.0.4"
-  }
+  },
+  "stableVersion": "0.53.15"
 }

--- a/projects/fastify-capture/package.json
+++ b/projects/fastify-capture/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/fastify-capture",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.16-0",
+  "version": "0.53.16",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -37,6 +37,5 @@
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
     "typescript": "^5.0.4"
-  },
-  "stableVersion": "0.53.15"
+  }
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.15",
+  "version": "0.53.16-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -32,5 +32,6 @@
   "dependencies": {
     "jsonpointer": "^5.0.1",
     "minimatch": "9.0.3"
-  }
+  },
+  "stableVersion": "0.53.15"
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.16-0",
+  "version": "0.53.16",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -32,6 +32,5 @@
   "dependencies": {
     "jsonpointer": "^5.0.1",
     "minimatch": "9.0.3"
-  },
-  "stableVersion": "0.53.15"
+  }
 }

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.16-0",
+  "version": "0.53.16",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -57,6 +57,5 @@
     "upath": "^2.0.1",
     "yaml": "^2.3.2",
     "yaml-ast-parser": "^0.0.43"
-  },
-  "stableVersion": "0.53.15"
+  }
 }

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.15",
+  "version": "0.53.16-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -57,5 +57,6 @@
     "upath": "^2.0.1",
     "yaml": "^2.3.2",
     "yaml-ast-parser": "^0.0.43"
-  }
+  },
+  "stableVersion": "0.53.15"
 }

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.15",
+  "version": "0.53.16-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -53,5 +53,6 @@
     "ts-invariant": "^0.9.3",
     "url-join": "^4.0.1",
     "yaml-ast-parser": "^0.0.43"
-  }
+  },
+  "stableVersion": "0.53.15"
 }

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.16-0",
+  "version": "0.53.16",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -53,6 +53,5 @@
     "ts-invariant": "^0.9.3",
     "url-join": "^4.0.1",
     "yaml-ast-parser": "^0.0.43"
-  },
-  "stableVersion": "0.53.15"
+  }
 }

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.16-0",
+  "version": "0.53.16",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -138,6 +138,5 @@
       "node18-win-x64"
     ],
     "outputPath": "../../dist"
-  },
-  "stableVersion": "0.53.15"
+  }
 }

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.15",
+  "version": "0.53.16-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -138,5 +138,6 @@
       "node18-win-x64"
     ],
     "outputPath": "../../dist"
-  }
+  },
+  "stableVersion": "0.53.15"
 }

--- a/projects/optic/src/commands/capture/patches/__tests__/__snapshots__/patches.test.ts.snap
+++ b/projects/optic/src/commands/capture/patches/__tests__/__snapshots__/patches.test.ts.snap
@@ -85,6 +85,182 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 3.0.x exclusiveMaximum an
 }
 `;
 
+exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf allOf in a property 1`] = `
+[
+  {
+    "description": "update response body: add property as",
+    "diff": {
+      "description": "'as' is not documented",
+      "example": 12,
+      "instancePath": "/data/asda/as",
+      "key": "as",
+      "keyword": "additionalProperties",
+      "kind": "AdditionalProperty",
+      "parentObjectPath": "/properties/data/allOf/1/properties/asda/properties",
+      "propertyExamplePath": "/data/asda/as",
+      "propertyPath": "/properties/data/allOf/1/properties/asda/properties/as",
+    },
+    "groupedOperations": [
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/allOf/1/properties/asda/required",
+        "value": [
+          "as",
+        ],
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/allOf/1/properties/asda/properties/as",
+        "value": {
+          "type": "number",
+        },
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"data":{"status":"ok","name":"me","age":50,"asda":{"as":12}}}",
+          "contentType": "application/json",
+          "size": 62,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+  {
+    "description": "update response body: add property age",
+    "diff": {
+      "description": "'age' is not documented",
+      "example": 50,
+      "instancePath": "/data/age",
+      "key": "age",
+      "keyword": "additionalProperties",
+      "kind": "AdditionalProperty",
+      "parentObjectPath": "/properties/data/allOf/0/properties",
+      "propertyExamplePath": "/data/age",
+      "propertyPath": "/properties/data/allOf/0/properties/age",
+    },
+    "groupedOperations": [
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/allOf/0/required/-",
+        "value": "age",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/allOf/0/properties/age",
+        "value": {
+          "type": "number",
+        },
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"data":{"status":"ok","name":"me","age":50,"asda":{"as":12}}}",
+          "contentType": "application/json",
+          "size": 62,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+]
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf allOf in a property 2`] = `
+{
+  "info": {},
+  "openapi": "3.0.1",
+  "paths": {
+    "/api/animals": {
+      "post": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "properties": {
+                            "age": {
+                              "type": "number",
+                            },
+                            "status": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "status",
+                            "age",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "properties": {
+                            "asda": {
+                              "properties": {
+                                "as": {
+                                  "type": "number",
+                                },
+                              },
+                              "required": [
+                                "as",
+                              ],
+                              "type": "object",
+                            },
+                            "name": {
+                              "type": "string",
+                            },
+                          },
+                          "type": "object",
+                        },
+                      ],
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
 exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf matching interaction 1`] = `[]`;
 
 exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf matching interaction 2`] = `
@@ -134,7 +310,117 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf matching interactio
 }
 `;
 
-exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf with extra keys in interaction 1`] = `[]`;
+exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf with extra keys in interaction 1`] = `
+[
+  {
+    "description": "update response body: add property as",
+    "diff": {
+      "description": "'as' is not documented",
+      "example": 12,
+      "instancePath": "/asda/as",
+      "key": "as",
+      "keyword": "additionalProperties",
+      "kind": "AdditionalProperty",
+      "parentObjectPath": "/allOf/1/properties/asda/properties",
+      "propertyExamplePath": "/asda/as",
+      "propertyPath": "/allOf/1/properties/asda/properties/as",
+    },
+    "groupedOperations": [
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/properties/asda/required",
+        "value": [
+          "as",
+        ],
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/properties/asda/properties/as",
+        "value": {
+          "type": "number",
+        },
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"status":"ok","name":"me","age":50,"asda":{"as":12}}",
+          "contentType": "application/json",
+          "size": 53,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+  {
+    "description": "update response body: add property age",
+    "diff": {
+      "description": "'age' is not documented",
+      "example": 50,
+      "instancePath": "/age",
+      "key": "age",
+      "keyword": "additionalProperties",
+      "kind": "AdditionalProperty",
+      "parentObjectPath": "/allOf/0/properties",
+      "propertyExamplePath": "/age",
+      "propertyPath": "/allOf/0/properties/age",
+    },
+    "groupedOperations": [
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/required/-",
+        "value": "age",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/properties/age",
+        "value": {
+          "type": "number",
+        },
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"status":"ok","name":"me","age":50,"asda":{"as":12}}",
+          "contentType": "application/json",
+          "size": 53,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+]
+`;
 
 exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf with extra keys in interaction 2`] = `
 {
@@ -151,17 +437,32 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf with extra keys in 
                   "allOf": [
                     {
                       "properties": {
+                        "age": {
+                          "type": "number",
+                        },
                         "status": {
                           "type": "string",
                         },
                       },
                       "required": [
                         "status",
+                        "age",
                       ],
                       "type": "object",
                     },
                     {
                       "properties": {
+                        "asda": {
+                          "properties": {
+                            "as": {
+                              "type": "number",
+                            },
+                          },
+                          "required": [
+                            "as",
+                          ],
+                          "type": "object",
+                        },
                         "name": {
                           "type": "string",
                         },
@@ -273,7 +574,124 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf with missing keys i
 }
 `;
 
-exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf with nested oneOf 1`] = `[]`;
+exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf with nested oneOf 1`] = `
+[
+  {
+    "description": "update response body: add property results",
+    "diff": {
+      "description": "'results' is not documented",
+      "example": [
+        "123",
+        "355",
+        34,
+      ],
+      "instancePath": "/results",
+      "key": "results",
+      "keyword": "additionalProperties",
+      "kind": "AdditionalProperty",
+      "parentObjectPath": "/allOf/0/oneOf/0/properties",
+      "propertyExamplePath": "/results",
+      "propertyPath": "/allOf/0/oneOf/0/properties/results",
+    },
+    "groupedOperations": [
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/oneOf/0/required/-",
+        "value": "results",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/oneOf/0/properties/results",
+        "value": {
+          "items": {
+            "type": "string",
+          },
+          "type": "array",
+        },
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"hello":"ok","goodbye":"me","results":["123","355",34]}",
+          "contentType": "application/json",
+          "size": 56,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+  {
+    "description": "update response body: make items oneOf",
+    "diff": {
+      "description": "'items' did not match schema",
+      "example": 34,
+      "expectedType": "string",
+      "instancePath": "/results/2",
+      "key": "items",
+      "keyword": "type",
+      "kind": "UnmatchedType",
+      "propertyPath": "/allOf/0/oneOf/0/properties/results/items",
+    },
+    "groupedOperations": [
+      {
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/oneOf/0/properties/results/items/type",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/oneOf/0/properties/results/items/oneOf",
+        "value": [
+          {
+            "type": "string",
+          },
+          {
+            "type": "number",
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsIncompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"hello":"ok","goodbye":"me","results":["123","355",34]}",
+          "contentType": "application/json",
+          "size": 56,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+]
+`;
 
 exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf with nested oneOf 2`] = `
 {
@@ -298,10 +716,24 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf with nested oneOf 2
                             "hello": {
                               "type": "string",
                             },
+                            "results": {
+                              "items": {
+                                "oneOf": [
+                                  {
+                                    "type": "string",
+                                  },
+                                  {
+                                    "type": "number",
+                                  },
+                                ],
+                              },
+                              "type": "array",
+                            },
                           },
                           "required": [
                             "hello",
                             "goodbye",
+                            "results",
                           ],
                           "type": "object",
                         },
@@ -6316,6 +6748,182 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented response bod
 }
 `;
 
+exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf allOf in a property 1`] = `
+[
+  {
+    "description": "update response body: add property as",
+    "diff": {
+      "description": "'as' is not documented",
+      "example": 12,
+      "instancePath": "/data/asda/as",
+      "key": "as",
+      "keyword": "additionalProperties",
+      "kind": "AdditionalProperty",
+      "parentObjectPath": "/properties/data/allOf/1/properties/asda/properties",
+      "propertyExamplePath": "/data/asda/as",
+      "propertyPath": "/properties/data/allOf/1/properties/asda/properties/as",
+    },
+    "groupedOperations": [
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/allOf/1/properties/asda/required",
+        "value": [
+          "as",
+        ],
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/allOf/1/properties/asda/properties/as",
+        "value": {
+          "type": "number",
+        },
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"data":{"status":"ok","name":"me","age":50,"asda":{"as":12}}}",
+          "contentType": "application/json",
+          "size": 62,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+  {
+    "description": "update response body: add property age",
+    "diff": {
+      "description": "'age' is not documented",
+      "example": 50,
+      "instancePath": "/data/age",
+      "key": "age",
+      "keyword": "additionalProperties",
+      "kind": "AdditionalProperty",
+      "parentObjectPath": "/properties/data/allOf/0/properties",
+      "propertyExamplePath": "/data/age",
+      "propertyPath": "/properties/data/allOf/0/properties/age",
+    },
+    "groupedOperations": [
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/allOf/0/required/-",
+        "value": "age",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/allOf/0/properties/age",
+        "value": {
+          "type": "number",
+        },
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"data":{"status":"ok","name":"me","age":50,"asda":{"as":12}}}",
+          "contentType": "application/json",
+          "size": 62,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+]
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf allOf in a property 2`] = `
+{
+  "info": {},
+  "openapi": "3.1.0",
+  "paths": {
+    "/api/animals": {
+      "post": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "allOf": [
+                        {
+                          "properties": {
+                            "age": {
+                              "type": "number",
+                            },
+                            "status": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "status",
+                            "age",
+                          ],
+                          "type": "object",
+                        },
+                        {
+                          "properties": {
+                            "asda": {
+                              "properties": {
+                                "as": {
+                                  "type": "number",
+                                },
+                              },
+                              "required": [
+                                "as",
+                              ],
+                              "type": "object",
+                            },
+                            "name": {
+                              "type": "string",
+                            },
+                          },
+                          "type": "object",
+                        },
+                      ],
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
 exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf matching interaction 1`] = `[]`;
 
 exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf matching interaction 2`] = `
@@ -6365,7 +6973,117 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf matching interactio
 }
 `;
 
-exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf with extra keys in interaction 1`] = `[]`;
+exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf with extra keys in interaction 1`] = `
+[
+  {
+    "description": "update response body: add property as",
+    "diff": {
+      "description": "'as' is not documented",
+      "example": 12,
+      "instancePath": "/asda/as",
+      "key": "as",
+      "keyword": "additionalProperties",
+      "kind": "AdditionalProperty",
+      "parentObjectPath": "/allOf/1/properties/asda/properties",
+      "propertyExamplePath": "/asda/as",
+      "propertyPath": "/allOf/1/properties/asda/properties/as",
+    },
+    "groupedOperations": [
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/properties/asda/required",
+        "value": [
+          "as",
+        ],
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/properties/asda/properties/as",
+        "value": {
+          "type": "number",
+        },
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"status":"ok","name":"me","age":50,"asda":{"as":12}}",
+          "contentType": "application/json",
+          "size": 53,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+  {
+    "description": "update response body: add property age",
+    "diff": {
+      "description": "'age' is not documented",
+      "example": 50,
+      "instancePath": "/age",
+      "key": "age",
+      "keyword": "additionalProperties",
+      "kind": "AdditionalProperty",
+      "parentObjectPath": "/allOf/0/properties",
+      "propertyExamplePath": "/age",
+      "propertyPath": "/allOf/0/properties/age",
+    },
+    "groupedOperations": [
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/required/-",
+        "value": "age",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/properties/age",
+        "value": {
+          "type": "number",
+        },
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"status":"ok","name":"me","age":50,"asda":{"as":12}}",
+          "contentType": "application/json",
+          "size": 53,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+]
+`;
 
 exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf with extra keys in interaction 2`] = `
 {
@@ -6382,17 +7100,32 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf with extra keys in 
                   "allOf": [
                     {
                       "properties": {
+                        "age": {
+                          "type": "number",
+                        },
                         "status": {
                           "type": "string",
                         },
                       },
                       "required": [
                         "status",
+                        "age",
                       ],
                       "type": "object",
                     },
                     {
                       "properties": {
+                        "asda": {
+                          "properties": {
+                            "as": {
+                              "type": "number",
+                            },
+                          },
+                          "required": [
+                            "as",
+                          ],
+                          "type": "object",
+                        },
                         "name": {
                           "type": "string",
                         },
@@ -6504,7 +7237,124 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf with missing keys i
 }
 `;
 
-exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf with nested oneOf 1`] = `[]`;
+exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf with nested oneOf 1`] = `
+[
+  {
+    "description": "update response body: add property results",
+    "diff": {
+      "description": "'results' is not documented",
+      "example": [
+        "123",
+        "355",
+        34,
+      ],
+      "instancePath": "/results",
+      "key": "results",
+      "keyword": "additionalProperties",
+      "kind": "AdditionalProperty",
+      "parentObjectPath": "/allOf/0/oneOf/0/properties",
+      "propertyExamplePath": "/results",
+      "propertyPath": "/allOf/0/oneOf/0/properties/results",
+    },
+    "groupedOperations": [
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/oneOf/0/required/-",
+        "value": "results",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/oneOf/0/properties/results",
+        "value": {
+          "items": {
+            "type": "string",
+          },
+          "type": "array",
+        },
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"hello":"ok","goodbye":"me","results":["123","355",34]}",
+          "contentType": "application/json",
+          "size": 56,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+  {
+    "description": "update response body: make items oneOf",
+    "diff": {
+      "description": "'items' did not match schema",
+      "example": 34,
+      "expectedType": "string",
+      "instancePath": "/results/2",
+      "key": "items",
+      "keyword": "type",
+      "kind": "UnmatchedType",
+      "propertyPath": "/allOf/0/oneOf/0/properties/results/items",
+    },
+    "groupedOperations": [
+      {
+        "op": "remove",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/oneOf/0/properties/results/items/type",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/oneOf/0/properties/results/items/oneOf",
+        "value": [
+          {
+            "type": "string",
+          },
+          {
+            "type": "number",
+          },
+        ],
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsIncompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"hello":"ok","goodbye":"me","results":["123","355",34]}",
+          "contentType": "application/json",
+          "size": 56,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+]
+`;
 
 exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf with nested oneOf 2`] = `
 {
@@ -6529,10 +7379,24 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf with nested oneOf 2
                             "hello": {
                               "type": "string",
                             },
+                            "results": {
+                              "items": {
+                                "oneOf": [
+                                  {
+                                    "type": "string",
+                                  },
+                                  {
+                                    "type": "number",
+                                  },
+                                ],
+                              },
+                              "type": "array",
+                            },
                           },
                           "required": [
                             "hello",
                             "goodbye",
+                            "results",
                           ],
                           "type": "object",
                         },

--- a/projects/optic/src/commands/capture/patches/__tests__/__snapshots__/patches.test.ts.snap
+++ b/projects/optic/src/commands/capture/patches/__tests__/__snapshots__/patches.test.ts.snap
@@ -1,5 +1,230 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf matching interaction 1`] = `
+[
+  {
+    "description": "update response body: add property name",
+    "diff": {
+      "description": "'name' is not documented",
+      "example": "me",
+      "instancePath": "/name",
+      "key": "name",
+      "keyword": "additionalProperties",
+      "kind": "AdditionalProperty",
+      "parentObjectPath": "/allOf/0/properties",
+      "propertyExamplePath": "/name",
+      "propertyPath": "/allOf/0/properties/name",
+    },
+    "groupedOperations": [
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/required/-",
+        "value": "name",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/properties/name",
+        "value": {
+          "type": "string",
+        },
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"status":"ok","name":"me","age":50}",
+          "contentType": "application/json",
+          "size": 36,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+  {
+    "description": "update response body: add property status",
+    "diff": {
+      "description": "'status' is not documented",
+      "example": "ok",
+      "instancePath": "/status",
+      "key": "status",
+      "keyword": "additionalProperties",
+      "kind": "AdditionalProperty",
+      "parentObjectPath": "/allOf/1/properties",
+      "propertyExamplePath": "/status",
+      "propertyPath": "/allOf/1/properties/status",
+    },
+    "groupedOperations": [
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/required",
+        "value": [
+          "status",
+        ],
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/properties/status",
+        "value": {
+          "type": "string",
+        },
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"status":"ok","name":"me","age":50}",
+          "contentType": "application/json",
+          "size": 36,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+  {
+    "description": "update response body: add property age",
+    "diff": {
+      "description": "'age' is not documented",
+      "example": 50,
+      "instancePath": "/age",
+      "key": "age",
+      "keyword": "additionalProperties",
+      "kind": "AdditionalProperty",
+      "parentObjectPath": "/allOf/1/properties",
+      "propertyExamplePath": "/age",
+      "propertyPath": "/allOf/1/properties/age",
+    },
+    "groupedOperations": [
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/required/-",
+        "value": "age",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/properties/age",
+        "value": {
+          "type": "number",
+        },
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"status":"ok","name":"me","age":50}",
+          "contentType": "application/json",
+          "size": 36,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+]
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf matching interaction 2`] = `
+{
+  "info": {},
+  "openapi": "3.0.1",
+  "paths": {
+    "/api/animals": {
+      "post": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "properties": {
+                        "age": {
+                          "type": "number",
+                        },
+                        "name": {
+                          "type": "string",
+                        },
+                        "status": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "status",
+                        "name",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "properties": {
+                        "age": {
+                          "type": "number",
+                        },
+                        "name": {
+                          "type": "string",
+                        },
+                        "status": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "status",
+                        "age",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
 exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf with extra keys in interaction 1`] = `
 [
   {
@@ -6594,6 +6819,231 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented response bod
               },
             },
             "description": "200 response",
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf matching interaction 1`] = `
+[
+  {
+    "description": "update response body: add property name",
+    "diff": {
+      "description": "'name' is not documented",
+      "example": "me",
+      "instancePath": "/name",
+      "key": "name",
+      "keyword": "additionalProperties",
+      "kind": "AdditionalProperty",
+      "parentObjectPath": "/allOf/0/properties",
+      "propertyExamplePath": "/name",
+      "propertyPath": "/allOf/0/properties/name",
+    },
+    "groupedOperations": [
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/required/-",
+        "value": "name",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/properties/name",
+        "value": {
+          "type": "string",
+        },
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"status":"ok","name":"me","age":50}",
+          "contentType": "application/json",
+          "size": 36,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+  {
+    "description": "update response body: add property status",
+    "diff": {
+      "description": "'status' is not documented",
+      "example": "ok",
+      "instancePath": "/status",
+      "key": "status",
+      "keyword": "additionalProperties",
+      "kind": "AdditionalProperty",
+      "parentObjectPath": "/allOf/1/properties",
+      "propertyExamplePath": "/status",
+      "propertyPath": "/allOf/1/properties/status",
+    },
+    "groupedOperations": [
+      {
+        "extra": "same",
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/required",
+        "value": [
+          "status",
+        ],
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/properties/status",
+        "value": {
+          "type": "string",
+        },
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"status":"ok","name":"me","age":50}",
+          "contentType": "application/json",
+          "size": 36,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+  {
+    "description": "update response body: add property age",
+    "diff": {
+      "description": "'age' is not documented",
+      "example": 50,
+      "instancePath": "/age",
+      "key": "age",
+      "keyword": "additionalProperties",
+      "kind": "AdditionalProperty",
+      "parentObjectPath": "/allOf/1/properties",
+      "propertyExamplePath": "/age",
+      "propertyPath": "/allOf/1/properties/age",
+    },
+    "groupedOperations": [
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/required/-",
+        "value": "age",
+      },
+      {
+        "op": "add",
+        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/properties/age",
+        "value": {
+          "type": "number",
+        },
+      },
+    ],
+    "impact": [
+      "Addition",
+      "BackwardsCompatible",
+    ],
+    "interaction": {
+      "request": {
+        "body": null,
+        "headers": [],
+        "host": "localhost:3030",
+        "method": "post",
+        "path": "/api/animals",
+        "query": [],
+      },
+      "response": {
+        "body": {
+          "body": "{"status":"ok","name":"me","age":50}",
+          "contentType": "application/json",
+          "size": 36,
+        },
+        "headers": [],
+        "statusCode": "200",
+      },
+    },
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
+  },
+]
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf matching interaction 2`] = `
+{
+  "info": {},
+  "openapi": "3.1.0",
+  "paths": {
+    "/api/animals": {
+      "post": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "properties": {
+                        "age": {
+                          "type": "number",
+                        },
+                        "name": {
+                          "type": "string",
+                        },
+                        "status": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "status",
+                        "name",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "properties": {
+                        "age": {
+                          "type": "number",
+                        },
+                        "name": {
+                          "type": "string",
+                        },
+                        "status": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "status",
+                        "age",
+                      ],
+                      "type": "object",
+                    },
+                  ],
+                },
+              },
+            },
           },
         },
       },

--- a/projects/optic/src/commands/capture/patches/__tests__/__snapshots__/patches.test.ts.snap
+++ b/projects/optic/src/commands/capture/patches/__tests__/__snapshots__/patches.test.ts.snap
@@ -1,38 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf matching interaction 1`] = `
+exports[`generateEndpointSpecPatches OAS version 3.0.1 3.0.x exclusiveMaximum and exclusiveMinimum booleans 1`] = `
 [
   {
-    "description": "update response body: add property name",
-    "diff": {
-      "description": "'name' is not documented",
-      "example": "me",
-      "instancePath": "/name",
-      "key": "name",
-      "keyword": "additionalProperties",
-      "kind": "AdditionalProperty",
-      "parentObjectPath": "/allOf/0/properties",
-      "propertyExamplePath": "/name",
-      "propertyPath": "/allOf/0/properties/name",
-    },
-    "groupedOperations": [
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/required/-",
-        "value": "name",
-      },
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/properties/name",
-        "value": {
-          "type": "string",
-        },
-      },
-    ],
-    "impact": [
-      "Addition",
-      "BackwardsCompatible",
-    ],
+    "bodyPath": "/paths/~1api~1animals/post/responses/200/content/application~1json",
+    "example": 20,
     "interaction": {
       "request": {
         "body": null,
@@ -44,125 +16,76 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf matching interactio
       },
       "response": {
         "body": {
-          "body": "{"status":"ok","name":"me","age":50}",
+          "body": "{"data":[{"no":10},{"no":20}]}",
           "contentType": "application/json",
-          "size": 36,
+          "size": 30,
         },
         "headers": [],
         "statusCode": "200",
       },
     },
-    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-  },
-  {
-    "description": "update response body: add property status",
-    "diff": {
-      "description": "'status' is not documented",
-      "example": "ok",
-      "instancePath": "/status",
-      "key": "status",
-      "keyword": "additionalProperties",
-      "kind": "AdditionalProperty",
-      "parentObjectPath": "/allOf/1/properties",
-      "propertyExamplePath": "/status",
-      "propertyPath": "/allOf/1/properties/status",
+    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/properties/data/items/properties/no/maximum",
+    "schemaPath": "/properties/data/items/properties/no/maximum",
+    "unpatchable": true,
+    "validationError": {
+      "instancePath": "/data/1/no",
+      "keyword": "maximum",
+      "message": "must be <= 19",
+      "params": {
+        "comparison": "<=",
+        "limit": 19,
+      },
+      "schemaPath": "#/properties/data/items/properties/no/maximum",
     },
-    "groupedOperations": [
-      {
-        "extra": "same",
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/required",
-        "value": [
-          "status",
-        ],
-      },
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/properties/status",
-        "value": {
-          "type": "string",
-        },
-      },
-    ],
-    "impact": [
-      "Addition",
-      "BackwardsCompatible",
-    ],
-    "interaction": {
-      "request": {
-        "body": null,
-        "headers": [],
-        "host": "localhost:3030",
-        "method": "post",
-        "path": "/api/animals",
-        "query": [],
-      },
-      "response": {
-        "body": {
-          "body": "{"status":"ok","name":"me","age":50}",
-          "contentType": "application/json",
-          "size": 36,
-        },
-        "headers": [],
-        "statusCode": "200",
-      },
-    },
-    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-  },
-  {
-    "description": "update response body: add property age",
-    "diff": {
-      "description": "'age' is not documented",
-      "example": 50,
-      "instancePath": "/age",
-      "key": "age",
-      "keyword": "additionalProperties",
-      "kind": "AdditionalProperty",
-      "parentObjectPath": "/allOf/1/properties",
-      "propertyExamplePath": "/age",
-      "propertyPath": "/allOf/1/properties/age",
-    },
-    "groupedOperations": [
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/required/-",
-        "value": "age",
-      },
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/properties/age",
-        "value": {
-          "type": "number",
-        },
-      },
-    ],
-    "impact": [
-      "Addition",
-      "BackwardsCompatible",
-    ],
-    "interaction": {
-      "request": {
-        "body": null,
-        "headers": [],
-        "host": "localhost:3030",
-        "method": "post",
-        "path": "/api/animals",
-        "query": [],
-      },
-      "response": {
-        "body": {
-          "body": "{"status":"ok","name":"me","age":50}",
-          "contentType": "application/json",
-          "size": 36,
-        },
-        "headers": [],
-        "statusCode": "200",
-      },
-    },
-    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
   },
 ]
 `;
+
+exports[`generateEndpointSpecPatches OAS version 3.0.1 3.0.x exclusiveMaximum and exclusiveMinimum booleans 2`] = `
+{
+  "info": {},
+  "openapi": "3.0.1",
+  "paths": {
+    "/api/animals": {
+      "post": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "properties": {
+                          "no": {
+                            "exclusiveMaximum": true,
+                            "exclusiveMinumum": true,
+                            "maximum": 20,
+                            "minumum": 10,
+                            "type": "number",
+                          },
+                        },
+                        "required": [
+                          "no",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf matching interaction 1`] = `[]`;
 
 exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf matching interaction 2`] = `
 {
@@ -182,35 +105,21 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf matching interactio
                         "age": {
                           "type": "number",
                         },
-                        "name": {
-                          "type": "string",
-                        },
                         "status": {
                           "type": "string",
                         },
                       },
                       "required": [
                         "status",
-                        "name",
                       ],
                       "type": "object",
                     },
                     {
                       "properties": {
-                        "age": {
-                          "type": "number",
-                        },
                         "name": {
                           "type": "string",
                         },
-                        "status": {
-                          "type": "string",
-                        },
                       },
-                      "required": [
-                        "status",
-                        "age",
-                      ],
                       "type": "object",
                     },
                   ],
@@ -225,221 +134,7 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf matching interactio
 }
 `;
 
-exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf with extra keys in interaction 1`] = `
-[
-  {
-    "description": "update response body: add property name",
-    "diff": {
-      "description": "'name' is not documented",
-      "example": "me",
-      "instancePath": "/name",
-      "key": "name",
-      "keyword": "additionalProperties",
-      "kind": "AdditionalProperty",
-      "parentObjectPath": "/allOf/0/properties",
-      "propertyExamplePath": "/name",
-      "propertyPath": "/allOf/0/properties/name",
-    },
-    "groupedOperations": [
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/required/-",
-        "value": "name",
-      },
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/properties/name",
-        "value": {
-          "type": "string",
-        },
-      },
-    ],
-    "impact": [
-      "Addition",
-      "BackwardsCompatible",
-    ],
-    "interaction": {
-      "request": {
-        "body": null,
-        "headers": [],
-        "host": "localhost:3030",
-        "method": "post",
-        "path": "/api/animals",
-        "query": [],
-      },
-      "response": {
-        "body": {
-          "body": "{"status":"ok","name":"me","age":50}",
-          "contentType": "application/json",
-          "size": 36,
-        },
-        "headers": [],
-        "statusCode": "200",
-      },
-    },
-    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-  },
-  {
-    "description": "update response body: add property age",
-    "diff": {
-      "description": "'age' is not documented",
-      "example": 50,
-      "instancePath": "/age",
-      "key": "age",
-      "keyword": "additionalProperties",
-      "kind": "AdditionalProperty",
-      "parentObjectPath": "/allOf/0/properties",
-      "propertyExamplePath": "/age",
-      "propertyPath": "/allOf/0/properties/age",
-    },
-    "groupedOperations": [
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/required/-",
-        "value": "age",
-      },
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/properties/age",
-        "value": {
-          "type": "number",
-        },
-      },
-    ],
-    "impact": [
-      "Addition",
-      "BackwardsCompatible",
-    ],
-    "interaction": {
-      "request": {
-        "body": null,
-        "headers": [],
-        "host": "localhost:3030",
-        "method": "post",
-        "path": "/api/animals",
-        "query": [],
-      },
-      "response": {
-        "body": {
-          "body": "{"status":"ok","name":"me","age":50}",
-          "contentType": "application/json",
-          "size": 36,
-        },
-        "headers": [],
-        "statusCode": "200",
-      },
-    },
-    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-  },
-  {
-    "description": "update response body: add property status",
-    "diff": {
-      "description": "'status' is not documented",
-      "example": "ok",
-      "instancePath": "/status",
-      "key": "status",
-      "keyword": "additionalProperties",
-      "kind": "AdditionalProperty",
-      "parentObjectPath": "/allOf/1/properties",
-      "propertyExamplePath": "/status",
-      "propertyPath": "/allOf/1/properties/status",
-    },
-    "groupedOperations": [
-      {
-        "extra": "same",
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/required",
-        "value": [
-          "status",
-        ],
-      },
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/properties/status",
-        "value": {
-          "type": "string",
-        },
-      },
-    ],
-    "impact": [
-      "Addition",
-      "BackwardsCompatible",
-    ],
-    "interaction": {
-      "request": {
-        "body": null,
-        "headers": [],
-        "host": "localhost:3030",
-        "method": "post",
-        "path": "/api/animals",
-        "query": [],
-      },
-      "response": {
-        "body": {
-          "body": "{"status":"ok","name":"me","age":50}",
-          "contentType": "application/json",
-          "size": 36,
-        },
-        "headers": [],
-        "statusCode": "200",
-      },
-    },
-    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-  },
-  {
-    "description": "update response body: add property age",
-    "diff": {
-      "description": "'age' is not documented",
-      "example": 50,
-      "instancePath": "/age",
-      "key": "age",
-      "keyword": "additionalProperties",
-      "kind": "AdditionalProperty",
-      "parentObjectPath": "/allOf/1/properties",
-      "propertyExamplePath": "/age",
-      "propertyPath": "/allOf/1/properties/age",
-    },
-    "groupedOperations": [
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/required/-",
-        "value": "age",
-      },
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/properties/age",
-        "value": {
-          "type": "number",
-        },
-      },
-    ],
-    "impact": [
-      "Addition",
-      "BackwardsCompatible",
-    ],
-    "interaction": {
-      "request": {
-        "body": null,
-        "headers": [],
-        "host": "localhost:3030",
-        "method": "post",
-        "path": "/api/animals",
-        "query": [],
-      },
-      "response": {
-        "body": {
-          "body": "{"status":"ok","name":"me","age":50}",
-          "contentType": "application/json",
-          "size": 36,
-        },
-        "headers": [],
-        "statusCode": "200",
-      },
-    },
-    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-  },
-]
-`;
+exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf with extra keys in interaction 1`] = `[]`;
 
 exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf with extra keys in interaction 2`] = `
 {
@@ -456,39 +151,21 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf with extra keys in 
                   "allOf": [
                     {
                       "properties": {
-                        "age": {
-                          "type": "number",
-                        },
-                        "name": {
-                          "type": "string",
-                        },
                         "status": {
                           "type": "string",
                         },
                       },
                       "required": [
                         "status",
-                        "name",
-                        "age",
                       ],
                       "type": "object",
                     },
                     {
                       "properties": {
-                        "age": {
-                          "type": "number",
-                        },
                         "name": {
                           "type": "string",
                         },
-                        "status": {
-                          "type": "string",
-                        },
                       },
-                      "required": [
-                        "status",
-                        "age",
-                      ],
                       "type": "object",
                     },
                   ],
@@ -548,58 +225,6 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf with missing keys i
     },
     "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
   },
-  {
-    "description": "update response body: add property status",
-    "diff": {
-      "description": "'status' is not documented",
-      "example": "ok",
-      "instancePath": "/status",
-      "key": "status",
-      "keyword": "additionalProperties",
-      "kind": "AdditionalProperty",
-      "parentObjectPath": "/allOf/1/properties",
-      "propertyExamplePath": "/status",
-      "propertyPath": "/allOf/1/properties/status",
-    },
-    "groupedOperations": [
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/required/-",
-        "value": "status",
-      },
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/properties/status",
-        "value": {
-          "type": "string",
-        },
-      },
-    ],
-    "impact": [
-      "Addition",
-      "BackwardsCompatible",
-    ],
-    "interaction": {
-      "request": {
-        "body": null,
-        "headers": [],
-        "host": "localhost:3030",
-        "method": "post",
-        "path": "/api/animals",
-        "query": [],
-      },
-      "response": {
-        "body": {
-          "body": "{"status":"ok"}",
-          "contentType": "application/json",
-          "size": 15,
-        },
-        "headers": [],
-        "statusCode": "200",
-      },
-    },
-    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-  },
 ]
 `;
 
@@ -632,13 +257,8 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf with missing keys i
                         "name": {
                           "type": "string",
                         },
-                        "status": {
-                          "type": "string",
-                        },
                       },
-                      "required": [
-                        "status",
-                      ],
+                      "required": [],
                       "type": "object",
                     },
                   ],
@@ -653,124 +273,7 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf with missing keys i
 }
 `;
 
-exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf with nested oneOf 1`] = `
-[
-  {
-    "description": "update response body: add property results",
-    "diff": {
-      "description": "'results' is not documented",
-      "example": [
-        "123",
-        "355",
-        34,
-      ],
-      "instancePath": "/results",
-      "key": "results",
-      "keyword": "additionalProperties",
-      "kind": "AdditionalProperty",
-      "parentObjectPath": "/allOf/0/oneOf/0/properties",
-      "propertyExamplePath": "/results",
-      "propertyPath": "/allOf/0/oneOf/0/properties/results",
-    },
-    "groupedOperations": [
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/oneOf/0/required/-",
-        "value": "results",
-      },
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/oneOf/0/properties/results",
-        "value": {
-          "items": {
-            "type": "string",
-          },
-          "type": "array",
-        },
-      },
-    ],
-    "impact": [
-      "Addition",
-      "BackwardsCompatible",
-    ],
-    "interaction": {
-      "request": {
-        "body": null,
-        "headers": [],
-        "host": "localhost:3030",
-        "method": "post",
-        "path": "/api/animals",
-        "query": [],
-      },
-      "response": {
-        "body": {
-          "body": "{"hello":"ok","goodbye":"me","results":["123","355",34]}",
-          "contentType": "application/json",
-          "size": 56,
-        },
-        "headers": [],
-        "statusCode": "200",
-      },
-    },
-    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-  },
-  {
-    "description": "update response body: make items oneOf",
-    "diff": {
-      "description": "'items' did not match schema",
-      "example": 34,
-      "expectedType": "string",
-      "instancePath": "/results/2",
-      "key": "items",
-      "keyword": "type",
-      "kind": "UnmatchedType",
-      "propertyPath": "/allOf/0/oneOf/0/properties/results/items",
-    },
-    "groupedOperations": [
-      {
-        "op": "remove",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/oneOf/0/properties/results/items/type",
-      },
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/oneOf/0/properties/results/items/oneOf",
-        "value": [
-          {
-            "type": "string",
-          },
-          {
-            "type": "number",
-          },
-        ],
-      },
-    ],
-    "impact": [
-      "Addition",
-      "BackwardsIncompatible",
-    ],
-    "interaction": {
-      "request": {
-        "body": null,
-        "headers": [],
-        "host": "localhost:3030",
-        "method": "post",
-        "path": "/api/animals",
-        "query": [],
-      },
-      "response": {
-        "body": {
-          "body": "{"hello":"ok","goodbye":"me","results":["123","355",34]}",
-          "contentType": "application/json",
-          "size": 56,
-        },
-        "headers": [],
-        "statusCode": "200",
-      },
-    },
-    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-  },
-]
-`;
+exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf with nested oneOf 1`] = `[]`;
 
 exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf with nested oneOf 2`] = `
 {
@@ -795,24 +298,10 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf with nested oneOf 2
                             "hello": {
                               "type": "string",
                             },
-                            "results": {
-                              "items": {
-                                "oneOf": [
-                                  {
-                                    "type": "string",
-                                  },
-                                  {
-                                    "type": "number",
-                                  },
-                                ],
-                              },
-                              "type": "array",
-                            },
                           },
                           "required": [
                             "hello",
                             "goodbye",
-                            "results",
                           ],
                           "type": "object",
                         },
@@ -6827,169 +6316,7 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 undocumented response bod
 }
 `;
 
-exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf matching interaction 1`] = `
-[
-  {
-    "description": "update response body: add property name",
-    "diff": {
-      "description": "'name' is not documented",
-      "example": "me",
-      "instancePath": "/name",
-      "key": "name",
-      "keyword": "additionalProperties",
-      "kind": "AdditionalProperty",
-      "parentObjectPath": "/allOf/0/properties",
-      "propertyExamplePath": "/name",
-      "propertyPath": "/allOf/0/properties/name",
-    },
-    "groupedOperations": [
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/required/-",
-        "value": "name",
-      },
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/properties/name",
-        "value": {
-          "type": "string",
-        },
-      },
-    ],
-    "impact": [
-      "Addition",
-      "BackwardsCompatible",
-    ],
-    "interaction": {
-      "request": {
-        "body": null,
-        "headers": [],
-        "host": "localhost:3030",
-        "method": "post",
-        "path": "/api/animals",
-        "query": [],
-      },
-      "response": {
-        "body": {
-          "body": "{"status":"ok","name":"me","age":50}",
-          "contentType": "application/json",
-          "size": 36,
-        },
-        "headers": [],
-        "statusCode": "200",
-      },
-    },
-    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-  },
-  {
-    "description": "update response body: add property status",
-    "diff": {
-      "description": "'status' is not documented",
-      "example": "ok",
-      "instancePath": "/status",
-      "key": "status",
-      "keyword": "additionalProperties",
-      "kind": "AdditionalProperty",
-      "parentObjectPath": "/allOf/1/properties",
-      "propertyExamplePath": "/status",
-      "propertyPath": "/allOf/1/properties/status",
-    },
-    "groupedOperations": [
-      {
-        "extra": "same",
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/required",
-        "value": [
-          "status",
-        ],
-      },
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/properties/status",
-        "value": {
-          "type": "string",
-        },
-      },
-    ],
-    "impact": [
-      "Addition",
-      "BackwardsCompatible",
-    ],
-    "interaction": {
-      "request": {
-        "body": null,
-        "headers": [],
-        "host": "localhost:3030",
-        "method": "post",
-        "path": "/api/animals",
-        "query": [],
-      },
-      "response": {
-        "body": {
-          "body": "{"status":"ok","name":"me","age":50}",
-          "contentType": "application/json",
-          "size": 36,
-        },
-        "headers": [],
-        "statusCode": "200",
-      },
-    },
-    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-  },
-  {
-    "description": "update response body: add property age",
-    "diff": {
-      "description": "'age' is not documented",
-      "example": 50,
-      "instancePath": "/age",
-      "key": "age",
-      "keyword": "additionalProperties",
-      "kind": "AdditionalProperty",
-      "parentObjectPath": "/allOf/1/properties",
-      "propertyExamplePath": "/age",
-      "propertyPath": "/allOf/1/properties/age",
-    },
-    "groupedOperations": [
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/required/-",
-        "value": "age",
-      },
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/properties/age",
-        "value": {
-          "type": "number",
-        },
-      },
-    ],
-    "impact": [
-      "Addition",
-      "BackwardsCompatible",
-    ],
-    "interaction": {
-      "request": {
-        "body": null,
-        "headers": [],
-        "host": "localhost:3030",
-        "method": "post",
-        "path": "/api/animals",
-        "query": [],
-      },
-      "response": {
-        "body": {
-          "body": "{"status":"ok","name":"me","age":50}",
-          "contentType": "application/json",
-          "size": 36,
-        },
-        "headers": [],
-        "statusCode": "200",
-      },
-    },
-    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-  },
-]
-`;
+exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf matching interaction 1`] = `[]`;
 
 exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf matching interaction 2`] = `
 {
@@ -7009,35 +6336,21 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf matching interactio
                         "age": {
                           "type": "number",
                         },
-                        "name": {
-                          "type": "string",
-                        },
                         "status": {
                           "type": "string",
                         },
                       },
                       "required": [
                         "status",
-                        "name",
                       ],
                       "type": "object",
                     },
                     {
                       "properties": {
-                        "age": {
-                          "type": "number",
-                        },
                         "name": {
                           "type": "string",
                         },
-                        "status": {
-                          "type": "string",
-                        },
                       },
-                      "required": [
-                        "status",
-                        "age",
-                      ],
                       "type": "object",
                     },
                   ],
@@ -7052,221 +6365,7 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf matching interactio
 }
 `;
 
-exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf with extra keys in interaction 1`] = `
-[
-  {
-    "description": "update response body: add property name",
-    "diff": {
-      "description": "'name' is not documented",
-      "example": "me",
-      "instancePath": "/name",
-      "key": "name",
-      "keyword": "additionalProperties",
-      "kind": "AdditionalProperty",
-      "parentObjectPath": "/allOf/0/properties",
-      "propertyExamplePath": "/name",
-      "propertyPath": "/allOf/0/properties/name",
-    },
-    "groupedOperations": [
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/required/-",
-        "value": "name",
-      },
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/properties/name",
-        "value": {
-          "type": "string",
-        },
-      },
-    ],
-    "impact": [
-      "Addition",
-      "BackwardsCompatible",
-    ],
-    "interaction": {
-      "request": {
-        "body": null,
-        "headers": [],
-        "host": "localhost:3030",
-        "method": "post",
-        "path": "/api/animals",
-        "query": [],
-      },
-      "response": {
-        "body": {
-          "body": "{"status":"ok","name":"me","age":50}",
-          "contentType": "application/json",
-          "size": 36,
-        },
-        "headers": [],
-        "statusCode": "200",
-      },
-    },
-    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-  },
-  {
-    "description": "update response body: add property age",
-    "diff": {
-      "description": "'age' is not documented",
-      "example": 50,
-      "instancePath": "/age",
-      "key": "age",
-      "keyword": "additionalProperties",
-      "kind": "AdditionalProperty",
-      "parentObjectPath": "/allOf/0/properties",
-      "propertyExamplePath": "/age",
-      "propertyPath": "/allOf/0/properties/age",
-    },
-    "groupedOperations": [
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/required/-",
-        "value": "age",
-      },
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/properties/age",
-        "value": {
-          "type": "number",
-        },
-      },
-    ],
-    "impact": [
-      "Addition",
-      "BackwardsCompatible",
-    ],
-    "interaction": {
-      "request": {
-        "body": null,
-        "headers": [],
-        "host": "localhost:3030",
-        "method": "post",
-        "path": "/api/animals",
-        "query": [],
-      },
-      "response": {
-        "body": {
-          "body": "{"status":"ok","name":"me","age":50}",
-          "contentType": "application/json",
-          "size": 36,
-        },
-        "headers": [],
-        "statusCode": "200",
-      },
-    },
-    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-  },
-  {
-    "description": "update response body: add property status",
-    "diff": {
-      "description": "'status' is not documented",
-      "example": "ok",
-      "instancePath": "/status",
-      "key": "status",
-      "keyword": "additionalProperties",
-      "kind": "AdditionalProperty",
-      "parentObjectPath": "/allOf/1/properties",
-      "propertyExamplePath": "/status",
-      "propertyPath": "/allOf/1/properties/status",
-    },
-    "groupedOperations": [
-      {
-        "extra": "same",
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/required",
-        "value": [
-          "status",
-        ],
-      },
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/properties/status",
-        "value": {
-          "type": "string",
-        },
-      },
-    ],
-    "impact": [
-      "Addition",
-      "BackwardsCompatible",
-    ],
-    "interaction": {
-      "request": {
-        "body": null,
-        "headers": [],
-        "host": "localhost:3030",
-        "method": "post",
-        "path": "/api/animals",
-        "query": [],
-      },
-      "response": {
-        "body": {
-          "body": "{"status":"ok","name":"me","age":50}",
-          "contentType": "application/json",
-          "size": 36,
-        },
-        "headers": [],
-        "statusCode": "200",
-      },
-    },
-    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-  },
-  {
-    "description": "update response body: add property age",
-    "diff": {
-      "description": "'age' is not documented",
-      "example": 50,
-      "instancePath": "/age",
-      "key": "age",
-      "keyword": "additionalProperties",
-      "kind": "AdditionalProperty",
-      "parentObjectPath": "/allOf/1/properties",
-      "propertyExamplePath": "/age",
-      "propertyPath": "/allOf/1/properties/age",
-    },
-    "groupedOperations": [
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/required/-",
-        "value": "age",
-      },
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/properties/age",
-        "value": {
-          "type": "number",
-        },
-      },
-    ],
-    "impact": [
-      "Addition",
-      "BackwardsCompatible",
-    ],
-    "interaction": {
-      "request": {
-        "body": null,
-        "headers": [],
-        "host": "localhost:3030",
-        "method": "post",
-        "path": "/api/animals",
-        "query": [],
-      },
-      "response": {
-        "body": {
-          "body": "{"status":"ok","name":"me","age":50}",
-          "contentType": "application/json",
-          "size": 36,
-        },
-        "headers": [],
-        "statusCode": "200",
-      },
-    },
-    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-  },
-]
-`;
+exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf with extra keys in interaction 1`] = `[]`;
 
 exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf with extra keys in interaction 2`] = `
 {
@@ -7283,39 +6382,21 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf with extra keys in 
                   "allOf": [
                     {
                       "properties": {
-                        "age": {
-                          "type": "number",
-                        },
-                        "name": {
-                          "type": "string",
-                        },
                         "status": {
                           "type": "string",
                         },
                       },
                       "required": [
                         "status",
-                        "name",
-                        "age",
                       ],
                       "type": "object",
                     },
                     {
                       "properties": {
-                        "age": {
-                          "type": "number",
-                        },
                         "name": {
                           "type": "string",
                         },
-                        "status": {
-                          "type": "string",
-                        },
                       },
-                      "required": [
-                        "status",
-                        "age",
-                      ],
                       "type": "object",
                     },
                   ],
@@ -7375,58 +6456,6 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf with missing keys i
     },
     "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
   },
-  {
-    "description": "update response body: add property status",
-    "diff": {
-      "description": "'status' is not documented",
-      "example": "ok",
-      "instancePath": "/status",
-      "key": "status",
-      "keyword": "additionalProperties",
-      "kind": "AdditionalProperty",
-      "parentObjectPath": "/allOf/1/properties",
-      "propertyExamplePath": "/status",
-      "propertyPath": "/allOf/1/properties/status",
-    },
-    "groupedOperations": [
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/required/-",
-        "value": "status",
-      },
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/1/properties/status",
-        "value": {
-          "type": "string",
-        },
-      },
-    ],
-    "impact": [
-      "Addition",
-      "BackwardsCompatible",
-    ],
-    "interaction": {
-      "request": {
-        "body": null,
-        "headers": [],
-        "host": "localhost:3030",
-        "method": "post",
-        "path": "/api/animals",
-        "query": [],
-      },
-      "response": {
-        "body": {
-          "body": "{"status":"ok"}",
-          "contentType": "application/json",
-          "size": 15,
-        },
-        "headers": [],
-        "statusCode": "200",
-      },
-    },
-    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-  },
 ]
 `;
 
@@ -7459,13 +6488,8 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf with missing keys i
                         "name": {
                           "type": "string",
                         },
-                        "status": {
-                          "type": "string",
-                        },
                       },
-                      "required": [
-                        "status",
-                      ],
+                      "required": [],
                       "type": "object",
                     },
                   ],
@@ -7480,124 +6504,7 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf with missing keys i
 }
 `;
 
-exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf with nested oneOf 1`] = `
-[
-  {
-    "description": "update response body: add property results",
-    "diff": {
-      "description": "'results' is not documented",
-      "example": [
-        "123",
-        "355",
-        34,
-      ],
-      "instancePath": "/results",
-      "key": "results",
-      "keyword": "additionalProperties",
-      "kind": "AdditionalProperty",
-      "parentObjectPath": "/allOf/0/oneOf/0/properties",
-      "propertyExamplePath": "/results",
-      "propertyPath": "/allOf/0/oneOf/0/properties/results",
-    },
-    "groupedOperations": [
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/oneOf/0/required/-",
-        "value": "results",
-      },
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/oneOf/0/properties/results",
-        "value": {
-          "items": {
-            "type": "string",
-          },
-          "type": "array",
-        },
-      },
-    ],
-    "impact": [
-      "Addition",
-      "BackwardsCompatible",
-    ],
-    "interaction": {
-      "request": {
-        "body": null,
-        "headers": [],
-        "host": "localhost:3030",
-        "method": "post",
-        "path": "/api/animals",
-        "query": [],
-      },
-      "response": {
-        "body": {
-          "body": "{"hello":"ok","goodbye":"me","results":["123","355",34]}",
-          "contentType": "application/json",
-          "size": 56,
-        },
-        "headers": [],
-        "statusCode": "200",
-      },
-    },
-    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-  },
-  {
-    "description": "update response body: make items oneOf",
-    "diff": {
-      "description": "'items' did not match schema",
-      "example": 34,
-      "expectedType": "string",
-      "instancePath": "/results/2",
-      "key": "items",
-      "keyword": "type",
-      "kind": "UnmatchedType",
-      "propertyPath": "/allOf/0/oneOf/0/properties/results/items",
-    },
-    "groupedOperations": [
-      {
-        "op": "remove",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/oneOf/0/properties/results/items/type",
-      },
-      {
-        "op": "add",
-        "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema/allOf/0/oneOf/0/properties/results/items/oneOf",
-        "value": [
-          {
-            "type": "string",
-          },
-          {
-            "type": "number",
-          },
-        ],
-      },
-    ],
-    "impact": [
-      "Addition",
-      "BackwardsIncompatible",
-    ],
-    "interaction": {
-      "request": {
-        "body": null,
-        "headers": [],
-        "host": "localhost:3030",
-        "method": "post",
-        "path": "/api/animals",
-        "query": [],
-      },
-      "response": {
-        "body": {
-          "body": "{"hello":"ok","goodbye":"me","results":["123","355",34]}",
-          "contentType": "application/json",
-          "size": 56,
-        },
-        "headers": [],
-        "statusCode": "200",
-      },
-    },
-    "path": "/paths/~1api~1animals/post/responses/200/content/application~1json/schema",
-  },
-]
-`;
+exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf with nested oneOf 1`] = `[]`;
 
 exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf with nested oneOf 2`] = `
 {
@@ -7622,24 +6529,10 @@ exports[`generateEndpointSpecPatches OAS version 3.1.0 allOf with nested oneOf 2
                             "hello": {
                               "type": "string",
                             },
-                            "results": {
-                              "items": {
-                                "oneOf": [
-                                  {
-                                    "type": "string",
-                                  },
-                                  {
-                                    "type": "number",
-                                  },
-                                ],
-                              },
-                              "type": "array",
-                            },
                           },
                           "required": [
                             "hello",
                             "goodbye",
-                            "results",
                           ],
                           "type": "object",
                         },

--- a/projects/optic/src/commands/capture/patches/__tests__/patches.test.ts
+++ b/projects/optic/src/commands/capture/patches/__tests__/patches.test.ts
@@ -632,8 +632,64 @@ describe('generateEndpointSpecPatches', () => {
       expect(specHolder.spec).toMatchSnapshot();
     });
 
+    test('3.0.x exclusiveMaximum and exclusiveMinimum booleans', async () => {
+      if (version !== '3.0.1') return;
+      specHolder.spec.paths['/api/animals'].post.responses = {
+        '200': {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  data: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      properties: {
+                        no: {
+                          type: 'number',
+                          maximum: 20,
+                          exclusiveMaximum: true,
+                          minumum: 10,
+                          exclusiveMinumum: true,
+                        },
+                      },
+                      required: ['no'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const interaction = makeInteraction(
+        { method: OpenAPIV3.HttpMethods.POST, path: '/api/animals' },
+        {
+          responseBody: {
+            data: [{ no: 10 }, { no: 20 }],
+          },
+        }
+      );
+
+      const patches = await AT.collect(
+        generateEndpointSpecPatches(
+          GenerateInteractions([interaction]),
+          specHolder,
+          {
+            method: 'post',
+            path: '/api/animals',
+          }
+        )
+      );
+
+      expect(patches).toMatchSnapshot();
+      expect(specHolder.spec).toMatchSnapshot();
+    });
+
     describe('allOf', () => {
-      test.only('matching interaction', async () => {
+      test('matching interaction', async () => {
         specHolder.spec.paths['/api/animals'].post.responses = {
           '200': {
             content: {

--- a/projects/optic/src/commands/capture/patches/__tests__/patches.test.ts
+++ b/projects/optic/src/commands/capture/patches/__tests__/patches.test.ts
@@ -767,6 +767,10 @@ describe('generateEndpointSpecPatches', () => {
                         name: {
                           type: 'string',
                         },
+                        asda: {
+                          type: 'object',
+                          properties: {},
+                        },
                       },
                     },
                   ],
@@ -779,7 +783,76 @@ describe('generateEndpointSpecPatches', () => {
         const interaction = makeInteraction(
           { method: OpenAPIV3.HttpMethods.POST, path: '/api/animals' },
           {
-            responseBody: { status: 'ok', name: 'me', age: 50 },
+            responseBody: {
+              status: 'ok',
+              name: 'me',
+              age: 50,
+              asda: { as: 12 },
+            },
+          }
+        );
+
+        const patches = await AT.collect(
+          generateEndpointSpecPatches(
+            GenerateInteractions([interaction]),
+            specHolder,
+            {
+              method: 'post',
+              path: '/api/animals',
+            }
+          )
+        );
+
+        expect(patches).toMatchSnapshot();
+        expect(specHolder.spec).toMatchSnapshot();
+      });
+
+      test('allOf in a property', async () => {
+        specHolder.spec.paths['/api/animals'].post.responses = {
+          '200': {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    data: {
+                      allOf: [
+                        {
+                          type: 'object',
+                          properties: {
+                            status: {
+                              type: 'string',
+                            },
+                          },
+                          required: ['status'],
+                        },
+                        {
+                          type: 'object',
+                          properties: {
+                            name: {
+                              type: 'string',
+                            },
+                            asda: {
+                              type: 'object',
+                              properties: {},
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        };
+
+        const interaction = makeInteraction(
+          { method: OpenAPIV3.HttpMethods.POST, path: '/api/animals' },
+          {
+            responseBody: {
+              data: { status: 'ok', name: 'me', age: 50, asda: { as: 12 } },
+            },
           }
         );
 

--- a/projects/optic/src/commands/capture/patches/__tests__/patches.test.ts
+++ b/projects/optic/src/commands/capture/patches/__tests__/patches.test.ts
@@ -633,6 +633,62 @@ describe('generateEndpointSpecPatches', () => {
     });
 
     describe('allOf', () => {
+      test.only('matching interaction', async () => {
+        specHolder.spec.paths['/api/animals'].post.responses = {
+          '200': {
+            content: {
+              'application/json': {
+                schema: {
+                  allOf: [
+                    {
+                      type: 'object',
+                      properties: {
+                        status: {
+                          type: 'string',
+                        },
+                        age: {
+                          type: 'number',
+                        },
+                      },
+                      required: ['status'],
+                    },
+                    {
+                      type: 'object',
+                      properties: {
+                        name: {
+                          type: 'string',
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        };
+
+        const interaction = makeInteraction(
+          { method: OpenAPIV3.HttpMethods.POST, path: '/api/animals' },
+          {
+            responseBody: { status: 'ok', name: 'me', age: 50 },
+          }
+        );
+
+        const patches = await AT.collect(
+          generateEndpointSpecPatches(
+            GenerateInteractions([interaction]),
+            specHolder,
+            {
+              method: 'post',
+              path: '/api/animals',
+            }
+          )
+        );
+
+        expect(patches).toMatchSnapshot();
+        expect(specHolder.spec).toMatchSnapshot();
+      });
+
       test('with extra keys in interaction', async () => {
         specHolder.spec.paths['/api/animals'].post.responses = {
           '200': {

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/diff.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/diff.ts
@@ -197,6 +197,7 @@ export class ShapeDiffTraverser {
     let oneOfBranchOther: [string, ErrorObject][] = [];
 
     for (let validationError of validationErrors) {
+      console.log(validationError);
       if (validationError.keyword === JsonSchemaKnownKeyword.oneOf) {
         let schemaPath = validationError.schemaPath.substring(1); // valid json pointer
         oneOfs.set(schemaPath, validationError);

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/unevaluatedProperties.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/unevaluatedProperties.ts
@@ -1,0 +1,96 @@
+import { SchemaObject } from '../schema';
+import {
+  JsonSchemaKnownKeyword,
+  ErrorObject,
+  ShapeDiffResult,
+  ShapeDiffResultKind,
+  UnpatchableDiff,
+} from '../diff';
+import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
+import { CapturedInteraction } from '../../../../sources/captured-interactions';
+import { OAS3 } from '@useoptic/openapi-utilities';
+
+export function* unevaluatedPropertiesDiffs(
+  validationError: ErrorObject,
+  example: any,
+  {
+    specJsonPath,
+    interaction,
+    schema,
+  }: {
+    specJsonPath: string;
+    interaction: CapturedInteraction;
+    schema: SchemaObject;
+  }
+): IterableIterator<ShapeDiffResult | UnpatchableDiff> {
+  if (validationError.keyword !== JsonSchemaKnownKeyword.unevaluatedProperties)
+    return;
+  const key = validationError.params.unevaluatedProperty;
+  const instancePath = jsonPointerHelpers.append(
+    validationError.instancePath,
+    key
+  );
+  const propertyExamplePath = jsonPointerHelpers.append(
+    validationError.instancePath,
+    key
+  );
+
+  const parts = jsonPointerHelpers.decode(
+    validationError.schemaPath.substring(1)
+  );
+  parts.pop();
+  const baseSchemaPath = jsonPointerHelpers.compile(parts);
+  const baseSchema = jsonPointerHelpers.tryGet(schema, baseSchemaPath);
+  let pathToAllofVariant: string | null = null;
+  if (baseSchema.match && baseSchema.value.allOf) {
+    const allOfVariants = baseSchema.value.allOf;
+    // TODO in the future we can use a more complicated heuristic to choose which allOf variant is most relevant
+    const allOfIdx = allOfVariants.findIndex((schema) =>
+      OAS3.isObjectType(schema.type)
+    );
+    if (allOfIdx > -1) {
+      pathToAllofVariant = jsonPointerHelpers.compile([
+        'allOf',
+        String(allOfIdx),
+        'properties',
+      ]);
+    }
+  }
+
+  if (!pathToAllofVariant) {
+    // This could happen if the allOf variant has a primitive type - in this case we surface that this is unpatchable and let the user resolve this
+    const schemaPath = validationError.schemaPath.substring(1);
+    yield {
+      validationError,
+      example: jsonPointerHelpers.get(example, validationError.instancePath),
+      unpatchable: true,
+      interaction,
+      bodyPath: specJsonPath,
+      schemaPath,
+      path: jsonPointerHelpers.append(
+        specJsonPath,
+        'schema',
+        ...jsonPointerHelpers.decode(schemaPath)
+      ),
+    };
+    return;
+  }
+
+  const parentObjectPath = jsonPointerHelpers.join(
+    baseSchemaPath,
+    pathToAllofVariant
+  );
+  const propertyPath = jsonPointerHelpers.append(parentObjectPath, key);
+
+  yield {
+    description: `'${key}' is not documented`,
+    kind: ShapeDiffResultKind.AdditionalProperty,
+    keyword: JsonSchemaKnownKeyword.additionalProperties,
+    example: jsonPointerHelpers.get(example, instancePath),
+    propertyPath,
+    instancePath,
+    parentObjectPath,
+    propertyExamplePath,
+    key,
+  };
+}

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/unevaluatedProperties.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/unevaluatedProperties.ts
@@ -59,6 +59,7 @@ export function* unevaluatedPropertiesDiffs(
 
   if (!pathToAllofVariant) {
     // This could happen if the allOf variant has a primitive type - in this case we surface that this is unpatchable and let the user resolve this
+    // Or if a user sets unevalutedProperties to their schema, we don't know how to handle if unless there's an allOf
     const schemaPath = validationError.schemaPath.substring(1);
     yield {
       validationError,

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.15",
+  "version": "0.53.16-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -40,5 +40,6 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
-  }
+  },
+  "stableVersion": "0.53.15"
 }

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.16-0",
+  "version": "0.53.16",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -40,6 +40,5 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
-  },
-  "stableVersion": "0.53.15"
+  }
 }

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.15",
+  "version": "0.53.16-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -45,5 +45,6 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
-  }
+  },
+  "stableVersion": "0.53.15"
 }

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.16-0",
+  "version": "0.53.16",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -45,6 +45,5 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
-  },
-  "stableVersion": "0.53.15"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2687,53 +2687,53 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry-internal/tracing@npm:7.89.0":
-  version: 7.89.0
-  resolution: "@sentry-internal/tracing@npm:7.89.0"
+"@sentry-internal/tracing@npm:7.90.0":
+  version: 7.90.0
+  resolution: "@sentry-internal/tracing@npm:7.90.0"
   dependencies:
-    "@sentry/core": "npm:7.89.0"
-    "@sentry/types": "npm:7.89.0"
-    "@sentry/utils": "npm:7.89.0"
-  checksum: 4f90dd6163b69464f26da1f8a489033a166cb6be76af7c7d6e1c19753a79ac6870486dd08ff6f0bb8d2f9039092862e99e8ce7c035504029281ea8c2e254e012
+    "@sentry/core": "npm:7.90.0"
+    "@sentry/types": "npm:7.90.0"
+    "@sentry/utils": "npm:7.90.0"
+  checksum: ab686bfd9ad22797b305c9077f5b932e2d7c4e2ef94805ba5ba0cdb42d9893a7c4a2a14acec511b8688019bb6d113de5afc1d82cf71579ae0313514609025cb8
   languageName: node
   linkType: hard
 
-"@sentry/core@npm:7.89.0":
-  version: 7.89.0
-  resolution: "@sentry/core@npm:7.89.0"
+"@sentry/core@npm:7.90.0":
+  version: 7.90.0
+  resolution: "@sentry/core@npm:7.90.0"
   dependencies:
-    "@sentry/types": "npm:7.89.0"
-    "@sentry/utils": "npm:7.89.0"
-  checksum: 1da6ce0f455d5ea720b089aa8a8b7d27ac09f9ecdd5d2af2e7faea530f28997f56001fca23433060bd2c8ad282bbfbdb50f73ccfa9cf62aa1e9ccf87cff8ccc7
+    "@sentry/types": "npm:7.90.0"
+    "@sentry/utils": "npm:7.90.0"
+  checksum: 57b8c81ac953ecf88ab78b9b981f34f7168c3d7241eb6099d3d66768ae3eb1a93cdf2bac2824447246fd53f367fb9f1553afc01503b9ac58b3f64ef307c50a08
   languageName: node
   linkType: hard
 
 "@sentry/node@npm:^7.74.0":
-  version: 7.89.0
-  resolution: "@sentry/node@npm:7.89.0"
+  version: 7.90.0
+  resolution: "@sentry/node@npm:7.90.0"
   dependencies:
-    "@sentry-internal/tracing": "npm:7.89.0"
-    "@sentry/core": "npm:7.89.0"
-    "@sentry/types": "npm:7.89.0"
-    "@sentry/utils": "npm:7.89.0"
+    "@sentry-internal/tracing": "npm:7.90.0"
+    "@sentry/core": "npm:7.90.0"
+    "@sentry/types": "npm:7.90.0"
+    "@sentry/utils": "npm:7.90.0"
     https-proxy-agent: "npm:^5.0.0"
-  checksum: b4f53ba3254d2511ebb33c95456ed721375ab2da485e3d5412acf81ff83865ed4c85e11127b75b80344f849257b1a19dfb625f3bac65988ed8e18d1700fa3f41
+  checksum: a92db05df470260ba8d7ea8cbb22b052e8f4743be8d80e20896abc656c4d1fe5565743010e13b8a373acfad8018ab9b691ba15e24691591c3a175f478be4c4e9
   languageName: node
   linkType: hard
 
-"@sentry/types@npm:7.89.0":
-  version: 7.89.0
-  resolution: "@sentry/types@npm:7.89.0"
-  checksum: 62317ca03dcdfdb7708b41c3928e1d4f62f4fd269c7809e0ff391de5d135ecc50d13ca94bd5202aac075157e1eb20c1ad2f34221ea74885d5540ba3f96dcc692
+"@sentry/types@npm:7.90.0":
+  version: 7.90.0
+  resolution: "@sentry/types@npm:7.90.0"
+  checksum: 6a3ea0dba33eb832845033cd345764689fc5a74f9b6a3f65ebed687250b4e177113eac8ecfc7b2f1299acddf77efa60470d0ff032780a6a5d63e3e771b2390e4
   languageName: node
   linkType: hard
 
-"@sentry/utils@npm:7.89.0":
-  version: 7.89.0
-  resolution: "@sentry/utils@npm:7.89.0"
+"@sentry/utils@npm:7.90.0":
+  version: 7.90.0
+  resolution: "@sentry/utils@npm:7.90.0"
   dependencies:
-    "@sentry/types": "npm:7.89.0"
-  checksum: d64bd06de707f7387ddb24d0e94653b543e482cd9c8f4a5ff3bc0646545f37a8bce57e1d4cc0dd6a273d7b5867fce9c7e19bf969f073ceea2b18692ae16ea943
+    "@sentry/types": "npm:7.90.0"
+  checksum: 2eb167cf68e4b94ae320503e7b834bfebb5bcdc4281a7b315746d765e0c6e6cbed1c93c3bfa6d6a467d6a33b01d0bb438f596a8122cef5934dc92afe4e82351e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Previously, allOf patches didn't work - this was because we were applying `additionalProperties: false` to every variant of allOf, meaning that they failed. What we needed was unevaluatedProperties which is only available in draft2019+. We want to set `unevaluatedProperties` on `allOf`, and additionalProperties: true to every allOf's direct children

This also means draft4 evaluation doesnt work - not really sure how this would work with OAS3, but the case we do know about we can handle
- exclusiveMaximum + exclusiveMinimum are boolean -> we convert to max / min with +-1 offset



## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
