### PR TITLE
Merge nested allof

### DIFF
--- a/projects/openapi-io/src/denormalizers/__tests__/__snapshots__/denormalize.test.ts.snap
+++ b/projects/openapi-io/src/denormalizers/__tests__/__snapshots__/denormalize.test.ts.snap
@@ -32,7 +32,6 @@ exports[`denormalize allOf merging does not merge allOf when all items are not a
                           "type": "string",
                         },
                       },
-                      "required": undefined,
                       "type": "object",
                     },
                   },
@@ -243,6 +242,69 @@ paths:
 }
 `;
 
+exports[`denormalize allOf merging merges allOf with only one item 1`] = `
+{
+  "jsonLike": {
+    "info": {
+      "title": "some thing",
+      "version": "v0",
+    },
+    "openapi": "3.0.1",
+    "paths": {
+      "/example": {
+        "get": {
+          "parameters": [],
+          "requestBody": null,
+          "responses": {
+            "200": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "format": "uuid",
+                    "type": "string",
+                  },
+                },
+              },
+              "description": "some thing",
+              "headers": {},
+            },
+          },
+        },
+      },
+    },
+  },
+  "sourcemap": JsonSchemaSourcemap {
+    "files": [
+      {
+        "contents": "openapi: '3.0.1'
+info:
+  title: 'some thing'
+  version: 'v0'
+paths:
+  /example:
+    get:
+      requestBody:
+      responses:
+        200:
+          description: 'some thing'
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - type: string
+                    format: uuid
+",
+        "index": null,
+        "path": "/src/denormalizers/__tests__/specs/allOf/single-child.yaml",
+        "sha256": "6536b93a83f2b2a5d776abac8830ba6750e4ba08056b78096b9c7ebf5653849c",
+      },
+    ],
+    "refMappings": {},
+    "rootFilePath": "/src/denormalizers/__tests__/specs/allOf/single-child.yaml",
+  },
+}
+`;
+
 exports[`denormalize allOf merging merges allOfs in type array object / items 1`] = `
 {
   "jsonLike": {
@@ -281,14 +343,12 @@ exports[`denormalize allOf merging merges allOfs in type array object / items 1`
                               "type": "string",
                             },
                           },
-                          "required": undefined,
                           "type": "object",
                         },
                         "e": {
                           "type": "string",
                         },
                       },
-                      "required": undefined,
                       "type": "object",
                     },
                     "properties": {
@@ -312,14 +372,12 @@ exports[`denormalize allOf merging merges allOfs in type array object / items 1`
                                 "type": "string",
                               },
                             },
-                            "required": undefined,
                             "type": "object",
                           },
                           "e": {
                             "type": "string",
                           },
                         },
-                        "required": undefined,
                         "type": "object",
                       },
                     },
@@ -515,7 +573,6 @@ exports[`denormalize allOf merging merges nested allOf 1`] = `
                             "type": "string",
                           },
                         },
-                        "required": undefined,
                         "type": "object",
                       },
                       "e": {
@@ -525,7 +582,6 @@ exports[`denormalize allOf merging merges nested allOf 1`] = `
                         "type": "string",
                       },
                     },
-                    "required": undefined,
                     "type": "object",
                   },
                 },

--- a/projects/openapi-io/src/denormalizers/__tests__/__snapshots__/denormalize.test.ts.snap
+++ b/projects/openapi-io/src/denormalizers/__tests__/__snapshots__/denormalize.test.ts.snap
@@ -27,19 +27,13 @@ exports[`denormalize allOf merging does not merge allOf when all items are not a
                       "type": "boolean",
                     },
                     "d": {
-                      "allOf": [
-                        {
-                          "properties": {
-                            "a": {
-                              "type": "string",
-                            },
-                          },
-                          "type": "object",
-                        },
-                        {
+                      "properties": {
+                        "a": {
                           "type": "string",
                         },
-                      ],
+                      },
+                      "required": undefined,
+                      "type": "object",
                     },
                   },
                   "type": "object",
@@ -106,7 +100,12 @@ paths:
         "sha256": "4921acb94767de410927bd6751ac8d9f712c11dc70dcb260236a6684df8dcdb2",
       },
     ],
-    "refMappings": {},
+    "refMappings": {
+      "/paths/~1example/get/requestBody/content/application~1json/schema/properties/d/properties/a": [
+        0,
+        "/paths/~1example/get/requestBody/content/application~1json/schema/properties/d/allOf/0/properties/a",
+      ],
+    },
     "rootFilePath": "/src/denormalizers/__tests__/specs/allOf/no-merge.yaml",
   },
 }

