### PR TITLE
chore: build multi-arch images locally too

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -74,7 +74,7 @@ tasks:
   docker:build:local:
     desc: Build an Optic image for your platform
     summary: |
-      Build an Optic image and publish a locally-running registry.
+      Build an Optic image and publish to a locally-running registry for testing.
 
       This is useful for building and inspecting the Optic image locally
       without needing to publish to an external registry. A multi-arch image

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -58,23 +58,41 @@ tasks:
         docker buildx create
         --name optic-multiplatform-builder
         --platform linux/amd64,linux/arm64
+        --driver-opt network=host
     status:
       - docker buildx ls | grep -Eq optic-multiplatform-builder
+
+  docker:registry:start:
+    cmds:
+      - docker run --name=registry --rm --detach --publish=5000:5000 registry:2
+    status:
+      - docker ps --filter "name=registry" | grep -Eq registry
+
+  docker:registry:stop:
+    cmds: ["docker stop registry"]
 
   docker:build:local:
     desc: Build an Optic image for your platform
     summary: |
-      Build an Optic image for your platform
+      Build an Optic image and publish a locally-running registry.
 
-      Most useful for produce a single-platform build for local use. Builds intended
-      for publishing should use `docker:build:release`.
+      This is useful for building and inspecting the Optic image locally
+      without needing to publish to an external registry. A multi-arch image
+      is built and published to `localhost:5000/useoptic/optic:local`.
+      
+      Builds intended for publishing should use `docker:build:release`.
 
       example:
-       task docker:build:local OPTIC_CLI_VERSION=v0.43.5
+       task docker:build:local OPTIC_CLI_VERSION=latest
+    deps:
+      - docker:setup
+      - docker:registry:start
     cmds:
       - >
-        docker build {{.CLI_ARGS}}
-        --tag docker.io/useoptic/optic:local
+        docker buildx build --push {{.CLI_ARGS}}
+        --tag localhost:5000/useoptic/optic:local
+        --platform linux/amd64,linux/arm64
+        --builder optic-multiplatform-builder
         --build-arg OPTIC_CLI_VERSION={{.OPTIC_CLI_VERSION}}
         .
 


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

updates the `docker:build:local` task to build multiarch images similarly to how `docker:build:release` does. we weren't doing this before, because i didnt understand how to get the images "available" without pushing to a registry. i mean, i still dont, but now we'll also just run a local (stateless) registry to push the image manifests there.

images (and the manifest) built with `docker:build:local` will be pushed to `localhost:5000/useoptic/optic:local`.

this makes it easier to inspect changes to the image with confidence that you're seeing something closer to what the release process would build. 👍 

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
