### PR TITLE
Support loading swagger 2.0 specs

### DIFF
--- a/projects/openapi-io/src/denormalizers/__tests__/denormalize.test.ts
+++ b/projects/openapi-io/src/denormalizers/__tests__/denormalize.test.ts
@@ -7,7 +7,7 @@ import {
   parseOpenAPIWithSourcemap,
 } from '../../parser/openapi-sourcemap-parser';
 
-function prepSnapshot(result: ParseOpenAPIResult) {
+function prepSnapshot(result: ParseOpenAPIResult<any>) {
   const cwd = process.cwd();
   result.sourcemap.files.forEach((i) => {
     i.path = i.path.split(cwd)[1];

--- a/projects/openapi-io/src/denormalizers/denormalize.ts
+++ b/projects/openapi-io/src/denormalizers/denormalize.ts
@@ -1,5 +1,10 @@
 import { ParseOpenAPIResult } from '../parser/openapi-sourcemap-parser';
-import { FlatOpenAPIV3, OpenAPIV3 } from '@useoptic/openapi-utilities';
+import {
+  FlatOpenAPIV2,
+  FlatOpenAPIV3,
+  FlatOpenAPIV3_1,
+  OpenAPIV3,
+} from '@useoptic/openapi-utilities';
 import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
 import { logPointer } from './pointer';
 import { denormalizeProperty } from './denormalizeProperty';
@@ -12,16 +17,21 @@ import { JsonSchemaSourcemap } from '../parser/sourcemap';
 // - adds response headers {} if not set
 // - adds parameters [] if not set
 export function denormalize<
+  Version extends
+    | FlatOpenAPIV2.Document
+    | FlatOpenAPIV3.Document
+    | FlatOpenAPIV3_1.Document,
   T extends {
-    jsonLike: ParseOpenAPIResult['jsonLike'];
-    sourcemap?: ParseOpenAPIResult['sourcemap'];
+    jsonLike: ParseOpenAPIResult<Version>['jsonLike'];
+    sourcemap?: ParseOpenAPIResult<Version>['sourcemap'];
   },
 >(parse: T, warnings?: string[]): T {
   parse = {
     ...parse,
     jsonLike: JSON.parse(JSON.stringify(parse.jsonLike)),
   } as T;
-  for (const [pathKey, path] of Object.entries(parse.jsonLike.paths)) {
+  // TODO handle denormalize for swagger2
+  for (const [pathKey, path] of Object.entries(parse.jsonLike.paths ?? {})) {
     if (path) {
       denormalizePaths(
         path as FlatOpenAPIV3.PathItemObject,

--- a/projects/openapi-io/src/parser/__tests__/parse-with-sourcemap.test.ts
+++ b/projects/openapi-io/src/parser/__tests__/parse-with-sourcemap.test.ts
@@ -8,7 +8,7 @@ import path from 'path';
 
 const cwd = process.cwd();
 
-function prepSnapshot(result: ParseOpenAPIResult) {
+function prepSnapshot(result: ParseOpenAPIResult<any>) {
   result.sourcemap.files.forEach((i) => {
     i.path = i.path.split(cwd)[1];
     // @ts-ignore

--- a/projects/openapi-io/src/parser/openapi-sourcemap-parser.ts
+++ b/projects/openapi-io/src/parser/openapi-sourcemap-parser.ts
@@ -6,7 +6,6 @@ import { dereference } from './insourced-dereference';
 import path from 'path';
 
 import fetch from 'node-fetch';
-import { OpenAPIV3 } from 'openapi-types';
 import isUrl from 'is-url';
 
 import { JsonSchemaSourcemap } from './sourcemap';
@@ -22,24 +21,39 @@ import {
   DEFAULT_HEADERS,
   getMostRelevantHeader,
 } from './resolvers/custom-http-ref-handler';
+import {
+  FlatOpenAPIV2,
+  FlatOpenAPIV3,
+  FlatOpenAPIV3_1,
+} from '@useoptic/openapi-utilities';
 
 export {
   JSONParserError,
   ResolverError,
 } from '@apidevtools/json-schema-ref-parser';
 
-export type ParseOpenAPIResult = {
-  jsonLike: OpenAPIV3.Document;
+export type ParseOpenAPIResult<
+  T extends
+    | FlatOpenAPIV2.Document
+    | FlatOpenAPIV3.Document
+    | FlatOpenAPIV3_1.Document,
+> = {
+  jsonLike: T;
   sourcemap: JsonSchemaSourcemap;
 };
 
-export async function dereferenceOpenApi(
+export async function dereferenceOpenApi<
+  T extends
+    | FlatOpenAPIV2.Document
+    | FlatOpenAPIV3.Document
+    | FlatOpenAPIV3_1.Document,
+>(
   path: string,
   options: {
     externalRefHandler?: ExternalRefHandler;
     externalRefHeaders?: UserDefinedHeadersByUrlPrefix;
   } = {}
-): Promise<ParseOpenAPIResult> {
+): Promise<ParseOpenAPIResult<T>> {
   const resolver = new $RefParser();
   const headersMap = parseHeadersConfig(options.externalRefHeaders ?? []);
 
@@ -112,25 +126,35 @@ export async function dereferenceOpenApi(
   return { jsonLike: resolver.schema as any, sourcemap: sourcemap };
 }
 
-export async function parseOpenAPIWithSourcemap(
+export async function parseOpenAPIWithSourcemap<
+  T extends
+    | FlatOpenAPIV2.Document
+    | FlatOpenAPIV3.Document
+    | FlatOpenAPIV3_1.Document,
+>(
   path: string,
   options: {
     externalRefHeaders?: UserDefinedHeadersByUrlPrefix;
   } = {}
-): Promise<ParseOpenAPIResult> {
+): Promise<ParseOpenAPIResult<T>> {
   return dereferenceOpenApi(path, {
     externalRefHeaders: options.externalRefHeaders,
   });
 }
 
-export async function parseOpenAPIFromRepoWithSourcemap(
+export async function parseOpenAPIFromRepoWithSourcemap<
+  T extends
+    | FlatOpenAPIV2.Document
+    | FlatOpenAPIV3.Document
+    | FlatOpenAPIV3_1.Document,
+>(
   name: string,
   repoPath: string,
   branch: string,
   options: {
     externalRefHeaders?: UserDefinedHeadersByUrlPrefix;
   } = {}
-): Promise<ParseOpenAPIResult> {
+): Promise<ParseOpenAPIResult<T>> {
   const inGitResolver = gitBranchResolver(repoPath, branch);
   const fileName = path.join(repoPath, name);
   return dereferenceOpenApi(fileName, {

--- a/projects/openapi-io/src/validation/openapi-versions.test.ts
+++ b/projects/openapi-io/src/validation/openapi-versions.test.ts
@@ -12,6 +12,11 @@ test('detects a 3.0.x openapi', async () => {
   expect(checkOpenAPIVersion({ openapi: '3.0.2' })).toBe('3.0.x');
 });
 
+test('detects a 2.x.x openapi', async () => {
+  expect(checkOpenAPIVersion({ swagger: '2.0.3' })).toBe('2.x.x');
+  expect(checkOpenAPIVersion({ swagger: '2.1.2' })).toBe('2.x.x');
+});
+
 test('throws for unsupported spec version', () => {
-  expect(() => checkOpenAPIVersion({ openapi: '2.0.2' })).toThrow();
+  expect(() => checkOpenAPIVersion({ openapi: '4.0.2' })).toThrow();
 });

--- a/projects/openapi-io/src/validation/openapi-versions.ts
+++ b/projects/openapi-io/src/validation/openapi-versions.ts
@@ -1,19 +1,19 @@
 import semver from 'semver';
 import { OpenAPIVersionError } from './errors';
 
-export type SupportedOpenAPIVersions = '3.1.x' | '3.0.x';
+export type SupportedOpenAPIVersions = '3.1.x' | '3.0.x' | '2.x.x';
 
 export function checkOpenAPIVersion(spec: {
-  openapi: string;
+  openapi?: string;
   swagger?: string;
 }): SupportedOpenAPIVersions {
-  if (semver.satisfies(spec.openapi, '3.1.x')) return '3.1.x';
-  if (semver.satisfies(spec.openapi, '3.0.x')) return '3.0.x';
-  const isSwagger = spec.swagger && semver.satisfies(spec.swagger, '2.x.x');
+  if (spec.openapi && semver.satisfies(spec.openapi, '3.1.x')) return '3.1.x';
+  if (spec.openapi && semver.satisfies(spec.openapi, '3.0.x')) return '3.0.x';
+  if (spec.swagger && semver.satisfies(spec.swagger, '2.x.x')) return '2.x.x';
   throw new OpenAPIVersionError(
     `Unsupported OpenAPI version ${
       spec.openapi ?? spec.swagger
     }. Optic supports OpenAPI 3.1.x and 3.0.x`,
-    isSwagger ? '2.x.x' : spec.openapi
+    spec.openapi ?? spec.swagger
   );
 }

--- a/projects/openapi-utilities/src/compare-specs/compare-specs.ts
+++ b/projects/openapi-utilities/src/compare-specs/compare-specs.ts
@@ -1,6 +1,6 @@
-import { OpenAPIV3 } from 'openapi-types';
 import { ObjectDiff, diff } from '../diff/diff';
 import { RuleResult } from '../results';
+import { FlatOpenAPIV3, FlatOpenAPIV3_1 } from '../flat-openapi-types';
 const packageJson = require('../../package.json');
 
 type SerializedSourcemap = {
@@ -16,7 +16,7 @@ type SerializedSourcemap = {
 };
 
 type InputSpec = {
-  jsonLike: OpenAPIV3.Document;
+  jsonLike: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document;
   sourcemap: SerializedSourcemap;
   isEmptySpec: boolean;
 };
@@ -25,8 +25,8 @@ type RuleRunner = {
   runRules: (inputs: {
     context: any;
     diffs: ObjectDiff[];
-    fromSpec: OpenAPIV3.Document;
-    toSpec: OpenAPIV3.Document;
+    fromSpec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document;
+    toSpec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document;
   }) => Promise<RuleResult[]>;
 };
 

--- a/projects/openapi-utilities/src/index.ts
+++ b/projects/openapi-utilities/src/index.ts
@@ -1,5 +1,5 @@
 import { OpenAPITraverser } from './openapi3/implementations/openapi3/openapi-traverser';
-import { OpenAPIV3, OpenAPIV3_1 } from 'openapi-types';
+import { OpenAPIV2, OpenAPIV3, OpenAPIV3_1 } from 'openapi-types';
 import { factsToChangelog } from './openapi3/sdk/facts-to-changelog';
 export {
   FlatOpenAPIV2,
@@ -110,6 +110,7 @@ export {
   OpenApiFieldFact,
   OpenApiBodyFact,
   OpenApiBodyExampleFact,
+  OpenAPIV2,
   OpenAPIV3,
   OpenAPIV3_1,
   OpenApiKind,

--- a/projects/openapi-utilities/src/openapi3/group-diff.ts
+++ b/projects/openapi-utilities/src/openapi3/group-diff.ts
@@ -10,8 +10,11 @@ import { OpenApiV3TraverserFact, V3FactType } from './types';
 import { RuleResult } from '../results';
 import { getEndpointId } from '../utilities/id';
 import { normalizeOpenApiPath } from './implementations/openapi3/openapi-traverser';
+import { FlatOpenAPIV3, FlatOpenAPIV3_1 } from '../flat-openapi-types';
 
-function constructTree(spec: OpenAPIV3.Document) {
+type OpenAPISpec = FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document;
+
+function constructTree(spec: OpenAPISpec) {
   const traverser = new OpenApiV3Traverser();
   traverser.traverse(spec);
 
@@ -231,7 +234,7 @@ export class GroupedDiffs {
   }
 }
 
-function getParameterName(spec: OpenAPIV3.Document, pointer: string) {
+function getParameterName(spec: OpenAPISpec, pointer: string) {
   // /paths/path/method/parameters/n
   const parts = jsonPointerHelpers.decode(pointer);
   const basePointer =
@@ -245,7 +248,7 @@ function getParameterName(spec: OpenAPIV3.Document, pointer: string) {
 }
 
 function normalizeRequiredDiff(
-  spec: OpenAPIV3.Document,
+  spec: OpenAPISpec,
   fact: OpenApiV3TraverserFact<'body'> | OpenApiV3TraverserFact<'field'>,
   pointers: {
     absolute: string;
@@ -300,7 +303,7 @@ function normalizeRequiredDiff(
 }
 
 export function groupDiffsByEndpoint(
-  specs: { from: OpenAPIV3.Document; to: OpenAPIV3.Document },
+  specs: { from: OpenAPISpec; to: OpenAPISpec },
   diffs: ObjectDiff[],
   rules: RuleResult[]
 ) {
@@ -313,13 +316,13 @@ export function groupDiffsByEndpoint(
         type: 'diffs';
         fact: OpenApiV3TraverserFact<V3FactType>;
         item: Diff;
-        spec: OpenAPIV3.Document;
+        spec: OpenAPISpec;
       }
     | {
         type: 'rules';
         item: RuleResult & { trail: string };
         fact: OpenApiV3TraverserFact<V3FactType>;
-        spec: OpenAPIV3.Document;
+        spec: OpenAPISpec;
       }
   )[] = [];
 

--- a/projects/openapi-utilities/src/utilities/changelog.ts
+++ b/projects/openapi-utilities/src/utilities/changelog.ts
@@ -1,6 +1,9 @@
-import { OpenAPIV3 } from 'openapi-types';
 import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
-import { HttpMethods } from '../flat-openapi-types';
+import {
+  FlatOpenAPIV3,
+  FlatOpenAPIV3_1,
+  HttpMethods,
+} from '../flat-openapi-types';
 import type { ObjectDiff } from '../diff/diff';
 
 export type EndpointChange = {
@@ -42,7 +45,10 @@ const isResponseContentChange = (segments: string[]) =>
 const isMethodParameterChange = (segments: string[]) =>
   isMethodChange(segments) && segments[3] === 'parameters';
 
-const getParameterValue = (segements: string[], spec: OpenAPIV3.Document) => {
+const getParameterValue = (
+  segements: string[],
+  spec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document
+) => {
   return jsonPointerHelpers.get(spec, segements);
 };
 
@@ -79,8 +85,8 @@ const removePolymorphicPaths = (segments: string[], offset = 0): string[] => {
 };
 
 export function getEndpointsChanges(
-  baseSpec: OpenAPIV3.Document,
-  headSpec: OpenAPIV3.Document,
+  baseSpec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document,
+  headSpec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document,
   diffs: ObjectDiff[]
 ) {
   const paths = new Map<string, Map<string, Set<string>>>();

--- a/projects/openapi-utilities/src/utilities/traverse-spec.ts
+++ b/projects/openapi-utilities/src/utilities/traverse-spec.ts
@@ -1,8 +1,10 @@
-import { OpenAPIV3 } from 'openapi-types';
 import { OpenAPITraverser } from '../openapi3/implementations/openapi3/openapi-traverser';
 import { IFact } from '../openapi3/sdk/types';
+import { FlatOpenAPIV3, FlatOpenAPIV3_1 } from '../flat-openapi-types';
 
-export const traverseSpec = (spec: OpenAPIV3.Document): IFact[] => {
+export const traverseSpec = (
+  spec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document
+): IFact[] => {
   const traverser = new OpenAPITraverser();
   traverser.traverse(spec);
   return [...traverser.facts()];

--- a/projects/optic/src/client/optic-backend.ts
+++ b/projects/optic/src/client/optic-backend.ts
@@ -165,7 +165,7 @@ export class OpticBackendClient extends JsonHttpClient {
 
   public async createSpec(spec: {
     tags: string[];
-    openapi_version: '3.0.x' | '3.1.x';
+    openapi_version: '2.x.x' | '3.0.x' | '3.1.x';
     upload_id: string;
     api_id: string;
     effective_at?: Date;

--- a/projects/optic/src/commands/api/list.ts
+++ b/projects/optic/src/commands/api/list.ts
@@ -10,7 +10,7 @@ import * as FsCandidates from './get-file-candidates';
 
 import { flushEvents } from '../../segment';
 import { errorHandler } from '../../error-handler';
-import { OpenAPIV3 } from '@useoptic/openapi-utilities';
+import { OpenAPIV2, OpenAPIV3 } from '@useoptic/openapi-utilities';
 import { validateOpenApiV3Document } from '@useoptic/openapi-io';
 
 const usage = () => `
@@ -77,7 +77,7 @@ export const getApiListAction =
 
     for await (const [file_path] of candidates) {
       const relativePath = path.relative(process.cwd(), file_path);
-      let spec: OpenAPIV3.Document;
+      let spec: OpenAPIV2.Document | OpenAPIV3.Document;
       try {
         spec = await loadRaw(file_path, config);
         // Checks that the document looks like an openapi document (i.e. has paths, etc )

--- a/projects/optic/src/commands/capture/actions/add-ignore-paths.ts
+++ b/projects/optic/src/commands/capture/actions/add-ignore-paths.ts
@@ -5,7 +5,7 @@ import { jsonOpsFromSpecPatches } from '../patches/patches';
 import { writePatchesToFiles } from '../write/file';
 
 export async function addIgnorePaths(
-  parseResult: ParseResult,
+  parseResult: Exclude<ParseResult, { version: '2.x.x' }>,
   ignorePaths: { method: string; path: string }[]
 ) {
   const specPatches: SpecPatches = (async function* (): SpecPatches {

--- a/projects/optic/src/commands/capture/actions/documented.ts
+++ b/projects/optic/src/commands/capture/actions/documented.ts
@@ -59,7 +59,7 @@ async function groupUnpatchableDiffs(
 
 export async function diffExistingEndpoint(
   interactions: CapturedInteractions,
-  parseResult: ParseResult,
+  parseResult: Exclude<ParseResult, { version: '2.x.x' }>,
   coverage: ApiCoverageCounter,
   endpoint: {
     path: string;

--- a/projects/optic/src/commands/capture/actions/undocumented.ts
+++ b/projects/optic/src/commands/capture/actions/undocumented.ts
@@ -145,7 +145,7 @@ export async function promptUserForPathPattern(
 
 export async function documentNewEndpoint(
   interactions: CapturedInteraction[],
-  parseResult: ParseResult,
+  parseResult: Exclude<ParseResult, { version: '2.x.x' }>,
   endpoint: { method: string; path: string }
 ) {
   const interactionsAsAsyncIterator = (async function* () {

--- a/projects/optic/src/commands/capture/capture.ts
+++ b/projects/optic/src/commands/capture/capture.ts
@@ -157,6 +157,11 @@ const getCaptureAction =
       strict: false,
       denormalize: false,
     });
+    if (spec.version === '2.x.x') {
+      logger.error(`capture does not support swagger 2 specifications`);
+      process.exitCode = 1;
+      return;
+    }
     let serverUrl: string | null = null;
     let captures: GroupedCaptures;
     const pathFromRoot = resolveRelativePath(config.root, filePath);
@@ -423,7 +428,7 @@ export async function processCaptures(
     filePath,
   }: {
     filePath: string;
-    spec: ParseResult;
+    spec: Exclude<ParseResult, { version: '2.x.x' }>;
     captures: GroupedCaptures;
     captureConfig?: CaptureConfigData;
     cliConfig: OpticCliConfig;
@@ -506,11 +511,11 @@ export async function processCaptures(
     let endpointCoverage = coverage.coverage.paths[path][method];
     if (options.update) {
       // Since we flush each endpoint updates to disk, we should reload the spec to get the latest spec and sourcemap which we both use to generate the next set of patches
-      spec = await loadSpec(filePath, cliConfig, {
+      spec = (await loadSpec(filePath, cliConfig, {
         strict: false,
         denormalize: false,
-      });
-      const operation = spec.jsonLike.paths[path]?.[method];
+      })) as Exclude<ParseResult, { version: '2.x.x' }>;
+      const operation = spec.jsonLike.paths?.[path]?.[method];
       if (operation) {
         coverage.addEndpoint(operation, path, method, {
           newlyDocumented: true,
@@ -604,10 +609,10 @@ export async function processCaptures(
         await documentNewEndpoint(filteredInteractions, spec, endpoint);
 
         // Since we flush each endpoint updates to disk, we should reload the spec to get the latest spec and sourcemap which we both use to generate the next set of patches
-        spec = await loadSpec(filePath, cliConfig, {
+        spec = (await loadSpec(filePath, cliConfig, {
           strict: false,
           denormalize: false,
-        });
+        })) as Exclude<ParseResult, { version: '2.x.x' }>;
         spinner?.succeed();
       }
 

--- a/projects/optic/src/commands/capture/coverage/api-coverage.ts
+++ b/projects/optic/src/commands/capture/coverage/api-coverage.ts
@@ -3,6 +3,8 @@ import {
   CoverageNode,
   ApiCoverage,
   countOperationCoverage,
+  FlatOpenAPIV3,
+  FlatOpenAPIV3_1,
 } from '@useoptic/openapi-utilities';
 import chalk from 'chalk';
 import sortby from 'lodash.sortby';
@@ -15,7 +17,7 @@ import { OperationDiffResultKind } from '../patches/patchers/spec/types';
 
 export class ApiCoverageCounter {
   coverage: ApiCoverage;
-  constructor(spec: OpenAPIV3.Document) {
+  constructor(spec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document) {
     this.coverage = {
       paths: {},
     };

--- a/projects/optic/src/commands/capture/interactions/grouped-interactions.ts
+++ b/projects/optic/src/commands/capture/interactions/grouped-interactions.ts
@@ -1,5 +1,10 @@
 import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
-import { OpenAPIV3, getEndpointId } from '@useoptic/openapi-utilities';
+import {
+  FlatOpenAPIV3,
+  FlatOpenAPIV3_1,
+  OpenAPIV3,
+  getEndpointId,
+} from '@useoptic/openapi-utilities';
 import crypto from 'crypto';
 import fs from 'node:fs/promises';
 import path from 'path';
@@ -15,7 +20,7 @@ import { getIgnorePaths } from '../../../utils/specs';
 import { minimatch } from 'minimatch';
 
 export function createHostBaseMap(
-  spec: OpenAPIV3.Document,
+  spec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document,
   options: {
     baseServerUrl?: string;
   } = {}
@@ -90,7 +95,7 @@ export async function* handleServerPathPrefix(
 
 export async function* filterIgnoredInteractions(
   interactions: CapturedInteractions,
-  spec: OpenAPIV3.Document
+  spec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document
 ) {
   const ignorePaths = getIgnorePaths(spec);
   const methodMap: Map<string, Set<string>> = new Map(
@@ -149,7 +154,7 @@ export class GroupedCaptures {
   private hostBaseMap: ReturnType<typeof createHostBaseMap>;
   constructor(
     trafficDir: string,
-    private spec: OpenAPIV3.Document,
+    private spec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document,
     options: {
       baseServerUrl?: string;
     } = {}

--- a/projects/optic/src/commands/capture/operations/path-inference.ts
+++ b/projects/optic/src/commands/capture/operations/path-inference.ts
@@ -1,5 +1,9 @@
 import pluralize from 'pluralize';
-import { OpenAPIV3 } from '@useoptic/openapi-utilities';
+import {
+  FlatOpenAPIV3,
+  FlatOpenAPIV3_1,
+  OpenAPIV3,
+} from '@useoptic/openapi-utilities';
 import { CapturedInteractions } from '../sources/captured-interactions';
 import { specToPaths } from './queries';
 
@@ -24,7 +28,7 @@ export class PathInference {
   }
 
   static async fromSpecAndInteractions(
-    spec: OpenAPIV3.Document,
+    spec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document,
     interactions: CapturedInteractions
   ): Promise<PathInference> {
     const pathInference = new PathInference();

--- a/projects/optic/src/commands/capture/operations/queries.ts
+++ b/projects/optic/src/commands/capture/operations/queries.ts
@@ -1,4 +1,8 @@
-import { OpenAPIV3 } from '@useoptic/openapi-utilities';
+import {
+  FlatOpenAPIV3,
+  FlatOpenAPIV3_1,
+  OpenAPIV3,
+} from '@useoptic/openapi-utilities';
 import { None, Ok, Option, Result, Some } from 'ts-results';
 import { matchPathPattern } from '../../../utils/pathPatterns';
 
@@ -85,13 +89,17 @@ export class OperationQueries {
   }
 }
 
-export function specToOperations(spec: OpenAPIV3.Document) {
+export function specToOperations(
+  spec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document
+) {
   return specToPaths(spec).flatMap((o) =>
     o.methods.map((m) => ({ method: m, pathPattern: o.pathPattern }))
   );
 }
 
-export function specToPaths(spec: OpenAPIV3.Document) {
+export function specToPaths(
+  spec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document
+) {
   const operations: { pathPattern: string; methods: string[] }[] = [];
 
   const allowedKeys = [
@@ -103,7 +111,7 @@ export function specToPaths(spec: OpenAPIV3.Document) {
     'head',
     'options',
   ];
-  Object.entries(spec.paths).forEach(([pathPattern, methods]) => {
+  Object.entries(spec.paths ?? {}).forEach(([pathPattern, methods]) => {
     if (methods) {
       operations.push({
         pathPattern,

--- a/projects/optic/src/commands/capture/patches/patchers/closeness/schema-inventory.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/closeness/schema-inventory.ts
@@ -1,4 +1,9 @@
-import { FlatOpenAPIV3, OAS3, OpenAPIV3 } from '@useoptic/openapi-utilities';
+import {
+  FlatOpenAPIV3,
+  FlatOpenAPIV3_1,
+  OAS3,
+  OpenAPIV3,
+} from '@useoptic/openapi-utilities';
 import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
 import { computeClosenessFromKeyValueTuples, walkSchema } from './closeness';
 import { PatchImpact } from '../../patch-operations';
@@ -51,7 +56,7 @@ export class SchemaInventory {
 
   async *refsForAdditions(
     addedPaths: Set<string>,
-    spec: OpenAPIV3.Document,
+    spec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document,
     meta: {
       usedExistingRef?: boolean;
     } = {}

--- a/projects/optic/src/commands/capture/patches/patchers/spec/patches.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/spec/patches.ts
@@ -1,6 +1,10 @@
 import { PatchImpact, PatchOperation } from '../../patch-operations';
 import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
-import { OpenAPIV3 } from '@useoptic/openapi-utilities';
+import {
+  FlatOpenAPIV3,
+  FlatOpenAPIV3_1,
+  OpenAPIV3,
+} from '@useoptic/openapi-utilities';
 import JsonPatch from 'fast-json-patch';
 
 import { ShapeDiffResult, UnpatchableDiff } from '../../patchers/shapes/diff';
@@ -83,7 +87,10 @@ export class SpecPatch {
     };
   }
 
-  static applyPatch(patch: SpecPatch, spec: OpenAPIV3.Document) {
+  static applyPatch(
+    patch: SpecPatch,
+    spec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document
+  ) {
     const operations = JsonPatch.deepClone([...SpecPatch.operations(patch)]);
     try {
       const result = JsonPatch.applyPatch(

--- a/projects/optic/src/commands/capture/patches/patchers/spec/spec.ts
+++ b/projects/optic/src/commands/capture/patches/patchers/spec/spec.ts
@@ -1,4 +1,8 @@
-import { OpenAPIV3 } from '@useoptic/openapi-utilities';
+import {
+  FlatOpenAPIV3,
+  FlatOpenAPIV3_1,
+  OpenAPIV3,
+} from '@useoptic/openapi-utilities';
 import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
 import { OPTIC_PATH_IGNORE_KEY } from '../../../../../constants';
 import { Operation } from 'fast-json-patch';
@@ -12,7 +16,7 @@ import {
 import { OperationDiffResultKind } from './types';
 
 export function getIgnorePathPatch(
-  spec: OpenAPIV3.Document,
+  spec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document,
   ignorePaths: (string | { method: string; path: string })[]
 ): SpecPatch {
   const hasExistingIgnorePaths = Array.isArray(spec[OPTIC_PATH_IGNORE_KEY]);

--- a/projects/optic/src/commands/capture/patches/patches.ts
+++ b/projects/optic/src/commands/capture/patches/patches.ts
@@ -19,12 +19,12 @@ import { UnpatchableDiff } from './patchers/shapes/diff';
 
 export async function* generatePathAndMethodSpecPatches(
   specHolder: {
-    spec: ParseResult['jsonLike'];
+    spec: Exclude<ParseResult, { version: '2.x.x' }>['jsonLike'];
   },
   endpoint: { method: string; path: string }
 ) {
-  const hasPath = !!specHolder.spec.paths[endpoint.path];
-  const hasMethod = !!specHolder.spec.paths[endpoint.path]?.[endpoint.method];
+  const hasPath = !!specHolder.spec.paths?.[endpoint.path];
+  const hasMethod = !!specHolder.spec.paths?.[endpoint.path]?.[endpoint.method];
   if (!hasPath) {
     const pathParameters = endpoint.path
       .split('/')
@@ -59,7 +59,7 @@ export async function* generatePathAndMethodSpecPatches(
 export async function* generateEndpointSpecPatches(
   interactions: CapturedInteractions,
   specHolder: {
-    spec: ParseResult['jsonLike'];
+    spec: Exclude<ParseResult, { version: '2.x.x' }>['jsonLike'];
   },
   endpoint: { method: string; path: string },
   opts: {
@@ -154,7 +154,7 @@ export async function* generateEndpointSpecPatches(
 // Creates a new ref or uses an existing ref for added paths
 export async function* generateRefRefactorPatches(
   specHolder: {
-    spec: ParseResult['jsonLike'];
+    spec: Exclude<ParseResult, { version: '2.x.x' }>['jsonLike'];
   },
   meta: {
     schemaAdditionsSet: Set<string>;

--- a/projects/optic/src/commands/ci/comment/__tests__/common.test.ts
+++ b/projects/optic/src/commands/ci/comment/__tests__/common.test.ts
@@ -6,9 +6,10 @@ import {
   diff,
   groupDiffsByEndpoint,
 } from '@useoptic/openapi-utilities';
+import { FlatOpenAPIV3 } from '@useoptic/openapi-utilities/src';
 
-const from = defaultEmptySpec;
-const to = {
+const from: FlatOpenAPIV3.Document = defaultEmptySpec as FlatOpenAPIV3.Document;
+const to: FlatOpenAPIV3.Document = {
   ...defaultEmptySpec,
   paths: {
     '/api': {
@@ -28,7 +29,7 @@ const to = {
       },
     },
   },
-};
+} as FlatOpenAPIV3.Document;
 
 const input: CiRunDetails = {
   completed: [

--- a/projects/optic/src/commands/dereference/dereference.ts
+++ b/projects/optic/src/commands/dereference/dereference.ts
@@ -82,7 +82,7 @@ const deferenceAction =
       const specJson = parsedFile.jsonLike;
 
       if (includeExtensions.length) {
-        Object.entries(specJson.paths).forEach(([path, operations]) => {
+        Object.entries(specJson.paths ?? {}).forEach(([path, operations]) => {
           Object.entries(operations!).forEach(([key, operation]) => {
             if (key === 'parameters') return;
             if (
@@ -106,7 +106,7 @@ const deferenceAction =
       }
 
       if (filterExtensions.length) {
-        Object.entries(specJson.paths).forEach(([path, operations]) => {
+        Object.entries(specJson.paths ?? {}).forEach(([path, operations]) => {
           Object.entries(operations!).forEach(([key, operation]) => {
             if (key === 'parameters') return;
             // should filter

--- a/projects/optic/src/commands/diff/changelog-renderers/__tests__/json-changelog.test.ts
+++ b/projects/optic/src/commands/diff/changelog-renderers/__tests__/json-changelog.test.ts
@@ -10,12 +10,12 @@ test('json changelog collects changes properly', () => {
   const specs = {
     from: petStoreBase,
     to: petStoreUpdated,
-  };
+  } as any;
   const groupedDiffs = groupDiffsByEndpoint(specs, diffs, []);
   const output = jsonChangelog(
     {
-      from: petStoreBase,
-      to: petStoreUpdated,
+      from: petStoreBase as any,
+      to: petStoreUpdated as any,
     },
     groupedDiffs
   );
@@ -24,16 +24,16 @@ test('json changelog collects changes properly', () => {
 });
 
 test('json changelog with parameter changes', async () => {
-  const { jsonLike: before } = await loadSpec(
+  const { jsonLike: before } = (await loadSpec(
     './src/commands/diff/changelog-renderers/__tests__/fixtures/params-old.yaml',
     {} as any,
     { strict: false, denormalize: true }
-  );
-  const { jsonLike: after } = await loadSpec(
+  )) as any;
+  const { jsonLike: after } = (await loadSpec(
     './src/commands/diff/changelog-renderers/__tests__/fixtures/params-new.yaml',
     {} as any,
     { strict: false, denormalize: true }
-  );
+  )) as any;
 
   const diffs = diff(before, after);
   const specs = {
@@ -53,16 +53,16 @@ test('json changelog with parameter changes', async () => {
 });
 
 test('json changelog with response header changes', async () => {
-  const { jsonLike: before } = await loadSpec(
+  const { jsonLike: before } = (await loadSpec(
     './src/commands/diff/changelog-renderers/__tests__/fixtures/response-headers-old.yaml',
     {} as any,
     { strict: false, denormalize: true }
-  );
-  const { jsonLike: after } = await loadSpec(
+  )) as any;
+  const { jsonLike: after } = (await loadSpec(
     './src/commands/diff/changelog-renderers/__tests__/fixtures/response-headers-new.yaml',
     {} as any,
     { strict: false, denormalize: true }
-  );
+  )) as any;
 
   const diffs = diff(before, after);
   const specs = {

--- a/projects/optic/src/commands/diff/changelog-renderers/common.ts
+++ b/projects/optic/src/commands/diff/changelog-renderers/common.ts
@@ -1,6 +1,11 @@
 import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
-import { OpenAPIV3 } from 'openapi-types';
+import { FlatOpenAPIV3, FlatOpenAPIV3_1 } from '@useoptic/openapi-utilities';
 import { Diff } from '@useoptic/openapi-utilities/build/openapi3/group-diff';
+
+export type SpecInput = {
+  from: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document;
+  to: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document;
+};
 
 export function getRootBodyPath(path: string): string {
   const parts = jsonPointerHelpers.decode(path);
@@ -11,7 +16,10 @@ export function getRootBodyPath(path: string): string {
   }
 }
 export function interpretFieldLevelDiffs(
-  specs: { from: OpenAPIV3.Document; to: OpenAPIV3.Document },
+  specs: {
+    from: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document;
+    to: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document;
+  },
   diffs: Record<string, { diffs: Diff[] }>
 ): Diff[] {
   return Object.entries(diffs)

--- a/projects/optic/src/commands/diff/changelog-renderers/json-changelog.ts
+++ b/projects/optic/src/commands/diff/changelog-renderers/json-changelog.ts
@@ -1,4 +1,3 @@
-import { OpenAPIV3 } from 'openapi-types';
 import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
 
 import {
@@ -13,7 +12,7 @@ import type {
   Response,
 } from '@useoptic/openapi-utilities/build/openapi3/group-diff';
 
-import { interpretFieldLevelDiffs } from './common';
+import { SpecInput, interpretFieldLevelDiffs } from './common';
 import isEqual from 'lodash.isequal';
 
 type RawChange<T> = { key: string } & (
@@ -132,7 +131,7 @@ type JsonChangelog = {
 };
 
 function attachRequiredToField(
-  specs: { from: OpenAPIV3.Document; to: OpenAPIV3.Document },
+  specs: SpecInput,
   diff: Diff,
   rawChange: RawChange<any>
 ) {
@@ -189,7 +188,7 @@ function attachRequiredToField(
 }
 
 export function jsonChangelog(
-  specs: { from: OpenAPIV3.Document; to: OpenAPIV3.Document },
+  specs: SpecInput,
   groupedChanges: GroupedDiffs
 ): JsonChangelog {
   const results: JsonChangelog = { operations: [] };
@@ -203,7 +202,7 @@ export function jsonChangelog(
 }
 
 function getEndpointLogs(
-  specs: { from: OpenAPIV3.Document; to: OpenAPIV3.Document },
+  specs: SpecInput,
   endpointChange: Endpoint
 ): OperationChangelog {
   const {
@@ -325,7 +324,7 @@ function getEndpointLogs(
 }
 
 function getResponseChangeLogs(
-  specs: { from: OpenAPIV3.Document; to: OpenAPIV3.Document },
+  specs: SpecInput,
   response: Response,
   statusCode: string
 ): OperationChangelog['responses'][number] {
@@ -359,7 +358,7 @@ function getResponseChangeLogs(
 }
 
 function getResponseHeaderChangelogs(
-  specs: { from: OpenAPIV3.Document; to: OpenAPIV3.Document },
+  specs: SpecInput,
   node: Response['headers']
 ): ChangedNode[] {
   return Object.entries(node).map(([name, node]) => {
@@ -378,7 +377,7 @@ function getResponseHeaderChangelogs(
 }
 
 function getRequestChangeLogs(
-  specs: { from: OpenAPIV3.Document; to: OpenAPIV3.Document },
+  specs: SpecInput,
   request: Endpoint['request']
 ): NonNullable<OperationChangelog['requestBody']> {
   const contentTypes: ChangedNode[] = [];
@@ -409,7 +408,7 @@ function getRequestChangeLogs(
 }
 
 function getBodyChangeLogs(
-  specs: { from: OpenAPIV3.Document; to: OpenAPIV3.Document },
+  specs: SpecInput,
   body: Body,
   contentType: string
 ): ChangedNode {
@@ -443,7 +442,7 @@ function getBodyChangeLogs(
 }
 
 function getParameterIndices(
-  specs: { from: OpenAPIV3.Document; to: OpenAPIV3.Document },
+  specs: SpecInput,
   location: { operation: string; name: string; type: string }
 ) {
   const beforeParameters = jsonPointerHelpers.tryGet(
@@ -473,7 +472,7 @@ function getParameterIndices(
 }
 
 function groupParameterDiffs(
-  specs: { from: OpenAPIV3.Document; to: OpenAPIV3.Document },
+  specs: SpecInput,
   {
     type,
     name,
@@ -538,7 +537,7 @@ function groupParameterDiffs(
 }
 
 function getParameterLogs(
-  specs: { from: OpenAPIV3.Document; to: OpenAPIV3.Document },
+  specs: SpecInput,
   {
     type,
     name,
@@ -578,10 +577,7 @@ function getParameterLogs(
   };
 }
 
-function getRawChange(
-  diff: Diff,
-  specs: { from: OpenAPIV3.Document; to: OpenAPIV3.Document }
-): RawChange<any> {
+function getRawChange(diff: Diff, specs: SpecInput): RawChange<any> {
   if (diff.before !== undefined && diff.after !== undefined) {
     return {
       key: diff.trail,

--- a/projects/optic/src/commands/diff/changelog-renderers/terminal-changelog.ts
+++ b/projects/optic/src/commands/diff/changelog-renderers/terminal-changelog.ts
@@ -25,7 +25,7 @@ import {
 } from '@useoptic/openapi-utilities/build/openapi3/group-diff';
 import { Instance as Chalk } from 'chalk';
 import { getLocation } from '@useoptic/openapi-utilities/build/openapi3/traverser';
-import { interpretFieldLevelDiffs } from './common';
+import { SpecInput, interpretFieldLevelDiffs } from './common';
 import { ParseResult } from '../../../utils/spec-loaders';
 
 const chalk = new Chalk();
@@ -202,29 +202,11 @@ function* indent(generator: Generator<string>) {
   }
 }
 
-function countUnusedEndpoints(
-  spec: OpenAPIV3.Document,
-  groupedDiffs: GroupedDiffs
-): number {
-  const endpoints = new Set<string>();
-
-  for (const [path, pathObj] of Object.entries(spec.paths)) {
-    for (const method of Object.keys(pathObj ?? {})) {
-      if (Object.values(OpenAPIV3.HttpMethods).includes(method as any)) {
-        endpoints.add(`${path}${method}`);
-      }
-    }
-  }
-
-  for (const { path, method } of Object.values(groupedDiffs.endpoints)) {
-    endpoints.delete(`${path}${method}`);
-  }
-
-  return endpoints.size;
-}
-
 export function* terminalChangelog(
-  specs: { from: ParseResult; to: ParseResult },
+  specs: {
+    from: Exclude<ParseResult, { version: '2.x.x' }>;
+    to: Exclude<ParseResult, { version: '2.x.x' }>;
+  },
   groupedDiffs: GroupedDiffs,
   comparison: {
     results: RuleResult[];
@@ -329,7 +311,7 @@ export function* terminalChangelog(
 }
 
 function* getEndpointLogs(
-  specs: { from: OpenAPIV3.Document; to: OpenAPIV3.Document },
+  specs: SpecInput,
   endpointChange: Endpoint,
   sourcemapReaders: {
     before: SourcemapReaderLine;
@@ -408,7 +390,7 @@ function* getEndpointLogs(
 }
 
 function* getResponseChangeLogs(
-  specs: { from: OpenAPIV3.Document; to: OpenAPIV3.Document },
+  specs: SpecInput,
   response: Response,
   statusCode: string,
   sourcemapReaders: {
@@ -456,7 +438,7 @@ function* getResponseChangeLogs(
 }
 
 function* getRequestChangeLogs(
-  specs: { from: OpenAPIV3.Document; to: OpenAPIV3.Document },
+  specs: SpecInput,
   request: Endpoint['request'],
   sourcemapReaders: {
     before: SourcemapReaderLine;
@@ -490,7 +472,7 @@ function* getRequestChangeLogs(
 }
 
 function* getBodyChangeLogs(
-  specs: { from: OpenAPIV3.Document; to: OpenAPIV3.Document },
+  specs: SpecInput,
   body: Body,
   key: string,
   sourcemapReaders: {

--- a/projects/optic/src/commands/diff/compressResults.ts
+++ b/projects/optic/src/commands/diff/compressResults.ts
@@ -3,6 +3,9 @@ import {
   OpenAPIV3,
   compareSpecs,
   getEndpointId,
+  FlatOpenAPIV3,
+  FlatOpenAPIV3_1,
+  FlatOpenAPIV2,
 } from '@useoptic/openapi-utilities';
 import { ParseResult } from '../../utils/spec-loaders';
 import { compute } from './compute';
@@ -13,19 +16,31 @@ type SpecResultsV2 = Awaited<ReturnType<typeof compareSpecs>>;
 // We can remove the components from spec since the changelog is flattened, and any valid refs will
 // already be added into endpoints they're used in
 const removeComponentsFromSpec = (
-  spec: OpenAPIV3.Document
-): OpenAPIV3.Document => {
-  const { components, ...componentlessSpec } = spec;
+  spec:
+    | FlatOpenAPIV2.Document
+    | FlatOpenAPIV3.Document
+    | FlatOpenAPIV3_1.Document
+):
+  | FlatOpenAPIV2.Document
+  | FlatOpenAPIV3.Document
+  | FlatOpenAPIV3_1.Document => {
+  const { components, definitions, ...componentlessSpec } = spec as any;
   return componentlessSpec;
 };
 
 const removeUnusedEndpoints = (
-  spec: OpenAPIV3.Document,
+  spec:
+    | FlatOpenAPIV2.Document
+    | FlatOpenAPIV3.Document
+    | FlatOpenAPIV3_1.Document,
   changelogData: Awaited<ReturnType<typeof compute>>['changelogData']
-): OpenAPIV3.Document => {
+):
+  | FlatOpenAPIV2.Document
+  | FlatOpenAPIV3.Document
+  | FlatOpenAPIV3_1.Document => {
   const { paths, ...specWithoutPaths } = spec;
   const newPaths = {};
-  for (const [pathPattern, methodObj] of Object.entries(paths)) {
+  for (const [pathPattern, methodObj] of Object.entries(paths ?? {})) {
     newPaths[pathPattern] = {};
     for (const method of Object.values(OpenAPIV3.HttpMethods)) {
       const normalized = normalizeOpenApiPath(pathPattern);

--- a/projects/optic/src/commands/diff/diff-all.ts
+++ b/projects/optic/src/commands/diff/diff-all.ts
@@ -362,6 +362,23 @@ async function computeAll(
       });
       continue;
     }
+    if (
+      fromParseResults.version === '2.x.x' ||
+      toParseResults.version === '2.x.x'
+    ) {
+      logger.error('Swagger 2 is not supported');
+      fromParseResults.version === '2.x.x' &&
+        allWarnings.unparseableFromSpec.push({
+          path: from!,
+          error: new Error('Swagger 2 is not supported'),
+        });
+      toParseResults.version === '2.x.x' &&
+        allWarnings.unparseableToSpec.push({
+          path: to!,
+          error: new Error('Swagger 2 is not supported'),
+        });
+      continue;
+    }
 
     logger.info(
       chalk.blue(`Diffing ${from ?? 'empty spec'} to ${to ?? 'empty spec'}`)
@@ -452,8 +469,8 @@ async function computeAll(
 }
 
 type Result = Awaited<ReturnType<typeof compute>> & {
-  fromParseResults: ParseResult;
-  toParseResults: ParseResult;
+  fromParseResults: Exclude<ParseResult, { version: '2.x.x' }>;
+  toParseResults: Exclude<ParseResult, { version: '2.x.x' }>;
   from?: string;
   to?: string;
   specUrl: string | null;

--- a/projects/optic/src/commands/diff/diff.ts
+++ b/projects/optic/src/commands/diff/diff.ts
@@ -374,6 +374,15 @@ const getDiffAction =
       return;
     }
 
+    if (
+      parsedFiles[0].version === '2.x.x' ||
+      parsedFiles[1].version === '2.x.x'
+    ) {
+      logger.error('Swagger 2 is not supported');
+      process.exitCode = 1;
+      return;
+    }
+
     const diffResult = await runDiff(parsedFiles, config, options, file1);
     let maybeChangelogUrl: string | null = null;
     let specUrl: string | null = null;

--- a/projects/optic/src/commands/diff/generate-rule-runner.ts
+++ b/projects/optic/src/commands/diff/generate-rule-runner.ts
@@ -59,7 +59,7 @@ export const generateRuleRunner = async (
     specRuleset?: string;
     rulesetArg?: string;
     config: OpticCliConfig;
-    specVersion: SupportedOpenAPIVersions;
+    specVersion: Exclude<SupportedOpenAPIVersions, '2.x.x'>;
   },
   checksEnabled: boolean
 ): Promise<{

--- a/projects/optic/src/commands/history.ts
+++ b/projects/optic/src/commands/history.ts
@@ -81,6 +81,14 @@ const logDiffs = async (
   headSpec: ParseResult,
   headDate?: Date
 ): Promise<boolean> => {
+  if (baseSpec.version === '2.x.x' || headSpec.version === '2.x.x') {
+    if (headSpec.version === '2.x.x')
+      logger.warn(
+        `skipping: ${headDate?.toDateString()} - swagger 2.0 specs are not supported`
+      );
+
+    return false;
+  }
   const rulesRunner = new RuleRunner([new BreakingChangesRuleset()]);
   const comparison = await compareSpecs(baseSpec, headSpec, rulesRunner, {});
   let hasChanges = false;

--- a/projects/optic/src/commands/identify-apis.ts
+++ b/projects/optic/src/commands/identify-apis.ts
@@ -25,7 +25,7 @@ export async function identifyOrCreateApis(
   const pathUrls = new Map<string, string>();
 
   for await (const specPath of localSpecPaths) {
-    let rawSpec: OpenAPIV3.Document<{}>;
+    let rawSpec: any;
 
     try {
       rawSpec = await loadRaw(specPath, config);

--- a/projects/optic/src/commands/oas/captures/getInteractions.ts
+++ b/projects/optic/src/commands/oas/captures/getInteractions.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { captureStorage } from './capture-storage';
 import { InputErrors } from '../reporters/feedback';
 import * as AT from '../lib/async-tools';
-import { OpenAPIV3 } from '@useoptic/openapi-utilities';
+import { FlatOpenAPIV3, FlatOpenAPIV3_1 } from '@useoptic/openapi-utilities';
 import { CapturedInteractions } from '../../capture/sources/captured-interactions';
 import { PostmanCollectionEntries } from '../../capture/sources/postman';
 import { HarEntries } from '../../capture/sources/har';
@@ -16,7 +16,7 @@ import {
 
 export async function getInteractions(
   options: { har?: string; postman?: string },
-  spec: OpenAPIV3.Document,
+  spec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document,
   specPath: string,
   feedback: any
 ): Promise<CapturedInteractions> {

--- a/projects/optic/src/commands/oas/diffing/document.ts
+++ b/projects/optic/src/commands/oas/diffing/document.ts
@@ -10,7 +10,11 @@ import {
   UndocumentedOperationType,
 } from '../operations';
 import { InferPathStructureLegacy } from './infer-path-structure-legacy';
-import { OpenAPIV3 } from '@useoptic/openapi-utilities';
+import {
+  FlatOpenAPIV3,
+  FlatOpenAPIV3_1,
+  OpenAPIV3,
+} from '@useoptic/openapi-utilities';
 import * as AT from '../lib/async-tools';
 import {
   SpecFile,
@@ -80,7 +84,7 @@ export async function addIfUndocumented(
   isAddAll: boolean,
   statusObservations: StatusObservations,
   interactions: CapturedInteractions,
-  spec: OpenAPIV3.Document,
+  spec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document,
   sourcemap: SpecFilesSourcemap
 ): Promise<Result<RecentlyDocumented, string>> {
   const operationsToUpdate = isAddAll
@@ -158,7 +162,7 @@ export async function observationToUndocumented(
 }
 
 export function matchInteractions(
-  spec: OpenAPIV3.Document,
+  spec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document,
   interactions: CapturedInteractions,
   coverage: ApiCoverageCounter = new ApiCoverageCounter(spec)
 ): { observations: StatusObservations; coverage: ApiCoverageCounter } {
@@ -282,7 +286,7 @@ export type StatusObservation = {
 export interface StatusObservations extends AsyncIterable<StatusObservation> {}
 
 export function addOperations(
-  spec: OpenAPIV3.Document,
+  spec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document,
   requiredOperations: ParsedOperation[],
   interactions: CapturedInteractions
 ): { results: SpecPatches; observations: AsyncIterable<AddObservation> } {
@@ -366,7 +370,9 @@ export function addOperations(
       [];
 
     // phase one: documented all undocumented operations
-    let updatingSpec: AT.Subject<OpenAPIV3.Document> = new AT.Subject();
+    let updatingSpec: AT.Subject<
+      FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document
+    > = new AT.Subject();
     const undocumentedOperations = UndocumentedOperations.fromPairs(
       AT.from(requiredOperations),
       spec,

--- a/projects/optic/src/commands/oas/diffing/infer-path-structure-legacy.ts
+++ b/projects/optic/src/commands/oas/diffing/infer-path-structure-legacy.ts
@@ -1,5 +1,9 @@
 import pluralize from 'pluralize';
-import { OpenAPIV3 } from '@useoptic/openapi-utilities';
+import {
+  OpenAPIV3,
+  FlatOpenAPIV3,
+  FlatOpenAPIV3_1,
+} from '@useoptic/openapi-utilities';
 import { CapturedInteractions } from '../../capture/sources/captured-interactions';
 import { specToPaths } from '../../capture/operations/queries';
 import {
@@ -74,7 +78,7 @@ export class InferPathStructureLegacy {
   }
 
   static async fromSpecAndInteractions(
-    spec: OpenAPIV3.Document,
+    spec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document,
     interactions: CapturedInteractions
   ): Promise<InferPathStructureLegacy> {
     const inferredPathStructure = new InferPathStructureLegacy(

--- a/projects/optic/src/commands/oas/diffing/patch.ts
+++ b/projects/optic/src/commands/oas/diffing/patch.ts
@@ -13,7 +13,11 @@ import {
 } from '@useoptic/openapi-io';
 import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
 import chalk from 'chalk';
-import { OpenAPIV3 } from '@useoptic/openapi-utilities';
+import {
+  FlatOpenAPIV3,
+  FlatOpenAPIV3_1,
+  OpenAPIV3,
+} from '@useoptic/openapi-utilities';
 import { Subject, tap } from '../lib/async-tools';
 import {
   DocumentedInteraction,
@@ -41,7 +45,7 @@ import { LegacySpecPatches } from '../specs/streams/patches';
 
 export async function patchOperationsAsNeeded(
   patchInteractions: CapturedInteractions,
-  spec: OpenAPIV3.Document,
+  spec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document,
   sourcemap: JsonSchemaSourcemap,
   isAddAll: boolean = true,
   filterToOperations: ParsedOperation[] = []
@@ -68,7 +72,7 @@ export async function patchOperationsAsNeeded(
 export async function renderDiffs(
   specPath: string,
   sourcemap: JsonSchemaSourcemap,
-  spec: OpenAPIV3.Document,
+  spec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document,
   patches: SpecPatches,
   coverage: ApiCoverageCounter
 ) {
@@ -213,13 +217,15 @@ ${nextCommand(
 }
 
 export function updateByInteractions(
-  spec: OpenAPIV3.Document,
+  spec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document,
   interactions: CapturedInteractions,
   isAddAll: boolean = true,
   filterToOperations: ParsedOperation[] = []
 ): { results: SpecPatches; observations: UpdateObservations } {
   const openAPIVersion = checkOpenAPIVersion(spec);
-  const updatingSpec = new Subject<OpenAPIV3.Document>();
+  const updatingSpec = new Subject<
+    FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document
+  >();
   const specUpdates = updatingSpec.iterator;
 
   const observing = new Subject<UpdateObservation>();

--- a/projects/optic/src/commands/oas/operations/diffs/index.test.ts
+++ b/projects/optic/src/commands/oas/operations/diffs/index.test.ts
@@ -6,7 +6,7 @@ import { OperationDiffResultKind } from '../../../capture/patches/patchers/spec/
 
 describe('diffOperationWithSpec', () => {
   it('yields diffs for unmatched paths', () => {
-    let testSpec: OpenAPIV3.Document = {
+    let testSpec: any = {
       openapi: '3.0.3',
       info: {
         title: 'test spec',
@@ -50,7 +50,7 @@ describe('diffOperationWithSpec', () => {
   });
 
   it('yields diffs for paths with no methods', () => {
-    let testSpec: OpenAPIV3.Document = {
+    let testSpec: any = {
       openapi: '3.0.3',
       info: {
         title: 'test spec',
@@ -79,7 +79,7 @@ describe('diffOperationWithSpec', () => {
   });
 
   it('matches paths irrespective of template names', () => {
-    let testSpec: OpenAPIV3.Document = {
+    let testSpec: any = {
       openapi: '3.0.3',
       info: {
         title: 'test spec',
@@ -107,7 +107,7 @@ describe('diffOperationWithSpec', () => {
   });
 
   it('yields diffs for unmatched methods', () => {
-    let testSpec: OpenAPIV3.Document = {
+    let testSpec: any = {
       openapi: '3.0.3',
       info: {
         title: 'test spec',

--- a/projects/optic/src/commands/oas/operations/diffs/index.ts
+++ b/projects/optic/src/commands/oas/operations/diffs/index.ts
@@ -1,13 +1,14 @@
 import { OpenAPIV3 } from '../../specs';
 import { OperationDiffResult } from '../../../capture/patches/patchers/spec/types';
 import { SpecOperationDiffTraverser } from './traversers';
+import { FlatOpenAPIV3, FlatOpenAPIV3_1 } from '@useoptic/openapi-utilities';
 
 export function* diffOperationWithSpec(
   operation: {
     pathPattern: string;
     methods: OpenAPIV3.HttpMethods[];
   },
-  spec: OpenAPIV3.Document
+  spec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document
 ): IterableIterator<OperationDiffResult> {
   const traverser = new SpecOperationDiffTraverser();
   traverser.traverse(operation, spec);

--- a/projects/optic/src/commands/oas/operations/streams/documented-interactions.ts
+++ b/projects/optic/src/commands/oas/operations/streams/documented-interactions.ts
@@ -8,6 +8,7 @@ import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
 import { Option, Some, None } from 'ts-results';
 import { ParsedOperation } from '../../diffing/document';
 import { CapturedInteractions } from '../../../capture/sources/captured-interactions';
+import { FlatOpenAPIV3, FlatOpenAPIV3_1 } from '@useoptic/openapi-utilities';
 
 export interface DocumentedInteractions
   extends AsyncIterable<DocumentedInteraction> {}
@@ -15,8 +16,10 @@ export interface DocumentedInteractions
 export class DocumentedInteractions {
   static async *fromCapturedInteractions(
     interactions: CapturedInteractions,
-    spec: OpenAPIV3.Document,
-    specUpdates?: AsyncIterable<OpenAPIV3.Document>,
+    spec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document,
+    specUpdates?: AsyncIterable<
+      FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document
+    >,
     isAddAll: boolean = true,
     filterToOperations: ParsedOperation[] = []
   ): AsyncIterable<Option<DocumentedInteraction>> {

--- a/projects/optic/src/commands/oas/operations/streams/undocumented.ts
+++ b/projects/optic/src/commands/oas/operations/streams/undocumented.ts
@@ -15,6 +15,7 @@ import {
   CapturedInteractions,
 } from '../../../capture/sources/captured-interactions';
 import { OperationDiffResultKind } from '../../../capture/patches/patchers/spec/types';
+import { FlatOpenAPIV3, FlatOpenAPIV3_1 } from '@useoptic/openapi-utilities';
 
 export interface UndocumentedOperations
   extends AsyncIterable<UndocumentedOperation> {}
@@ -27,8 +28,10 @@ interface OperationPair {
 export class UndocumentedOperations {
   static async *fromPairs(
     operations: AsyncIterable<OperationPair>,
-    spec: OpenAPIV3.Document,
-    specUpdates?: AsyncIterable<OpenAPIV3.Document>
+    spec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document,
+    specUpdates?: AsyncIterable<
+      FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document
+    >
   ): UndocumentedOperations {
     const specUpdatesIterator =
       specUpdates && specUpdates[Symbol.asyncIterator]();
@@ -98,8 +101,10 @@ export class UndocumentedOperations {
 
   static async *fromCapturedInteractions(
     interactions: CapturedInteractions,
-    spec: OpenAPIV3.Document,
-    specUpdates?: AsyncIterable<OpenAPIV3.Document>
+    spec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document,
+    specUpdates?: AsyncIterable<
+      FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document
+    >
   ): UndocumentedOperations {
     const operations = AT.map<CapturedInteraction, OperationPair>(
       (interaction) => {

--- a/projects/optic/src/commands/oas/specs/io.ts
+++ b/projects/optic/src/commands/oas/specs/io.ts
@@ -7,7 +7,7 @@ import { Result, Ok, Err } from 'ts-results';
 
 export async function readDeferencedSpec(
   path: string
-): Promise<Result<ParseOpenAPIResult, JSONParserError>> {
+): Promise<Result<ParseOpenAPIResult<any>, JSONParserError>> {
   try {
     return Ok(await parseOpenAPIWithSourcemap(path));
   } catch (err) {

--- a/projects/optic/src/commands/oas/verify.ts
+++ b/projects/optic/src/commands/oas/verify.ts
@@ -4,7 +4,6 @@ import path from 'path';
 
 import { createCommandFeedback, InputErrors } from './reporters/feedback';
 import { flushEvents, trackEvent } from '../../segment';
-import { OpenAPIV3 } from './specs';
 import { captureStorage } from './captures/capture-storage';
 import chalk from 'chalk';
 import {
@@ -18,9 +17,13 @@ import { OpticCliConfig, VCS } from '../../config';
 import { OPTIC_URL_KEY } from '../../constants';
 import { getApiFromOpticUrl, getSpecUrl } from '../../utils/cloud-urls';
 import { uploadSpec, uploadSpecVerification } from '../../utils/cloud-specs';
-import { loadSpec } from '../../utils/spec-loaders';
+import { loadSpec, ParseResult } from '../../utils/spec-loaders';
 import * as Git from '../../utils/git-utils';
-import { sanitizeGitTag } from '@useoptic/openapi-utilities';
+import {
+  FlatOpenAPIV3,
+  FlatOpenAPIV3_1,
+  sanitizeGitTag,
+} from '@useoptic/openapi-utilities';
 import { nextCommand } from './reporters/next-command';
 import { getInteractions } from './captures';
 import { logger } from '../../logger';
@@ -100,7 +103,10 @@ export async function runVerify(
     denormalize: true,
   });
 
-  const { jsonLike: spec, sourcemap } = parseResult;
+  const { jsonLike: spec, sourcemap } = parseResult as Exclude<
+    ParseResult,
+    { version: '2.x.x' }
+  >;
 
   const opticUrlDetails = getApiFromOpticUrl(spec[OPTIC_URL_KEY]);
 
@@ -243,7 +249,7 @@ export async function runVerify(
 }
 async function renderOperationStatus(
   observations: StatusObservations,
-  spec: OpenAPIV3.Document,
+  spec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document,
   specPath: string,
   feedback: ReturnType<typeof createCommandFeedback>
 ) {

--- a/projects/optic/src/commands/run.ts
+++ b/projects/optic/src/commands/run.ts
@@ -407,6 +407,18 @@ const runDiffs = async ({
       error: `Failed to load cloud specification: ${e}`,
     } as const;
   }
+  if (localSpec.version === '2.x.x') {
+    return {
+      success: false,
+      error: `Local spec for ${specPath} is swagger 2 - not supported`,
+    } as const;
+  }
+  if (cloudSpec.version === '2.x.x') {
+    return {
+      success: false,
+      error: `Cloud spec for ${specPath} is swagger 2 - not supported`,
+    } as const;
+  }
 
   if (cloudSpec.jsonLike['x-optic-ci-empty-spec']) {
     cloudSpec.jsonLike.info.title = localSpec.jsonLike.info.title;
@@ -489,6 +501,12 @@ const runCapture = async ({
   runId?: string;
   organizationId?: string;
 }) => {
+  if (localSpec.version === '2.x.x') {
+    logger.error(
+      `${specPath} is Swagger 2 - capture does not support swagger 2`
+    );
+    return;
+  }
   const pathFromRoot = resolveRelativePath(config.root, specPath);
   const captureConfig = config.capture?.[pathFromRoot];
 

--- a/projects/optic/src/utils/__tests__/diff-renderer.test.ts
+++ b/projects/optic/src/utils/__tests__/diff-renderer.test.ts
@@ -21,7 +21,7 @@ describe('generateComparisonLogsV2', () => {
 
     const diffs = diff(from, to);
     const groupedDiffs = groupDiffsByEndpoint(
-      { from: from.jsonLike, to: to.jsonLike },
+      { from: from.jsonLike as any, to: to.jsonLike as any },
       diffs,
       []
     );

--- a/projects/optic/src/utils/specs.ts
+++ b/projects/optic/src/utils/specs.ts
@@ -1,10 +1,15 @@
-import { OpenAPIV3, defaultEmptySpec } from '@useoptic/openapi-utilities';
+import {
+  FlatOpenAPIV3,
+  FlatOpenAPIV3_1,
+  OpenAPIV3,
+  defaultEmptySpec,
+} from '@useoptic/openapi-utilities';
 import { OPTIC_EMPTY_SPEC_KEY, OPTIC_PATH_IGNORE_KEY } from '../constants';
 import { JsonSchemaSourcemap } from '@useoptic/openapi-io';
 import { logger } from '../logger';
 
 export function getIgnorePaths(
-  spec: OpenAPIV3.Document
+  spec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document
 ): { path: string; method?: string }[] {
   const ignorePaths: (
     | string
@@ -45,15 +50,15 @@ export function createNewSpecFile(version: string): OpenAPIV3.Document {
   };
 }
 
-export function createNullSpec(): OpenAPIV3.Document {
+export function createNullSpec(): FlatOpenAPIV3.Document {
   return {
     ...defaultEmptySpec,
     [OPTIC_EMPTY_SPEC_KEY]: true,
-  } as OpenAPIV3.Document;
+  } as FlatOpenAPIV3.Document;
 }
 
 export function createNullSpecSourcemap(
-  nullSpec: OpenAPIV3.Document
+  nullSpec: FlatOpenAPIV3.Document
 ): JsonSchemaSourcemap {
   const emptySpecName = 'empty.json';
   const sourcemap = new JsonSchemaSourcemap(emptySpecName);

--- a/projects/rulesets-base/src/extended-rules/spectral-rule.ts
+++ b/projects/rulesets-base/src/extended-rules/spectral-rule.ts
@@ -25,7 +25,7 @@ import { spawn } from 'child_process';
 import path from 'node:path';
 import os from 'node:os';
 import fs from 'node:fs/promises';
-import { RuleContext } from '..';
+import { OpenAPIDocument, RuleContext } from '..';
 import { NodeDetail, OpenAPIFactNodes } from '../rule-runner/rule-runner-types';
 import {
   createOperation,
@@ -114,7 +114,7 @@ function toOpticRuleResult(
 }
 
 function createSpecNode(
-  spec: OpenAPIV3.Document
+  spec: OpenAPIDocument
 ): Parameters<typeof createRuleContextWithoutOperation>['0'] {
   const { paths, components, ...specificationFact } = spec;
 
@@ -142,8 +142,8 @@ function createSpecNode(
 function createOperationNode(
   facts: OpenAPIFactNodes,
   jsonPath: string,
-  before: OpenAPIV3.Document,
-  after: OpenAPIV3.Document
+  before: OpenAPIDocument,
+  after: OpenAPIDocument
 ): Parameters<typeof createRuleContextWithOperation>['1'] {
   const [, path, method] = jsonPointerHelpers.decode(jsonPath);
 
@@ -189,8 +189,8 @@ export class SpectralRule extends ExternalRuleBase {
   async runRulesV2(inputs: {
     context: any;
     diffs: ObjectDiff[];
-    fromSpec: OpenAPIV3.Document;
-    toSpec: OpenAPIV3.Document;
+    fromSpec: OpenAPIDocument;
+    toSpec: OpenAPIDocument;
     groupedFacts: OpenAPIFactNodes;
   }): Promise<RuleResult[]> {
     if ((inputs.toSpec as any)['x-optic-ci-empty-spec'] === true) {
@@ -374,8 +374,8 @@ export class SpectralRule extends ExternalRuleBase {
     nextFacts: IFact[];
     currentFacts: IFact[];
     changelog: IChange[];
-    nextJsonLike: OpenAPIV3.Document<{}>;
-    currentJsonLike: OpenAPIV3.Document<{}>;
+    nextJsonLike: OpenAPIDocument;
+    currentJsonLike: OpenAPIDocument;
     groupedFacts: OpenAPIFactNodes;
   }): Promise<Result[]> {
     if ((inputs.nextJsonLike as any)['x-optic-ci-empty-spec'] === true) {

--- a/projects/rulesets-base/src/rule-runner/data-constructors.ts
+++ b/projects/rulesets-base/src/rule-runner/data-constructors.ts
@@ -15,6 +15,7 @@ import {
   RequestBody,
   Response,
   ResponseBody,
+  OpenAPIDocument,
 } from '../types';
 import {
   OpenAPIFactNodes,
@@ -30,7 +31,7 @@ type SpecFactsFrom = 'before' | 'after';
 const createFactsWithRaw = <T extends OpenApiKind>(
   nodeDetailMap: Map<string, NodeDetail<T>>,
   key: SpecFactsFrom,
-  openApiSpec: OpenAPIV3.Document
+  openApiSpec: OpenAPIDocument
 ): Map<string, FactVariant<T> & { raw: any }> => {
   const factsWithRaw: Map<string, FactVariant<T> & { raw: any }> = new Map();
 
@@ -49,7 +50,7 @@ const createFactsWithRaw = <T extends OpenApiKind>(
 const createPropertyFactsWithRaw = <T extends OpenApiKind>(
   nodeDetailMap: Map<string, NodeDetail<T>>,
   key: SpecFactsFrom,
-  openApiSpec: OpenAPIV3.Document
+  openApiSpec: OpenAPIDocument
 ): Map<
   string,
   FactVariant<T> & { raw: any; parent: OpenAPIV3.NonArraySchemaObject }
@@ -80,7 +81,7 @@ export const createRequest = (
   request: RequestNode,
   contentType: string,
   key: SpecFactsFrom,
-  openApiSpec: OpenAPIV3.Document
+  openApiSpec: OpenAPIDocument
 ): RequestBody | null => {
   const requestFact = request[key];
   const requestBody = request.bodies.get(contentType);
@@ -114,7 +115,7 @@ export const createRequest = (
 export const createResponse = (
   response: ResponseNode,
   key: SpecFactsFrom,
-  openApiSpec: OpenAPIV3.Document
+  openApiSpec: OpenAPIDocument
 ): Response | null => {
   const responseFact = response[key];
   if (!responseFact) {
@@ -150,7 +151,7 @@ export const createResponseBody = (
   statusCode: string,
   contentType: string,
   key: SpecFactsFrom,
-  openApiSpec: OpenAPIV3.Document
+  openApiSpec: OpenAPIDocument
 ): ResponseBody | null => {
   const responseBodyFact = bodyNode?.[key];
   if (!responseBodyFact) {
@@ -173,7 +174,7 @@ export const createResponseBody = (
 export const createOperation = (
   endpoint: EndpointNode,
   key: SpecFactsFrom,
-  openApiSpec: OpenAPIV3.Document
+  openApiSpec: OpenAPIDocument
 ): Operation | null => {
   const operationFact = endpoint[key];
 
@@ -260,7 +261,7 @@ export const createOperation = (
 export const createSpecification = (
   specificationNode: OpenAPIFactNodes['specification'],
   key: SpecFactsFrom,
-  openApiSpec: OpenAPIV3.Document
+  openApiSpec: OpenAPIDocument
 ): Specification | null => {
   const specificationFact = specificationNode[key];
   if (!specificationFact) {
@@ -269,6 +270,6 @@ export const createSpecification = (
 
   return {
     ...specificationFact,
-    raw: openApiSpec,
+    raw: openApiSpec as any,
   };
 };

--- a/projects/rulesets-base/src/rule-runner/operation.ts
+++ b/projects/rulesets-base/src/rule-runner/operation.ts
@@ -5,7 +5,7 @@ import { createRuleContextWithOperation, isExempted } from './utils';
 
 import { Rule, Ruleset, OperationRule } from '../rules';
 import { createOperationAssertions, AssertionResult } from './assertions';
-import { Operation } from '../types';
+import { OpenAPIDocument, Operation } from '../types';
 import { getOperationRules } from './rule-filters';
 
 const createOperationResult = (
@@ -73,8 +73,8 @@ export const runOperationRules = ({
   operationNode: EndpointNode;
   rules: (Ruleset | Rule)[];
   customRuleContext: any;
-  beforeApiSpec: OpenAPIV3.Document;
-  afterApiSpec: OpenAPIV3.Document;
+  beforeApiSpec: OpenAPIDocument;
+  afterApiSpec: OpenAPIDocument;
 }): Result[] => {
   const operationRules = getOperationRules(rules);
   const beforeSpecification = createSpecification(

--- a/projects/rulesets-base/src/rule-runner/request.ts
+++ b/projects/rulesets-base/src/rule-runner/request.ts
@@ -14,7 +14,13 @@ import {
   createPropertyAssertions,
   createRequestAssertions,
 } from './assertions';
-import { Field, Operation, RequestBody, Schema } from '../types';
+import {
+  Field,
+  OpenAPIDocument,
+  Operation,
+  RequestBody,
+  Schema,
+} from '../types';
 import { getPropertyRules, getRequestRules } from './rule-filters';
 
 const createRequestBodyResult = (
@@ -81,8 +87,8 @@ export const runRequestRules = ({
   requestNode: RequestNode;
   rules: (Ruleset | Rule)[];
   customRuleContext: any;
-  beforeApiSpec: OpenAPIV3.Document;
-  afterApiSpec: OpenAPIV3.Document;
+  beforeApiSpec: OpenAPIDocument;
+  afterApiSpec: OpenAPIDocument;
 }) => {
   const results: Result[] = [];
   const requestRules = getRequestRules(rules);

--- a/projects/rulesets-base/src/rule-runner/response-body.ts
+++ b/projects/rulesets-base/src/rule-runner/response-body.ts
@@ -14,7 +14,13 @@ import {
   createPropertyAssertions,
   createResponseBodyAssertions,
 } from './assertions';
-import { Field, Operation, ResponseBody, Schema } from '../types';
+import {
+  Field,
+  OpenAPIDocument,
+  Operation,
+  ResponseBody,
+  Schema,
+} from '../types';
 import { getPropertyRules, getResponseBodyRules } from './rule-filters';
 
 const createResponseBodyResult = (
@@ -82,8 +88,8 @@ export const runResponseBodyRules = ({
   responseNode: ResponseNode;
   rules: (Ruleset | Rule)[];
   customRuleContext: any;
-  beforeApiSpec: OpenAPIV3.Document;
-  afterApiSpec: OpenAPIV3.Document;
+  beforeApiSpec: OpenAPIDocument;
+  afterApiSpec: OpenAPIDocument;
 }) => {
   const results: Result[] = [];
   const responseRules = getResponseBodyRules(rules);

--- a/projects/rulesets-base/src/rule-runner/response.ts
+++ b/projects/rulesets-base/src/rule-runner/response.ts
@@ -10,7 +10,7 @@ import { createRuleContextWithOperation, isExempted } from './utils';
 
 import { Rule, Ruleset, ResponseRule } from '../rules';
 import { AssertionResult, createResponseAssertions } from './assertions';
-import { Operation, Response } from '../types';
+import { OpenAPIDocument, Operation, Response } from '../types';
 import { getResponseRules } from './rule-filters';
 
 const createResponseResult = (
@@ -77,8 +77,8 @@ export const runResponseRules = ({
   rules: (Ruleset | Rule)[];
 
   customRuleContext: any;
-  beforeApiSpec: OpenAPIV3.Document;
-  afterApiSpec: OpenAPIV3.Document;
+  beforeApiSpec: OpenAPIDocument;
+  afterApiSpec: OpenAPIDocument;
 }) => {
   const results: Result[] = [];
   const responseRules = getResponseRules(rules);

--- a/projects/rulesets-base/src/rule-runner/rule-filters.ts
+++ b/projects/rulesets-base/src/rule-runner/rule-filters.ts
@@ -8,7 +8,6 @@ import {
   ResponseRule,
   PropertyRule,
 } from '../rules';
-import { ExternalRuleBase } from '../rules/external-rule-base';
 import { RuleContext } from '../types';
 
 type RulesetData = {

--- a/projects/rulesets-base/src/rule-runner/rule-runner.ts
+++ b/projects/rulesets-base/src/rule-runner/rule-runner.ts
@@ -1,7 +1,6 @@
 import {
   IFact,
   IChange,
-  OpenAPIV3,
   Result,
   OperationLocation,
   ILocation,
@@ -30,6 +29,7 @@ import { runResponseBodyRules } from './response-body';
 import { runResponseRules } from './response';
 import { ExternalRule, Rule, Ruleset } from '../rules';
 import { ExternalRuleBase } from '../rules/external-rule-base';
+import { OpenAPIDocument } from '..';
 
 type SpectralRules = Extract<
   SpectralRulesetDefinition,
@@ -69,7 +69,7 @@ export class RuleRunner {
   }: {
     ruleset: SpectralRules;
     nextFacts: IFact[];
-    nextJsonLike: OpenAPIV3.Document;
+    nextJsonLike: OpenAPIDocument;
   }): Promise<Result[]> {
     if ((nextJsonLike as any)['x-optic-ci-empty-spec'] === true) {
       return [];
@@ -125,8 +125,8 @@ export class RuleRunner {
     nextFacts: IFact[];
     currentFacts: IFact[];
     changelog: IChange[];
-    nextJsonLike: OpenAPIV3.Document;
-    currentJsonLike: OpenAPIV3.Document;
+    nextJsonLike: OpenAPIDocument;
+    currentJsonLike: OpenAPIDocument;
   }): Promise<Result[]> {
     const {
       context,
@@ -224,8 +224,8 @@ export class RuleRunner {
   async runRules(inputs: {
     context: any;
     diffs: ObjectDiff[];
-    fromSpec: OpenAPIV3.Document;
-    toSpec: OpenAPIV3.Document;
+    fromSpec: OpenAPIDocument;
+    toSpec: OpenAPIDocument;
   }): Promise<RuleResult[]> {
     const { context, fromSpec: beforeApiSpec, toSpec: afterApiSpec } = inputs;
     const externalRules = this.rules.filter((rule) =>
@@ -239,11 +239,11 @@ export class RuleRunner {
     const beforeFacts =
       inputs.fromSpec['x-optic-ci-empty-spec'] === true
         ? []
-        : traverseSpec(inputs.fromSpec);
+        : traverseSpec(inputs.fromSpec as any);
     const afterFacts =
       inputs.toSpec['x-optic-ci-empty-spec'] === true
         ? []
-        : traverseSpec(inputs.toSpec);
+        : traverseSpec(inputs.toSpec as any);
     const changelog = factsToChangelog(beforeFacts, afterFacts);
 
     const openApiFactNodes = groupFacts({

--- a/projects/rulesets-base/src/rule-runner/specification.ts
+++ b/projects/rulesets-base/src/rule-runner/specification.ts
@@ -7,6 +7,7 @@ import { createRuleContextWithoutOperation, isExempted } from './utils';
 import { Rule, Ruleset, SpecificationRule } from '../rules';
 import { createSpecificationAssertions, AssertionResult } from './assertions';
 import { getSpecificationRules } from './rule-filters';
+import { OpenAPIDocument } from '..';
 
 const createSpecificationResult = (
   assertionResult: AssertionResult,
@@ -38,8 +39,8 @@ export const runSpecificationRules = ({
   specificationNode: NodeDetail<OpenApiKind.Specification>;
   rules: (Ruleset | Rule)[];
   customRuleContext: any;
-  beforeApiSpec: OpenAPIV3.Document;
-  afterApiSpec: OpenAPIV3.Document;
+  beforeApiSpec: OpenAPIDocument;
+  afterApiSpec: OpenAPIDocument;
 }) => {
   const results: Result[] = [];
   const specificationRules = getSpecificationRules(rules);

--- a/projects/rulesets-base/src/rules/external-rule-base.ts
+++ b/projects/rulesets-base/src/rules/external-rule-base.ts
@@ -7,6 +7,7 @@ import {
   RuleResult,
 } from '@useoptic/openapi-utilities';
 import { OpenAPIFactNodes } from '../rule-runner/rule-runner-types';
+import { OpenAPIDocument } from '..';
 
 class NotImplementedError extends Error {}
 
@@ -25,8 +26,8 @@ export class ExternalRuleBase {
     nextFacts: IFact[];
     currentFacts: IFact[];
     changelog: IChange[];
-    nextJsonLike: OpenAPIV3.Document;
-    currentJsonLike: OpenAPIV3.Document;
+    nextJsonLike: OpenAPIDocument;
+    currentJsonLike: OpenAPIDocument;
     groupedFacts: OpenAPIFactNodes;
   }): Promise<Result[]> {
     throw new NotImplementedError();
@@ -35,8 +36,8 @@ export class ExternalRuleBase {
   runRulesV2(inputs: {
     context: any;
     diffs: ObjectDiff[];
-    fromSpec: OpenAPIV3.Document;
-    toSpec: OpenAPIV3.Document;
+    fromSpec: OpenAPIDocument;
+    toSpec: OpenAPIDocument;
     groupedFacts: OpenAPIFactNodes;
   }): Promise<RuleResult[]> {
     throw new NotImplementedError();

--- a/projects/rulesets-base/src/test-helpers.ts
+++ b/projects/rulesets-base/src/test-helpers.ts
@@ -8,10 +8,11 @@ import {
 import { RuleRunner } from './rule-runner';
 import { Rule, Ruleset } from './rules';
 import { ExternalRuleBase } from './rules/external-rule-base';
+import { OpenAPIDocument } from '.';
 
 export const createRuleInputs = (
-  beforeJson: OpenAPIV3.Document,
-  afterJson: OpenAPIV3.Document
+  beforeJson: OpenAPIDocument,
+  afterJson: OpenAPIDocument
 ): Parameters<RuleRunner['runRulesWithFacts']>[0] => {
   const currentTraverser = new OpenAPITraverser();
   const nextTraverser = new OpenAPITraverser();
@@ -34,8 +35,8 @@ export const createRuleInputs = (
 
 export const runRulesWithInputs = (
   rules: (Rule | Ruleset)[],
-  beforeJson: OpenAPIV3.Document,
-  afterJson: OpenAPIV3.Document
+  beforeJson: OpenAPIDocument,
+  afterJson: OpenAPIDocument
 ): Promise<Result[]> => {
   const ruleRunner = new RuleRunner(rules);
   return ruleRunner.runRulesWithFacts(createRuleInputs(beforeJson, afterJson));
@@ -43,17 +44,18 @@ export const runRulesWithInputs = (
 
 export const externalRulesWithInputs = (
   rules: ExternalRuleBase,
-  beforeJson: OpenAPIV3.Document,
-  afterJson: OpenAPIV3.Document
+  beforeJson: OpenAPIDocument,
+  afterJson: OpenAPIDocument
 ): Promise<Result[]> => {
   const ruleRunner = new RuleRunner([rules]);
   return ruleRunner.runRulesWithFacts(createRuleInputs(beforeJson, afterJson));
 };
 
-export const createEmptySpec = (): OpenAPIV3.Document => ({
-  ...defaultEmptySpec,
-  paths: {},
-  info: {
-    ...defaultEmptySpec.info,
-  },
-});
+export const createEmptySpec = (): OpenAPIV3.Document =>
+  ({
+    ...defaultEmptySpec,
+    paths: {},
+    info: {
+      ...defaultEmptySpec.info,
+    },
+  }) as OpenAPIV3.Document;

--- a/projects/rulesets-base/src/types.ts
+++ b/projects/rulesets-base/src/types.ts
@@ -1,8 +1,15 @@
 import {
   FactVariant,
+  FlatOpenAPIV3,
+  FlatOpenAPIV3_1,
   OpenApiKind,
   OpenAPIV3,
 } from '@useoptic/openapi-utilities';
+
+export type OpenAPIDocument =
+  | OpenAPIV3.Document
+  | FlatOpenAPIV3.Document
+  | FlatOpenAPIV3_1.Document;
 
 // Value constructs - these are types that represent the node you are working on
 export type RuleContext = {

--- a/projects/standard-rulesets/src/lintgpt/index.ts
+++ b/projects/standard-rulesets/src/lintgpt/index.ts
@@ -5,6 +5,8 @@ import {
   Severity,
   SeverityText,
   SeverityTextOptions,
+  FlatOpenAPIV3,
+  FlatOpenAPIV3_1,
 } from '@useoptic/openapi-utilities';
 import Ajv from 'ajv';
 import { appliesWhen } from './constants';
@@ -18,7 +20,6 @@ import {
 } from './rules-helper';
 import { ExternalRuleBase } from '@useoptic/rulesets-base/build/rules/external-rule-base';
 import { OpenAPIFactNodes } from '@useoptic/rulesets-base/build/rule-runner/rule-runner-types';
-import { OpenAPIV3 } from 'openapi-types';
 import { jsonPointerHelpers } from '@useoptic/json-pointer-helpers';
 import stableStringify from 'json-stable-stringify';
 import { prepareOperation, prepareResponse } from './prepare-openapi';
@@ -122,8 +123,8 @@ export class LintGpt extends ExternalRuleBase {
   async runRulesV2(inputs: {
     context: any;
     diffs: ObjectDiff[];
-    fromSpec: OpenAPIV3.Document;
-    toSpec: OpenAPIV3.Document;
+    fromSpec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document;
+    toSpec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document;
     groupedFacts: OpenAPIFactNodes;
   }): Promise<RuleResult[]> {
     const operationsToRun: AIRuleRunInputs[] = [];

--- a/projects/standard-rulesets/src/spectral/index.ts
+++ b/projects/standard-rulesets/src/spectral/index.ts
@@ -4,7 +4,8 @@ import {
   IChange,
   IFact,
   ObjectDiff,
-  OpenAPIV3,
+  FlatOpenAPIV3,
+  FlatOpenAPIV3_1,
   Result,
   RuleResult,
 } from '@useoptic/openapi-utilities';
@@ -93,8 +94,8 @@ export class SpectralRulesets extends ExternalRuleBase {
     nextFacts: IFact[];
     currentFacts: IFact[];
     changelog: IChange[];
-    nextJsonLike: OpenAPIV3.Document<{}>;
-    currentJsonLike: OpenAPIV3.Document<{}>;
+    nextJsonLike: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document;
+    currentJsonLike: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document;
     groupedFacts: OpenAPIFactNodes;
   }): Promise<Result[]> {
     const absolutePathTmpSpec = path.join(
@@ -177,8 +178,8 @@ export class SpectralRulesets extends ExternalRuleBase {
   async runRulesV2(inputs: {
     context: any;
     diffs: ObjectDiff[];
-    fromSpec: OpenAPIV3.Document;
-    toSpec: OpenAPIV3.Document;
+    fromSpec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document;
+    toSpec: FlatOpenAPIV3.Document | FlatOpenAPIV3_1.Document;
     groupedFacts: OpenAPIFactNodes;
   }): Promise<RuleResult[]> {
     const absolutePathTmpSpec = path.join(


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Supports loading swagger 2.0 specs - this PR changes all the internal typings to expect a swagger 2, 3 or 3.1 spec but does not support the following commands with swagger 2 specs (swagger 2 code to check is moved to the edges)
- `run`
- `dereference` or `bundle`
- `diff` or `diff-all` or `lint`
- `capture`

Things that need to be fixed in follow up PRs
- update compute.ts (diff) and handle
  - Swagger2 and diff between versions
- Fix denormalize v2
- handle validation and denormalize for v2

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
