### PR TITLE
chore(ci): test on more node versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest-16-core
     strategy:
       matrix:
-        node_version: [16, 18, 20]
+        node_version: [16, 18] # todo: get 20 passing
     env:
       YARN_IGNORE_NODE: 1 # silence node 16 complaints
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,11 +10,14 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest-16-core
+    strategy:
+      matrix:
+        node_version: [16, 18, 20]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: ${{ matrix.node_version }}
           cache: yarn
 
       - name: Install Task

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,8 @@ jobs:
     strategy:
       matrix:
         node_version: [16, 18, 20]
+    env:
+      YARN_IGNORE_NODE: 1 # silence node 16 complaints
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

- switches the test workflow to a matrix build
- adds node 16 to the test suite (still in use by some customers)
- node 20 has some fetch related problems and fails tests, leaving a todo to work on

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_

- 16 & 18 pass: https://github.com/opticdev/optic/actions/runs/7572802128/workflow
- 20 fails: https://github.com/opticdev/optic/actions/runs/7572637075/workflow