### PR TITLE
Revert "fix polymoprhic with nullable patching (#2636)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.53.17",
+  "version": "0.53.18",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/fastify-capture/package.json
+++ b/projects/fastify-capture/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/fastify-capture",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.17",
+  "version": "0.53.18",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.17",
+  "version": "0.53.18",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.17",
+  "version": "0.53.18",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.17",
+  "version": "0.53.18",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.17",
+  "version": "0.53.18",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/src/commands/capture/patches/__tests__/__snapshots__/patches.test.ts.snap
+++ b/projects/optic/src/commands/capture/patches/__tests__/__snapshots__/patches.test.ts.snap
@@ -751,57 +751,6 @@ exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf with nested oneOf 2
 }
 `;
 
-exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf with nullable 1`] = `[]`;
-
-exports[`generateEndpointSpecPatches OAS version 3.0.1 allOf with nullable 2`] = `
-{
-  "info": {},
-  "openapi": "3.0.1",
-  "paths": {
-    "/api/animals": {
-      "post": {
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "key": {
-                      "allOf": [
-                        {
-                          "properties": {
-                            "goodbye": {
-                              "type": "string",
-                            },
-                            "hello": {
-                              "type": "string",
-                            },
-                          },
-                          "required": [
-                            "hello",
-                            "goodbye",
-                          ],
-                          "type": "object",
-                        },
-                      ],
-                      "nullable": true,
-                    },
-                  },
-                  "required": [
-                    "key",
-                  ],
-                  "type": "object",
-                },
-              },
-            },
-          },
-        },
-      },
-    },
-  },
-}
-`;
-
 exports[`generateEndpointSpecPatches OAS version 3.0.1 array with multiple items 1`] = `
 [
   {

--- a/projects/optic/src/commands/capture/patches/__tests__/patches.test.ts
+++ b/projects/optic/src/commands/capture/patches/__tests__/patches.test.ts
@@ -980,65 +980,6 @@ describe('generateEndpointSpecPatches', () => {
         expect(patches).toMatchSnapshot();
         expect(specHolder.spec).toMatchSnapshot();
       });
-
-      test('with nullable', async () => {
-        // nullable keyword only valid in 3.0.1
-        if (version !== '3.0.1') return;
-        specHolder.spec.paths['/api/animals'].post.responses = {
-          '200': {
-            content: {
-              'application/json': {
-                schema: {
-                  type: 'object',
-                  required: ['key'],
-                  properties: {
-                    key: {
-                      nullable: true,
-                      allOf: [
-                        {
-                          type: 'object',
-                          properties: {
-                            hello: {
-                              type: 'string',
-                            },
-                            goodbye: {
-                              type: 'string',
-                            },
-                          },
-                          required: ['hello', 'goodbye'],
-                        },
-                      ],
-                    },
-                  },
-                },
-              },
-            },
-          },
-        };
-
-        const interaction = makeInteraction(
-          { method: OpenAPIV3.HttpMethods.POST, path: '/api/animals' },
-          {
-            responseBody: {
-              key: null,
-            },
-          }
-        );
-
-        const patches = await AT.collect(
-          generateEndpointSpecPatches(
-            GenerateInteractions([interaction]),
-            specHolder,
-            {
-              method: 'post',
-              path: '/api/animals',
-            }
-          )
-        );
-
-        expect(patches).toMatchSnapshot();
-        expect(specHolder.spec).toMatchSnapshot();
-      });
     });
 
     describe.each([['query'], ['header']])('%s parameter', (location) => {

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/diff.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/diff.ts
@@ -321,8 +321,10 @@ function prepareSchemaForDiff(input: SchemaObject): SchemaObject {
 
       // Fix case where nullable is set and there is no type key
       if (!schema.type && schema.nullable) {
-        // if polymorphic, this could also be nullable
-        if (!(schema.oneOf || schema.anyOf || schema.allOf)) {
+        if (schema.oneOf || schema.anyOf || schema.allOf) {
+          // in the polymorphic case we have to remove nullable, since type will override and you cannot use
+          delete schema.nullable;
+        } else {
           // We set this to string since we're not sure what the actual type is; this should be fine for us since we'll use this schema for diffing purposes and update
           schema.type = 'string';
         }

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.17",
+  "version": "0.53.18",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.17",
+  "version": "0.53.18",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
This reverts commit 2849178872145d8e1b3bdfdc1f7bd304a6722d97.

## 🍗 Description
_What does this PR do? Anything folks should know?_

reverts pr to support nullable - for some reason my test that i wrote didn't trigger the failing path, but running it with that schema in the full capture flow triggers this error 
```
  stack: 'Error: Error compiling schema: "nullable" cannot be used without "type"\n' +
...
```

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
