### PR TITLE
replace __dirname in favor of process.cwd in diff command web flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1-0",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",
@@ -31,5 +31,6 @@
     "**/*.+(js|jsx|ts|tsx|json|css)": [
       "yarn prettier --write"
     ]
-  }
+  },
+  "stableVersion": "1.0.0"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "1.0.1-0",
+  "version": "1.0.1",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",
@@ -31,6 +31,5 @@
     "**/*.+(js|jsx|ts|tsx|json|css)": [
       "yarn prettier --write"
     ]
-  },
-  "stableVersion": "1.0.0"
+  }
 }

--- a/projects/fastify-capture/package.json
+++ b/projects/fastify-capture/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/fastify-capture",
   "license": "MIT",
   "packageManager": "yarn@4.1.1",
-  "version": "1.0.0",
+  "version": "1.0.1-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -41,5 +41,6 @@
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
     "typescript": "^5.0.4"
-  }
+  },
+  "stableVersion": "1.0.0"
 }

--- a/projects/fastify-capture/package.json
+++ b/projects/fastify-capture/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/fastify-capture",
   "license": "MIT",
   "packageManager": "yarn@4.1.1",
-  "version": "1.0.1-0",
+  "version": "1.0.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -41,6 +41,5 @@
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
     "typescript": "^5.0.4"
-  },
-  "stableVersion": "1.0.0"
+  }
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@4.1.1",
-  "version": "1.0.1-0",
+  "version": "1.0.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -36,6 +36,5 @@
   "dependencies": {
     "jsonpointer": "^5.0.1",
     "minimatch": "9.0.3"
-  },
-  "stableVersion": "1.0.0"
+  }
 }

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@4.1.1",
-  "version": "1.0.0",
+  "version": "1.0.1-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -36,5 +36,6 @@
   "dependencies": {
     "jsonpointer": "^5.0.1",
     "minimatch": "9.0.3"
-  }
+  },
+  "stableVersion": "1.0.0"
 }

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@4.1.1",
-  "version": "1.0.1-0",
+  "version": "1.0.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -61,6 +61,5 @@
     "upath": "^2.0.1",
     "yaml": "^2.3.2",
     "yaml-ast-parser": "^0.0.43"
-  },
-  "stableVersion": "1.0.0"
+  }
 }

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@4.1.1",
-  "version": "1.0.0",
+  "version": "1.0.1-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -61,5 +61,6 @@
     "upath": "^2.0.1",
     "yaml": "^2.3.2",
     "yaml-ast-parser": "^0.0.43"
-  }
+  },
+  "stableVersion": "1.0.0"
 }

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@4.1.1",
-  "version": "1.0.0",
+  "version": "1.0.1-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -57,5 +57,6 @@
     "ts-invariant": "^0.9.3",
     "url-join": "^4.0.1",
     "yaml-ast-parser": "^0.0.43"
-  }
+  },
+  "stableVersion": "1.0.0"
 }

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@4.1.1",
-  "version": "1.0.1-0",
+  "version": "1.0.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -57,6 +57,5 @@
     "ts-invariant": "^0.9.3",
     "url-join": "^4.0.1",
     "yaml-ast-parser": "^0.0.43"
-  },
-  "stableVersion": "1.0.0"
+  }
 }

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@4.1.1",
-  "version": "1.0.1-0",
+  "version": "1.0.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -144,6 +144,5 @@
       "node18-win-x64"
     ],
     "outputPath": "../../dist"
-  },
-  "stableVersion": "1.0.0"
+  }
 }

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@4.1.1",
-  "version": "1.0.0",
+  "version": "1.0.1-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -144,5 +144,6 @@
       "node18-win-x64"
     ],
     "outputPath": "../../dist"
-  }
+  },
+  "stableVersion": "1.0.0"
 }

--- a/projects/optic/src/commands/diff/diff.ts
+++ b/projects/optic/src/commands/diff/diff.ts
@@ -455,7 +455,7 @@ const getDiffAction =
           analyticsData.compressedDataLength = compressedData.length;
           logger.info('Opening up diff in web view');
           const baseHtml = path.resolve(
-            __dirname,
+            process.cwd(),
             '../../../web/build/index.html'
           );
           maybeChangelogUrl = `${baseHtml}#${compressedData}`;

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@4.1.1",
-  "version": "1.0.1-0",
+  "version": "1.0.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -44,6 +44,5 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
-  },
-  "stableVersion": "1.0.0"
+  }
 }

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@4.1.1",
-  "version": "1.0.0",
+  "version": "1.0.1-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -44,5 +44,6 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
-  }
+  },
+  "stableVersion": "1.0.0"
 }

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@4.1.1",
-  "version": "1.0.0",
+  "version": "1.0.1-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -49,5 +49,6 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
-  }
+  },
+  "stableVersion": "1.0.0"
 }

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@4.1.1",
-  "version": "1.0.1-0",
+  "version": "1.0.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [
@@ -49,6 +49,5 @@
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
-  },
-  "stableVersion": "1.0.0"
+  }
 }


### PR DESCRIPTION
## 🍗 Description
_What does this PR do? Anything folks should know?_

A bit of context: to facilitate the consumption of `@useoptic/optic`, we package it using [pkg](https://www.npmjs.com/package/pkg) to make it an executable.

If I run the diff command using native TypeScript compilers such as [ts-node](https://www.npmjs.com/package/ts-node), I have no issue because the final HTML file resolves to a local file in my filesystem, for example, `file:///Users/xxxxxxx/work/tools/tool-api-standards/node_modules/@useoptic/optic/web/build/index.html#W0cZF0U`

But because we package using [pkg](https://www.npmjs.com/package/pkg), [it prefixes the local file path with snapshot](https://www.npmjs.com/package/pkg#snapshot-filesystem), so it becomes:
`file:///snapshot/tool-api-standards/node_modules/@useoptic/optic/web/build/index.html#W0cZF0U`

>During packaging process pkg collects project files and places them into executable. It is called a snapshot. At run time the packaged application has access to snapshot filesystem where all that files reside.
Packaged files have /snapshot/ prefix in their paths (or C:\snapshot\ in Windows). If you used pkg /path/app.js command line, then __filename value will be likely /snapshot/path/app.js at run time. __dirname will be /snapshot/path as well.

I think it is caused by `maybeChangelogUrl` found in the following line in combination with our use of pkg to make executables: [maybeChangelogUrl](https://github.com/opticdev/optic/blob/0799dbcae573be501c85244255e4d9a20449fc36/projects/optic/src/commands/diff/diff.ts#L461)

[pkg](https://www.npmjs.com/package/pkg) recommends to use `process.cwd()`  instead of `__dirname`

>On the other hand, to access a real file system at run time (pick up a user’s external javascript plugin, JSON configuration or even get a list of the user’s directory) you should take process.cwd() or path.dirname(process.execPath) 

One can assert the following is true: `(process.execPath) === __dirname === true`

## 📚 References
_Links to relevant docs (Notion, Twist, GH issues, etc.), if applicable._
https://www.npmjs.com/package/pkg#snapshot-filesystem
https://www.npmjs.com/package/ts-node
## 👹 QA
_How can other humans verify that this PR is correct?_

When running `diff` with the `--web` flag, it should open a browser window with the results.
