### PR TITLE
Order capture patch summaries

### DIFF
--- a/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/capture.test.ts.snap
@@ -8,9 +8,9 @@ exports[`capture with inputs --har updating an OpenAPI spec 1`] = `
   [32m[200 response body] 'has_more_data' has been added (/properties/has_more_data)[39m
 POST /form
   [32m✓ [39mRequest Body, [32m✓ [39m200 response
-  [32m[200 response body] body has been added[39m
   [32m[request body] 'name' has been added (/properties/name)[39m
   [32m[request body] 'surname' has been added (/properties/surname)[39m
+  [32m[200 response body] body has been added[39m
 
 [1m[90mLearning path patterns for unmatched requests...[39m[22m
 [1m[90mDocumenting new operations:[39m[22m
@@ -280,9 +280,9 @@ exports[`capture with inputs --har verifying OpenAPI spec 1`] = `
   [31m[200 response body] 'has_more_data' is not documented (/properties)[39m
 POST /form
   [31m× [39mRequest Body
-  [31m[200 response body] body is not documented[39m
   [31m[request body] 'name' is not documented (/properties)[39m
   [31m[request body] 'surname' is not documented (/properties)[39m
+  [31m[200 response body] body is not documented[39m
 
 100.0% coverage of your documented operations. 8 requests did not match a documented path (10 total requests).
 6 diffs detected in documented operations
@@ -1863,17 +1863,17 @@ GET /books
   [31m ⛔️ schema could not be automatically updated. Update the schema manually at [4mopenapi.yml:82:1887[24m[39m
 POST /books
   [32m✓ [39mRequest Body, [32m✓ [39m200 response
-  [32m[200 response body] body has been added[39m
   [33m[request body] 'price' is now type string (/properties/price)[39m
   [32m[request body] body is now optional[39m
+  [32m[200 response body] body has been added[39m
 POST /form
   [32m✓ [39mRequest Body, [32m✓ [39m200 response
-  [32m[200 response body] body has been added[39m
   [32m[request body] 'param2' has been added (/properties/param2)[39m
+  [32m[200 response body] body has been added[39m
 POST /multipart-form
   [32m✓ [39mRequest Body, [32m✓ [39m200 response
-  [32m[200 response body] body has been added[39m
   [32m[request body] 'key1' has been added (/properties/key1)[39m
+  [32m[200 response body] body has been added[39m
 
 [1m[90mLearning path patterns for unmatched requests...[39m[22m
 [1m[90mDocumenting new operations:[39m[22m
@@ -2134,17 +2134,17 @@ GET /books
   [31m ⛔️ schema could not be automatically updated. Update the schema manually at [4mopenapi.yml:82:1887[24m[39m
 POST /books
   [32m✓ [39mRequest Body, [32m✓ [39m200 response
-  [32m[200 response body] body has been added[39m
   [33m[request body] 'price' is now type string (/properties/price)[39m
   [32m[request body] body is now optional[39m
+  [32m[200 response body] body has been added[39m
 POST /form
   [32m✓ [39mRequest Body, [32m✓ [39m200 response
-  [32m[200 response body] body has been added[39m
   [32m[request body] 'param2' has been added (/properties/param2)[39m
+  [32m[200 response body] body has been added[39m
 POST /multipart-form
   [32m✓ [39mRequest Body, [32m✓ [39m200 response
-  [32m[200 response body] body has been added[39m
   [32m[request body] 'key1' has been added (/properties/key1)[39m
+  [32m[200 response body] body has been added[39m
 
 4 unmatched requests
 
@@ -2317,8 +2317,8 @@ GET /books/{bookId}
   [31m[200 response body] 'price' is not documented (/properties)[39m
 GET /books
   200 response
-  [31m[404 response body] body is not documented[39m
   [31m[query parameter] list is not documented[39m
+  [31m[404 response body] body is not documented[39m
 
 83.3% coverage of your documented operations. 2 requests did not match a documented path (6 total requests).
 4 diffs detected in documented operations
@@ -2371,7 +2371,6 @@ GET /books
 
 POST /books
   [31m× [39mRequest Body
-  [31m[200 response body] body is not documented[39m
   [31m[request body] 'price' does not match type string. Received 1 (/properties/price)[39m
   [41m  Diff  [49m 'price' did not match schema
 [90m42 |[39m properties:
@@ -2384,14 +2383,15 @@ POST /books
 [90m$workspace$/openapi.yml[39m
 
   [31m[request body] body is required and missing[39m
+  [31m[200 response body] body is not documented[39m
 POST /form
   [31m× [39mRequest Body
-  [31m[200 response body] body is not documented[39m
   [31m[request body] 'param2' is not documented (/properties)[39m
+  [31m[200 response body] body is not documented[39m
 POST /multipart-form
   [31m× [39mRequest Body
-  [31m[200 response body] body is not documented[39m
   [31m[request body] 'key1' is not documented (/properties)[39m
+  [31m[200 response body] body is not documented[39m
 
 100.0% coverage of your documented operations. 4 requests did not match a documented path (9 total requests).
 17 diffs detected in documented operations
@@ -2414,17 +2414,17 @@ GET /books
   [31m[200 response body] schema (/properties/books/items/properties/price/maximum) with keyword 'maximum' and parameters {"comparison":"<=","limit":6} received invalid values 10, 15[39m
 POST /books
   [31m× [39mRequest Body
-  [31m[200 response body] body is not documented[39m
   [31m[request body] 'price' does not match type string. Received 1 (/properties/price)[39m
   [31m[request body] body is required and missing[39m
+  [31m[200 response body] body is not documented[39m
 POST /form
   [31m× [39mRequest Body
-  [31m[200 response body] body is not documented[39m
   [31m[request body] 'param2' is not documented (/properties)[39m
+  [31m[200 response body] body is not documented[39m
 POST /multipart-form
   [31m× [39mRequest Body
-  [31m[200 response body] body is not documented[39m
   [31m[request body] 'key1' is not documented (/properties)[39m
+  [31m[200 response body] body is not documented[39m
 
 100.0% coverage of your documented operations. 4 requests did not match a documented path (9 total requests).
 13 diffs detected in documented operations

--- a/projects/optic/src/commands/capture/actions/documented.ts
+++ b/projects/optic/src/commands/capture/actions/documented.ts
@@ -1,5 +1,3 @@
-import chalk from 'chalk';
-import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
 import { ParseResult } from '../../../utils/spec-loaders';
 import {
   generateEndpointSpecPatches,
@@ -10,273 +8,13 @@ import { CapturedInteractions } from '../sources/captured-interactions';
 import { ApiCoverageCounter } from '../coverage/api-coverage';
 import * as AT from '../../oas/lib/async-tools';
 import { writePatchesToFiles } from '../write/file';
-import { logger } from '../../../logger';
 
-import { jsonPointerLogger } from '@useoptic/openapi-io';
 import { UnpatchableDiff } from '../patches/patchers/shapes/diff';
 import { SpecPatch } from '../patches/patchers/spec/patches';
-import { getSourcemapLink, sourcemapReader } from '@useoptic/openapi-utilities';
-
-type GroupedUnpatchableDiff = Omit<UnpatchableDiff, 'example'> & {
-  examples: any[];
-};
-
-function getShapeDiffDetails(
-  description: string,
-  pathToHighlight: string,
-  error: string,
-  pointerLogger: ReturnType<typeof jsonPointerLogger>
-): string {
-  const lines = `${chalk.bgRed('  Diff  ')} ${description}
-${pointerLogger.log(pathToHighlight, {
-  highlightColor: 'yellow',
-  observation: error,
-})}\n`;
-  return lines;
-}
-
-function locationFromPath(path: string) {
-  // expected patterns:
-  // /paths/:path/:method/requestBody
-  // /paths/:path/:method/responses/:statusCode
-  const parts = jsonPointerHelpers.decode(path);
-
-  const location =
-    parts[3] === 'requestBody'
-      ? '[request body]'
-      : parts[3] === 'responses' && parts[4]
-        ? `[${parts[4]} response body]`
-        : '';
-  return location;
-}
-
-function summarizePatch(
-  patch: SpecPatch,
-  parseResult: ParseResult,
-  options: {
-    mode: 'update' | 'verify';
-    verbose: boolean;
-  }
-): string[] {
-  const verbose = options.verbose && options.mode === 'verify';
-  const { jsonLike: spec, sourcemap } = parseResult;
-  const pointerLogger = jsonPointerLogger(sourcemap);
-  const { diff, path, groupedOperations } = patch;
-  const color = options.mode === 'update' ? chalk.green : chalk.red;
-  if (!diff || groupedOperations.length === 0) return [];
-  if (diff.kind === 'MissingRequestBody') {
-    const action =
-      options.mode === 'update' ? 'is now optional' : 'is required and missing';
-    return [color(`[request body] body ${action}`)];
-  } else if (
-    diff.kind === 'UnmatchdResponseBody' ||
-    diff.kind === 'UnmatchedRequestBody' ||
-    diff.kind === 'UnmatchedResponseStatusCode'
-  ) {
-    const location =
-      diff.kind === 'UnmatchedRequestBody'
-        ? '[request body]'
-        : `[${diff.statusCode} response body]`;
-    const action =
-      options.mode === 'update' ? 'has been added' : 'is not documented';
-    return [color(`${location} body ${action}`)];
-  } else if (
-    diff.kind === 'UnmatchedRequestParameter' ||
-    diff.kind === 'UnmatchedResponseHeader'
-  ) {
-    const location =
-      diff.kind === 'UnmatchedRequestParameter'
-        ? `[${diff.in} parameter]`
-        : `[${diff.statusCode} response header]`;
-
-    const action =
-      options.mode === 'update' ? 'has been added' : 'is not documented';
-    return [color(`${location} ${diff.name} ${action}`)];
-  } else if (
-    diff.kind === 'MissingRequiredRequiredParameter' ||
-    diff.kind === 'MissingRequiredResponseHeader'
-  ) {
-    const location =
-      diff.kind === 'MissingRequiredRequiredParameter'
-        ? `[${diff.in} parameter]`
-        : `[${diff.statusCode} response header]`;
-    const action =
-      options.mode === 'update' ? 'is now optional' : 'is required and missing';
-    return [color(`${location} ${diff.name} ${action}`)];
-  } else {
-    const location = locationFromPath(path);
-
-    if (diff.kind === 'AdditionalProperty') {
-      // filter out dependent diffs
-      if (
-        !jsonPointerHelpers.tryGet(
-          spec,
-          jsonPointerHelpers.join(path, diff.parentObjectPath)
-        ).match
-      )
-        return [];
-
-      const action =
-        options.mode === 'update' ? 'has been added' : 'is not documented';
-      const propertyLocation =
-        options.mode === 'update'
-          ? `(${diff.propertyPath})`
-          : diff.parentObjectPath
-            ? `(${diff.parentObjectPath})`
-            : '';
-      return [color(`${location} '${diff.key}' ${action} ${propertyLocation}`)];
-    } else if (diff.kind === 'UnmatchedType') {
-      // filter out dependent diffs
-      if (
-        !jsonPointerHelpers.tryGet(
-          spec,
-          jsonPointerHelpers.join(path, diff.propertyPath)
-        ).match
-      )
-        return [];
-      let action: string;
-      if (diff.keyword === 'oneOf') {
-        action =
-          options.mode === 'update'
-            ? 'now matches schema'
-            : `does not match schema`;
-      } else {
-        action =
-          options.mode === 'update'
-            ? `is now type ${diff.expectedType}`
-            : `does not match type ${diff.expectedType}. Received ${diff.example}`;
-      }
-      const color = options.mode === 'update' ? chalk.yellow : chalk.red;
-
-      const lines = [
-        color(`${location} '${diff.key}' ${action} (${diff.propertyPath})`),
-      ];
-      if (verbose) {
-        lines.push(
-          getShapeDiffDetails(
-            diff.description,
-            jsonPointerHelpers.join(path, diff.propertyPath),
-            `[Actual] ${JSON.stringify(diff.example)}`,
-            pointerLogger
-          )
-        );
-      }
-      return lines;
-    } else if (diff.kind === 'MissingRequiredProperty') {
-      // filter out dependent diffs
-      if (
-        !jsonPointerHelpers.tryGet(
-          spec,
-          jsonPointerHelpers.join(path, diff.propertyPath)
-        ).match
-      )
-        return [];
-
-      const action =
-        options.mode === 'update'
-          ? `is now optional`
-          : `is required and missing`;
-      const color = options.mode === 'update' ? chalk.yellow : chalk.red;
-
-      const lines = [
-        color(`${location} '${diff.key}' ${action} (${diff.propertyPath})`),
-      ];
-      if (verbose) {
-        lines.push(
-          getShapeDiffDetails(
-            diff.description,
-            jsonPointerHelpers.join(path, diff.propertyPath),
-            `missing`,
-            pointerLogger
-          )
-        );
-      }
-      return lines;
-    } else if (diff.kind === 'MissingEnumValue') {
-      if (
-        !jsonPointerHelpers.tryGet(
-          spec,
-          jsonPointerHelpers.join(path, diff.propertyPath)
-        ).match
-      )
-        return [];
-
-      const action =
-        options.mode === 'update'
-          ? `now has enum value '${diff.value}'`
-          : `missing enum value '${diff.value}'`;
-      const color = options.mode === 'update' ? chalk.yellow : chalk.red;
-
-      const lines = [
-        color(`${location} '${diff.key}' ${action} (${diff.propertyPath})`),
-      ];
-      if (verbose) {
-        lines.push(
-          getShapeDiffDetails(
-            diff.description,
-            jsonPointerHelpers.join(path, diff.propertyPath),
-            `missing enum value '${diff.value}'`,
-            pointerLogger
-          )
-        );
-      }
-      return lines;
-    }
-  }
-
-  return [];
-}
-
-function summarizeUnpatchableDiff(
-  diff: GroupedUnpatchableDiff,
-  parseResult: ParseResult,
-  options: {
-    mode: 'update' | 'verify';
-    verbose: boolean;
-  }
-): string[] {
-  const verbose = options.verbose && options.mode === 'verify';
-  const pointerLogger = jsonPointerLogger(parseResult.sourcemap);
-  const reader = sourcemapReader(parseResult.sourcemap);
-  const { path: jsonPath, validationError, examples } = diff;
-  const location = locationFromPath(jsonPath);
-  const summarizedExamples =
-    examples
-      .slice(0, 3)
-      .map((e) => JSON.stringify(e))
-      .join(', ') +
-    (examples.length > 3 ? ` and ${examples.length - 3} other values` : '');
-
-  const lines = [
-    chalk.red(
-      `${location} schema (${diff.schemaPath}) with keyword '${
-        validationError.keyword
-      }' and parameters ${JSON.stringify(
-        validationError.params
-      )} received invalid values ${summarizedExamples}`
-    ),
-  ];
-  if (options.mode === 'update') {
-    const sourcemap = reader.findFileAndLines(jsonPath);
-    lines.push(
-      chalk.red(
-        ` ⛔️ schema could not be automatically updated. Update the schema manually` +
-          (sourcemap ? ` at ${getSourcemapLink(sourcemap)}` : '')
-      )
-    );
-  }
-  if (verbose) {
-    lines.push(
-      getShapeDiffDetails(
-        'interaction did not match schema',
-        jsonPath,
-        `[Actual] ${summarizedExamples}`,
-        pointerLogger
-      )
-    );
-  }
-  return lines;
-}
+import {
+  EndpointPatchSummaries,
+  GroupedUnpatchableDiff,
+} from '../patches/summaries';
 
 // Groups together diffs that are triggered from the same schema instance (we could have multiple interactions or array items that trigger a custom schema error)
 // The reason we need to group these diffs and not the patches, is because once a patchable diff is hit the in-memory spec used to continue diffing never generates the second diff.
@@ -332,28 +70,10 @@ export async function diffExistingEndpoint(
     verbose: boolean;
   }
 ) {
-  const patchSummaries: string[] = [];
+  const patchSummaries = new EndpointPatchSummaries(parseResult, options);
   function addPatchSummary(patchOrDiff: SpecPatch | GroupedUnpatchableDiff) {
     coverage.shapeDiff(patchOrDiff);
-    const summarized =
-      'unpatchable' in patchOrDiff
-        ? summarizeUnpatchableDiff(patchOrDiff, parseResult, {
-            mode: options.update ? 'update' : 'verify',
-            verbose: options.verbose,
-          })
-        : summarizePatch(patchOrDiff, parseResult, {
-            mode: options.update ? 'update' : 'verify',
-            verbose: options.verbose,
-          });
-
-    if (summarized.length) {
-      if (logger.getLevel() <= 1 && patchOrDiff.interaction) {
-        patchSummaries.push(
-          `Originating request: ${JSON.stringify(patchOrDiff.interaction)}`
-        );
-      }
-      patchSummaries.push(...summarized);
-    }
+    patchSummaries.addPatch(patchOrDiff);
   }
   const groupedDiffs = await groupUnpatchableDiffs(
     await AT.collect(
@@ -380,5 +100,7 @@ export async function diffExistingEndpoint(
     }
   }
 
-  return { patchSummaries, hasDiffs: patchSummaries.length > 0 };
+  const summaries = patchSummaries.getPatchSummaries();
+
+  return { patchSummaries: summaries, hasDiffs: summaries.length > 0 };
 }

--- a/projects/optic/src/commands/capture/patches/summaries.ts
+++ b/projects/optic/src/commands/capture/patches/summaries.ts
@@ -1,0 +1,433 @@
+import chalk from 'chalk';
+import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
+import { ParseResult } from '../../../utils/spec-loaders';
+import { logger } from '../../../logger';
+
+import { jsonPointerLogger } from '@useoptic/openapi-io';
+import { SpecPatch } from '../patches/patchers/spec/patches';
+import { getSourcemapLink, sourcemapReader } from '@useoptic/openapi-utilities';
+import { UnpatchableDiff } from './patchers/shapes/diff';
+
+export type GroupedUnpatchableDiff = Omit<UnpatchableDiff, 'example'> & {
+  examples: any[];
+};
+
+type PatchLocation =
+  | {
+      type: 'request';
+    }
+  | {
+      type: 'request-param';
+    }
+  | {
+      type: 'response';
+      statusCode: number;
+    }
+  | {
+      type: 'response-header';
+      statusCode: number;
+    };
+
+function getShapeDiffDetails(
+  description: string,
+  pathToHighlight: string,
+  error: string,
+  pointerLogger: ReturnType<typeof jsonPointerLogger>
+): string {
+  const lines = `${chalk.bgRed('  Diff  ')} ${description}
+${pointerLogger.log(pathToHighlight, {
+  highlightColor: 'yellow',
+  observation: error,
+})}\n`;
+  return lines;
+}
+
+function locationFromPath(path: string): {
+  text: string;
+  location: PatchLocation;
+} {
+  // expected patterns:
+  // /paths/:path/:method/requestBody
+  // /paths/:path/:method/responses/:statusCode
+  const parts = jsonPointerHelpers.decode(path);
+  if (parts[3] === 'requestBody') {
+    return {
+      text: '[request body]',
+      location: { type: 'request' },
+    };
+  } else if (parts[3] === 'responses' && parts[4]) {
+    const statusCode = parts[4];
+    return {
+      text: `[${statusCode} response body]`,
+      location: { type: 'response', statusCode: Number(statusCode) },
+    };
+  }
+
+  return { text: '', location: { type: 'request' } };
+}
+
+function summarizePatch(
+  patch: SpecPatch,
+  parseResult: ParseResult,
+  options: {
+    mode: 'update' | 'verify';
+    verbose: boolean;
+  }
+): { summarized: string[]; location: PatchLocation } | null {
+  const verbose = options.verbose && options.mode === 'verify';
+  const { jsonLike: spec, sourcemap } = parseResult;
+  const pointerLogger = jsonPointerLogger(sourcemap);
+  const { diff, path, groupedOperations } = patch;
+  const color = options.mode === 'update' ? chalk.green : chalk.red;
+  if (!diff || groupedOperations.length === 0) return null;
+  if (diff.kind === 'MissingRequestBody') {
+    const action =
+      options.mode === 'update' ? 'is now optional' : 'is required and missing';
+    return {
+      summarized: [color(`[request body] body ${action}`)],
+      location: { type: 'request' },
+    };
+  } else if (
+    diff.kind === 'UnmatchdResponseBody' ||
+    diff.kind === 'UnmatchedRequestBody' ||
+    diff.kind === 'UnmatchedResponseStatusCode'
+  ) {
+    const location: PatchLocation =
+      diff.kind === 'UnmatchedRequestBody'
+        ? { type: 'request' }
+        : { type: 'response', statusCode: Number(diff.statusCode) };
+
+    const action =
+      options.mode === 'update' ? 'has been added' : 'is not documented';
+    return {
+      location,
+      summarized: [
+        color(
+          `${
+            diff.kind === 'UnmatchedRequestBody'
+              ? '[request body]'
+              : `[${diff.statusCode} response body]`
+          } body ${action}`
+        ),
+      ],
+    };
+  } else if (
+    diff.kind === 'UnmatchedRequestParameter' ||
+    diff.kind === 'UnmatchedResponseHeader'
+  ) {
+    const location: PatchLocation =
+      diff.kind === 'UnmatchedRequestParameter'
+        ? { type: 'request-param' }
+        : { type: 'response-header', statusCode: Number(diff.statusCode) };
+
+    const action =
+      options.mode === 'update' ? 'has been added' : 'is not documented';
+    return {
+      location,
+      summarized: [
+        color(
+          `${
+            diff.kind === 'UnmatchedRequestParameter'
+              ? `[${diff.in} parameter]`
+              : `[${diff.statusCode} response header]`
+          } ${diff.name} ${action}`
+        ),
+      ],
+    };
+  } else if (
+    diff.kind === 'MissingRequiredRequiredParameter' ||
+    diff.kind === 'MissingRequiredResponseHeader'
+  ) {
+    const location: PatchLocation =
+      diff.kind === 'MissingRequiredRequiredParameter'
+        ? { type: 'request-param' }
+        : { type: 'response-header', statusCode: Number(diff.statusCode) };
+
+    const action =
+      options.mode === 'update' ? 'is now optional' : 'is required and missing';
+    return {
+      location,
+      summarized: [
+        color(
+          `${
+            diff.kind === 'MissingRequiredRequiredParameter'
+              ? `[${diff.in} parameter]`
+              : `[${diff.statusCode} response header]`
+          } ${diff.name} ${action}`
+        ),
+      ],
+    };
+  } else {
+    const location = locationFromPath(path);
+
+    if (diff.kind === 'AdditionalProperty') {
+      // filter out dependent diffs
+      if (
+        !jsonPointerHelpers.tryGet(
+          spec,
+          jsonPointerHelpers.join(path, diff.parentObjectPath)
+        ).match
+      )
+        return null;
+
+      const action =
+        options.mode === 'update' ? 'has been added' : 'is not documented';
+      const propertyLocation =
+        options.mode === 'update'
+          ? `(${diff.propertyPath})`
+          : diff.parentObjectPath
+            ? `(${diff.parentObjectPath})`
+            : '';
+      return {
+        summarized: [
+          color(`${location.text} '${diff.key}' ${action} ${propertyLocation}`),
+        ],
+        location: location.location,
+      };
+    } else if (diff.kind === 'UnmatchedType') {
+      // filter out dependent diffs
+      if (
+        !jsonPointerHelpers.tryGet(
+          spec,
+          jsonPointerHelpers.join(path, diff.propertyPath)
+        ).match
+      )
+        return null;
+      let action: string;
+      if (diff.keyword === 'oneOf') {
+        action =
+          options.mode === 'update'
+            ? 'now matches schema'
+            : `does not match schema`;
+      } else {
+        action =
+          options.mode === 'update'
+            ? `is now type ${diff.expectedType}`
+            : `does not match type ${diff.expectedType}. Received ${diff.example}`;
+      }
+      const color = options.mode === 'update' ? chalk.yellow : chalk.red;
+
+      const lines = [
+        color(
+          `${location.text} '${diff.key}' ${action} (${diff.propertyPath})`
+        ),
+      ];
+      if (verbose) {
+        lines.push(
+          getShapeDiffDetails(
+            diff.description,
+            jsonPointerHelpers.join(path, diff.propertyPath),
+            `[Actual] ${JSON.stringify(diff.example)}`,
+            pointerLogger
+          )
+        );
+      }
+      return { summarized: lines, location: location.location };
+    } else if (diff.kind === 'MissingRequiredProperty') {
+      // filter out dependent diffs
+      if (
+        !jsonPointerHelpers.tryGet(
+          spec,
+          jsonPointerHelpers.join(path, diff.propertyPath)
+        ).match
+      )
+        return null;
+
+      const action =
+        options.mode === 'update'
+          ? `is now optional`
+          : `is required and missing`;
+      const color = options.mode === 'update' ? chalk.yellow : chalk.red;
+
+      const lines = [
+        color(
+          `${location.text} '${diff.key}' ${action} (${diff.propertyPath})`
+        ),
+      ];
+      if (verbose) {
+        lines.push(
+          getShapeDiffDetails(
+            diff.description,
+            jsonPointerHelpers.join(path, diff.propertyPath),
+            `missing`,
+            pointerLogger
+          )
+        );
+      }
+      return { summarized: lines, location: location.location };
+    } else if (diff.kind === 'MissingEnumValue') {
+      if (
+        !jsonPointerHelpers.tryGet(
+          spec,
+          jsonPointerHelpers.join(path, diff.propertyPath)
+        ).match
+      )
+        return null;
+
+      const action =
+        options.mode === 'update'
+          ? `now has enum value '${diff.value}'`
+          : `missing enum value '${diff.value}'`;
+      const color = options.mode === 'update' ? chalk.yellow : chalk.red;
+
+      const lines = [
+        color(
+          `${location.text} '${diff.key}' ${action} (${diff.propertyPath})`
+        ),
+      ];
+      if (verbose) {
+        lines.push(
+          getShapeDiffDetails(
+            diff.description,
+            jsonPointerHelpers.join(path, diff.propertyPath),
+            `missing enum value '${diff.value}'`,
+            pointerLogger
+          )
+        );
+      }
+      return { summarized: lines, location: location.location };
+    }
+  }
+
+  return null;
+}
+
+function summarizeUnpatchableDiff(
+  diff: GroupedUnpatchableDiff,
+  parseResult: ParseResult,
+  options: {
+    mode: 'update' | 'verify';
+    verbose: boolean;
+  }
+): { summarized: string[]; location: PatchLocation } {
+  const verbose = options.verbose && options.mode === 'verify';
+  const pointerLogger = jsonPointerLogger(parseResult.sourcemap);
+  const reader = sourcemapReader(parseResult.sourcemap);
+  const { path: jsonPath, validationError, examples } = diff;
+  const location = locationFromPath(jsonPath);
+  const summarizedExamples =
+    examples
+      .slice(0, 3)
+      .map((e) => JSON.stringify(e))
+      .join(', ') +
+    (examples.length > 3 ? ` and ${examples.length - 3} other values` : '');
+
+  const lines = [
+    chalk.red(
+      `${location.text} schema (${diff.schemaPath}) with keyword '${
+        validationError.keyword
+      }' and parameters ${JSON.stringify(
+        validationError.params
+      )} received invalid values ${summarizedExamples}`
+    ),
+  ];
+  if (options.mode === 'update') {
+    const sourcemap = reader.findFileAndLines(jsonPath);
+    lines.push(
+      chalk.red(
+        ` ⛔️ schema could not be automatically updated. Update the schema manually` +
+          (sourcemap ? ` at ${getSourcemapLink(sourcemap)}` : '')
+      )
+    );
+  }
+  if (verbose) {
+    lines.push(
+      getShapeDiffDetails(
+        'interaction did not match schema',
+        jsonPath,
+        `[Actual] ${summarizedExamples}`,
+        pointerLogger
+      )
+    );
+  }
+  return { summarized: lines, location: location.location };
+}
+
+export class EndpointPatchSummaries {
+  private patches: {
+    requestParams: string[];
+    requestBody: string[];
+    responses: Map<
+      number,
+      {
+        headers: string[];
+        body: string[];
+      }
+    >;
+  };
+  constructor(
+    private parseResult: ParseResult,
+    private options: {
+      update?: 'documented' | 'interactive' | 'automatic';
+      verbose: boolean;
+    }
+  ) {
+    this.patches = {
+      requestParams: [],
+      requestBody: [],
+      responses: new Map(),
+    };
+  }
+
+  addPatch(patchOrDiff: SpecPatch | GroupedUnpatchableDiff) {
+    const patchDetails =
+      'unpatchable' in patchOrDiff
+        ? summarizeUnpatchableDiff(patchOrDiff, this.parseResult, {
+            mode: this.options.update ? 'update' : 'verify',
+            verbose: this.options.verbose,
+          })
+        : summarizePatch(patchOrDiff, this.parseResult, {
+            mode: this.options.update ? 'update' : 'verify',
+            verbose: this.options.verbose,
+          });
+    if (patchDetails) {
+      const { summarized, location } = patchDetails;
+      if (logger.getLevel() <= 1 && patchOrDiff.interaction) {
+        summarized.push(
+          `Originating request: ${JSON.stringify(patchOrDiff.interaction)}`
+        );
+      }
+      switch (location.type) {
+        case 'request': {
+          this.patches.requestBody.push(...summarized);
+          break;
+        }
+        case 'request-param': {
+          this.patches.requestParams.push(...summarized);
+          break;
+        }
+        case 'response': {
+          const responsePatches = this.patches.responses.get(
+            location.statusCode
+          ) ?? { headers: [], body: [] };
+          responsePatches.body.push(...summarized);
+          this.patches.responses.set(location.statusCode, responsePatches);
+          break;
+        }
+        case 'response-header': {
+          const responsePatches = this.patches.responses.get(
+            location.statusCode
+          ) ?? { headers: [], body: [] };
+          responsePatches.headers.push(...summarized);
+          break;
+        }
+      }
+    }
+  }
+
+  getPatchSummaries(): string[] {
+    const patchSummaries: string[] = [
+      ...this.patches.requestParams,
+      ...this.patches.requestBody,
+    ];
+
+    // sort by asc status code
+    const sortedResponses = [...this.patches.responses.entries()].sort(
+      ([a], [b]) => a - b
+    );
+    for (const [, response] of sortedResponses) {
+      patchSummaries.push(...response.headers, ...response.body);
+    }
+    return patchSummaries;
+  }
+}


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

I noticed that node20 tests were being flaky, particularly around `optic capture` outputs. Not sure why node 20 specifically had differnet outputs, but I realized that patches were being summarized in the order the interactions happened, meaning we could have out of order patch summaries... E.g.

```
POST /form
  [31m× [39mRequest Body
  # Here 200 response body comes between the request bodies
  [31m[200 response body] body is not documented[39m
  [31m[request body] 'name' is not documented (/properties)[39m
  [31m[request body] 'surname' is not documented (/properties)[39m
```

This PR orders the patch summaries so that we list them by request, then response (sorted by status code ascending)

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
