### PR TITLE
fix(optic): don't loop forever when running from `/`

### DIFF
--- a/projects/optic/src/config.ts
+++ b/projects/optic/src/config.ts
@@ -157,7 +157,7 @@ export async function detectCliConfig(
 ): Promise<string | undefined> {
   let currentDir = process.cwd();
   // search up from pwd to specified dir
-  while (topLevelDir.length < currentDir.length) {
+  while (topLevelDir.length <= currentDir.length) {
     const expectedDevYmlPath = path.join(currentDir, OPTIC_DEV_YML_NAME);
     const expectedYmlPath = path.join(currentDir, OPTIC_YML_NAME);
     try {
@@ -170,7 +170,9 @@ export async function detectCliConfig(
       return expectedDevYmlPath;
     } catch (e) {}
 
-    currentDir = path.dirname(currentDir);
+    const next = path.dirname(currentDir);
+    if (currentDir === next) break;
+    currentDir = next;
   }
 
   return undefined;

--- a/projects/optic/src/config.ts
+++ b/projects/optic/src/config.ts
@@ -157,7 +157,7 @@ export async function detectCliConfig(
 ): Promise<string | undefined> {
   let currentDir = process.cwd();
   // search up from pwd to specified dir
-  while (topLevelDir.length <= currentDir.length) {
+  while (topLevelDir.length < currentDir.length) {
     const expectedDevYmlPath = path.join(currentDir, OPTIC_DEV_YML_NAME);
     const expectedYmlPath = path.join(currentDir, OPTIC_YML_NAME);
     try {


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

i noticed what i thought was an issue with our docker image, where any invocation of optic would hang without output and require a `kill -9` to stop. after some stracing and validating where it first sprung up i narrowed it down to the seemingly innocuous way we walk the file tree to find a config.

when `$PWD` is `/` the walk enters an infinite loop. this most noticeable in the image because we leave its `WORKDIR` set at the root, `/`. you can however replicate this on macOS as well with,

```shell
cd / && optic --version
```

just be ready to grab the pid so you can kill it :)

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
