### PR TITLE
chore(optic): increase buffer size when getting git rev-list

### DIFF
--- a/projects/optic/src/commands/api/git-get-file-candidates.ts
+++ b/projects/optic/src/commands/api/git-get-file-candidates.ts
@@ -61,7 +61,9 @@ export async function getPathCandidatesForSha(
         ? `git rev-list HEAD --first-parent`
         : `git rev-list HEAD -n ${opts.depth} --first-parent`;
     try {
-      const commandResults = await exec(command).then(({ stdout }) =>
+      // Repos with a large set of commits may exceed the size of the default buffer
+      const opts = { maxBuffer: 1024 * 1024 * 2 }; // 2MB
+      const commandResults = await exec(command, opts).then(({ stdout }) =>
         stdout.trim()
       );
       hashes = commandResults.split('\n');


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

- increases the buffer size when getting rev-list. repos with large lists may exceed the default buffer size.

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
