### PR TITLE
Allow url accessible rules

### DIFF
--- a/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
@@ -533,7 +533,6 @@ exports[`diff with mock server custom rules 1`] = `
 `;
 
 exports[`diff with mock server extends 1`] = `
-"Extending ruleset from @test-org/ruleset-id
 [31mx [39m[1mEmpty[22m [90mexample-api-v0.json[39m
 [1mOperations: [22m1 operation added, 3 changed, 1 removed
 [31mx [39m [1mChecks:[22m 3/5 passed 

--- a/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
+++ b/projects/optic/src/__tests__/integration/__snapshots__/diff.test.ts.snap
@@ -533,7 +533,7 @@ exports[`diff with mock server custom rules 1`] = `
 `;
 
 exports[`diff with mock server extends 1`] = `
-[31mx [39m[1mEmpty[22m [90mexample-api-v0.json[39m
+"[31mx [39m[1mEmpty[22m [90mexample-api-v0.json[39m
 [1mOperations: [22m1 operation added, 3 changed, 1 removed
 [31mx [39m [1mChecks:[22m 3/5 passed 
 

--- a/projects/optic/src/commands/diff/generate-rule-runner.ts
+++ b/projects/optic/src/commands/diff/generate-rule-runner.ts
@@ -19,6 +19,16 @@ export function setRulesets(rulesets: (Ruleset | ExternalRule)[]) {
 }
 
 const isLocalJsFile = (name: string) => name.endsWith('.js');
+const isUrl = (name: string) => {
+  try {
+    const parsed = new URL(name);
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:')
+      return true;
+    return false;
+  } catch (e) {
+    return false;
+  }
+};
 
 type InputPayload = Parameters<typeof prepareRulesets>[0];
 
@@ -105,6 +115,11 @@ export const generateRuleRunner = async (
           ? path.dirname(options.config.configPath)
           : process.cwd();
         localRulesets[rule.name] = path.resolve(rootPath, rule.name); // the path is the name
+      } else if (isUrl(rule.name)) {
+        hostedRulesets[rule.name] = {
+          uploaded_at: String(Math.random()),
+          url: rule.name,
+        };
       } else {
         rulesToFetch.push(rule.name);
       }

--- a/projects/optic/src/commands/diff/generate-rule-runner.ts
+++ b/projects/optic/src/commands/diff/generate-rule-runner.ts
@@ -45,19 +45,27 @@ const getStandardToUse = async (options: {
     );
     return config.ruleset;
   } else if (options.specRuleset) {
-    try {
-      const ruleset = await options.config.client.getStandard(
-        options.specRuleset
-      );
-      return ruleset.config.ruleset;
-    } catch (e) {
-      logger.warn(
-        `${chalk.red('Warning:')} Could not download standard ${
+    if (options.specRuleset.startsWith('@')) {
+      try {
+        const ruleset = await options.config.client.getStandard(
           options.specRuleset
-        }. Please check the ruleset name and whether you are authenticated (run: optic login).`
+        );
+        return ruleset.config.ruleset;
+      } catch (e) {
+        logger.warn(
+          `${chalk.red('Warning:')} Could not download standard ${
+            options.specRuleset
+          }. Please check the ruleset name and whether you are authenticated (run: optic login).`
+        );
+        process.exitCode = 1;
+        return [];
+      }
+    } else {
+      const config = await loadCliConfig(
+        options.specRuleset,
+        options.config.client
       );
-      process.exitCode = 1;
-      return [];
+      return config.ruleset;
     }
   } else {
     return options.config.ruleset;

--- a/projects/optic/src/commands/diff/generate-rule-runner.ts
+++ b/projects/optic/src/commands/diff/generate-rule-runner.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { ConfigRuleset, OpticCliConfig } from '../../config';
+import { ConfigRuleset, OpticCliConfig, initializeRules } from '../../config';
 import { StandardRulesets } from '@useoptic/standard-rulesets';
 import {
   RuleRunner,
@@ -61,11 +61,12 @@ const getStandardToUse = async (options: {
         return [];
       }
     } else {
-      const config = await loadCliConfig(
-        options.specRuleset,
-        options.config.client
-      );
-      return config.ruleset;
+      const rules: any = {
+        extends: options.specRuleset,
+      };
+      await initializeRules(rules, options.config.client);
+
+      return rules.ruleset;
     }
   } else {
     return options.config.ruleset;
@@ -127,6 +128,7 @@ export const generateRuleRunner = async (
         hostedRulesets[rule.name] = {
           uploaded_at: String(Math.random()),
           url: rule.name,
+          should_decompress: false,
         };
       } else {
         rulesToFetch.push(rule.name);
@@ -141,6 +143,7 @@ export const generateRuleRunner = async (
         hostedRulesets[hostedRuleset.name] = {
           uploaded_at: hostedRuleset.uploaded_at,
           url: hostedRuleset.url,
+          should_decompress: true,
         };
       }
     }

--- a/projects/optic/src/config.ts
+++ b/projects/optic/src/config.ts
@@ -220,7 +220,7 @@ export const initializeRules = async (
   let rulesetMap: Map<string, ConfigRuleset> = new Map();
   let rawRulesets = config.ruleset ? config.ruleset : [];
   if (config.extends) {
-    console.log(`Extending ruleset from ${config.extends}`);
+    logger.debug(`Extending ruleset from ${config.extends}`);
 
     try {
       if (config.extends.startsWith('@')) {
@@ -238,7 +238,7 @@ export const initializeRules = async (
           }
         });
         const parsed = yaml.load(response);
-        rawRulesets.push((parsed as any).ruleset);
+        rawRulesets.push(...(parsed as any).ruleset);
       }
     } catch (e) {
       console.error(e);

--- a/projects/rulesets-base/src/custom-rulesets/__tests__/download-ruleset.test.ts
+++ b/projects/rulesets-base/src/custom-rulesets/__tests__/download-ruleset.test.ts
@@ -20,7 +20,8 @@ describe('downloadRuleset', () => {
       downloadRuleset(
         'test-ruleset',
         'https://some-url.com',
-        '2022-11-01T19:32:22.148Z'
+        '2022-11-01T19:32:22.148Z',
+        true
       )
     ).rejects.toThrow(new Error('Downloading ruleset failed (404): Missing'));
   });
@@ -35,7 +36,8 @@ describe('downloadRuleset', () => {
     await downloadRuleset(
       'test-ruleset',
       'https://some-url.com',
-      '2022-11-01T19:32:22.148Z'
+      '2022-11-01T19:32:22.148Z',
+      true
     );
     expect(fs.mkdir).toBeCalled();
     expect(fs.writeFile).toHaveBeenCalledWith(
@@ -49,7 +51,8 @@ describe('downloadRuleset', () => {
     await downloadRuleset(
       'test-ruleset',
       'https://some-url.com',
-      '2022-11-01T19:32:22.148Z'
+      '2022-11-01T19:32:22.148Z',
+      true
     );
 
     expect(fetch).not.toBeCalled();

--- a/projects/rulesets-base/src/custom-rulesets/__tests__/prepare-ruleset.test.ts
+++ b/projects/rulesets-base/src/custom-rulesets/__tests__/prepare-ruleset.test.ts
@@ -32,6 +32,7 @@ describe('prepareRulesets', () => {
           '@team/custom-ruleset': {
             url: 'https://some-url.com',
             uploaded_at: '123',
+            should_decompress: true,
           },
         },
         standardRulesets: {
@@ -76,6 +77,7 @@ describe('prepareRulesets', () => {
         '@team/custom-ruleset': {
           url: 'https://some-url.com',
           uploaded_at: '123',
+          should_decompress: true,
         },
       },
       standardRulesets: {

--- a/projects/rulesets-base/src/custom-rulesets/prepare-rulesets.ts
+++ b/projects/rulesets-base/src/custom-rulesets/prepare-rulesets.ts
@@ -15,6 +15,7 @@ export type RulesetPayload = {
     {
       uploaded_at: string;
       url: string;
+      should_decompress: boolean;
     }
   >;
   standardRulesets: Record<
@@ -81,7 +82,8 @@ export async function prepareRulesets(
         rulesetPath = await downloadRuleset(
           ruleset.name,
           hostedRuleset.url,
-          hostedRuleset.uploaded_at
+          hostedRuleset.uploaded_at,
+          hostedRuleset.should_decompress
         );
       } catch (e) {
         warnings.push(`Loading ruleset ${ruleset.name} failed`);


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

Handles the different ways to specify your ruleset and allows it to be downloaded via URL (e.g. github URL)
- from the optic.yml file -> `extends` key
  - in the optic.yml config: `extends: https://gist.githubusercontent.com/niclim/9daff82cf3f68386fa24fec689796c18/raw/59f441e0bfe3911891e897fec6b8d515214a4047/gistfile1.txt`
- from the `x-optic-standard` key
  - e.g. in the api file `x-optic-standard: https://gist.githubusercontent.com/niclim/9daff82cf3f68386fa24fec689796c18/raw/59f441e0bfe3911891e897fec6b8d515214a4047/gistfile1.txt`

Also handles the hosting rule definitions locally
- from the hosted custom rule -> can point to a GH url


## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._

## 👹 QA
_How can other humans verify that this PR is correct?_