--- a/projects/openapi-io/src/denormalizers/__tests__/__snapshots__/denormalize.test.ts.snap
+++ b/projects/openapi-io/src/denormalizers/__tests__/__snapshots__/denormalize.test.ts.snap
@@ -522,6 +522,9 @@ exports[`denormalize allOf merging merges nested allOf 1`] = `
                       "e": {
                         "type": "string",
                       },
+                      "x": {
+                        "type": "string",
+                      },
                     },
                     "required": undefined,
                     "type": "object",
@@ -555,6 +558,11 @@ paths:
               schema:
                 type: object
                 allOf:
+                  - allOf:
+                      - type: object
+                        properties:
+                          x:
+                            type: string
                   - type: object
                     properties:
                       a:
@@ -582,37 +590,45 @@ paths:
 ",
         "index": null,
         "path": "/src/denormalizers/__tests__/specs/allOf/nested.yaml",
-        "sha256": "19bb796a8fe63c93a2d80c8769ccc08255dcb7d55e5ab9b4a110c308f759cff2",
+        "sha256": "f40a14b89b16b1dbccde926823ead4a870178e400878f5114b21936725d99527",
       },
     ],
     "refMappings": {
+      "/paths/~1example/get/responses/200/content/application~1json/schema/allOf/0/properties/x": [
+        0,
+        "/paths/~1example/get/responses/200/content/application~1json/schema/allOf/0/allOf/0/properties/x",
+      ],
       "/paths/~1example/get/responses/200/content/application~1json/schema/properties/a": [
         0,
-        "/paths/~1example/get/responses/200/content/application~1json/schema/allOf/0/properties/a",
+        "/paths/~1example/get/responses/200/content/application~1json/schema/allOf/1/properties/a",
       ],
       "/paths/~1example/get/responses/200/content/application~1json/schema/properties/b": [
         0,
-        "/paths/~1example/get/responses/200/content/application~1json/schema/allOf/1/properties/b",
+        "/paths/~1example/get/responses/200/content/application~1json/schema/allOf/2/properties/b",
       ],
       "/paths/~1example/get/responses/200/content/application~1json/schema/properties/c": [
         0,
-        "/paths/~1example/get/responses/200/content/application~1json/schema/allOf/1/properties/c",
+        "/paths/~1example/get/responses/200/content/application~1json/schema/allOf/2/properties/c",
       ],
       "/paths/~1example/get/responses/200/content/application~1json/schema/properties/d": [
         0,
-        "/paths/~1example/get/responses/200/content/application~1json/schema/allOf/2/properties/d",
+        "/paths/~1example/get/responses/200/content/application~1json/schema/allOf/3/properties/d",
       ],
       "/paths/~1example/get/responses/200/content/application~1json/schema/properties/d/properties/a": [
         0,
-        "/paths/~1example/get/responses/200/content/application~1json/schema/allOf/2/properties/d/allOf/0/properties/a",
+        "/paths/~1example/get/responses/200/content/application~1json/schema/allOf/3/properties/d/allOf/0/properties/a",
       ],
       "/paths/~1example/get/responses/200/content/application~1json/schema/properties/d/properties/b": [
         0,
-        "/paths/~1example/get/responses/200/content/application~1json/schema/allOf/2/properties/d/allOf/1/properties/b",
+        "/paths/~1example/get/responses/200/content/application~1json/schema/allOf/3/properties/d/allOf/1/properties/b",
       ],
       "/paths/~1example/get/responses/200/content/application~1json/schema/properties/e": [
         0,
-        "/paths/~1example/get/responses/200/content/application~1json/schema/allOf/2/properties/e",
+        "/paths/~1example/get/responses/200/content/application~1json/schema/allOf/3/properties/e",
+      ],
+      "/paths/~1example/get/responses/200/content/application~1json/schema/properties/x": [
+        0,
+        "/paths/~1example/get/responses/200/content/application~1json/schema/allOf/0/properties/x",
       ],
     },
     "rootFilePath": "/src/denormalizers/__tests__/specs/allOf/nested.yaml",

--- a/projects/openapi-io/src/denormalizers/__tests__/denormalize.test.ts
+++ b/projects/openapi-io/src/denormalizers/__tests__/denormalize.test.ts
@@ -52,6 +52,10 @@ describe('denormalize', () => {
         'merges allOfs in type array object / items',
         'src/denormalizers/__tests__/specs/allOf/in-type-array.yaml',
       ],
+      [
+        'merges allOf with only one item',
+        'src/denormalizers/__tests__/specs/allOf/single-child.yaml',
+      ],
     ])('%s', async (_, openapiFilePath) => {
       const spec = await parseOpenAPIWithSourcemap(
         path.resolve(openapiFilePath)

--- a/projects/openapi-io/src/denormalizers/__tests__/specs/allOf/nested.yaml
+++ b/projects/openapi-io/src/denormalizers/__tests__/specs/allOf/nested.yaml
@@ -14,6 +14,11 @@ paths:
               schema:
                 type: object
                 allOf:
+                  - allOf:
+                      - type: object
+                        properties:
+                          x:
+                            type: string
                   - type: object
                     properties:
                       a:

--- a/projects/openapi-io/src/denormalizers/__tests__/specs/allOf/single-child.yaml
+++ b/projects/openapi-io/src/denormalizers/__tests__/specs/allOf/single-child.yaml
@@ -1,0 +1,17 @@
+openapi: '3.0.1'
+info:
+  title: 'some thing'
+  version: 'v0'
+paths:
+  /example:
+    get:
+      requestBody:
+      responses:
+        200:
+          description: 'some thing'
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - type: string
+                    format: uuid

--- a/projects/openapi-io/src/denormalizers/denormalize.ts
+++ b/projects/openapi-io/src/denormalizers/denormalize.ts
@@ -16,7 +16,7 @@ export function denormalize<
     jsonLike: ParseOpenAPIResult['jsonLike'];
     sourcemap?: ParseOpenAPIResult['sourcemap'];
   },
->(parse: T): T {
+>(parse: T, warnings?: string[]): T {
   parse = {
     ...parse,
     jsonLike: JSON.parse(JSON.stringify(parse.jsonLike)),
@@ -26,7 +26,8 @@ export function denormalize<
       denormalizePaths(
         path as FlatOpenAPIV3.PathItemObject,
         pathKey,
-        parse.sourcemap
+        parse.sourcemap,
+        warnings
       );
 
       for (const method of Object.values(OpenAPIV3.HttpMethods)) {
@@ -37,7 +38,8 @@ export function denormalize<
           denormalizeOperation(
             operation,
             { path: pathKey, method },
-            parse.sourcemap
+            parse.sourcemap,
+            warnings
           );
         }
       }
@@ -50,7 +52,8 @@ export function denormalize<
 export function denormalizePaths(
   path: FlatOpenAPIV3.PathItemObject,
   pathKey: string,
-  sourcemap?: JsonSchemaSourcemap
+  sourcemap?: JsonSchemaSourcemap,
+  warnings?: string[]
 ) {
   if (path.parameters) {
     for (const method of Object.values(OpenAPIV3.HttpMethods)) {
@@ -110,7 +113,8 @@ export function denormalizeOperation(
     path: string;
     method: string;
   },
-  sourcemap?: JsonSchemaSourcemap
+  sourcemap?: JsonSchemaSourcemap,
+  warnings?: string[]
 ) {
   // For all schemas, flatten allOfs
   if (operation.requestBody) {
@@ -127,10 +131,11 @@ export function denormalizeOperation(
         'schema',
       ]);
       if (body.schema) {
-        denormalizeProperty(body.schema, sourcemap, {
+        const w = denormalizeProperty(body.schema, sourcemap, {
           old: pointer,
           new: pointer,
         });
+        warnings?.push(...w);
       }
     }
   }
@@ -147,10 +152,11 @@ export function denormalizeOperation(
         'schema',
       ]);
       if (body.schema) {
-        denormalizeProperty(body.schema, sourcemap, {
+        const w = denormalizeProperty(body.schema, sourcemap, {
           old: pointer,
           new: pointer,
         });
+        warnings?.push(...w);
       }
     }
   }

--- a/projects/openapi-io/src/denormalizers/denormalizeProperty.ts
+++ b/projects/openapi-io/src/denormalizers/denormalizeProperty.ts
@@ -92,13 +92,11 @@ export function denormalizeProperty(
         : null;
   const polymorphicValue = schema.allOf || schema.anyOf || schema.oneOf;
   if (polymorphicKey && polymorphicValue) {
-    if (
-      polymorphicKey === 'allOf' &&
-      polymorphicValue.every(
+    if (polymorphicKey === 'allOf') {
+      const objectsAndAllOf = polymorphicValue.filter(
         (schema) => OAS3.isObjectType(schema.type) || schema.allOf
-      )
-    ) {
-      const effectiveObject = mergeAllOf(polymorphicValue, sourcemap, pointers);
+      );
+      const effectiveObject = mergeAllOf(objectsAndAllOf, sourcemap, pointers);
       schema.type = effectiveObject.type;
       schema.properties = effectiveObject.properties;
       schema.required = effectiveObject.required;

--- a/projects/optic/src/utils/spec-loaders.ts
+++ b/projects/optic/src/utils/spec-loaders.ts
@@ -23,6 +23,7 @@ import { getApiFromOpticUrl, getApiUrl } from './cloud-urls';
 import { OPTIC_URL_KEY } from '../constants';
 import chalk from 'chalk';
 import { getDetailsForGeneration } from './generated';
+import { logger } from '../logger';
 
 const exec = promisify(callbackExec);
 
@@ -298,8 +299,13 @@ function validateAndDenormalize(
   validateOpenApiV3Document(parseResult.jsonLike, parseResult.sourcemap, {
     strictOpenAPI: options.strict,
   });
+  const warnings = [];
+  const result = options.denormalize
+    ? denormalize(parseResult, warnings)
+    : parseResult;
+  if (warnings.length !== 0) logger.warn(...warnings);
 
-  return options.denormalize ? denormalize(parseResult) : parseResult;
+  return result;
 }
 
 // Optic ref supports


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

This PR merges nested allOf keys (e.g. `allOf: [ { allOf: [...] } ]`)

This PR also changes how we handle invalid allOf definitions. Instead of ignoring the `allOf` if there's a `type: string` and not flattening allOf, we ignore the `type: string` variant and flatten the rest (assuming there is an object). I think this is likely a better user experience, especially downstream in the rest of our app (e.g. allOf is assumed to not be there, and if it's invalid we'll get things like "every key in the allOf is removed" rule errors).

TODO
- [x] Surface reason / errors / warnings as part of denormalizing

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
