### PR TITLE
Handle spaces in file path for capture

### DIFF
--- a/projects/openapi-io/src/parser/sourcemap.ts
+++ b/projects/openapi-io/src/parser/sourcemap.ts
@@ -79,17 +79,19 @@ export class JsonSchemaSourcemap {
   }
 
   logPointer(pathRelativeToFile: string, pathRelativeToRoot: string) {
+    const relativePathDecoded =
+      jsonPointerHelpers.unescapeUriSafePointer(pathRelativeToFile);
+    const rootKey = jsonPointerHelpers.unescapeUriSafePointer(
+      pathRelativeToRoot.substring(1)
+    );
+
     const thisFile = this.files.find((i) =>
-      pathRelativeToFile.startsWith(i.path)
+      relativePathDecoded.startsWith(i.path)
     );
 
     if (thisFile) {
-      const rootKey = jsonPointerHelpers.unescapeUriSafePointer(
-        pathRelativeToRoot.substring(1)
-      );
-
       const jsonPointer = jsonPointerHelpers.unescapeUriSafePointer(
-        pathRelativeToFile.split(thisFile.path)[1].substring(1) || '/'
+        relativePathDecoded.split(thisFile.path)[1].substring(1) || '/'
       );
 
       if (rootKey === jsonPointer) return;

--- a/projects/openapi-utilities/src/openapi3/implementations/openapi3/sourcemap-reader.ts
+++ b/projects/openapi-utilities/src/openapi3/implementations/openapi3/sourcemap-reader.ts
@@ -115,8 +115,6 @@ export function sourcemapReader(sourcemap: SerializedSourcemap) {
       } else {
         cursor.pathInCurrentFile.push(component);
       }
-
-      // console.log(cursor);
     });
 
     const file = sourcemap.files.find((i) => i.index === cursor.currentFile)!;

--- a/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
@@ -1726,6 +1726,71 @@ exports[`capture with requests update behavior handles update in other file 3`] 
 "
 `;
 
+exports[`capture with requests update behavior handles update in other file with spaces 1`] = `
+"Generating traffic to send to server
+GET /books
+  [32m✓ [39m200 response
+  [32m[200 response body] 'name' has been added (/properties/books/items/properties/name)[39m
+  [32m[200 response body] 'author_id' has been added (/properties/books/items/properties/author_id)[39m
+  [32m[200 response body] 'status' has been added (/properties/books/items/properties/status)[39m
+  [32m[200 response body] 'price' has been added (/properties/books/items/properties/price)[39m
+  [32m[200 response body] 'created_at' has been added (/properties/books/items/properties/created_at)[39m
+  [32m[200 response body] 'updated_at' has been added (/properties/books/items/properties/updated_at)[39m
+"
+`;
+
+exports[`capture with requests update behavior handles update in other file with spaces 2`] = `
+"openapi: 3.0.3
+info:
+  title: a spec
+  description: The API
+  version: 0.1.0
+paths:
+  /books:
+    get:
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                $ref: ./with space/books.yml#/GetBooks200ResponseBody
+"
+`;
+
+exports[`capture with requests update behavior handles update in other file with spaces 3`] = `
+"GetBooks200ResponseBody:
+  type: object
+  properties:
+    books:
+      type: array
+      items:
+        type: object
+        properties:
+          id:
+            type: string
+          name:
+            type: string
+          author_id:
+            type: string
+          status:
+            type: string
+          price:
+            type: number
+          created_at:
+            type: string
+          updated_at:
+            type: string
+        required:
+          - name
+          - author_id
+          - status
+          - price
+          - created_at
+          - updated_at
+"
+`;
+
 exports[`capture with requests update behavior respects x-optic-path-ignore 1`] = `
 "Generating traffic to send to server
 GET /authors

--- a/projects/optic/src/__tests__/integration/capture.test.ts
+++ b/projects/optic/src/__tests__/integration/capture.test.ts
@@ -216,6 +216,30 @@ describe('capture with requests', () => {
         )
       ).toMatchSnapshot();
     });
+
+    test('handles update in other file with spaces', async () => {
+      const workspace = await setupWorkspace('capture/with-server');
+      await setPortInFile(workspace, 'optic.yml');
+
+      const { combined, code } = await runOptic(
+        workspace,
+        'capture openapi-with-external-ref-spaces.yml --update'
+      );
+      expect(normalizeWorkspace(workspace, combined)).toMatchSnapshot();
+      expect(code).toBe(0);
+      expect(
+        await fs.readFile(
+          path.join(workspace, 'openapi-with-external-ref-spaces.yml'),
+          'utf-8'
+        )
+      ).toMatchSnapshot();
+      expect(
+        await fs.readFile(
+          path.join(workspace, './with space/books.yml'),
+          'utf-8'
+        )
+      ).toMatchSnapshot();
+    });
   });
 });
 

--- a/projects/optic/src/__tests__/integration/workspaces/capture/with-server/openapi-with-external-ref-spaces.yml
+++ b/projects/optic/src/__tests__/integration/workspaces/capture/with-server/openapi-with-external-ref-spaces.yml
@@ -1,0 +1,15 @@
+openapi: 3.0.3
+info:
+  title: a spec
+  description: The API
+  version: 0.1.0
+paths:
+  /books:
+    get:
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                $ref: ./with space/books.yml#/GetBooks200ResponseBody

--- a/projects/optic/src/__tests__/integration/workspaces/capture/with-server/optic.yml
+++ b/projects/optic/src/__tests__/integration/workspaces/capture/with-server/optic.yml
@@ -98,6 +98,16 @@ capture:
       send:
         - path: /books
           method: GET
+  openapi-with-external-ref-spaces.yml:
+    server:
+      command: node server.js
+      url: http://localhost:%PORT
+      ready_endpoint: /healthcheck
+      ready_timeout: 5000
+    requests:
+      send:
+        - path: /books
+          method: GET
   openapi-with-server-prefix.yml:
     server:
       command: node server.js

--- a/projects/optic/src/__tests__/integration/workspaces/capture/with-server/with space/books.yml
+++ b/projects/optic/src/__tests__/integration/workspaces/capture/with-server/with space/books.yml
@@ -1,0 +1,10 @@
+GetBooks200ResponseBody:
+  type: object
+  properties:
+    books:
+      type: array
+      items:
+        type: object
+        properties:
+          id:
+            type: string


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Capture fails if there is spaces anywhere in the file path - e.g. `~/some folder with spaces/openapi.yml` - our traverser emits URI encoded paths, and our sourcemap expects non-URI encoded paths

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
