### PR TITLE
fix triggering generation when no token

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.54.3",
+  "version": "0.54.4",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/fastify-capture/package.json
+++ b/projects/fastify-capture/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/fastify-capture",
   "license": "MIT",
   "packageManager": "yarn@4.1.0",
-  "version": "0.54.3",
+  "version": "0.54.4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@4.1.0",
-  "version": "0.54.3",
+  "version": "0.54.4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@4.1.0",
-  "version": "0.54.3",
+  "version": "0.54.4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@4.1.0",
-  "version": "0.54.3",
+  "version": "0.54.4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@4.1.0",
-  "version": "0.54.3",
+  "version": "0.54.4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/src/utils/generated.ts
+++ b/projects/optic/src/utils/generated.ts
@@ -15,6 +15,7 @@ export async function getDetailsForGeneration(config: OpticCliConfig): Promise<{
   const maybeOrigin = await Git.guessRemoteOrigin();
 
   const message = `Select the organization that your APIs belong to. Use an organization token to disambiguate in non interactive environments.`;
+  if (!config.isAuthenticated) return null;
   const orgRes = await getOrganizationFromToken(config.client, message);
 
   const maybeDefaultBranch = await Git.getDefaultBranchName();

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@4.1.0",
-  "version": "0.54.3",
+  "version": "0.54.4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@4.1.0",
-  "version": "0.54.3",
+  "version": "0.54.4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

https://github.com/opticdev/optic/issues/2723

Fixes this by bypassing the diff-all check when no Optic token is set - this should mean we just pass the generate details check

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
