### PR TITLE
chore(docker): run optic as unprivileged user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM alpine:latest
 
 ARG OPTIC_CLI_VERSION=latest
 
-RUN addgroup -S optic && adduser -S optic -G optic && \
+RUN addgroup -S optic && \
+    adduser -S optic -G optic && \
     apk --no-cache add git curl && \
     echo "optic-docker" > /etc/machine-id
 RUN set -e; sh -c "$(curl -s --location https://install.useoptic.com/install.sh)" -- $OPTIC_CLI_VERSION /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,23 @@
-FROM alpine:latest
+# Doing the intial installation of Optic and Spectral separately
+# saves a bit of space in the final image--Probably due to temp
+# file creation.
+FROM alpine:latest as dl
 ARG OPTIC_CLI_VERSION=latest
+RUN apk --no-cache add curl
+# install Optic
+RUN set -e; sh -c "$(curl -s --location https://install.useoptic.com/install.sh)" -- $OPTIC_CLI_VERSION /usr/local/bin
+# install Spectral
+RUN curl -L https://raw.github.com/stoplightio/spectral/master/scripts/install.sh | sh
+
+FROM alpine:latest
 ENV INSTALLATION_METHOD="docker"
 RUN addgroup -S optic && \
     adduser -S optic -G optic && \
     apk --no-cache add git curl && \
     echo "optic-docker" > /etc/machine-id
-RUN set -e; sh -c "$(curl -s --location https://install.useoptic.com/install.sh)" -- $OPTIC_CLI_VERSION /usr/local/bin
+
+COPY --from=dl /usr/local/bin/optic /usr/local/bin/
+COPY --from=dl /usr/local/bin/spectral /usr/local/bin/
 
 USER optic
 ENTRYPOINT ["/usr/local/bin/optic"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,11 @@ FROM alpine:latest
 
 ARG OPTIC_CLI_VERSION=latest
 
-RUN apk --no-cache add git curl
-RUN echo "optic-docker" > /etc/machine-id
+RUN addgroup -S optic && adduser -S optic -G optic && \
+    apk --no-cache add git curl && \
+    echo "optic-docker" > /etc/machine-id
 RUN set -e; sh -c "$(curl -s --location https://install.useoptic.com/install.sh)" -- $OPTIC_CLI_VERSION /usr/local/bin
 
+USER optic
 ENV INSTALLATION_METHOD="docker"
 ENTRYPOINT ["/usr/local/bin/optic"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM alpine:latest
-
 ARG OPTIC_CLI_VERSION=latest
-
+ENV INSTALLATION_METHOD="docker"
 RUN addgroup -S optic && \
     adduser -S optic -G optic && \
     apk --no-cache add git curl && \
@@ -9,5 +8,4 @@ RUN addgroup -S optic && \
 RUN set -e; sh -c "$(curl -s --location https://install.useoptic.com/install.sh)" -- $OPTIC_CLI_VERSION /usr/local/bin
 
 USER optic
-ENV INSTALLATION_METHOD="docker"
 ENTRYPOINT ["/usr/local/bin/optic"]

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -95,6 +95,8 @@ tasks:
         --builder optic-multiplatform-builder
         --build-arg OPTIC_CLI_VERSION={{.OPTIC_CLI_VERSION}}
         .
+      # ensure we have the latest image pulled from the registry, easy to forget to do this
+      - docker pull localhost:5000/useoptic/optic:local
 
   docker:build:release:
     desc: Build an Optic image for all supported platforms, suitable for publishing

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "0.54.7",
+  "version": "0.54.8",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/fastify-capture/package.json
+++ b/projects/fastify-capture/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/fastify-capture",
   "license": "MIT",
   "packageManager": "yarn@4.1.0",
-  "version": "0.54.7",
+  "version": "0.54.8",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@4.1.0",
-  "version": "0.54.7",
+  "version": "0.54.8",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@4.1.0",
-  "version": "0.54.7",
+  "version": "0.54.8",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@4.1.0",
-  "version": "0.54.7",
+  "version": "0.54.8",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@4.1.0",
-  "version": "0.54.7",
+  "version": "0.54.8",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@4.1.0",
-  "version": "0.54.7",
+  "version": "0.54.8",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@4.1.0",
-  "version": "0.54.7",
+  "version": "0.54.8",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

- drops into an unprivileged user in the container image.

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
kicked the tires a bit with bookstore-example and everything seemed ok,

```
docker run --rm -it --volume=$HOME/code/bookstore-example:/repo --workdir /repo localhost:5000/useoptic/optic:local capture openapi.yml --update interactive
```
