### PR TITLE
downgrade typebox

### DIFF
--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -61,7 +61,7 @@
     "@octokit/rest": "^19.0.0",
     "@segment/analytics-node": "^1.1.3",
     "@sentry/node": "^7.74.0",
-    "@sinclair/typebox": "^0.32.0",
+    "@sinclair/typebox": "0.31.28",
     "@stoplight/spectral-core": "^1.8.1",
     "@useoptic/openapi-io": "workspace:*",
     "@useoptic/openapi-utilities": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2737,6 +2737,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sinclair/typebox@npm:0.31.28":
+  version: 0.31.28
+  resolution: "@sinclair/typebox@npm:0.31.28"
+  checksum: b3125e370e040738cc42c1ca5210bab44cdfc220b156ccd876f5fa1697ff6fe3ea110190c135e268e41d203d6481750b350add33e79b9874da68dc3a4d601f5a
+  languageName: node
+  linkType: hard
+
 "@sinclair/typebox@npm:^0.24.1":
   version: 0.24.51
   resolution: "@sinclair/typebox@npm:0.24.51"
@@ -2748,13 +2755,6 @@ __metadata:
   version: 0.27.8
   resolution: "@sinclair/typebox@npm:0.27.8"
   checksum: ef6351ae073c45c2ac89494dbb3e1f87cc60a93ce4cde797b782812b6f97da0d620ae81973f104b43c9b7eaa789ad20ba4f6a1359f1cc62f63729a55a7d22d4e
-  languageName: node
-  linkType: hard
-
-"@sinclair/typebox@npm:^0.32.0":
-  version: 0.32.4
-  resolution: "@sinclair/typebox@npm:0.32.4"
-  checksum: b9811f798441b8ffa2468a40ddb040ceb473a3ca9a5aaeadf8632e6c7bd8b8544178c56ba44d039e9933ee18b6b5f09e4b53de0b644ad65231cb1b2344ca7e56
   languageName: node
   linkType: hard
 
@@ -3764,7 +3764,7 @@ __metadata:
     "@octokit/rest": "npm:^19.0.0"
     "@segment/analytics-node": "npm:^1.1.3"
     "@sentry/node": "npm:^7.74.0"
-    "@sinclair/typebox": "npm:^0.32.0"
+    "@sinclair/typebox": "npm:0.31.28"
     "@stoplight/spectral-core": "npm:^1.8.1"
     "@types/babel__core": "npm:^7"
     "@types/babel__preset-env": "npm:^7"


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

The binary build was broken because `0.32.0` typebox uses the `exports` field in package.json to build support for ESM, but `pkg` does not respect it https://github.com/vercel/pkg/issues/1873

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
