### PR TITLE
allow overriding ci comment

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openapi-workspaces",
   "license": "MIT",
   "private": true,
-  "version": "1.0.4",
+  "version": "1.0.5",
   "workspaces": [
     "projects/json-pointer-helpers",
     "projects/openapi-io",

--- a/projects/fastify-capture/package.json
+++ b/projects/fastify-capture/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/fastify-capture",
   "license": "MIT",
   "packageManager": "yarn@4.1.1",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/json-pointer-helpers/package.json
+++ b/projects/json-pointer-helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/json-pointer-helpers",
   "license": "MIT",
   "packageManager": "yarn@4.1.1",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-io/package.json
+++ b/projects/openapi-io/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-io",
   "license": "MIT",
   "packageManager": "yarn@4.1.1",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/openapi-utilities/package.json
+++ b/projects/openapi-utilities/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/openapi-utilities",
   "license": "MIT",
   "packageManager": "yarn@4.1.1",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/package.json
+++ b/projects/optic/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/optic",
   "license": "MIT",
   "packageManager": "yarn@4.1.1",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/optic/src/commands/ci/comment/comment.ts
+++ b/projects/optic/src/commands/ci/comment/comment.ts
@@ -51,6 +51,7 @@ export const registerCiComment = (cli: Command, config: OpticCliConfig) => {
       '--enterprise-base-url <enterprise-base-url>',
       '(only for enterprise versions of github or gitlab) - the base url to your enterprise github / gitlab instance'
     )
+    .option('--comment-url <comment-url>', 'override the url of the comment')
     .option('--verbose', 'show all operations changed in each API', false)
     .description('comment on a pull request / merge request')
     .action(
@@ -60,6 +61,7 @@ export const registerCiComment = (cli: Command, config: OpticCliConfig) => {
 
 type CommonOptions = {
   verbose: boolean;
+  commentUrl: string;
 };
 
 type UnvalidatedOptions = CommonOptions & {
@@ -153,6 +155,7 @@ const getCiCommentAction =
       await commenter.getComment(COMPARE_SUMMARY_IDENTIFIER);
     const body = generateCompareSummaryMarkdown({ sha: options.sha }, data, {
       verbose: options.verbose,
+      overrideUrl: options.commentUrl,
     });
 
     if (maybeComment) {

--- a/projects/optic/src/commands/ci/comment/common.ts
+++ b/projects/optic/src/commands/ci/comment/common.ts
@@ -82,7 +82,7 @@ const getCaptureIssuesLabel = ({
 export const generateCompareSummaryMarkdown = (
   commit: { sha: string },
   results: CiRunDetails,
-  options: { verbose: boolean }
+  options: { verbose: boolean; overrideUrl?: string }
 ) => {
   const anyCompletedHasWarning = results.completed.some(
     (s) => s.warnings.length > 0
@@ -122,7 +122,7 @@ ${s.apiName}
 <td>
 
 ${getOperationsText(s.comparison.groupedDiffs, {
-  webUrl: s.opticWebUrl,
+  webUrl: options.overrideUrl || s.opticWebUrl,
   verbose: options.verbose,
   labelJoiner: ',\n',
 })}
@@ -163,7 +163,7 @@ ${
 
 <td>
 
-${s.opticWebUrl ? `[View report](${s.opticWebUrl})` : ''}
+${options.overrideUrl || s.opticWebUrl ? `[View report](${options.overrideUrl || s.opticWebUrl})` : ''}
 
 </td>
 </tr>`

--- a/projects/rulesets-base/package.json
+++ b/projects/rulesets-base/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/rulesets-base",
   "license": "MIT",
   "packageManager": "yarn@4.1.1",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [

--- a/projects/standard-rulesets/package.json
+++ b/projects/standard-rulesets/package.json
@@ -2,7 +2,7 @@
   "name": "@useoptic/standard-rulesets",
   "license": "MIT",
   "packageManager": "yarn@4.1.1",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "files": [


### PR DESCRIPTION
## 🍗 Description
`--comment-url` flag added to internal command for enterprise users `optic comment`
