### PR TITLE
Add form support to `capture`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.53.20",
+  "version": "0.53.21",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/fastify-capture/package.json
+++ b/projects/fastify-capture/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/fastify-capture",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.20",
+  "version": "0.53.21",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.20",
+  "version": "0.53.21",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.20",
+  "version": "0.53.21",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.20",
+  "version": "0.53.21",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.20",
+  "version": "0.53.21",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
@@ -6,6 +6,11 @@ exports[`capture with inputs --har updating an OpenAPI spec 1`] = `
   [32m[200 response body] 'data' has been added (/properties/data)[39m
   [32m[200 response body] 'next' has been added (/properties/next)[39m
   [32m[200 response body] 'has_more_data' has been added (/properties/has_more_data)[39m
+POST /form
+  [32m✓ [39mRequest Body, [32m✓ [39m200 response
+  [32m[200 response body] body has been added[39m
+  [32m[request body] 'name' has been added (/properties/name)[39m
+  [32m[request body] 'surname' has been added (/properties/surname)[39m
 
 [1m[90mLearning path patterns for unmatched requests...[39m[22m
 [1m[90mDocumenting new operations:[39m[22m
@@ -24,6 +29,36 @@ info:
   description: The API
   version: 0.1.0
 paths:
+  /form:
+    post:
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                name:
+                  type: string
+                surname:
+                  type: string
+              required:
+                - name
+                - surname
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json; charset=utf-8:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
   /books:
     get:
       responses:
@@ -236,9 +271,14 @@ exports[`capture with inputs --har verifying OpenAPI spec 1`] = `
   [31m[200 response body] 'data' is not documented (/properties)[39m
   [31m[200 response body] 'next' is not documented (/properties)[39m
   [31m[200 response body] 'has_more_data' is not documented (/properties)[39m
+POST /form
+  [31m× [39mRequest Body
+  [31m[200 response body] body is not documented[39m
+  [31m[request body] 'name' is not documented (/properties)[39m
+  [31m[request body] 'surname' is not documented (/properties)[39m
 
-100.0% coverage of your documented operations. 7 requests did not match a documented path (8 total requests).
-3 diffs detected in documented operations
+100.0% coverage of your documented operations. 7 requests did not match a documented path (9 total requests).
+6 diffs detected in documented operations
 
 [33mNew endpoints are only added in interactive mode. Run 'optic capture openapi.yml --update interactive' to add new endpoints[39m
 "
@@ -451,7 +491,7 @@ paths:
               type: string
           application/x-www-form-urlencoded:
             schema:
-              type: string
+              $ref: "#/components/schemas/PostPostRequestBody"
   /put:
     put:
       responses:
@@ -751,6 +791,16 @@ components:
         - normalized_param_string
         - base_string
         - signing_key
+    PostPostRequestBody:
+      type: object
+      properties:
+        foo1:
+          type: string
+        foo2:
+          type: string
+      required:
+        - foo1
+        - foo2
     PutPutRequestBody:
       oneOf:
         - type: object
@@ -1926,6 +1976,23 @@ components:
 
 exports[`capture with requests update behavior updates all endpoints with --update automatic 1`] = `
 "Generating traffic to send to server
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+
+  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
+
+100   324    0     2  100   322    197  31846 --:--:-- --:--:-- --:--:-- 32400
+
+{}
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+
+  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--
+     0
+
+100    29    0     2  100    27    832  11240 --:--:-- --:--:-- --:--:-- 14500
+
+{}
 GET /books
   [32m✓ [39m200 response
   [32m[200 response body] 'name' has been added (/properties/books/items/properties/name)[39m
@@ -1934,12 +2001,20 @@ GET /books
   [33m[200 response body] 'author_id' is now type number (/properties/books/items/properties/author_id)[39m
   [33m[200 response body] 'status' now has enum value 'hold' (/properties/books/items/properties/status/enum)[39m
   [31m[200 response body] schema (/properties/books/items/properties/price/maximum) with keyword 'maximum' and parameters {"comparison":"<=","limit":6} received invalid values 10, 15[39m
-  [31m ⛔️ schema could not be automatically updated. Update the schema manually at [4mopenapi.yml:56:1304[24m[39m
+  [31m ⛔️ schema could not be automatically updated. Update the schema manually at [4mopenapi.yml:80:1840[24m[39m
 POST /books
   [32m✓ [39mRequest Body, [32m✓ [39m200 response
   [32m[200 response body] body has been added[39m
   [33m[request body] 'price' is now type string (/properties/price)[39m
   [32m[request body] body is now optional[39m
+POST /form
+  [32m✓ [39mRequest Body, [32m✓ [39m200 response
+  [32m[200 response body] body has been added[39m
+  [32m[request body] 'param2' has been added (/properties/param2)[39m
+POST /multipart-form
+  [32m✓ [39mRequest Body, [32m✓ [39m200 response
+  [32m[200 response body] body has been added[39m
+  [32m[request body] 'key1' has been added (/properties/key1)[39m
 
 [1m[90mLearning path patterns for unmatched requests...[39m[22m
 [1m[90mDocumenting new operations:[39m[22m
@@ -1956,6 +2031,50 @@ info:
   description: The API
   version: 0.1.0
 paths:
+  /form:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                param1:
+                  type: string
+                param2:
+                  type: string
+              required:
+                - param2
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: object
+  /multipart-form:
+    post:
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                key1:
+                  type: string
+              required:
+                - key1
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: object
   /books:
     post:
       requestBody:
@@ -2142,6 +2261,22 @@ components:
 
 exports[`capture with requests update behavior updates only existing endpoints by default 1`] = `
 "Generating traffic to send to server
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+
+  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
+
+100   324    0     2  100   322    207  33475 --:--:-- --:--:-- --:--:-- 36000
+
+{}
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+
+  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
+
+100    29    0     2  100    27    965  13030 --:--:-- --:--:-- --:--:-- 14500
+
+{}
 GET /books
   [32m✓ [39m200 response
   [32m[200 response body] 'name' has been added (/properties/books/items/properties/name)[39m
@@ -2150,12 +2285,20 @@ GET /books
   [33m[200 response body] 'author_id' is now type number (/properties/books/items/properties/author_id)[39m
   [33m[200 response body] 'status' now has enum value 'hold' (/properties/books/items/properties/status/enum)[39m
   [31m[200 response body] schema (/properties/books/items/properties/price/maximum) with keyword 'maximum' and parameters {"comparison":"<=","limit":6} received invalid values 10, 15[39m
-  [31m ⛔️ schema could not be automatically updated. Update the schema manually at [4mopenapi.yml:56:1304[24m[39m
+  [31m ⛔️ schema could not be automatically updated. Update the schema manually at [4mopenapi.yml:80:1840[24m[39m
 POST /books
   [32m✓ [39mRequest Body, [32m✓ [39m200 response
   [32m[200 response body] body has been added[39m
   [33m[request body] 'price' is now type string (/properties/price)[39m
   [32m[request body] body is now optional[39m
+POST /form
+  [32m✓ [39mRequest Body, [32m✓ [39m200 response
+  [32m[200 response body] body has been added[39m
+  [32m[request body] 'param2' has been added (/properties/param2)[39m
+POST /multipart-form
+  [32m✓ [39mRequest Body, [32m✓ [39m200 response
+  [32m[200 response body] body has been added[39m
+  [32m[request body] 'key1' has been added (/properties/key1)[39m
 
 4 unmatched requests
 
@@ -2170,6 +2313,50 @@ info:
   description: The API
   version: 0.1.0
 paths:
+  /form:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                param1:
+                  type: string
+                param2:
+                  type: string
+              required:
+                - param2
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: object
+  /multipart-form:
+    post:
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                key1:
+                  type: string
+              required:
+                - key1
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                type: object
   /books:
     post:
       requestBody:
@@ -2295,6 +2482,22 @@ GET /books
 
 exports[`capture with requests verify behavior verifies the specification in verbose mode 1`] = `
 "Generating traffic to send to server
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+
+  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
+
+100   324    0     2  100   322    214  34586 --:--:-- --:--:-- --:--:-- 36000
+
+{}
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+
+  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
+
+100    29    0     2  100    27    573   7745 --:--:-- --:--:-- --:--:--  9666
+
+{}
 GET /books
   [31m× [39m200 response
   [31m[200 response body] 'name' is not documented (/properties/books/items/properties)[39m
@@ -2302,35 +2505,35 @@ GET /books
   [31m[200 response body] 'updated_at' is not documented (/properties/books/items/properties)[39m
   [31m[200 response body] 'author_id' does not match type number. Received 6nTxAFM5ck4Hob77hGQoL (/properties/books/items/properties/author_id)[39m
   [41m  Diff  [49m 'author_id' did not match schema
-[90m44 |[39m properties:
-[90m45 |[39m   id:
-[90m46 |[39m     type: string
-[90m47 |[39m [1m[33m  author_id:  [41m[Actual] "6nTxAFM5ck4Hob77hGQoL"[49m[39m[22m
-[90m48 |[39m     type: number
-[90m49 |[39m   status:
-[90m50 |[39m     type: string
+[90m68 |[39m properties:
+[90m69 |[39m   id:
+[90m70 |[39m     type: string
+[90m71 |[39m [1m[33m  author_id:  [41m[Actual] "6nTxAFM5ck4Hob77hGQoL"[49m[39m[22m
+[90m72 |[39m     type: number
+[90m73 |[39m   status:
+[90m74 |[39m     type: string
 [90m$workspace$/openapi.yml[39m
 
   [31m[200 response body] 'status' missing enum value 'hold' (/properties/books/items/properties/status/enum)[39m
   [41m  Diff  [49m 'status' does not have enum value hold
-[90m48 |[39m   type: number
-[90m49 |[39m status:
-[90m50 |[39m   type: string
-[90m51 |[39m [1m[33m  enum:  [41mmissing enum value 'hold'[49m[39m[22m
-[90m52 |[39m     - ready
-[90m53 |[39m     - not_ready
-[90m54 |[39m price:
+[90m72 |[39m   type: number
+[90m73 |[39m status:
+[90m74 |[39m   type: string
+[90m75 |[39m [1m[33m  enum:  [41mmissing enum value 'hold'[49m[39m[22m
+[90m76 |[39m     - ready
+[90m77 |[39m     - not_ready
+[90m78 |[39m price:
 [90m$workspace$/openapi.yml[39m
 
   [31m[200 response body] schema (/properties/books/items/properties/price/maximum) with keyword 'maximum' and parameters {"comparison":"<=","limit":6} received invalid values 10, 15[39m
   [41m  Diff  [49m interaction did not match schema
-[90m53 |[39m       - not_ready
-[90m54 |[39m   price:
-[90m55 |[39m     type: number
-[90m56 |[39m [1m[33m    maximum: 6  [41m[Actual] 10, 15[49m[39m[22m
-[90m57 |[39m     minimum: 2
-[90m58 |[39m required:
-[90m59 |[39m   - id
+[90m77 |[39m       - not_ready
+[90m78 |[39m   price:
+[90m79 |[39m     type: number
+[90m80 |[39m [1m[33m    maximum: 6  [41m[Actual] 10, 15[49m[39m[22m
+[90m81 |[39m     minimum: 2
+[90m82 |[39m required:
+[90m83 |[39m   - id
 [90m$workspace$/openapi.yml[39m
 
 POST /books
@@ -2338,19 +2541,27 @@ POST /books
   [31m[200 response body] body is not documented[39m
   [31m[request body] 'price' does not match type string. Received 1 (/properties/price)[39m
   [41m  Diff  [49m 'price' did not match schema
-[90m16 |[39m properties:
-[90m17 |[39m   name:
-[90m18 |[39m     type: string
-[90m19 |[39m [1m[33m  price:  [41m[Actual] 1[49m[39m[22m
-[90m20 |[39m     type: string
-[90m21 |[39m   author_id:
-[90m22 |[39m     type: string
+[90m40 |[39m properties:
+[90m41 |[39m   name:
+[90m42 |[39m     type: string
+[90m43 |[39m [1m[33m  price:  [41m[Actual] 1[49m[39m[22m
+[90m44 |[39m     type: string
+[90m45 |[39m   author_id:
+[90m46 |[39m     type: string
 [90m$workspace$/openapi.yml[39m
 
   [31m[request body] body is required and missing[39m
+POST /form
+  [31m× [39mRequest Body
+  [31m[200 response body] body is not documented[39m
+  [31m[request body] 'param2' is not documented (/properties)[39m
+POST /multipart-form
+  [31m× [39mRequest Body
+  [31m[200 response body] body is not documented[39m
+  [31m[request body] 'key1' is not documented (/properties)[39m
 
-100.0% coverage of your documented operations. 4 requests did not match a documented path (7 total requests).
-13 diffs detected in documented operations
+100.0% coverage of your documented operations. 4 requests did not match a documented path (9 total requests).
+17 diffs detected in documented operations
 
 [33mNew endpoints are only added in interactive mode. Run 'optic capture openapi.yml --update interactive' to add new endpoints[39m
 "
@@ -2358,6 +2569,22 @@ POST /books
 
 exports[`capture with requests verify behavior verifies the specification with coverage 1`] = `
 "Generating traffic to send to server
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+
+  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
+
+100   324    0     2  100   322    224  36200 --:--:-- --:--:-- --:--:-- 40500
+
+{}
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+
+  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
+
+100    29    0     2  100    27    914  12340 --:--:-- --:--:-- --:--:-- 14500
+
+{}
 GET /books
   [31m× [39m200 response
   [31m[200 response body] 'name' is not documented (/properties/books/items/properties)[39m
@@ -2371,9 +2598,17 @@ POST /books
   [31m[200 response body] body is not documented[39m
   [31m[request body] 'price' does not match type string. Received 1 (/properties/price)[39m
   [31m[request body] body is required and missing[39m
+POST /form
+  [31m× [39mRequest Body
+  [31m[200 response body] body is not documented[39m
+  [31m[request body] 'param2' is not documented (/properties)[39m
+POST /multipart-form
+  [31m× [39mRequest Body
+  [31m[200 response body] body is not documented[39m
+  [31m[request body] 'key1' is not documented (/properties)[39m
 
-100.0% coverage of your documented operations. 4 requests did not match a documented path (7 total requests).
-9 diffs detected in documented operations
+100.0% coverage of your documented operations. 4 requests did not match a documented path (9 total requests).
+13 diffs detected in documented operations
 
 [33mNew endpoints are only added in interactive mode. Run 'optic capture openapi.yml --update interactive' to add new endpoints[39m
 "

--- a/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
@@ -45,6 +45,7 @@ paths:
                 surname:
                   type: string
               required:
+                - file
                 - name
                 - surname
       responses:
@@ -1976,22 +1977,7 @@ components:
 
 exports[`capture with requests update behavior updates all endpoints with --update automatic 1`] = `
 "Generating traffic to send to server
-  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                                 Dload  Upload   Total   Spent    Left  Speed
-
-  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
-
-100   324    0     2  100   322    197  31846 --:--:-- --:--:-- --:--:-- 32400
-
 {}
-  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                                 Dload  Upload   Total   Spent    Left  Speed
-
-  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--
-     0
-
-100    29    0     2  100    27    832  11240 --:--:-- --:--:-- --:--:-- 14500
-
 {}
 GET /books
   [32m✓ [39m200 response
@@ -2001,7 +1987,7 @@ GET /books
   [33m[200 response body] 'author_id' is now type number (/properties/books/items/properties/author_id)[39m
   [33m[200 response body] 'status' now has enum value 'hold' (/properties/books/items/properties/status/enum)[39m
   [31m[200 response body] schema (/properties/books/items/properties/price/maximum) with keyword 'maximum' and parameters {"comparison":"<=","limit":6} received invalid values 10, 15[39m
-  [31m ⛔️ schema could not be automatically updated. Update the schema manually at [4mopenapi.yml:80:1840[24m[39m
+  [31m ⛔️ schema could not be automatically updated. Update the schema manually at [4mopenapi.yml:82:1887[24m[39m
 POST /books
   [32m✓ [39mRequest Body, [32m✓ [39m200 response
   [32m[200 response body] body has been added[39m
@@ -2067,6 +2053,7 @@ paths:
                 key1:
                   type: string
               required:
+                - file
                 - key1
       responses:
         "200":
@@ -2261,21 +2248,7 @@ components:
 
 exports[`capture with requests update behavior updates only existing endpoints by default 1`] = `
 "Generating traffic to send to server
-  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                                 Dload  Upload   Total   Spent    Left  Speed
-
-  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
-
-100   324    0     2  100   322    207  33475 --:--:-- --:--:-- --:--:-- 36000
-
 {}
-  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                                 Dload  Upload   Total   Spent    Left  Speed
-
-  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
-
-100    29    0     2  100    27    965  13030 --:--:-- --:--:-- --:--:-- 14500
-
 {}
 GET /books
   [32m✓ [39m200 response
@@ -2285,7 +2258,7 @@ GET /books
   [33m[200 response body] 'author_id' is now type number (/properties/books/items/properties/author_id)[39m
   [33m[200 response body] 'status' now has enum value 'hold' (/properties/books/items/properties/status/enum)[39m
   [31m[200 response body] schema (/properties/books/items/properties/price/maximum) with keyword 'maximum' and parameters {"comparison":"<=","limit":6} received invalid values 10, 15[39m
-  [31m ⛔️ schema could not be automatically updated. Update the schema manually at [4mopenapi.yml:80:1840[24m[39m
+  [31m ⛔️ schema could not be automatically updated. Update the schema manually at [4mopenapi.yml:82:1887[24m[39m
 POST /books
   [32m✓ [39mRequest Body, [32m✓ [39m200 response
   [32m[200 response body] body has been added[39m
@@ -2349,6 +2322,7 @@ paths:
                 key1:
                   type: string
               required:
+                - file
                 - key1
       responses:
         "200":
@@ -2482,21 +2456,7 @@ GET /books
 
 exports[`capture with requests verify behavior verifies the specification in verbose mode 1`] = `
 "Generating traffic to send to server
-  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                                 Dload  Upload   Total   Spent    Left  Speed
-
-  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
-
-100   324    0     2  100   322    214  34586 --:--:-- --:--:-- --:--:-- 36000
-
 {}
-  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                                 Dload  Upload   Total   Spent    Left  Speed
-
-  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
-
-100    29    0     2  100    27    573   7745 --:--:-- --:--:-- --:--:--  9666
-
 {}
 GET /books
   [31m× [39m200 response
@@ -2505,35 +2465,35 @@ GET /books
   [31m[200 response body] 'updated_at' is not documented (/properties/books/items/properties)[39m
   [31m[200 response body] 'author_id' does not match type number. Received 6nTxAFM5ck4Hob77hGQoL (/properties/books/items/properties/author_id)[39m
   [41m  Diff  [49m 'author_id' did not match schema
-[90m68 |[39m properties:
-[90m69 |[39m   id:
-[90m70 |[39m     type: string
-[90m71 |[39m [1m[33m  author_id:  [41m[Actual] "6nTxAFM5ck4Hob77hGQoL"[49m[39m[22m
-[90m72 |[39m     type: number
-[90m73 |[39m   status:
-[90m74 |[39m     type: string
+[90m70 |[39m properties:
+[90m71 |[39m   id:
+[90m72 |[39m     type: string
+[90m73 |[39m [1m[33m  author_id:  [41m[Actual] "6nTxAFM5ck4Hob77hGQoL"[49m[39m[22m
+[90m74 |[39m     type: number
+[90m75 |[39m   status:
+[90m76 |[39m     type: string
 [90m$workspace$/openapi.yml[39m
 
   [31m[200 response body] 'status' missing enum value 'hold' (/properties/books/items/properties/status/enum)[39m
   [41m  Diff  [49m 'status' does not have enum value hold
-[90m72 |[39m   type: number
-[90m73 |[39m status:
-[90m74 |[39m   type: string
-[90m75 |[39m [1m[33m  enum:  [41mmissing enum value 'hold'[49m[39m[22m
-[90m76 |[39m     - ready
-[90m77 |[39m     - not_ready
-[90m78 |[39m price:
+[90m74 |[39m   type: number
+[90m75 |[39m status:
+[90m76 |[39m   type: string
+[90m77 |[39m [1m[33m  enum:  [41mmissing enum value 'hold'[49m[39m[22m
+[90m78 |[39m     - ready
+[90m79 |[39m     - not_ready
+[90m80 |[39m price:
 [90m$workspace$/openapi.yml[39m
 
   [31m[200 response body] schema (/properties/books/items/properties/price/maximum) with keyword 'maximum' and parameters {"comparison":"<=","limit":6} received invalid values 10, 15[39m
   [41m  Diff  [49m interaction did not match schema
-[90m77 |[39m       - not_ready
-[90m78 |[39m   price:
-[90m79 |[39m     type: number
-[90m80 |[39m [1m[33m    maximum: 6  [41m[Actual] 10, 15[49m[39m[22m
-[90m81 |[39m     minimum: 2
-[90m82 |[39m required:
-[90m83 |[39m   - id
+[90m79 |[39m       - not_ready
+[90m80 |[39m   price:
+[90m81 |[39m     type: number
+[90m82 |[39m [1m[33m    maximum: 6  [41m[Actual] 10, 15[49m[39m[22m
+[90m83 |[39m     minimum: 2
+[90m84 |[39m required:
+[90m85 |[39m   - id
 [90m$workspace$/openapi.yml[39m
 
 POST /books
@@ -2541,13 +2501,13 @@ POST /books
   [31m[200 response body] body is not documented[39m
   [31m[request body] 'price' does not match type string. Received 1 (/properties/price)[39m
   [41m  Diff  [49m 'price' did not match schema
-[90m40 |[39m properties:
-[90m41 |[39m   name:
-[90m42 |[39m     type: string
-[90m43 |[39m [1m[33m  price:  [41m[Actual] 1[49m[39m[22m
+[90m42 |[39m properties:
+[90m43 |[39m   name:
 [90m44 |[39m     type: string
-[90m45 |[39m   author_id:
+[90m45 |[39m [1m[33m  price:  [41m[Actual] 1[49m[39m[22m
 [90m46 |[39m     type: string
+[90m47 |[39m   author_id:
+[90m48 |[39m     type: string
 [90m$workspace$/openapi.yml[39m
 
   [31m[request body] body is required and missing[39m
@@ -2569,21 +2529,7 @@ POST /multipart-form
 
 exports[`capture with requests verify behavior verifies the specification with coverage 1`] = `
 "Generating traffic to send to server
-  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                                 Dload  Upload   Total   Spent    Left  Speed
-
-  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
-
-100   324    0     2  100   322    224  36200 --:--:-- --:--:-- --:--:-- 40500
-
 {}
-  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                                 Dload  Upload   Total   Spent    Left  Speed
-
-  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
-
-100    29    0     2  100    27    914  12340 --:--:-- --:--:-- --:--:-- 14500
-
 {}
 GET /books
   [31m× [39m200 response

--- a/projects/optic/src/__tests__/integration/workspaces/capture/har/har.har
+++ b/projects/optic/src/__tests__/integration/workspaces/capture/har/har.har
@@ -343,6 +343,50 @@
         "timings": { "send": 100, "wait": 100, "receive": 100 },
         "startedDateTime": "1970-01-01T00:01:48.997Z",
         "time": 300
+      },
+      {
+        "startedDateTime": "2024-01-10T13:03:07.346-05:00",
+        "request": {
+          "bodySize": 295,
+          "method": "POST",
+          "url": "http://localhost:3030/form",
+          "httpVersion": "HTTP/3",
+          "headers": [],
+          "cookies": [],
+          "queryString": [],
+          "headersSize": 576,
+          "postData": {
+            "mimeType": "multipart/form-data; boundary=---------------------------384139230136988226904278155800",
+            "params": [],
+            "text": "-----------------------------384139230136988226904278155800\r\nContent-Disposition: form-data; name=\"name\"\r\n\r\nJohn\r\n-----------------------------384139230136988226904278155800\r\nContent-Disposition: form-data; name=\"surname\"\r\n\r\nSmith\r\n-----------------------------384139230136988226904278155800--\r\nContent-Disposition: form-data; name=\"file\"; filename=\"upload.txt\"\nContent-Type: text/plain\r\n\r\nupload\r\n-----------------------------384139230136988226904278155800--"
+          }
+        },
+        "response": {
+          "status": 200,
+          "statusText": "",
+          "httpVersion": "HTTP/3",
+          "headers": [],
+          "cookies": [],
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 24,
+            "text": "{\"message\":\"User saved\"}"
+          },
+          "redirectURL": "",
+          "headersSize": 618,
+          "bodySize": 642
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 0,
+          "dns": 0,
+          "connect": 0,
+          "ssl": 0,
+          "send": 0,
+          "wait": 135,
+          "receive": 0
+        },
+        "time": 135
       }
     ]
   }

--- a/projects/optic/src/__tests__/integration/workspaces/capture/har/openapi.yml
+++ b/projects/optic/src/__tests__/integration/workspaces/capture/har/openapi.yml
@@ -4,6 +4,18 @@ info:
   description: The API
   version: 0.1.0
 paths:
+  /form:
+    post:
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+      responses: {}
   /books:
     get:
       responses:

--- a/projects/optic/src/__tests__/integration/workspaces/capture/har/openapi.yml
+++ b/projects/optic/src/__tests__/integration/workspaces/capture/har/openapi.yml
@@ -15,6 +15,8 @@ paths:
               properties:
                 file:
                   type: string
+              required:
+                - file
       responses: {}
   /books:
     get:

--- a/projects/optic/src/__tests__/integration/workspaces/capture/with-server/file.txt
+++ b/projects/optic/src/__tests__/integration/workspaces/capture/with-server/file.txt
@@ -1,0 +1,2 @@
+file-info
+morestuff

--- a/projects/optic/src/__tests__/integration/workspaces/capture/with-server/openapi.yml
+++ b/projects/optic/src/__tests__/integration/workspaces/capture/with-server/openapi.yml
@@ -27,6 +27,8 @@ paths:
               properties:
                 file:
                   type: string
+              required:
+                - file
       responses: {}
   /books:
     post:

--- a/projects/optic/src/__tests__/integration/workspaces/capture/with-server/openapi.yml
+++ b/projects/optic/src/__tests__/integration/workspaces/capture/with-server/openapi.yml
@@ -4,6 +4,30 @@ info:
   description: The API
   version: 0.1.0
 paths:
+  /form:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                param1:
+                  type: string
+      responses: {}
+  /multipart-form:
+    post:
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+      responses: {}
   /books:
     post:
       requestBody:

--- a/projects/optic/src/__tests__/integration/workspaces/capture/with-server/optic.yml
+++ b/projects/optic/src/__tests__/integration/workspaces/capture/with-server/optic.yml
@@ -28,6 +28,8 @@ capture:
       url: http://localhost:%PORT
       ready_endpoint: /healthcheck
     requests:
+      run:
+        command: "curl -X POST $OPTIC_PROXY/multipart-form -F key1=value1 -F file=@file.txt -H 'Content-Type: multipart/form-data' && curl -X POST $OPTIC_PROXY/form -H 'Content-Type: application/x-www-form-urlencoded' -d 'param1=value1&param2=value2'"
       send:
         - path: /
         - path: /books

--- a/projects/optic/src/__tests__/integration/workspaces/capture/with-server/optic.yml
+++ b/projects/optic/src/__tests__/integration/workspaces/capture/with-server/optic.yml
@@ -29,7 +29,7 @@ capture:
       ready_endpoint: /healthcheck
     requests:
       run:
-        command: "curl -X POST $OPTIC_PROXY/multipart-form -F key1=value1 -F file=@file.txt -H 'Content-Type: multipart/form-data' && curl -X POST $OPTIC_PROXY/form -H 'Content-Type: application/x-www-form-urlencoded' -d 'param1=value1&param2=value2'"
+        command: "curl -s -X POST $OPTIC_PROXY/multipart-form -F key1=value1 -F file=@file.txt -H 'Content-Type: multipart/form-data' && curl -s -X POST $OPTIC_PROXY/form -H 'Content-Type: application/x-www-form-urlencoded' -d 'param1=value1&param2=value2'"
       send:
         - path: /
         - path: /books

--- a/projects/optic/src/__tests__/integration/workspaces/capture/with-server/server.js
+++ b/projects/optic/src/__tests__/integration/workspaces/capture/with-server/server.js
@@ -68,7 +68,11 @@ const requestListener = function (req, res) {
   } else if (normalizedUrl === '/healthcheck' && req.method === 'GET') {
     res.writeHead(200);
     res.end(JSON.stringify({authors}));
-  } else {
+  }else if ((normalizedUrl === '/form' || normalizedUrl === '/multipart-form') && req.method === 'POST') {
+    res.writeHead(200);
+    res.end(JSON.stringify({}));
+  }
+   else {
     res.writeHead(404);
     res.end(JSON.stringify({ error: "Resource not found" }));
   }

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/documented-bodies.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/documented-bodies.ts
@@ -290,9 +290,7 @@ function parseMultipartFormBody(
   const boundary = contentType.split(';')[1].split('=')[1].trim();
 
   // the boundary could be padded with `-`
-  const chunks = body
-    .split(new RegExp(`-*${boundary}-*[\\r\\n]+`))
-    .slice(1, -1);
+  const chunks = body.split(new RegExp(`-*${boundary}-*[\\r\\n]+`)).slice(1); // remove the header part of the body
   const parsed = {};
 
   for (let chunk of chunks) {

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/documented-bodies.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/documented-bodies.ts
@@ -289,7 +289,6 @@ function parseMultipartFormBody(
   // multipart/form-data; boundary=---------------------------123456789
   const boundary = contentType.split(';')[1].split('=')[1].trim();
 
-  // Here we just care about the field names
   // the boundary could be padded with `-`
   const chunks = body
     .split(new RegExp(`-*${boundary}-*[\\r\\n]+`))

--- a/projects/optic/src/commands/capture/sources/har.ts
+++ b/projects/optic/src/commands/capture/sources/har.ts
@@ -143,7 +143,7 @@ export class HarEntries {
                 mimeType: requestContentType,
                 text: requestBodyEncoded,
                 encoding: 'base64',
-                params: [], // not supporting posted formdata
+                params: [],
               }
             : undefined,
       };

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.20",
+  "version": "0.53.21",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.20",
+  "version": "0.53.21",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Adds support for `application/x-www-form-urlencoded` and `multipart/form-data` content types.

- x-www-form-encoded is a simple query string we parse
- multipart form data is in a different format - there are parsers available, but they're mainly designed as streaming consumers to be used in web frameworks. Wrote a more specific one for our usecase (i.e. pull out field name and value)

Note that these fields are similar to query parameters (i.e. you can send multiple keys and some parsers will handle as arrays, etc) but we haven't handled it here since there are many ways to define arrays in forms and or JSON objects.

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._
https://github.com/opticdev/optic/issues/2535
## 👹 QA
_How can other humans verify that this PR is correct?_
