### PR TITLE
Fix git parse when file in space

### DIFF
--- a/projects/openapi-io/src/parser/resolvers/git-branch-file-resolver.ts
+++ b/projects/openapi-io/src/parser/resolvers/git-branch-file-resolver.ts
@@ -17,10 +17,10 @@ export const gitBranchResolver = (
   },
   read(file) {
     return new Promise((resolve, reject) => {
-      const toGit = filePathToGitPath(gitBaseRepo, file.url);
       // We need to decode the git path, because we receive the file path / url as a URL encoded string
-      const decodedGitPath = decodeURIComponent(toGit);
-      const command = `git show "${branch}:${decodedGitPath}"`;
+      const decodedFilePath = decodeURIComponent(file.url);
+      const toGit = filePathToGitPath(gitBaseRepo, decodedFilePath);
+      const command = `git show "${branch}:${toGit}"`;
       try {
         exec(
           command,
@@ -29,8 +29,8 @@ export const gitBranchResolver = (
             if (err)
               reject(
                 new ResolverError(
-                  ono(err.message, `Error opening file "${decodedGitPath}"`),
-                  decodedGitPath
+                  ono(err.message, `Error opening file "${toGit}"`),
+                  toGit
                 )
               );
             if (stdout) resolve(stdout);
@@ -39,8 +39,8 @@ export const gitBranchResolver = (
       } catch (err) {
         reject(
           new ResolverError(
-            ono(err as any, `Error opening file "${decodedGitPath}"`),
-            decodedGitPath
+            ono(err as any, `Error opening file "${toGit}"`),
+            toGit
           )
         );
       }


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

If the git repo is in a folder with a space, the relative path check breaks (i.e. the space in the path to folder includes an encoded space) so the git show command ends up failing here

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
