### PR TITLE
handle swagger 2.0 semver check

### DIFF
--- a/projects/openapi-io/src/validation/openapi-versions.test.ts
+++ b/projects/openapi-io/src/validation/openapi-versions.test.ts
@@ -13,6 +13,7 @@ test('detects a 3.0.x openapi', async () => {
 });
 
 test('detects a 2.x.x openapi', async () => {
+  expect(checkOpenAPIVersion({ swagger: '2.0' })).toBe('2.x.x');
   expect(checkOpenAPIVersion({ swagger: '2.0.3' })).toBe('2.x.x');
   expect(checkOpenAPIVersion({ swagger: '2.1.2' })).toBe('2.x.x');
 });

--- a/projects/openapi-io/src/validation/openapi-versions.ts
+++ b/projects/openapi-io/src/validation/openapi-versions.ts
@@ -9,7 +9,11 @@ export function checkOpenAPIVersion(spec: {
 }): SupportedOpenAPIVersions {
   if (spec.openapi && semver.satisfies(spec.openapi, '3.1.x')) return '3.1.x';
   if (spec.openapi && semver.satisfies(spec.openapi, '3.0.x')) return '3.0.x';
-  if (spec.swagger && semver.satisfies(spec.swagger, '2.x.x')) return '2.x.x';
+  if (
+    spec.swagger &&
+    (spec.swagger === '2.0' || semver.satisfies(spec.swagger, '2.x.x'))
+  )
+    return '2.x.x';
   throw new OpenAPIVersionError(
     `Unsupported OpenAPI version ${
       spec.openapi ?? spec.swagger


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Looking at the validator, swagger version seems to also be set as `2.0` which fails our semver check

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
