### PR TITLE
fix enum patching in array

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.53.21",
+  "version": "0.53.22-0",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",
@@ -27,5 +27,6 @@
     "**/*.+(js|jsx|ts|tsx|json|css)": [
       "yarn prettier --write"
     ]
-  }
+  },
+  "stableVersion": "0.53.21"
 }

--- a/projects/fastify-capture/package.json
+++ b/projects/fastify-capture/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/fastify-capture",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.21",
+  "version": "0.53.22-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -37,5 +37,6 @@
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
     "typescript": "^5.0.4"
-  }
+  },
+  "stableVersion": "0.53.21"
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.21",
+  "version": "0.53.22-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -32,5 +32,6 @@
   "dependencies": {
     "jsonpointer": "^5.0.1",
     "minimatch": "9.0.3"
-  }
+  },
+  "stableVersion": "0.53.21"
 }

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.21",
+  "version": "0.53.22-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -57,5 +57,6 @@
     "upath": "^2.0.1",
     "yaml": "^2.3.2",
     "yaml-ast-parser": "^0.0.43"
-  }
+  },
+  "stableVersion": "0.53.21"
 }

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.21",
+  "version": "0.53.22-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -53,5 +53,6 @@
     "ts-invariant": "^0.9.3",
     "url-join": "^4.0.1",
     "yaml-ast-parser": "^0.0.43"
-  }
+  },
+  "stableVersion": "0.53.21"
 }

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.21",
+  "version": "0.53.22-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -138,5 +138,6 @@
       "node18-win-x64"
     ],
     "outputPath": "../../dist"
-  }
+  },
+  "stableVersion": "0.53.21"
 }

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/__tests__/__snapshots__/enum.test.ts.snap
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/__tests__/__snapshots__/enum.test.ts.snap
@@ -57,7 +57,7 @@ exports[`enum shape patch generator when enum is nested in array 1`] = `
         "query": [],
       },
     },
-    "shouldRegeneratePatches": false,
+    "shouldRegeneratePatches": true,
   },
 ]
 `;

--- a/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/enum.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/shapes/handlers/enum.ts
@@ -52,12 +52,17 @@ export function* enumPatches(
     path: jsonPointerHelpers.append(diff.propertyPath, '-'), // "-" indicates append to array
     value: diff.value,
   });
+  // If the enum is inside of an array, we could have multiple instances of enum - this updates the enum and reruns diffs
+  const shouldRegeneratePatches = jsonPointerHelpers
+    .decode(diff.propertyPath)
+    .includes('items');
+
   yield {
     description: `add enum ${diff.value} to ${diff.key} `,
     diff,
     impact: [PatchImpact.Addition],
     groupedOperations,
-    shouldRegeneratePatches: false,
+    shouldRegeneratePatches,
     interaction,
   };
 }

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.21",
+  "version": "0.53.22-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -40,5 +40,6 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
-  }
+  },
+  "stableVersion": "0.53.21"
 }

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@4.0.2",
-  "version": "0.53.21",
+  "version": "0.53.22-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -45,5 +45,6 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
-  }
+  },
+  "stableVersion": "0.53.21"
 }


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Updates enum patching when in an array to regenerate patches. An enum schema with multiple array items could result in multiple enum variants being generated

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

https://github.com/opticdev/optic/issues/2656

## 👹 QA
_How can other humans verify that this PR is correct?_
