### PR TITLE
Ignore request bodies from 4xx and 5xx interactions

### DIFF
--- a/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
@@ -106,6 +106,12 @@ paths:
             application/json; charset=utf-8:
               schema:
                 $ref: "#/components/schemas/PostAuthors201ResponseBody"
+        "400":
+          description: 400 response
+          content:
+            text/plain:
+              schema:
+                type: string
       requestBody:
         content:
           application/json:
@@ -278,7 +284,7 @@ POST /form
   [31m[request body] 'name' is not documented (/properties)[39m
   [31m[request body] 'surname' is not documented (/properties)[39m
 
-100.0% coverage of your documented operations. 7 requests did not match a documented path (9 total requests).
+100.0% coverage of your documented operations. 8 requests did not match a documented path (10 total requests).
 6 diffs detected in documented operations
 
 [33mNew endpoints are only added in interactive mode. Run 'optic capture openapi.yml --update interactive' to add new endpoints[39m
@@ -394,11 +400,6 @@ paths:
     delete:
       responses:
         {}
-      requestBody:
-        content:
-          text/plain:
-            schema:
-              type: string
   /digest-auth:
     get:
       responses:
@@ -476,35 +477,14 @@ paths:
     patch:
       responses:
         {}
-      requestBody:
-        content:
-          text/plain:
-            schema:
-              type: string
   /post:
     post:
       responses:
         {}
-      requestBody:
-        content:
-          text/plain:
-            schema:
-              type: string
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: "#/components/schemas/PostPostRequestBody"
   /put:
     put:
       responses:
         {}
-      requestBody:
-        content:
-          text/plain:
-            schema:
-              type: string
-          application/json:
-            schema:
-              $ref: "#/components/schemas/PutPutRequestBody"
   /response-headers:
     get:
       responses:
@@ -623,11 +603,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PostTransformCollection200ResponseBody"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/PostTransformCollectionRequestBody"
       parameters:
         - schema:
             type: string
@@ -639,6 +614,11 @@ paths:
           in: query
           name: to
           required: true
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PostTransformCollectionRequestBody"
 components:
   schemas:
     GetBooks200ResponseBody:
@@ -792,113 +772,6 @@ components:
         - normalized_param_string
         - base_string
         - signing_key
-    PostPostRequestBody:
-      type: object
-      properties:
-        foo1:
-          type: string
-        foo2:
-          type: string
-      required:
-        - foo1
-        - foo2
-    PutPutRequestBody:
-      oneOf:
-        - type: object
-          properties:
-            hello:
-              type: string
-            my:
-              type: number
-            name:
-              type: boolean
-            is:
-              type: object
-              properties:
-                legally:
-                  type: string
-                num:
-                  type: number
-                mixed:
-                  type: array
-                  items:
-                    oneOf:
-                      - type: object
-                        properties:
-                          name:
-                            type: string
-                        required:
-                          - name
-                      - type: boolean
-                      - type: string
-                      - type: number
-              required:
-                - legally
-                - num
-                - mixed
-          required:
-            - hello
-            - my
-            - name
-            - is
-        - type: array
-          items:
-            type: object
-            properties:
-              hello:
-                type: string
-              my:
-                type: number
-              name:
-                type: boolean
-              is:
-                type: object
-                properties:
-                  legally:
-                    type: string
-                  num:
-                    type: number
-                  mixed:
-                    type: array
-                    items:
-                      oneOf:
-                        - type: object
-                          properties:
-                            name:
-                              type: string
-                          required:
-                            - name
-                        - type: boolean
-                        - type: string
-                        - type: number
-                required:
-                  - legally
-                  - num
-                  - mixed
-              authenticated:
-                type: boolean
-            required:
-              []
-        - type: array
-          items:
-            type: object
-            properties:
-              hello:
-                type: string
-              my:
-                type: number
-              name:
-                type: boolean
-              is:
-                type: object
-              authenticated:
-                type: boolean
-            required:
-              - hello
-              - my
-              - name
-              - is
-              - authenticated
     GetStatusStatus200ResponseBody:
       type: object
       properties:

--- a/projects/optic/src/__tests__/integration/workspaces/capture/har/har.har
+++ b/projects/optic/src/__tests__/integration/workspaces/capture/har/har.har
@@ -345,6 +345,55 @@
         "time": 300
       },
       {
+        "request": {
+          "method": "POST",
+          "url": "http://localhost:3030/authors",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" },
+            { "name": "Content-Type", "value": "application/json" },
+            { "name": "Content-Length", "value": "18" }
+          ],
+          "headersSize": -1,
+          "bodySize": 18,
+          "cookies": [],
+          "queryString": [],
+          "postData": {
+            "mimeType": "application/json",
+            "text": "e30=",
+            "encoding": "base64",
+            "params": []
+          }
+        },
+        "response": {
+          "status": 400,
+          "statusText": "Created",
+          "httpVersion": "1.1",
+          "headers": [
+            { "name": "Host", "value": "localhost:3030" },
+            { "name": "User-Agent", "value": "curl/7.88.1" },
+            { "name": "Accept", "value": "*/*" },
+            { "name": "Content-Type", "value": "application/json" },
+            { "name": "Content-Length", "value": "18" }
+          ],
+          "headersSize": -1,
+          "cookies": [],
+          "redirectURL": "",
+          "bodySize": 46,
+          "content": {
+            "mimeType": "text/plain",
+            "size": 64,
+            "text": "error"
+          }
+        },
+        "cache": {},
+        "timings": { "send": 100, "wait": 100, "receive": 100 },
+        "startedDateTime": "1970-01-01T00:01:48.997Z",
+        "time": 300
+      },
+      {
         "startedDateTime": "2024-01-10T13:03:07.346-05:00",
         "request": {
           "bodySize": 295,

--- a/projects/optic/src/commands/capture/coverage/api-coverage.ts
+++ b/projects/optic/src/commands/capture/coverage/api-coverage.ts
@@ -71,24 +71,27 @@ export class ApiCoverageCounter {
     pathPattern: string,
     method: string,
     hasRequestBody: boolean,
-    responseStatusCodeMatcher?: string
+    statusCode?: string
   ) => {
     const operation = this.coverage.paths[pathPattern]?.[method];
     if (operation) {
       operation.interactions++;
       operation.seen = true;
-      if (hasRequestBody && operation.requestBody)
+      const hasValidStatusCode = statusCode
+        ? Number(statusCode) >= 200 && Number(statusCode) < 400
+        : false;
+      if (hasRequestBody && operation.requestBody && hasValidStatusCode)
         operation.requestBody.seen = true;
 
       let partialMatch;
       // exact match
-      if (responseStatusCodeMatcher) {
-        if (operation.responses[responseStatusCodeMatcher]) {
-          operation.responses[responseStatusCodeMatcher].seen = true;
+      if (statusCode) {
+        if (operation.responses[statusCode]) {
+          operation.responses[statusCode].seen = true;
         } else if (
           (partialMatch = partialMatches(
             Object.keys(operation.responses),
-            responseStatusCodeMatcher
+            statusCode
           ))
         ) {
           operation.responses[partialMatch].seen = true;

--- a/projects/optic/src/commands/capture/patches/patchers/spec/operations.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/spec/operations.ts
@@ -27,6 +27,13 @@ function* generateRequestPatches(
   documentedInteraction: DocumentedInteraction
 ): OperationPatches {
   const { operation, interaction } = documentedInteraction;
+  // Skip interactions for request body when the status code is not 2xx - i.e. the captured interaction didn't result in a valid response
+  const statusCode = interaction.response?.statusCode
+    ? Number(interaction.response.statusCode)
+    : null;
+  if (!statusCode || !(statusCode >= 200 && statusCode < 400)) {
+    return;
+  }
 
   // Handle requests
   if (!interaction.request.body && operation.requestBody?.required) {


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

We have the documented bodies code that ignores / does not learn schemas for request bodies in interactions that result in an `4xx` or `5xx`. Updating the code to also extend this to apply to coverage and for documenting a request body

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
